### PR TITLE
Update lading to 0.31.2

### DIFF
--- a/test/regression/cases/file_to_blackhole_0ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_0ms_latency/experiment.yaml
@@ -32,8 +32,8 @@ checks:
       # The machine has 12GiB free.
       upper_bound: 1.2GiB
 
-  - name: lost_bytes
+  - name: missed_bytes
     description: "Available bytes not polled by log Agent"
     bounds:
-      series: lost_bytes
+      series: missed_bytes
       upper_bound: 0KiB

--- a/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_1000ms_latency/experiment.yaml
@@ -32,8 +32,8 @@ checks:
       # The machine has 12GiB free.
       upper_bound: 1.2GiB
 
-  - name: lost_bytes
+  - name: missed_bytes
     description: "Allowable bytes not polled by log Agent"
     bounds:
-      series: lost_bytes
+      series: missed_bytes
       upper_bound: 0KiB

--- a/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_100ms_latency/experiment.yaml
@@ -32,8 +32,8 @@ checks:
       # The machine has 12GiB free.
       upper_bound: 1.2GiB
 
-  - name: lost_bytes
+  - name: missed_bytes
     description: "Allowable bytes not polled by log Agent"
     bounds:
-      series: lost_bytes
+      series: missed_bytes
       upper_bound: 0KiB

--- a/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
+++ b/test/regression/cases/file_to_blackhole_500ms_latency/experiment.yaml
@@ -32,8 +32,8 @@ checks:
       # The machine has 12GiB free.
       upper_bound: 1.2GiB
 
-  - name: lost_bytes
+  - name: missed_bytes
     description: "Allowable bytes not polled by log Agent"
     bounds:
-      series: lost_bytes
+      series: missed_bytes
       upper_bound: 0KiB

--- a/test/regression/cases/quality_gate_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_logs/experiment.yaml
@@ -33,10 +33,10 @@ checks:
       # When updating this, update the memory_allotment in the target section to 20% higher
       upper_bound: "220 MiB"
 
-  - name: lost_bytes
+  - name: missed_bytes
     description: "Allowable bytes not polled by log Agent"
     bounds:
-      series: lost_bytes
+      series: missed_bytes
       upper_bound: 0KiB
 
   - name: intake_connections

--- a/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
+++ b/test/regression/cases/quality_gate_metrics_logs/experiment.yaml
@@ -47,10 +47,10 @@ checks:
       series: "connection.current"
       upper_bound: 6
 
-  - name: lost_bytes
+  - name: missed_bytes
     description: "Allowable bytes not processed by Agent"
     bounds:
-      series: lost_bytes
+      series: missed_bytes
       upper_bound: 0KiB
 
 report_links:

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.31.1
+  version: 0.31.2
 
 target:
   ddprof_replicas: 1

--- a/test/regression/config.yaml
+++ b/test/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.30.0
+  version: 0.31.1
 
 target:
   ddprof_replicas: 1

--- a/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/experiment.yaml
+++ b/test/regression/x-disabled-cases/file_to_blackhole_0ms_latency_ramp_up/experiment.yaml
@@ -32,8 +32,8 @@ checks:
       # The machine has 12GiB free.
       upper_bound: 1.2GiB
 
-  - name: lost_bytes
+  - name: missed_bytes
     description: "Available bytes not polled by log Agent"
     bounds:
-      series: lost_bytes
+      series: missed_bytes
       upper_bound: 0KiB


### PR DESCRIPTION
### What does this PR do?

Update lading to 0.31.1. Prerequisite for SMP 0.26.

### Motivation

Update Agent's SMP deploy.

### Describe how you validated your changes

SMP QA.

### Additional Notes

Lading 0.31 renamed the `lost_bytes` series to `missed_bytes` in blackhole generators. Update the version and all experiment configs that reference this series.