### PR TITLE
Fix shell tests for Windows CI

### DIFF
--- a/pkg/shell/interp/allowed_paths_internal_test.go
+++ b/pkg/shell/interp/allowed_paths_internal_test.go
@@ -68,6 +68,9 @@ func runScriptInternal(t *testing.T, script, dir string, opts ...RunnerOption) (
 }
 
 func TestAllowedPathsExecInside(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/bin and /usr do not exist on Windows")
+	}
 	dir := t.TempDir()
 	// /bin/echo should be within the allowed path if we allow /bin or /usr
 	stdout, _, exitCode := runScriptInternal(t, `/bin/echo hello`, dir,
@@ -88,6 +91,9 @@ func TestAllowedPathsExecOutside(t *testing.T) {
 }
 
 func TestAllowedPathsExecNonexistent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("/bin and /usr do not exist on Windows")
+	}
 	dir := t.TempDir()
 	// Command that doesn't exist at all — ExecLookPathDir fails
 	_, stderr, exitCode := runScriptInternal(t, `totally_nonexistent_cmd_12345`, dir,

--- a/pkg/shell/interp/allowed_paths_test.go
+++ b/pkg/shell/interp/allowed_paths_test.go
@@ -99,7 +99,7 @@ func TestAllowedPathsCatOutside(t *testing.T) {
 	secret := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(secret, "hidden.txt"), []byte("secret"), 0644))
 
-	_, stderr, exitCode := runScript(t, "cat "+filepath.Join(secret, "hidden.txt"), allowed,
+	_, stderr, exitCode := runScript(t, "cat "+filepath.ToSlash(filepath.Join(secret, "hidden.txt")), allowed,
 		interp.AllowedPaths([]string{allowed}),
 	)
 	assert.Equal(t, 1, exitCode)

--- a/pkg/shell/tests/scenarios/shell/allowed_paths/nonexistent_file_in_allowed.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_paths/nonexistent_file_in_allowed.yaml
@@ -1,4 +1,5 @@
 description: "Non-existent file inside allowed directory returns an error"
+target_os: [linux, darwin]
 test_against_local_shell: false
 setup:
   files:

--- a/pkg/shell/tests/scenarios/shell/environment/pwd_is_set.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/pwd_is_set.yaml
@@ -1,4 +1,5 @@
 description: "PWD is set to the working directory"
+target_os: [linux, darwin]
 input:
   script: |
     echo "$PWD"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"0d92a298-5cba-4aed-9ce9-b26744c66bb5","source":"chat","resourceId":"5031b559-57ee-477d-ac9e-56a0bd015ce2","workflowId":"2419f653-adcd-499e-b386-ea10da10f093","codeChangeId":"2419f653-adcd-499e-b386-ea10da10f093","sourceType":"chat"} -->
### What does this PR do?

Fixes Windows CI test failures in `pkg/shell/interp` and `pkg/shell/tests` by addressing platform-specific issues with path handling and error messages.

### Motivation

The Windows CI job (`tests-windows-x64`) fails due to 4 distinct issues in the shell package tests:

1. `TestAllowedPathsExecInside` / `TestAllowedPathsExecNonexistent` reference Unix-only directories (`/bin`, `/usr`) in `AllowedPaths` which don't exist on Windows, causing validation to fail.
2. `TestAllowedPathsCatOutside` passes Windows backslash paths directly into shell scripts where backslashes are interpreted as escape characters, mangling the path.
3. `nonexistent_file_in_allowed.yaml` expects `"no such file or directory"` but Windows returns `"The system cannot find the file specified."`.
4. `pwd_is_set.yaml` expects stdout to contain `"/"` but Windows `$PWD` uses backslash paths (`C:\...`).

### Describe how you validated your changes

- Ran `go test ./pkg/shell/interp/ -run TestAllowedPaths` — all pass on Linux.
- Ran `go test ./pkg/shell/tests/ -run TestShellScenarios` — all pass on Linux.
- Verified `target_os` filtering skips scenarios appropriately (existing mechanism used by other scenarios).

### Additional Notes

- Tests using Unix-specific paths (`/bin`, `/usr`) are skipped on Windows with descriptive messages.
- `TestAllowedPathsCatOutside` uses `filepath.ToSlash()` to prevent shell backslash interpretation on Windows.
- Two scenario YAML files restricted to `target_os: [linux, darwin]` due to OS-specific error messages and path formats.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/5031b559-57ee-477d-ac9e-56a0bd015ce2)

Comment @datadog to request changes