### PR TITLE
Fix shell tests for Windows CI

### DIFF
--- a/pkg/shell/interp/allowed_paths_internal_test.go
+++ b/pkg/shell/interp/allowed_paths_internal_test.go
@@ -69,12 +69,25 @@ func runScriptInternal(t *testing.T, script, dir string, opts ...RunnerOption) (
 
 func TestAllowedPathsExecInside(t *testing.T) {
 	dir := t.TempDir()
-	// /bin/echo should be within the allowed path if we allow /bin or /usr
-	stdout, _, exitCode := runScriptInternal(t, `/bin/echo hello`, dir,
-		AllowedPaths([]string{dir, "/bin", "/usr"}),
-	)
-	assert.Equal(t, 0, exitCode)
-	assert.Equal(t, "hello\n", stdout)
+	if runtime.GOOS == "windows" {
+		// On Windows, use the system directory for echo
+		systemRoot := os.Getenv("SystemRoot")
+		if systemRoot == "" {
+			systemRoot = `C:\Windows`
+		}
+		stdout, _, exitCode := runScriptInternal(t, `echo hello`, dir,
+			AllowedPaths([]string{dir, systemRoot}),
+		)
+		assert.Equal(t, 0, exitCode)
+		assert.Equal(t, "hello\n", stdout)
+	} else {
+		// /bin/echo should be within the allowed path if we allow /bin or /usr
+		stdout, _, exitCode := runScriptInternal(t, `/bin/echo hello`, dir,
+			AllowedPaths([]string{dir, "/bin", "/usr"}),
+		)
+		assert.Equal(t, 0, exitCode)
+		assert.Equal(t, "hello\n", stdout)
+	}
 }
 
 func TestAllowedPathsExecOutside(t *testing.T) {
@@ -89,9 +102,17 @@ func TestAllowedPathsExecOutside(t *testing.T) {
 
 func TestAllowedPathsExecNonexistent(t *testing.T) {
 	dir := t.TempDir()
+	allowedPaths := []string{dir, "/bin", "/usr"}
+	if runtime.GOOS == "windows" {
+		systemRoot := os.Getenv("SystemRoot")
+		if systemRoot == "" {
+			systemRoot = `C:\Windows`
+		}
+		allowedPaths = []string{dir, systemRoot}
+	}
 	// Command that doesn't exist at all — ExecLookPathDir fails
 	_, stderr, exitCode := runScriptInternal(t, `totally_nonexistent_cmd_12345`, dir,
-		AllowedPaths([]string{dir, "/bin", "/usr"}),
+		AllowedPaths(allowedPaths),
 	)
 	assert.Equal(t, 127, exitCode)
 	assert.Contains(t, stderr, "command not found")

--- a/pkg/shell/interp/allowed_paths_test.go
+++ b/pkg/shell/interp/allowed_paths_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -103,7 +104,11 @@ func TestAllowedPathsCatOutside(t *testing.T) {
 		interp.AllowedPaths([]string{allowed}),
 	)
 	assert.Equal(t, 1, exitCode)
-	assert.Contains(t, stderr, "permission denied")
+	if runtime.GOOS == "windows" {
+		assert.Contains(t, stderr, "path escapes from parent")
+	} else {
+		assert.Contains(t, stderr, "permission denied")
+	}
 }
 
 func TestAllowedPathsRedirectInside(t *testing.T) {

--- a/pkg/shell/tests/scenarios/shell/allowed_paths/nonexistent_file_in_allowed_windows.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_paths/nonexistent_file_in_allowed_windows.yaml
@@ -1,6 +1,6 @@
-description: "Non-existent file inside allowed directory returns an error"
+description: "Non-existent file inside allowed directory returns an error (Windows)"
 test_against_local_shell: false
-target_os: [linux, darwin]
+target_os: [windows]
 setup:
   files:
     - path: "data/exists.txt"
@@ -12,5 +12,5 @@ input:
     - "data"
 expect:
   stderr_contains:
-    - "no such file or directory"
+    - "The system cannot find the file specified."
   exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/environment/pwd_is_set.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/pwd_is_set.yaml
@@ -1,4 +1,5 @@
 description: "PWD is set to the working directory"
+target_os: [linux, darwin]
 input:
   script: |
     echo "$PWD"

--- a/pkg/shell/tests/scenarios/shell/environment/pwd_is_set_windows.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/pwd_is_set_windows.yaml
@@ -1,0 +1,9 @@
+description: "PWD is set to the working directory (Windows)"
+target_os: [windows]
+input:
+  script: |
+    echo "$PWD"
+expect:
+  stdout_contains:
+    - "\\"
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"81308df5-2b92-4099-a2ad-9ebc1ab040c9","source":"chat","resourceId":"9a895f6b-6492-4e80-a55c-ad13da850df0","workflowId":"8197d84d-7329-43c0-8553-630a7f8547c5","codeChangeId":"8197d84d-7329-43c0-8553-630a7f8547c5","sourceType":"chat"} -->
### What does this PR do?

Fixes Windows CI test failures in `pkg/shell/interp` and `pkg/shell/tests` by adapting tests to handle Windows-specific paths and error messages while keeping full Linux/macOS coverage.

### Motivation

Windows CI was failing with 8 test failures because:
- `TestAllowedPathsExecInside` / `TestAllowedPathsExecNonexistent`: Used `/bin` which doesn't exist on Windows
- `TestAllowedPathsCatOutside`: Expected "permission denied" but Windows returns "path escapes from parent"
- `TestShellScenarios/nonexistent_file_in_allowed`: Expected "no such file or directory" but Windows returns "The system cannot find the file specified."
- `TestShellScenarios/pwd_is_set`: Expected `/` in PWD but Windows uses `\` backslash paths

### Describe how you validated your changes

- All existing tests pass on Linux (`go test ./pkg/shell/interp/ ./pkg/shell/tests/`)
- Windows scenario variants are properly skipped on Linux via `target_os`
- Linux/darwin scenarios remain unchanged in behavior

### Additional Notes

- Created Windows-specific scenario YAML files (`*_windows.yaml`) following the existing pattern (e.g., `nonexistent_file_windows.yaml`)
- Added `target_os: [linux, darwin]` to existing scenarios that had platform-specific expected output
- Used `runtime.GOOS` checks in Go tests to use appropriate paths (`SystemRoot` on Windows vs `/bin` on Unix)

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/9a895f6b-6492-4e80-a55c-ad13da850df0)

Comment @datadog to request changes