### PR TITLE
[WP] Fix not triggered custom event not properly sent

### DIFF
--- a/pkg/security/probe/remediations_linux.go
+++ b/pkg/security/probe/remediations_linux.go
@@ -359,7 +359,7 @@ func (p *EBPFProbe) HandleRemediationNotTriggered() {
 	p.activeRemediationsLock.Lock()
 	defer p.activeRemediationsLock.Unlock()
 	for remediationKey, remediation := range p.activeRemediations {
-		if len(remediationKey) > 4 && strings.HasPrefix(remediationKey, RemediationKeyPrefix) {
+		if !strings.HasPrefix(remediationKey, RemediationKeyPrefix) {
 			// Only send events for remediation rules
 			continue
 		}

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -1390,80 +1390,80 @@ func TestRemediationCustomEvents(t *testing.T) {
 		})
 	}
 
+	// Network isolation remediation requires raw packet support.
 	checkKernelCompatibility(t, "network feature", isRawPacketNotSupported)
 
-	ruleDefs := []*rules.RuleDefinition{
-		{
-			ID: "kill_remediation",
-			Expression: `process.file.name == "syscall_tester" && open.file.path == "{{.Root}}/test-kill-remediation" 
+	ruleDefs := []*rules.RuleDefinition{}
+	killRemediationRule := &rules.RuleDefinition{
+		ID: "kill_remediation",
+		Expression: `event.source == "replay" && exec.file.name == "syscall_tester"
 			&& ${process.kill_remediation_performed} != "done"`,
-			Actions: []*rules.ActionDefinition{
-				{
-					Set: &rules.SetDefinition{
-						Scope: "process",
-						Name:  "kill_remediation_performed",
-						Value: "done",
-					},
-				}, {
-					Kill: &rules.KillDefinition{
-						Signal: "SIGKILL",
-						Scope:  "process",
-					},
+		Actions: []*rules.ActionDefinition{
+			{
+				Set: &rules.SetDefinition{
+					Scope: "process",
+					Name:  "kill_remediation_performed",
+					Value: "done",
+				},
+			}, {
+				Kill: &rules.KillDefinition{
+					Signal: "SIGKILL",
+					Scope:  "process",
 				},
 			},
-			Tags: map[string]string{
-				"remediation_rule": "true",
-				"agent_event_id":   "AZoIdt0EAAAbKF9Rg_3TKKJ",
-				"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
-				"creator_name":     "Allan Turing",
-				"creator_handle":   "allan.turing@example.com",
-			},
 		},
-		{
-			ID: "kill_no_tags",
-			Expression: `process.file.name == "syscall_tester" && open.file.path == "{{.Root}}/test-kill-no-tags" 
+		Tags: map[string]string{
+			"remediation_rule": "true",
+			"agent_event_id":   "AZoIdt0EAAAbKF9Rg_3TKKJ",
+			"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
+			"creator_name":     "Allan Turing",
+			"creator_handle":   "allan.turing@example.com",
+		},
+	}
+	killNoTagsRule := &rules.RuleDefinition{
+		ID: "kill_no_tags",
+		Expression: `event.source == "replay" && exec.file.name == "syscall_tester"
 			&& ${process.kill_no_tags_performed} != "done"`,
-			Actions: []*rules.ActionDefinition{
-				{
-					Set: &rules.SetDefinition{
-						Scope: "process",
-						Name:  "kill_no_tags_performed",
-						Value: "done",
-					},
-				}, {
-					Kill: &rules.KillDefinition{
-						Signal: "SIGKILL",
-						Scope:  "process",
-					},
+		Actions: []*rules.ActionDefinition{
+			{
+				Set: &rules.SetDefinition{
+					Scope: "process",
+					Name:  "kill_no_tags_performed",
+					Value: "done",
+				},
+			}, {
+				Kill: &rules.KillDefinition{
+					Signal: "SIGKILL",
+					Scope:  "process",
 				},
 			},
 		},
-		{
-			ID:         "network_remediation",
-			Expression: `exec.file.name == "sleep" && exec.args in ["123"] && ${process.network_remediation_performed} != "done"`,
-			Actions: []*rules.ActionDefinition{
-				{
-					Set: &rules.SetDefinition{
-						Scope: "process",
-						Name:  "network_remediation_performed",
-						Value: "done",
-					},
-				},
-				{
-					NetworkFilter: &rules.NetworkFilterDefinition{
-						BPFFilter: "port 53",
-						Policy:    "drop",
-						Scope:     "process",
-					},
+	}
+	networkIsolationRule := &rules.RuleDefinition{
+		ID:         "network_remediation",
+		Expression: `event.source == "replay" && exec.file.name == "syscall_tester" && ${process.network_remediation_performed} != "done"`,
+		Actions: []*rules.ActionDefinition{
+			{
+				Set: &rules.SetDefinition{
+					Scope: "process",
+					Name:  "network_remediation_performed",
+					Value: "done",
 				},
 			},
-			Tags: map[string]string{
-				"remediation_rule": "true",
-				"agent_event_id":   "AZoIdt0EAAAbKF9Rg_4IIJ",
-				"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
-				"creator_name":     "Allan Turing",
-				"creator_handle":   "allan.turing@example.com",
+			{
+				NetworkFilter: &rules.NetworkFilterDefinition{
+					BPFFilter: "port 53",
+					Policy:    "drop",
+					Scope:     "process",
+				},
 			},
+		},
+		Tags: map[string]string{
+			"remediation_rule": "true",
+			"agent_event_id":   "AZoIdt0EAAAbKF9Rg_4IIJ",
+			"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
+			"creator_name":     "Allan Turing",
+			"creator_handle":   "allan.turing@example.com",
 		},
 	}
 
@@ -1479,30 +1479,27 @@ func TestRemediationCustomEvents(t *testing.T) {
 	}
 
 	t.Run("kill-remediation-status", func(t *testing.T) {
-		testFile, _, err := test.Path("test-kill-remediation")
+		newRuleDefs := []*rules.RuleDefinition{killRemediationRule}
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer os.Remove(testFile)
 
+		// Start a long-lived process (syscall_tester sleep) so the rule can match after policy reload.
+		go func() {
+			cmd := exec.Command(syscallTester, "sleep", "11")
+			_ = cmd.Run()
+		}()
+		// Deploy policy containing only the kill remediation rule.
+		if err := setTestPolicy(commonCfgDir, nil, newRuleDefs); err != nil {
+			t.Fatalf("failed to set new policy: %v", err)
+		}
+		// Reload policies and wait until the rule fires (event for "kill_remediation" is sent).
 		err = test.GetEventSent(t, func() error {
-			ch := make(chan bool, 1)
-
-			go func() {
-				timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-
-				cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";")
-				_ = cmd.Run()
-
-				ch <- true
-			}()
-
-			select {
-			case <-ch:
-			case <-time.After(time.Second * 3):
-				t.Error("signal timeout")
+			err := test.reloadPolicies()
+			if err != nil {
+				return fmt.Errorf("failed to reload policies: %w", err)
 			}
+
 			return nil
 		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
@@ -1512,12 +1509,14 @@ func TestRemediationCustomEvents(t *testing.T) {
 			t.Error(err)
 		}
 
+		// Poll until a remediation_status message is received, then validate its fields.
 		err = retry.Do(func() error {
 			msg := test.msgSender.getMsg("remediation_status")
 			if msg == nil {
 				return errors.New("not found")
 			}
 
+			// Assert remediation_status payload: rule_id, event_type, action, status, scope, process.pid, rule_tags.
 			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_id`); err != nil || el != "remediation_status" {
 					t.Errorf("agent.rule_id should be 'remediation_status': %s => %v", string(msg.Data), err)
@@ -1557,30 +1556,23 @@ func TestRemediationCustomEvents(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("kill-no-tags", func(t *testing.T) {
-		testFile, _, err := test.Path("test-kill-no-tags")
-		if err != nil {
-			t.Fatal(err)
+		newRuleDefs := []*rules.RuleDefinition{killNoTagsRule}
+		if err := setTestPolicy(commonCfgDir, nil, newRuleDefs); err != nil {
+			t.Fatalf("failed to set new policy: %v", err)
 		}
-		defer os.Remove(testFile)
 
+		// Spawn another syscall_tester process for this rule to match.
+		go func() {
+			cmd := exec.Command(syscallTester, "sleep", "22")
+			_ = cmd.Run()
+		}()
+		// Reload and wait for the kill_no_tags rule to trigger.
 		err = test.GetEventSent(t, func() error {
-			ch := make(chan bool, 1)
-
-			go func() {
-				timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-
-				cmd := exec.CommandContext(timeoutCtx, syscallTester, "open", testFile, ";", "sleep", "1", ";")
-				_ = cmd.Run()
-
-				ch <- true
-			}()
-
-			select {
-			case <-ch:
-			case <-time.After(time.Second * 3):
-				t.Error("signal timeout")
+			err := test.reloadPolicies()
+			if err != nil {
+				return fmt.Errorf("failed to reload policies: %w", err)
 			}
+
 			return nil
 		}, func(_ *rules.Rule, _ *model.Event) bool {
 			return true
@@ -1590,12 +1582,14 @@ func TestRemediationCustomEvents(t *testing.T) {
 			t.Error(err)
 		}
 
+		// Ensure remediation_status is sent even when rule has no remediation_rule/agent_event_id tags.
 		err = retry.Do(func() error {
 			msg := test.msgSender.getMsg("remediation_status")
 			if msg == nil {
 				return errors.New("not found")
 			}
 
+			// Validate core fields only (no rule_tags checks for this rule).
 			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_id`); err != nil || el != "remediation_status" {
 					t.Errorf("agent.rule_id should be 'remediation_status': %s => %v", string(msg.Data), err)
@@ -1628,15 +1622,21 @@ func TestRemediationCustomEvents(t *testing.T) {
 	})
 
 	t.Run("network-isolation-remediation-status", func(t *testing.T) {
-		err = test.GetEventSent(t, func() error {
-			cmd := exec.Command("sleep", "123")
-			if err := cmd.Start(); err != nil {
-				return err
-			}
-			time.Sleep(500 * time.Millisecond)
+		newRuleDefs := []*rules.RuleDefinition{networkIsolationRule}
+		if err := setTestPolicy(commonCfgDir, nil, newRuleDefs); err != nil {
+			t.Fatalf("failed to set new policy: %v", err)
+		}
+		// Start process that will get network filter applied.
+		go func() {
+			cmd := exec.Command(syscallTester, "sleep", "33")
+			_ = cmd.Run()
+		}()
 
-			if cmd.Process != nil {
-				cmd.Process.Kill()
+		// Reload policies and wait for network_remediation rule to fire.
+		err = test.GetEventSent(t, func() error {
+			err := test.reloadPolicies()
+			if err != nil {
+				return fmt.Errorf("failed to reload policies: %w", err)
 			}
 
 			return nil
@@ -1648,12 +1648,14 @@ func TestRemediationCustomEvents(t *testing.T) {
 			t.Error(err)
 		}
 
+		// Poll for remediation_status and assert action is network_isolation and status is performed.
 		err = retry.Do(func() error {
 			msg := test.msgSender.getMsg("remediation_status")
 			if msg == nil {
 				return errors.New("not found")
 			}
 
+			// Validate remediation_status for network isolation: event_type, remediation_action, status, scope, rule_tags.
 			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_id`); err != nil || el != "remediation_status" {
 					t.Errorf("agent.rule_id should be 'remediation_status': %s => %v", string(msg.Data), err)
@@ -1706,45 +1708,71 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
-			ID:         "kill_remediation_not_triggering",
-			Expression: `exec.file.name == "there-is-no-file-like-that" && ${process.kill_remediation_performed} != "done"`,
-			Actions: []*rules.ActionDefinition{
-				{
-					Set: &rules.SetDefinition{
-						Scope: "process",
-						Name:  "kill_remediation_performed",
-						Value: "done",
-					},
-				}, {
-					Kill: &rules.KillDefinition{
-						Signal: "SIGKILL",
-						Scope:  "process",
-					},
+			ID:         "dummy_rule",
+			Expression: `exec.file.name == "qwerty"`,
+		},
+	}
+
+	remediationNotTriggeredRule := &rules.RuleDefinition{
+		ID:         "kill_remediation_not_triggering",
+		Expression: `exec.file.name == "there-is-no-file-like-that" && ${process.kill_remediation_performed} != "done"`,
+		Actions: []*rules.ActionDefinition{
+			{
+				Set: &rules.SetDefinition{
+					Scope: "process",
+					Name:  "kill_remediation_performed",
+					Value: "done",
+				},
+			}, {
+				Kill: &rules.KillDefinition{
+					Signal: "SIGKILL",
+					Scope:  "process",
 				},
 			},
-			Tags: map[string]string{
-				"remediation_rule": "true",
-				"agent_event_id":   "BDoIdt0EAAAbKF9Rg_3TKKJ",
-				"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
-				"creator_name":     "Allan Turing",
-				"creator_handle":   "allan.turing@example.com",
+		},
+		Tags: map[string]string{
+			"remediation_rule": "true",
+			"agent_event_id":   "BDoIdt0EAAAbKF9Rg_3TKKJ",
+			"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
+			"creator_name":     "Allan Turing",
+			"creator_handle":   "allan.turing@example.com",
+		},
+	}
+	noEventRule := &rules.RuleDefinition{
+
+		ID:         "kill_remediation_not_triggering",
+		Expression: `exec.file.name == "there-is-again-no-file-like-that"`,
+		Actions: []*rules.ActionDefinition{
+			{
+				Kill: &rules.KillDefinition{
+					Signal: "SIGKILL",
+					Scope:  "process",
+				},
 			},
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	test, err := newTestModule(t, nil, ruleDefs)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer test.Close()
 
 	t.Run("not-triggered-sent-at-startup", func(t *testing.T) {
+		newRuleDefs := []*rules.RuleDefinition{remediationNotTriggeredRule}
+		if err := setTestPolicy(commonCfgDir, nil, newRuleDefs); err != nil {
+			t.Fatalf("failed to set new policy: %v", err)
+		}
+
+		// After reload, the engine evaluates remediation rules and sends not_triggered for rules that did not fire.
 		err = retry.Do(func() error {
+			test.reloadPolicies()
 			msg := test.msgSender.getMsg("remediation_status")
 			if msg == nil {
 				return errors.New("remediation_status message not found")
 			}
 
+			// Assert status is "not_triggered", remediation_action "kill", and rule_tags present.
 			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
 				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_id`); err != nil || el != "remediation_status" {
 					t.Errorf("agent.rule_id should be 'remediation_status': %s => %v", string(msg.Data), err)
@@ -1775,6 +1803,26 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 				}
 			})
 
+			return nil
+		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
+		assert.NoError(t, err)
+	})
+	t.Run("not-triggered-no-event", func(t *testing.T) {
+		test.msgSender.flush()
+		// Allow any in-flight remediation_status from the previous subtest to be delivered, then clear again.
+		time.Sleep(500 * time.Millisecond)
+		test.msgSender.flush()
+		newRuleDefs := []*rules.RuleDefinition{noEventRule}
+		if err := setTestPolicy(commonCfgDir, nil, newRuleDefs); err != nil {
+			t.Fatalf("failed to set new policy: %v", err)
+		}
+		// Reload and repeatedly check that no remediation_status message appears (only remediation rules send it).
+		err = retry.Do(func() error {
+			test.reloadPolicies()
+			msg := test.msgSender.getMsg("remediation_status")
+			if msg != nil {
+				return errors.New("should not find remediation_status message, got event : " + string(msg.Data))
+			}
 			return nil
 		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
 		assert.NoError(t, err)

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -1765,8 +1765,8 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 		}
 
 		// After reload, the engine evaluates remediation rules and sends not_triggered for rules that did not fire.
+		test.reloadPolicies()
 		err = retry.Do(func() error {
-			test.reloadPolicies()
 			msg := test.msgSender.getMsg("remediation_status")
 			if msg == nil {
 				return errors.New("remediation_status message not found")
@@ -1804,7 +1804,7 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 			})
 
 			return nil
-		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
+		}, retry.Delay(200*time.Millisecond), retry.Attempts(10), retry.DelayType(retry.FixedDelay))
 		assert.NoError(t, err)
 	})
 	t.Run("not-triggered-no-event", func(t *testing.T) {
@@ -1817,14 +1817,16 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 			t.Fatalf("failed to set new policy: %v", err)
 		}
 		// Reload and repeatedly check that no remediation_status message appears (only remediation rules send it).
+
+		test.reloadPolicies()
 		err = retry.Do(func() error {
-			test.reloadPolicies()
+
 			msg := test.msgSender.getMsg("remediation_status")
 			if msg != nil {
 				return errors.New("should not find remediation_status message, got event : " + string(msg.Data))
 			}
 			return nil
-		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
+		}, retry.Delay(200*time.Millisecond), retry.Attempts(10), retry.DelayType(retry.FixedDelay))
 		assert.NoError(t, err)
 	})
 }

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -1694,3 +1694,89 @@ func TestRemediationCustomEvents(t *testing.T) {
 	})
 
 }
+
+func TestRemediationCustomEventNotTriggered(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	if !ebpfLessEnabled {
+		checkKernelCompatibility(t, "agent is running in container mode", func(_ *kernel.Version) bool {
+			return env.IsContainerized()
+		})
+	}
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "kill_remediation_not_triggering",
+			Expression: `exec.file.name == "there-is-no-file-like-that" && ${process.kill_remediation_performed} != "done"`,
+			Actions: []*rules.ActionDefinition{
+				{
+					Set: &rules.SetDefinition{
+						Scope: "process",
+						Name:  "kill_remediation_performed",
+						Value: "done",
+					},
+				}, {
+					Kill: &rules.KillDefinition{
+						Signal: "SIGKILL",
+						Scope:  "process",
+					},
+				},
+			},
+			Tags: map[string]string{
+				"remediation_rule": "true",
+				"agent_event_id":   "BDoIdt0EAAAbKF9Rg_3TKKJ",
+				"creator_uuid":     "b6497050-10b2-11f0-a294-324b18620407",
+				"creator_name":     "Allan Turing",
+				"creator_handle":   "allan.turing@example.com",
+			},
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, withStaticOpts(testOpts{networkRawPacketEnabled: true}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("not-triggered-sent-at-startup", func(t *testing.T) {
+		err = retry.Do(func() error {
+			msg := test.msgSender.getMsg("remediation_status")
+			if msg == nil {
+				return errors.New("remediation_status message not found")
+			}
+
+			jsonPathValidation(test, msg.Data, func(_ *testModule, obj interface{}) {
+				if el, err := jsonpath.JsonPathLookup(obj, `$.agent.rule_id`); err != nil || el != "remediation_status" {
+					t.Errorf("agent.rule_id should be 'remediation_status': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.event_type`); err != nil || el != "remediation_status" {
+					t.Errorf("event_type should be 'remediation_status': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.status`); err != nil || el != sprobe.RemediationStatusNotTriggered {
+					t.Errorf("status should be 'not_triggered': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.remediation_action`); err != nil || el != "kill" {
+					t.Errorf("remediation_action should be 'kill': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.scope`); err != nil || el != "process" {
+					t.Errorf("scope should be 'process': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_tags.remediation_rule`); err != nil || el != "true" {
+					t.Errorf("rule_tags.remediation_rule should be 'true': %s => %v", string(msg.Data), err)
+				}
+
+				if el, err := jsonpath.JsonPathLookup(obj, `$.rule_tags.agent_event_id`); err != nil || el != "BDoIdt0EAAAbKF9Rg_3TKKJ" {
+					t.Errorf("rule_tags.agent_event_id should be 'BDoIdt0EAAAbKF9Rg_3TKKJ': %s => %v", string(msg.Data), err)
+				}
+			})
+
+			return nil
+		}, retry.Delay(200*time.Millisecond), retry.Attempts(30), retry.DelayType(retry.FixedDelay))
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
### What does this PR do?
This PR fix a bug where we did not send the custom event `not triggerred` for remediation rules.

### Motivation
This feature is needed for the remediation feature that will be available for agent version >= 7.77

### Describe how you validated your changes
Add 2 tests to make sure we don't introduce any regression in the future.

