### PR TITLE
[workloadmeta] Delete unnecessary ProcessAgent references from collector catalogs

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/container/cf_container.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/container/cf_container.go
@@ -41,7 +41,7 @@ func NewCollector() (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
 			id:      collectorID,
-			catalog: workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog: workloadmeta.NodeAgent,
 		},
 	}, nil
 }

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm.go
@@ -48,7 +48,7 @@ func NewCollector() (workloadmeta.CollectorProvider, error) {
 		Collector: &collector{
 			id:      collectorID,
 			seen:    make(map[workloadmeta.EntityID]struct{}),
-			catalog: workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog: workloadmeta.NodeAgent,
 		},
 	}, nil
 }

--- a/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/containerd.go
@@ -119,7 +119,7 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
 			id:                     collectorID,
-			catalog:                workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog:                workloadmeta.NodeAgent,
 			contToExitInfo:         make(map[string]*exitInfo),
 			knownImages:            newKnownImages(),
 			filterPausedContainers: deps.FilterStore.GetContainerPausedFilters(),

--- a/comp/core/workloadmeta/collectors/internal/crio/crio.go
+++ b/comp/core/workloadmeta/collectors/internal/crio/crio.go
@@ -54,7 +54,7 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 			id:             collectorID,
 			seenContainers: make(map[workloadmeta.EntityID]struct{}),
 			seenImages:     make(map[workloadmeta.EntityID]struct{}),
-			catalog:        workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog:        workloadmeta.NodeAgent,
 			sbomFilter:     deps.Filter.GetContainerSBOMFilters(),
 		},
 	}, nil

--- a/comp/core/workloadmeta/collectors/internal/docker/docker.go
+++ b/comp/core/workloadmeta/collectors/internal/docker/docker.go
@@ -93,7 +93,7 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
 			id:                     collectorID,
-			catalog:                workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog:                workloadmeta.NodeAgent,
 			filterPausedContainers: deps.FilterStore.GetContainerPausedFilters(),
 			filterSBOMContainers:   deps.FilterStore.GetContainerSBOMFilters(),
 		},

--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs.go
@@ -91,7 +91,7 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 			id:                           collectorID,
 			resourceTags:                 make(map[string]resourceTags),
 			seen:                         make(map[workloadmeta.EntityID]struct{}),
-			catalog:                      workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog:                      workloadmeta.NodeAgent,
 			config:                       deps.Config,
 			taskCollectionEnabled:        util.IsTaskCollectionEnabled(deps.Config),
 			taskCache:                    cache.New(deps.Config.GetDuration("ecs_task_cache_ttl"), 30*time.Second),

--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs_test.go
@@ -135,7 +135,7 @@ func TestGetID(t *testing.T) {
 
 // TestGetTargetCatalog tests the GetTargetCatalog method
 func TestGetTargetCatalog(t *testing.T) {
-	catalog := workloadmeta.NodeAgent | workloadmeta.ProcessAgent
+	catalog := workloadmeta.NodeAgent
 	collector := &collector{
 		catalog: catalog,
 	}

--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -56,7 +56,7 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 	return workloadmeta.CollectorProvider{
 		Collector: &collector{
 			id:                         collectorID,
-			catalog:                    workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog:                    workloadmeta.NodeAgent,
 			collectEphemeralContainers: deps.Config.GetBool("include_ephemeral_containers"),
 		},
 	}, nil

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -62,7 +62,7 @@ func NewCollector() (workloadmeta.CollectorProvider, error) {
 			id:                collectorID,
 			seen:              make(map[workloadmeta.EntityID]struct{}),
 			namespaceLastSeen: make(map[string]time.Time),
-			catalog:           workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog:           workloadmeta.NodeAgent,
 		},
 	}, nil
 }

--- a/comp/core/workloadmeta/collectors/internal/podman/podman.go
+++ b/comp/core/workloadmeta/collectors/internal/podman/podman.go
@@ -51,7 +51,7 @@ func NewCollector() (workloadmeta.CollectorProvider, error) {
 		Collector: &collector{
 			id:      collectorID,
 			seen:    make(map[workloadmeta.EntityID]struct{}),
-			catalog: workloadmeta.NodeAgent | workloadmeta.ProcessAgent,
+			catalog: workloadmeta.NodeAgent,
 		},
 	}, nil
 }

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -181,7 +181,6 @@ type AgentType uint8
 const (
 	NodeAgent AgentType = 1 << iota
 	ClusterAgent
-	ProcessAgent
 	Remote
 )
 


### PR DESCRIPTION
### What does this PR do?

This PR is a cleanup in the workloadmeta component.

There are multiple references to the process-agent in workloadmeta catalogs. This seems to imply that some collectors run in the process-agent but that's not actually the case. The process agent always uses the remote workloadmeta implementation, see:
- https://github.com/DataDog/datadog-agent/blob/9fb819567d4b7642fdc7eb33407415f46d56a4b6/cmd/process-agent/command/main_common.go#L173
- https://github.com/DataDog/datadog-agent/blob/9fb819567d4b7642fdc7eb33407415f46d56a4b6/cmd/process-agent/subcommands/check/check.go#L56

This PR simply removes those references to make this clear.

### Describe how you validated your changes

CI