### PR TITLE
Fix Windows CI failures in pkg/shell tests

### DIFF
--- a/pkg/shell/interp/allowed_paths_internal_test.go
+++ b/pkg/shell/interp/allowed_paths_internal_test.go
@@ -21,6 +21,14 @@ import (
 	"mvdan.cc/sh/v3/syntax"
 )
 
+func systemExecAllowedPaths(t *testing.T) []string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		return []string{filepath.Join(os.Getenv("SystemRoot"), "System32")}
+	}
+	return []string{"/bin", "/usr"}
+}
+
 func runScriptInternal(t *testing.T, script, dir string, opts ...RunnerOption) (stdout, stderr string, exitCode int) {
 	t.Helper()
 	parser := syntax.NewParser()
@@ -69,12 +77,20 @@ func runScriptInternal(t *testing.T, script, dir string, opts ...RunnerOption) (
 
 func TestAllowedPathsExecInside(t *testing.T) {
 	dir := t.TempDir()
-	// /bin/echo should be within the allowed path if we allow /bin or /usr
-	stdout, _, exitCode := runScriptInternal(t, `/bin/echo hello`, dir,
-		AllowedPaths([]string{dir, "/bin", "/usr"}),
+
+	var script string
+	if runtime.GOOS == "windows" {
+		system32 := filepath.Join(os.Getenv("SystemRoot"), "System32")
+		script = strings.ReplaceAll(filepath.Join(system32, "cmd.exe"), `\`, `/`) + " /c echo hello"
+	} else {
+		script = `/bin/echo hello`
+	}
+
+	stdout, _, exitCode := runScriptInternal(t, script, dir,
+		AllowedPaths(append([]string{dir}, systemExecAllowedPaths(t)...)),
 	)
 	assert.Equal(t, 0, exitCode)
-	assert.Equal(t, "hello\n", stdout)
+	assert.Equal(t, "hello\n", strings.ReplaceAll(stdout, "\r\n", "\n"))
 }
 
 func TestAllowedPathsExecOutside(t *testing.T) {
@@ -89,9 +105,8 @@ func TestAllowedPathsExecOutside(t *testing.T) {
 
 func TestAllowedPathsExecNonexistent(t *testing.T) {
 	dir := t.TempDir()
-	// Command that doesn't exist at all — ExecLookPathDir fails
 	_, stderr, exitCode := runScriptInternal(t, `totally_nonexistent_cmd_12345`, dir,
-		AllowedPaths([]string{dir, "/bin", "/usr"}),
+		AllowedPaths(append([]string{dir}, systemExecAllowedPaths(t)...)),
 	)
 	assert.Equal(t, 127, exitCode)
 	assert.Contains(t, stderr, "command not found")

--- a/pkg/shell/interp/allowed_paths_test.go
+++ b/pkg/shell/interp/allowed_paths_test.go
@@ -99,7 +99,8 @@ func TestAllowedPathsCatOutside(t *testing.T) {
 	secret := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(secret, "hidden.txt"), []byte("secret"), 0644))
 
-	_, stderr, exitCode := runScript(t, "cat "+filepath.Join(secret, "hidden.txt"), allowed,
+	catPath := strings.ReplaceAll(filepath.Join(secret, "hidden.txt"), `\`, `/`)
+	_, stderr, exitCode := runScript(t, "cat "+catPath, allowed,
 		interp.AllowedPaths([]string{allowed}),
 	)
 	assert.Equal(t, 1, exitCode)

--- a/pkg/shell/tests/scenarios/shell/allowed_paths/nonexistent_file_in_allowed_windows.yaml
+++ b/pkg/shell/tests/scenarios/shell/allowed_paths/nonexistent_file_in_allowed_windows.yaml
@@ -1,5 +1,5 @@
-description: "Non-existent file inside allowed directory returns an error"
-target_os: [linux, darwin]
+description: "Non-existent file inside allowed directory returns an error (Windows)"
+target_os: [windows]
 test_against_local_shell: false
 setup:
   files:
@@ -12,5 +12,5 @@ input:
     - "data"
 expect:
   stderr_contains:
-    - "no such file or directory"
+    - "The system cannot find the file specified."
   exit_code: 1

--- a/pkg/shell/tests/scenarios/shell/environment/pwd_is_set.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/pwd_is_set.yaml
@@ -1,4 +1,5 @@
 description: "PWD is set to the working directory"
+target_os: [linux, darwin]
 input:
   script: |
     echo "$PWD"

--- a/pkg/shell/tests/scenarios/shell/environment/pwd_is_set_windows.yaml
+++ b/pkg/shell/tests/scenarios/shell/environment/pwd_is_set_windows.yaml
@@ -1,0 +1,9 @@
+description: "PWD is set to the working directory (Windows)"
+target_os: [windows]
+input:
+  script: |
+    echo "$PWD"
+expect:
+  stdout_contains:
+    - "\\"
+  exit_code: 0


### PR DESCRIPTION
<!-- dd-meta {"pullId":"b28082f4-36f5-4338-bc56-2ec777be52d7","source":"chat","resourceId":"f90c40fe-d085-4011-8d77-34c56a771c89","workflowId":"353be6c5-d866-4f78-b98c-1058066afe99","codeChangeId":"353be6c5-d866-4f78-b98c-1058066afe99","sourceType":"chat"} -->
### What does this PR do?

Fixes 5 Windows CI test failures in `pkg/shell` by adapting tests for cross-platform compatibility while maintaining full coverage on all platforms.

**Go test fixes:**
- `TestAllowedPathsExecInside` / `TestAllowedPathsExecNonexistent`: Use `%SystemRoot%\System32` on Windows instead of `/bin`/`/usr` which don't exist on Windows
- `TestAllowedPathsCatOutside`: Convert backslashes to forward slashes in shell script paths to prevent the shell parser from interpreting `\` as escape characters

**YAML scenario fixes (following existing `_windows.yaml` pattern):**
- `nonexistent_file_in_allowed`: Windows `os.Root.OpenFile` returns "The system cannot find the file specified." instead of "no such file or directory"
- `pwd_is_set`: Windows PWD uses `\` path separators instead of `/`

### Motivation

The `tests_windows-x64` CI job fails on the `alex/safe-shell-skeleton` branch with 5 test failures in `pkg/shell/interp` and `pkg/shell/tests`, all caused by Unix-specific assumptions in tests (hardcoded `/bin`/`/usr` paths, backslash shell escaping, OS-native error messages, path separator differences).

### Describe how you validated your changes

- Verified all `pkg/shell/interp` and `pkg/shell/tests` tests pass on Linux
- Go files compile cleanly with `go build ./pkg/shell/...`

### Additional Notes

No implementation changes — only test adaptations. Follows the existing pattern of `symlink_escape_to_dir.yaml` + `symlink_escape_to_dir_windows.yaml` for platform-specific scenario variants.

---

PR by Bits
[View session in Datadog](https://app.datadoghq.com/code/f90c40fe-d085-4011-8d77-34c56a771c89)

Comment @datadog to request changes