### PR TITLE
Fix docker_image_build_otel disk space failure

### DIFF
--- a/Dockerfiles/agent-ddot/Dockerfile.agent-otel
+++ b/Dockerfiles/agent-ddot/Dockerfile.agent-otel
@@ -76,11 +76,13 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Copy the manifest file
 COPY manifest.yaml /workspace/datadog-agent/comp/otelcol/collector-contrib/impl/manifest.yaml
 
-# Generate the files
-RUN dda inv collector.generate
+# Generate the files and clean up go cache to free space
+RUN dda inv collector.generate && \
+    go clean -cache -modcache
 
-# Build the OTel agent
-RUN dda inv otel-agent.build --byoc
+# Build the OTel agent with cleanup
+RUN dda inv otel-agent.build --byoc && \
+    go clean -cache
 
 # Install nfpm if package type is specified
 ARG PACKAGE_TYPE


### PR DESCRIPTION
### What does this PR do?

Add `go clean -cache -modcache` after `collector.generate` and `go clean -cache` after `otel-agent.build` in the BYOC Dockerfile to free disk space during Docker builds.

### Motivation

`docker_image_build_otel` fails on 7.76.x with "No space left on device" during the final link step (e.g. [job 1481883186](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1481883186)). The Go module/build cache from `collector.generate` fills the DinD sidecar volume before `otel-agent.build` can complete linking.

This was already fixed on main as part of #45874, but that PR also bumps OTel to 0.145.0 so it can't be cherry-picked directly.

### Describe how you validated your changes

CI — `docker_image_build_otel` job should pass on 7.76.x.

### Additional Notes

Minimal backport of the Dockerfile changes from #45874.