### PR TITLE
[CONTP-547] Remove TestAdmissionControllerWithAutoDetectedLanguage from flaky e2e tests

### DIFF
--- a/flakes.yaml
+++ b/flakes.yaml
@@ -24,9 +24,6 @@ test/new-e2e/tests/containers:
   - test: TestEKSSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - test: TestKindSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
   - test: TestOpenShiftVMSuite/TestCPU/metric___container.cpu.usage{^kube_deployment:stress-ng$,^kube_namespace:workload-cpustress$}
-  - test: TestKindSuite/TestAdmissionControllerWithAutoDetectedLanguage
-  - test: TestEKSSuite/TestAdmissionControllerWithAutoDetectedLanguage
-  - test: TestOpenShiftVMSuite/TestAdmissionControllerWithAutoDetectedLanguage
 
 /tests/installer/windows:
   - test: TestAgentUpgradesOnDCWithGMSA


### PR DESCRIPTION
### What does this PR do?

See title.

### Motivation

Flakiness fixed by [this](https://github.com/DataDog/datadog-agent/pull/46736) PR. 

### Describe how you validated your changes

<img width="2174" height="320" alt="image" src="https://github.com/user-attachments/assets/07d91990-91ab-49db-88da-edea2d6b2dc1" />

https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.name%3ATestKindSuite%2FTestAdmissionControllerWithAutoDetectedLanguage%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&start=1772192478322&end=1772797278322&paused=false

<img width="2174" height="320" alt="image" src="https://github.com/user-attachments/assets/1ffacff3-afab-43a7-a13e-73718c67de0b" />


https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.name%3ATestEKSSuite%2FTestAdmissionControllerWithAutoDetectedLanguage%20%40git.branch%3Amain&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1772192658320&end=1772797458320&paused=false