### PR TITLE
Fix patch order of ssl paths

### DIFF
--- a/deps/openssl.BUILD.bazel
+++ b/deps/openssl.BUILD.bazel
@@ -66,24 +66,27 @@ FIX_OPENSSL_PATHS = """
     SANDBOX="$$BUILD_TMPDIR/$$INSTALL_PREFIX"
 
     # === OPENSSLDIR paths ===
-    # OPENSSLDIR display string: /ssl"
+    # Longer suffixes MUST be replaced before shorter ones to avoid partial matches
+    # (e.g. bare /ssl would clobber /ssl/cert.pem and /ssl/certs)
     if [ $$(echo $${SANDBOX} | wc -c) -lt $$(echo $${TARGET} | wc -c) ]; then
         echo "The new path placeholder is larger than the target it should replace replace ($${SANDBOX})";
         exit 1;
     fi
-    OLD_PATH="$${SANDBOX}/ssl\\"" NEW_PATH="$${TARGET}/ssl\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
-
-    # OPENSSLDIR internal path (bare, no quote) - used for actual config lookup
-    OLD_PATH="$${SANDBOX}/ssl" NEW_PATH="$${TARGET}/ssl" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
     # SSL private dir: /ssl/private
     OLD_PATH="$${SANDBOX}/ssl/private" NEW_PATH="$${TARGET}/ssl/private" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
+    # SSL cert.pem: /ssl/cert.pem
+    OLD_PATH="$${SANDBOX}/ssl/cert.pem" NEW_PATH="$${TARGET}/ssl/cert.pem" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+
     # SSL certs dir: /ssl/certs
     OLD_PATH="$${SANDBOX}/ssl/certs" NEW_PATH="$${TARGET}/ssl/certs" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
-    # SSL cert.pem: /ssl/cert.pem
-    OLD_PATH="$${SANDBOX}/ssl/cert.pem" NEW_PATH="$${TARGET}/ssl/cert.pem" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+    # OPENSSLDIR display string: /ssl"
+    OLD_PATH="$${SANDBOX}/ssl\\"" NEW_PATH="$${TARGET}/ssl\\"" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
+
+    # OPENSSLDIR internal path (bare, no quote) - must come after all /ssl/* paths
+    OLD_PATH="$${SANDBOX}/ssl" NEW_PATH="$${TARGET}/ssl" perl -0777 -pi -e 's/\\Q$$ENV{OLD_PATH}\\E/$$ENV{NEW_PATH} . ("\\x00" x (length($$ENV{OLD_PATH}) - length($$ENV{NEW_PATH})))/ge' $$LIBS
 
     # === ENGINESDIR and MODULESDIR paths ===
     # ENGINESDIR display string: /lib/engines-3"


### PR DESCRIPTION
### What does this PR do?
The `FIX_OPENSSL_PATHS` postfix script replaced the bare `/ssl` path before the longer `/ssl/cert.pem`, `/ssl/certs`, and `/ssl/private` paths. Since `/ssl` is a prefix of all three, the global regex match clobbered them — inserting null padding that truncated the strings. This caused `X509_get_default_cert_file()` and `X509_get_default_cert_dir()` to both return `/opt/datadog-agent/embedded/ssl` instead of `.../ssl/cert.pem` and `.../ssl/certs`, making Python's ssl module unable to find the CA bundle installed by `cacerts.rb`.
This reorders replacements to process longer suffixes first (matching the correct order already used in `fix_openssl_paths.sh`).

Currently reported paths to certificate related locations:
```
Default cert file: /opt/datadog-agent/embedded/ssl
Default cert dir: /opt/datadog-agent/embedded/ssl
```

### Describe how you validated your changes
I pulled the image `registry.ddbuild.io/ci/datadog-agent/agent:v100871702-23d3fab0-7-full-arm64` produced by the pipeline and ran the script below to ensure the paths are correct.
```shell
/opt/datadog-agent/embedded/bin/python3.13 -c "
import ssl
print('Default cert file:', ssl.get_default_verify_paths().openssl_cafile)
print('Default cert dir:', ssl.get_default_verify_paths().openssl_capath)
"
```

Indeed:

```shell
Default cert file: /opt/datadog-agent/embedded/ssl/cert.pem
Default cert dir: /opt/datadog-agent/embedded/ssl/certs
```
