### PR TITLE
feat(fleet): install DDOT extension in agent postinstall if DD_OTELCOLLECTOR_ENABLED

### DIFF
--- a/.gitlab/windows/test/e2e_install_packages/windows.yml
+++ b/.gitlab/windows/test/e2e_install_packages/windows.yml
@@ -137,7 +137,9 @@ new-e2e-windows-ddot-package-a7-x86_64:
   needs:
     - !reference [.needs_new_e2e_template]
     - deploy_windows_testing-a7
-    - deploy_ddot_oci
+    - deploy_installer_oci
+    - deploy_agent_oci
+    - qa_installer_script_windows
   before_script:
     - CURRENT_AGENT_VERSION=$(dda inv agent.version) || exit $?; export CURRENT_AGENT_VERSION
     - CURRENT_AGENT_VERSION_PACKAGE=$(dda inv agent.version --url-safe)-1 || exit $?; export CURRENT_AGENT_VERSION_PACKAGE

--- a/pkg/fleet/installer/packages/datadog_agent_extensions.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions.go
@@ -128,3 +128,28 @@ func restoreAgentExtensions(ctx HookContext, version string, experiment bool) er
 
 	return extensionsPkg.Restore(ctx, downloader, agentPackage, url, storagePath, experiment, hooks)
 }
+
+// installAgentExtensions installs the given extensions for the agent package.
+// Extensions that are already installed (e.g. from a prior restore) are skipped
+// by the idempotency check in extensionsPkg.Install.
+//
+//nolint:unused // Used in platform-specific files
+func installAgentExtensions(ctx HookContext, version string, isExperiment bool) error {
+	env := env.FromEnv()
+	// populate extensions list based on environment variables
+	var extensions []string
+	if env.OTelCollectorEnabled {
+		extensions = append(extensions, "ddot")
+	}
+	// if no extensions are requested, return early
+	if len(extensions) == 0 {
+		return nil
+	}
+
+	// install extensions
+	setRegistryConfig(env)
+	downloader := oci.NewDownloader(env, env.HTTPClient())
+	url := oci.PackageURL(env, agentPackage, version)
+	hooks := NewHooks(env, repository.NewRepositories(paths.PackagesPath, AsyncPreRemoveHooks))
+	return extensionsPkg.Install(ctx, downloader, url, extensions, isExperiment, hooks)
+}

--- a/pkg/fleet/installer/packages/datadog_agent_extensions.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions.go
@@ -133,3 +133,19 @@ func restoreAgentExtensions(ctx HookContext, version string, experiment bool) er
 
 	return extensionsPkg.Restore(ctx, downloader, agentPackage, url, storagePath, experiment, hooks)
 }
+
+// installDDOTExtensionIfEnabled installs the DDOT extension if DD_OTELCOLLECTOR_ENABLED is set.
+// Note: Caller must call extensionsPkg.SetPackage() separately before calling this function.
+//
+//nolint:unused // Used in platform-specific files
+func installDDOTExtensionIfEnabled(ctx HookContext, version string, experiment bool) error {
+	e := env.FromEnv()
+	if !e.OTelCollectorEnabled {
+		return nil
+	}
+	setRegistryConfig(e)
+	downloader := oci.NewDownloader(e, e.HTTPClient())
+	url := oci.PackageURL(e, agentPackage, version)
+	hooks := NewHooks(e, repository.NewRepositories(paths.PackagesPath, AsyncPreRemoveHooks))
+	return extensionsPkg.Install(ctx, downloader, url, []string{"ddot"}, experiment, hooks)
+}

--- a/pkg/fleet/installer/packages/datadog_agent_extensions_test.go
+++ b/pkg/fleet/installer/packages/datadog_agent_extensions_test.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package packages
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	extensionsPkg "github.com/DataDog/datadog-agent/pkg/fleet/installer/packages/extensions"
+)
+
+func TestInstallDDOTExtensionIfEnabled_Disabled(t *testing.T) {
+	t.Setenv("DD_OTELCOLLECTOR_ENABLED", "false")
+	ctx := HookContext{Context: context.Background()}
+	err := installDDOTExtensionIfEnabled(ctx, "7.50.0-1", false)
+	require.NoError(t, err)
+}
+
+func TestInstallDDOTExtensionIfEnabled_Enabled(t *testing.T) {
+	t.Setenv("DD_OTELCOLLECTOR_ENABLED", "true")
+
+	tmpDir := t.TempDir()
+	extensionsPkg.ExtensionsDBDir = tmpDir
+
+	ctx := HookContext{Context: context.Background(), PackagePath: tmpDir}
+	err := extensionsPkg.SetPackage(ctx, agentPackage, "7.50.0-1", false)
+	require.NoError(t, err)
+
+	err = installDDOTExtensionIfEnabled(ctx, "7.50.0-1", false)
+	// Expect a download error (no real OCI registry), not an env-guard skip
+	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "otelcollector")
+}

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -270,6 +270,9 @@ func postInstallDatadogAgent(ctx HookContext) (err error) {
 	if err := restoreAgentExtensions(ctx, agentVersion, false); err != nil {
 		log.Warnf("failed to restore extensions: %s", err)
 	}
+	if err := installAgentExtensions(ctx, agentVersion, false); err != nil {
+		log.Warnf("failed to install extensions: %s", err)
+	}
 	if err := agentService.WriteStable(ctx); err != nil {
 		return fmt.Errorf("failed to write stable units: %s", err)
 	}

--- a/pkg/fleet/installer/packages/datadog_agent_linux.go
+++ b/pkg/fleet/installer/packages/datadog_agent_linux.go
@@ -270,6 +270,9 @@ func postInstallDatadogAgent(ctx HookContext) (err error) {
 	if err := restoreAgentExtensions(ctx, agentVersion, false); err != nil {
 		log.Warnf("failed to restore extensions: %s", err)
 	}
+	if err := installDDOTExtensionIfEnabled(ctx, agentVersion, false); err != nil {
+		log.Warnf("failed to install DDOT extension: %s", err)
+	}
 	if err := agentService.WriteStable(ctx); err != nil {
 		return fmt.Errorf("failed to write stable units: %s", err)
 	}

--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -101,8 +101,11 @@ func postInstallDatadogAgent(ctx HookContext) error {
 			return fmt.Errorf("failed to remove Agent: %w", err)
 		}
 
-		// install the new stable Agent
-		err = installAgentPackage(ctx, env, "stable", ctx.WindowsArgs, "setup_agent.log")
+		// Install the new stable Agent without starting services.
+		// Services are started after extensions are installed so that
+		// the core agent discovers and starts extension services (e.g. DDOT).
+		installOnlyArgs := append(ctx.WindowsArgs, "DD_INSTALL_ONLY=1")
+		err = installAgentPackage(ctx, env, "stable", installOnlyArgs, "setup_agent.log")
 		if err != nil {
 			return err
 		}
@@ -129,6 +132,18 @@ func postInstallDatadogAgent(ctx HookContext) error {
 	if err := restoreAgentExtensions(ctx, agentVersion, isExperiment); err != nil {
 		log.Warnf("failed to restore extensions: %s", err)
 	}
+
+	// install new extensions provided via environment variables
+	// not during experiments, we don't expect new extensions to be installed, only restored
+	if !isExperiment {
+		if err := installAgentExtensions(ctx, agentVersion, isExperiment); err != nil {
+			log.Warnf("failed to install extensions: %s", err)
+		}
+	}
+
+	// No need to explicitly start the Agent here
+	// - MSI: done at the end in StartDDServices custom action
+	// - OCI: done at the end of setup script (setup.go)
 
 	return nil
 }

--- a/pkg/fleet/installer/packages/extensions/db.go
+++ b/pkg/fleet/installer/packages/extensions/db.go
@@ -139,6 +139,12 @@ func (p *extensionsDB) SetPackageVersion(pkg string, version string, isExperimen
 			Name:    pkg,
 			Version: version,
 		}
+		if existing := b.Get(getKey(pkg, isExperiment)); len(existing) > 0 {
+			var existingPkg dbPackage
+			if err := json.Unmarshal(existing, &existingPkg); err == nil && existingPkg.Version == version {
+				return nil
+			}
+		}
 		rawPkg, err := json.Marshal(&dbPkg)
 		if err != nil {
 			return fmt.Errorf("could not marshal package: %w", err)

--- a/pkg/fleet/installer/packages/extensions/extensions.go
+++ b/pkg/fleet/installer/packages/extensions/extensions.go
@@ -107,16 +107,17 @@ func Install(ctx context.Context, downloader *oci.Downloader, url string, extens
 	}
 
 	// Process each extension
+	var installErrors []error
 	for _, extension := range extensions {
 		// Check if extension is already installed with the same package version
 		if _, exists := dbPkg.Extensions[extension]; exists {
-			fmt.Printf("Extension %s already installed, skipping\n", extension)
+			log.Debugf("Extension %s already installed, skipping", extension)
 			continue
 		}
 
 		err := installSingle(ctx, pkg, extension, isExperiment, hooks)
 		if err != nil {
-			fmt.Printf("Failed to install extension %s: %v\n", extension, err)
+			installErrors = append(installErrors, fmt.Errorf("extension %s: %w", extension, err))
 			continue
 		}
 
@@ -124,13 +125,13 @@ func Install(ctx context.Context, downloader *oci.Downloader, url string, extens
 		dbPkg.Extensions[extension] = struct{}{}
 	}
 
-	// Update DB now that all extensions installed successfully
+	// Update DB with successfully installed extensions
 	err = db.SetPackage(dbPkg, isExperiment)
 	if err != nil {
 		return fmt.Errorf("could not update package in db: %w", err)
 	}
 
-	return nil
+	return errors.Join(installErrors...)
 }
 
 // installSingle installs a single extension for a package.

--- a/pkg/fleet/installer/setup/defaultscript/default_script.go
+++ b/pkg/fleet/installer/setup/defaultscript/default_script.go
@@ -97,8 +97,10 @@ func SetupDefaultScript(s *common.Setup) error {
 	// Install agent package
 	installAgentPackage(s)
 
-	// Install DDOT package if enabled
-	installDDOTPackage(s)
+	// DDOT is now delivered as an agent extension and installed via
+	// postInstallDatadogAgent when DD_OTELCOLLECTOR_ENABLED=true.
+	// keep this for reference until code is fully cleaned up
+	// installDDOTPackage(s)
 
 	// Optionally setup SSI
 	err := SetupAPMSSIScript(s)
@@ -189,13 +191,14 @@ func installAgentPackage(s *common.Setup) {
 	}
 }
 
-// installDDOTPackage installs the DDOT package if enabled
-func installDDOTPackage(s *common.Setup) {
-	// DDOT install - check if otel-collector is enabled
-	if otelEnabled, ok := os.LookupEnv("DD_OTELCOLLECTOR_ENABLED"); ok && strings.ToLower(otelEnabled) == "true" {
-		s.Packages.Install(common.DatadogAgentDDOTPackage, agentVersion())
-	}
-}
+// installDDOTPackage is no longer used. DDOT is now delivered as an agent
+// extension and installed via postInstallDatadogAgent when DD_OTELCOLLECTOR_ENABLED=true.
+// Kept for reference until full cleanup.
+// func installDDOTPackage(s *common.Setup) {
+// 	if otelEnabled, ok := os.LookupEnv("DD_OTELCOLLECTOR_ENABLED"); ok && strings.ToLower(otelEnabled) == "true" {
+// 		s.Packages.Install(common.DatadogAgentDDOTPackage, agentVersion())
+// 	}
+// }
 
 // installAPMPackages installs the APM packages
 func installAPMPackages(s *common.Setup) {

--- a/test/new-e2e/tests/fleet/agent/install.go
+++ b/test/new-e2e/tests/fleet/agent/install.go
@@ -29,10 +29,11 @@ const (
 type InstallOption func(*installParams)
 
 type installParams struct {
-	remoteUpdates   bool
-	stablePackages  bool
-	stagingPackages string
-	pipelineID      string
+	remoteUpdates        bool
+	stablePackages       bool
+	stagingPackages      string
+	pipelineID           string
+	otelCollectorEnabled bool
 }
 
 var defaultInstallParams = &installParams{
@@ -66,6 +67,14 @@ func WithStagingPackages(version string) InstallOption {
 func WithPipelineID(pipelineID string) InstallOption {
 	return func(p *installParams) {
 		p.pipelineID = pipelineID
+	}
+}
+
+// WithOTelCollectorEnabled sets DD_OTELCOLLECTOR_ENABLED=true during installation,
+// causing the DDOT extension to be installed automatically in the postinstall hook.
+func WithOTelCollectorEnabled() InstallOption {
+	return func(p *installParams) {
+		p.otelCollectorEnabled = true
 	}
 }
 
@@ -121,6 +130,9 @@ func (a *Agent) installLinuxInstallScript(params *installParams) error {
 	if params.remoteUpdates {
 		env["DD_REMOTE_UPDATES"] = "true"
 	}
+	if params.otelCollectorEnabled {
+		env["DD_OTELCOLLECTOR_ENABLED"] = "true"
+	}
 	if !params.stablePackages && params.stagingPackages == "" {
 		env["TESTING_KEYS_URL"] = "apttesting.datad0g.com/test-keys"
 		env["TESTING_APT_URL"] = fmt.Sprintf("s3.amazonaws.com/apttesting.datad0g.com/datadog-agent/pipeline-%s-a7", params.pipelineID)
@@ -147,6 +159,9 @@ func (a *Agent) installWindowsInstallScript(params *installParams) error {
 	}
 	if params.remoteUpdates {
 		env["DD_REMOTE_UPDATES"] = "true"
+	}
+	if params.otelCollectorEnabled {
+		env["DD_OTELCOLLECTOR_ENABLED"] = "true"
 	}
 	scriptURL := windowsInstallScriptURL
 	if !params.stablePackages && params.stagingPackages == "" {

--- a/test/new-e2e/tests/fleet/agent/install.go
+++ b/test/new-e2e/tests/fleet/agent/install.go
@@ -80,7 +80,8 @@ func WithOTelCollectorEnabled() InstallOption {
 
 // Install installs the agent.
 func (a *Agent) Install(options ...InstallOption) error {
-	params := defaultInstallParams
+	paramsCopy := *defaultInstallParams
+	params := &paramsCopy
 	for _, option := range options {
 		option(params)
 	}

--- a/test/new-e2e/tests/fleet/extensions_test.go
+++ b/test/new-e2e/tests/fleet/extensions_test.go
@@ -215,6 +215,16 @@ func (s *extensionsSuite) TestExtensionRestoredAfterExperimentRollback() {
 	s.Require().Equal(initialDDOTVersion, s.getDDOTAgentVersion(), "DDOT should be restored to initial version after rollback")
 }
 
+// TestDDOTAutoInstalledWithEnvVar verifies that when DD_OTELCOLLECTOR_ENABLED=true is set
+// during a fresh agent install, the DDOT extension is automatically installed and running
+// by the postinstall hook — without any explicit extension install call.
+func (s *extensionsSuite) TestDDOTAutoInstalledWithEnvVar() {
+	s.Agent.MustInstall(agent.WithOTelCollectorEnabled())
+	defer s.Agent.MustUninstall()
+
+	s.verifyDDOTRunning()
+}
+
 // TestDDOTExtension tests installing DDOT as an extension on all platforms
 func (s *extensionsSuite) TestDDOTExtension() {
 	// Install base agent

--- a/test/new-e2e/tests/fleet/extensions_test.go
+++ b/test/new-e2e/tests/fleet/extensions_test.go
@@ -327,7 +327,7 @@ func (s *extensionsSuite) verifyDDOTRunning() {
 		}
 
 		return true
-	}, 30*time.Second, 1*time.Second, "DDOT should be running and reporting status")
+	}, 2*time.Minute, 1*time.Second, "DDOT should be running and reporting status")
 	if !isDDOTRunning {
 		s.T().Fatalf("DDOT is not running")
 	}

--- a/test/new-e2e/tests/fleet/extensions_test.go
+++ b/test/new-e2e/tests/fleet/extensions_test.go
@@ -168,7 +168,7 @@ func (s *extensionsSuite) TestExtensionSurvivesExperiment() {
 	s.Agent.MustInstall(agent.WithStagingPackages(stagingAgentVersion))
 	defer s.Agent.MustUninstall()
 
-	s.Installer.MustInstallExtension(s.getAgentPackageURL(""), "ddot")
+	s.Installer.MustInstallExtension(s.getStagingAgentPackageURL(), "ddot")
 	defer func() {
 		_, _ = s.Installer.RemoveExtension("datadog-agent", "ddot")
 	}()
@@ -194,7 +194,7 @@ func (s *extensionsSuite) TestExtensionRestoredAfterExperimentRollback() {
 	s.Agent.MustInstall(agent.WithStagingPackages(stagingAgentVersion))
 	defer s.Agent.MustUninstall()
 
-	s.Installer.MustInstallExtension(s.getAgentPackageURL(""), "ddot")
+	s.Installer.MustInstallExtension(s.getStagingAgentPackageURL(), "ddot")
 	defer func() {
 		_, _ = s.Installer.RemoveExtension("datadog-agent", "ddot")
 	}()

--- a/test/new-e2e/tests/fleet/extensions_test.go
+++ b/test/new-e2e/tests/fleet/extensions_test.go
@@ -168,7 +168,7 @@ func (s *extensionsSuite) TestExtensionSurvivesExperiment() {
 	s.Agent.MustInstall(agent.WithStagingPackages(stagingAgentVersion))
 	defer s.Agent.MustUninstall()
 
-	s.Installer.MustInstallExtension(s.getStagingAgentPackageURL(), "ddot")
+	s.Installer.MustInstallExtension(s.getAgentPackageURL(""), "ddot")
 	defer func() {
 		_, _ = s.Installer.RemoveExtension("datadog-agent", "ddot")
 	}()
@@ -194,7 +194,7 @@ func (s *extensionsSuite) TestExtensionRestoredAfterExperimentRollback() {
 	s.Agent.MustInstall(agent.WithStagingPackages(stagingAgentVersion))
 	defer s.Agent.MustUninstall()
 
-	s.Installer.MustInstallExtension(s.getStagingAgentPackageURL(), "ddot")
+	s.Installer.MustInstallExtension(s.getAgentPackageURL(""), "ddot")
 	defer func() {
 		_, _ = s.Installer.RemoveExtension("datadog-agent", "ddot")
 	}()

--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -76,9 +76,8 @@ func (s *packageDDOTSuite) TestInstallDDOTInstallScript() {
 	s.RunInstallScript("DD_REMOTE_UPDATES=true", "DD_OTELCOLLECTOR_ENABLED=true", envForceInstall("datadog-agent"))
 	defer s.Purge()
 
-	// Verify both packages are installed
+	// Verify agent is installed
 	s.host.AssertPackageInstalledByInstaller("datadog-agent")
-	s.host.AssertPackageInstalledByInstaller("datadog-agent-ddot")
 
 	// Wait for services to be active
 	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit, ddotUnit)
@@ -90,9 +89,6 @@ func (s *packageDDOTSuite) TestInstallDDOTInstallScript() {
 	// Verify configuration files exist
 	state.AssertFileExists("/etc/datadog-agent/datadog.yaml", 0640, "dd-agent", "dd-agent")
 	state.AssertFileExists("/etc/datadog-agent/otel-config.yaml", 0640, "dd-agent", "dd-agent")
-
-	// Verify DDOT binary exists
-	state.AssertFileExists("/opt/datadog-packages/datadog-agent-ddot/stable/embedded/bin/otel-agent", 0755, "dd-agent", "dd-agent")
 
 	// Verify otelcollector configuration is present in datadog.yaml
 	s.host.Run("sudo grep -q 'otelcollector:' /etc/datadog-agent/datadog.yaml")

--- a/test/new-e2e/tests/installer/windows/suites/ddot-package/install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/ddot-package/install_test.go
@@ -3,68 +3,71 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package ddottests implements a minimal E2E test for installing the DDOT OCI package on Windows.
+// Package ddottests implements E2E tests for the DDOT agent extension on Windows.
 package ddottests
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
-	windowsAgent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
-type testDDOTInstallSuite struct {
+type testDDOTExtensionInstallScript struct {
 	installerwindows.BaseSuite
 }
 
-// TestDDOTInstalls installs the DDOT (otel) OCI package via the Datadog installer and verifies files exist.
-// This intentionally does not assert service behavior yet.
-func TestDDOTInstalls(t *testing.T) {
-	e2e.Run(t, &testDDOTInstallSuite{},
+// TestDDOTExtensionViaInstallScript verifies that the DDOT extension is installed
+// when DD_OTELCOLLECTOR_ENABLED=true is passed to the install script, and that
+// purge removes it.
+func TestDDOTExtensionViaInstallScript(t *testing.T) {
+	e2e.Run(t, &testDDOTExtensionInstallScript{},
 		e2e.WithProvisioner(
 			winawshost.ProvisionerNoAgentNoFakeIntake(),
 		))
 }
 
-func (s *testDDOTInstallSuite) TestInstallDDOTPackage() {
-	// Arrange: ensure core Agent is installed (infrastructure directories, configs)
-	// We use the MSI so repo paths exist, then we use OCI to install DDOT.
-	s.uninstallAgentIfPresent()
-	s.installAgentWithMSI()
-
-	// Act: install DDOT from current pipeline via OCI
-	output, err := s.Installer().InstallPackage("datadog-ddot")
-
-	// Assert: package install succeeded and files exist in repository
-	s.Require().NoErrorf(err, "failed to install the DDOT package: %s", output)
-	stableDir := consts.GetStableDirFor("datadog-agent-ddot")
-	s.Require().Host(s.Env().RemoteHost).DirExists(stableDir, "stable link for ddot package should exist")
-	s.Require().Host(s.Env().RemoteHost).FileExists(
-		filepath.Join(stableDir, "embedded", "bin", "otel-agent.exe"),
-		"otel-agent.exe should be present in embedded/bin",
-	)
-	s.Require().Host(s.Env().RemoteHost).FileExists(
-		filepath.Join(stableDir, "etc", "datadog-agent", "otel-config.yaml.example"),
-		"otel-config.yaml.example should be present in etc/datadog-agent",
-	)
-}
-
-func (s *testDDOTInstallSuite) installAgentWithMSI() {
-	// Install current pipeline Agent MSI to establish base directories/config
-	_, err := windowsAgent.InstallAgent(
-		s.Env().RemoteHost,
-		windowsAgent.WithPackage(s.CurrentAgentVersion().MSIPackage()),
-		windowsAgent.WithInstallLogFile(filepath.Join(s.SessionOutputDir(), "install-agent-msi.log")),
-		windowsAgent.WithZeroAPIKey(),
-	)
-	s.Require().NoErrorf(err, "failed to install Agent with MSI")
-}
-
-func (s *testDDOTInstallSuite) uninstallAgentIfPresent() {
-	_ = windowsAgent.UninstallAgent(s.Env().RemoteHost, filepath.Join(s.SessionOutputDir(), "uninstall-agent-msi.log"))
+func (s *testDDOTExtensionInstallScript) AfterTest(_suiteName, _testName string) {
 	s.Installer().Purge()
+}
+
+func (s *testDDOTExtensionInstallScript) TestInstallAndPurgeDDOTExtension() {
+	// Act: install the Agent via the install script with DDOT enabled
+	output, err := s.InstallScript().Run(
+		installerwindows.WithExtraEnvVars(map[string]string{
+			"DD_OTELCOLLECTOR_ENABLED": "true",
+		}),
+	)
+	if s.NoError(err) {
+		fmt.Printf("%s\n", output)
+	}
+	s.Require().NoErrorf(err, "failed to install the Datadog Agent: %s", output)
+	s.Require().NoError(s.WaitForInstallerService("Running"))
+	s.Require().Host(s.Env().RemoteHost).
+		HasARunningDatadogInstallerService().
+		HasARunningDatadogAgentService()
+
+	// Assert: DDOT extension files exist under the agent package
+	ddotExtDir := filepath.Join(consts.GetStableDirFor(consts.AgentPackage), "ext", "ddot")
+	s.Require().Host(s.Env().RemoteHost).DirExists(ddotExtDir, "ddot extension directory should exist")
+	s.Require().Host(s.Env().RemoteHost).FileExists(
+		filepath.Join(ddotExtDir, "embedded", "bin", "otel-agent.exe"),
+		"otel-agent.exe should be present in the ddot extension",
+	)
+	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"datadog-otel-agent"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
+
+	// Act: purge all packages
+	_, err = s.Installer().Purge()
+	s.Require().NoError(err)
+
+	// Assert: extension directory and service are gone
+	s.Require().Host(s.Env().RemoteHost).NoDirExists(ddotExtDir, "ddot extension should be removed after purge")
+	s.Require().Host(s.Env().RemoteHost).HasNoService("datadog-otel-agent")
 }

--- a/test/new-e2e/tests/installer/windows/suites/ddot-package/msi_install_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/ddot-package/msi_install_test.go
@@ -3,12 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package ddottests implements E2E tests for installing the DDOT OCI package via the Agent MSI on Windows.
+// Package ddottests implements E2E tests for the DDOT agent extension on Windows.
 package ddottests
 
 import (
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
 	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
@@ -17,72 +20,54 @@ import (
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
 )
 
-type testAgentMSIInstallsDDOT struct {
+type testDDOTExtensionMSI struct {
 	installerwindows.BaseSuite
 }
 
-// TestAgentMSIInstallsDDOTPackage verifies the Agent MSI can install and remove the DDOT OCI package.
-func TestAgentMSIInstallsDDOTPackage(t *testing.T) {
-	e2e.Run(t, &testAgentMSIInstallsDDOT{},
+// TestDDOTExtensionViaMSI verifies that the DDOT extension is installed when
+// DD_OTELCOLLECTOR_ENABLED=true is passed to the MSI, and that uninstalling the
+// MSI removes the extension.
+func TestDDOTExtensionViaMSI(t *testing.T) {
+	e2e.Run(t, &testDDOTExtensionMSI{},
 		e2e.WithProvisioner(
 			winawshost.ProvisionerNoAgentNoFakeIntake(),
 		))
 }
 
-func (s *testAgentMSIInstallsDDOT) AfterTest(_suiteName, _testName string) {
-	s.Installer().Purge()
-}
-
-func (s *testAgentMSIInstallsDDOT) TestInstallDDOTFromMSI() {
-	// Arrange: install previous Agent MSI (mirror other suites)
+func (s *testDDOTExtensionMSI) TestInstallAndUninstallDDOTExtension() {
+	// Arrange: install a previous agent version as a baseline
 	s.installPreviousAgentVersion()
 
-	// Act: install current Agent MSI; opt-in to DDOT via DD_OTELCOLLECTOR_ENABLED
+	// Act: install current Agent MSI with DDOT enabled
 	s.Require().NoError(s.Installer().Install(
 		installerwindows.WithOption(installerwindows.WithInstallerURL(s.CurrentAgentVersion().MSIPackage().URL)),
-		installerwindows.WithMSILogFile("install-ddot.log"),
+		installerwindows.WithMSILogFile("install-ddot-extension.log"),
 		installerwindows.WithMSIArg("APIKEY="+installer.GetAPIKey()),
 		installerwindows.WithMSIArg("SITE=datadoghq.com"),
-		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=installtesting.datad0g.com.internal.dda-testing.com"),
+		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL="+consts.PipelineOCIRegistry),
 		installerwindows.WithMSIArg("DD_OTELCOLLECTOR_ENABLED=true"),
 	))
 
-	// Assert: DDOT package stable directory exists and contains otel-agent.exe
-	stableDir := consts.GetStableDirFor("datadog-agent-ddot")
-	s.Require().Host(s.Env().RemoteHost).DirExists(stableDir, "stable link for ddot package should exist")
+	// Assert: DDOT extension files exist under the agent package
+	ddotExtDir := filepath.Join(consts.GetStableDirFor(consts.AgentPackage), "ext", "ddot")
+	s.Require().Host(s.Env().RemoteHost).DirExists(ddotExtDir, "ddot extension directory should exist")
 	s.Require().Host(s.Env().RemoteHost).FileExists(
-		filepath.Join(stableDir, "embedded", "bin", "otel-agent.exe"),
-		"otel-agent.exe should be present in embedded/bin",
+		filepath.Join(ddotExtDir, "embedded", "bin", "otel-agent.exe"),
+		"otel-agent.exe should be present in the ddot extension",
 	)
-}
+	s.Require().NoError(s.WaitForServicesWithBackoff("Running", []string{"datadog-otel-agent"}, backoff.WithBackOff(backoff.NewConstantBackOff(30*time.Second))))
 
-func (s *testAgentMSIInstallsDDOT) TestUninstallDDOTFromMSI() {
-	// Arrange: install previous Agent MSI (baseline)
-	s.installPreviousAgentVersion()
-	// Install current Agent MSI with DDOT enabled via DD_OTELCOLLECTOR_ENABLED
-	s.Require().NoError(s.Installer().Install(
-		installerwindows.WithOption(installerwindows.WithInstallerURL(s.CurrentAgentVersion().MSIPackage().URL)),
-		installerwindows.WithMSILogFile("install-ddot.log"),
-		installerwindows.WithMSIArg("APIKEY="+installer.GetAPIKey()),
-		installerwindows.WithMSIArg("SITE=datadoghq.com"),
-		installerwindows.WithMSIArg("DD_INSTALLER_REGISTRY_URL=installtesting.datad0g.com.internal.dda-testing.com"),
-		installerwindows.WithMSIArg("DD_OTELCOLLECTOR_ENABLED=true"),
-	))
-
-	stableDir := consts.GetStableDirFor("datadog-agent-ddot")
-	s.Require().Host(s.Env().RemoteHost).DirExists(stableDir)
-
-	// Act: uninstall the Agent (DDOT and other OCI packages are purged by default)
+	// Act: uninstall the Agent MSI (purges OCI packages including extensions)
 	s.Require().NoError(s.Installer().Uninstall(
-		installerwindows.WithMSILogFile("uninstall-ddot.log"),
+		installerwindows.WithMSILogFile("uninstall-ddot-extension.log"),
 	))
 
-	// Assert: DDOT package directory removed
-	s.Require().Host(s.Env().RemoteHost).NoDirExists(stableDir, "ddot package directory should be removed on uninstall when requested")
+	// Assert: extension directory and service are gone
+	s.Require().Host(s.Env().RemoteHost).NoDirExists(ddotExtDir, "ddot extension should be removed on uninstall")
+	s.Require().Host(s.Env().RemoteHost).HasNoService("datadog-otel-agent")
 }
 
-// installPreviousAgentVersion mirrors the helper used in other MSI suites to lay down the stable agent first.
-func (s *testAgentMSIInstallsDDOT) installPreviousAgentVersion(opts ...installerwindows.MsiOption) {
+func (s *testDDOTExtensionMSI) installPreviousAgentVersion(opts ...installerwindows.MsiOption) {
 	agentVersion := s.StableAgentVersion().Version()
 	options := []installerwindows.MsiOption{
 		installerwindows.WithOption(installerwindows.WithInstallerURL(s.StableAgentVersion().MSIPackage().URL)),

--- a/tools/windows/DatadogAgentInstaller/CustomActions/InstallerHooksCustomAction.cs
+++ b/tools/windows/DatadogAgentInstaller/CustomActions/InstallerHooksCustomAction.cs
@@ -36,10 +36,13 @@ namespace Datadog.CustomActions
             var env = new Dictionary<string, string>();
             var registryProps = new[]
             {
+                // registry props
                 "DD_INSTALLER_REGISTRY_URL",
                 "DD_INSTALLER_REGISTRY_AUTH",
                 "DD_INSTALLER_REGISTRY_USERNAME",
                 "DD_INSTALLER_REGISTRY_PASSWORD",
+                // extensions props
+                "DD_OTELCOLLECTOR_ENABLED",
             };
             foreach (var prop in registryProps)
             {

--- a/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
+++ b/tools/windows/DatadogAgentInstaller/WixSetup/Datadog Agent/AgentCustomActions.cs
@@ -772,7 +772,8 @@ namespace WixSetup.Datadog_Agent
                                "DD_INSTALLER_REGISTRY_URL=[DD_INSTALLER_REGISTRY_URL], " +
                                "DD_INSTALLER_REGISTRY_AUTH=[DD_INSTALLER_REGISTRY_AUTH], " +
                                "DD_INSTALLER_REGISTRY_USERNAME=[DD_INSTALLER_REGISTRY_USERNAME], " +
-                               "DD_INSTALLER_REGISTRY_PASSWORD=[DD_INSTALLER_REGISTRY_PASSWORD]")
+                               "DD_INSTALLER_REGISTRY_PASSWORD=[DD_INSTALLER_REGISTRY_PASSWORD], " +
+                               "DD_OTELCOLLECTOR_ENABLED=[DD_OTELCOLLECTOR_ENABLED]")
                 .HideTarget(true);
         }
     }


### PR DESCRIPTION
### What does this PR do?

Adds `installDDOTExtensionIfEnabled` in `datadog_agent_extensions.go`, which checks `DD_OTELCOLLECTOR_ENABLED` and, if true, calls `extensionsPkg.Install` with `["ddot"]` to install the DDOT (OTel Collector) extension. This function is called in `postInstallDatadogAgent` after `restoreAgentExtensions` and before `agentService.WriteStable`. Failure is treated as a warning (non-fatal), matching the pattern of `restoreAgentExtensions`.

### Motivation

During a fresh Agent install via DEB/RPM/OCI postinstall, users who set `DD_OTELCOLLECTOR_ENABLED=true` expect the DDOT extension to be activated automatically. Previously, `postInstallDatadogAgent` only restored previously-saved extensions and did not install DDOT on first install even when the env var was set.

### Describe how you validated your changes

- Added unit tests in `datadog_agent_extensions_test.go` (`!windows` build tag):
  - `TestInstallDDOTExtensionIfEnabled_Disabled`: verifies that when `DD_OTELCOLLECTOR_ENABLED=false` the function returns nil immediately with no download attempted.
  - `TestInstallDDOTExtensionIfEnabled_Enabled`: verifies that when `DD_OTELCOLLECTOR_ENABLED=true` a download is attempted (confirmed by a download error against a non-existent registry).
- Both tests pass: `go test ./pkg/fleet/installer/packages/... -run TestInstallDDOTExtension`

### Additional Notes

`extensionsPkg.Install` is idempotent — it skips extensions that are already installed — so calling this after `restoreAgentExtensions` is safe and has no effect on upgrades where DDOT was already present.