### PR TITLE
Have agent-build own all bazel (.bzl) files in the repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -877,6 +877,7 @@
 # Temporary during Bazel migration
 # This needs to go after all other rules that may include BUILD.bazel files, it otherwise gets overridden
 /**/BUILD.bazel                         @DataDog/agent-build
+/**/*.bzl                               @DataDog/agent-build
 
 # With the introduction of go.work, dependencies bump modify go.mod and go.sum in a lot of file.
 # Which bring a lot of team in the review each time. To make it smoother we no longer consider go.mod and go.sum owned by teams.


### PR DESCRIPTION
### What does this PR do?

Gives ownership of all *.bzl files to agent-build.

### Motivation

https://github.com/DataDog/datadog-agent/pull/47405#discussion_r2890313866

At least for the time being we're not expecting individual teams to independently write their own starlark rules and macros, therefore a catch-all rule makes sense.

### Describe how you validated your changes

### Additional Notes
