### PR TITLE
[observer] Save all intermediate results

### DIFF
--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -78,10 +78,12 @@ func main() {
 	}
 
 	// Resolve results dir early so it's available in CLIParams.
-	// Defaults to the scenario directory so results land alongside the input parquet files.
+	// Defaults to a dedicated subdirectory inside the scenario directory so that output
+	// artifacts (observer-results*.parquet) never land alongside input parquet files and
+	// are not accidentally picked up as inputs on subsequent runs.
 	resolvedResultsDir := *resultsDir
 	if resolvedResultsDir == "" && *headless != "" {
-		resolvedResultsDir = filepath.Join(*scenariosDir, *headless)
+		resolvedResultsDir = filepath.Join(*scenariosDir, *headless, "observer-results")
 	}
 
 	err := fxutil.OneShot(run,

--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -38,7 +38,7 @@ type CLIParams struct {
 	Headless   string // scenario name to run (empty = interactive mode)
 	Output     string // path for observer JSON output
 	Verbose    bool   // include full detail in JSON output (headless mode only)
-	ResultsDir string // directory to save intermediate results (virtual metrics parquet); defaults to the scenario directory
+	ResultsDir string // directory for intermediate results (virtual metrics parquet); defaults to the scenario directory
 }
 
 func main() {
@@ -49,7 +49,7 @@ func main() {
 	headless := flag.String("headless", "", "Run scenario in headless mode (no HTTP server) and exit")
 	output := flag.String("output", "", "Path for eval JSON output (headless mode only)")
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
-	resultsDir := flag.String("results-dir", "", "Directory to save intermediate results (virtual metrics parquet); defaults to the scenario directory in headless mode")
+	resultsDir := flag.String("results-dir", "", "Directory for intermediate results (virtual metrics parquet); defaults to the scenario directory in headless mode")
 	flag.Parse()
 
 	overrides := make(map[string]bool)
@@ -77,6 +77,13 @@ func main() {
 		fmt.Println()
 	}
 
+	// Resolve results dir early so it's available in CLIParams.
+	// Defaults to the scenario directory so results land alongside the input parquet files.
+	resolvedResultsDir := *resultsDir
+	if resolvedResultsDir == "" && *headless != "" {
+		resolvedResultsDir = filepath.Join(*scenariosDir, *headless)
+	}
+
 	err := fxutil.OneShot(run,
 		recorderfx.Module(),
 		core.Bundle(),
@@ -92,7 +99,7 @@ func main() {
 			Headless:        *headless,
 			Output:          *output,
 			Verbose:         *verbose,
-			ResultsDir:      *resultsDir,
+			ResultsDir:      resolvedResultsDir,
 		}),
 	)
 	if err != nil {
@@ -114,20 +121,14 @@ func run(recorder recorderdef.Component, params CLIParams) error {
 		return err
 	}
 
-	// Headless mode: run scenario, write output, exit (no HTTP server)
+	// Headless mode: run scenario, write output, exit (no HTTP server).
 	if params.Headless != "" {
-		// Enable saving of intermediate results (virtual metrics parquet).
-		// Defaults to the scenario directory so results land alongside the input parquet files.
-		// This only initializes the virtual metrics writer — raw input data (metrics, logs,
-		// traces) is never re-recorded.
-		resultsDir := params.ResultsDir
-		if resultsDir == "" {
-			resultsDir = filepath.Join(params.ScenariosDir, params.Headless)
-		}
-		if err := recorder.EnableResultsSaving(resultsDir); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to enable results saving to %s: %v\n", resultsDir, err)
+		// Enable results saving (virtual metrics parquet) now that the recorder is initialized.
+		// This only activates the virtual metrics writer; raw input data is never re-recorded.
+		if err := recorder.EnableResultsSaving(params.ResultsDir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to enable results saving to %s: %v\n", params.ResultsDir, err)
 		} else {
-			fmt.Printf("Results saving enabled: virtual metrics → %s\n", resultsDir)
+			fmt.Printf("Results saving enabled: virtual metrics → %s\n", params.ResultsDir)
 		}
 		return tb.RunHeadless(params.Headless, params.Output, params.Verbose)
 	}

--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -34,9 +35,10 @@ type CLIParams struct {
 	EnableOverrides map[string]bool
 
 	// Headless mode: run a scenario and exit (no HTTP server)
-	Headless string // scenario name to run (empty = interactive mode)
-	Output   string // path for observer JSON output
-	Verbose  bool   // include full detail in JSON output (headless mode only)
+	Headless   string // scenario name to run (empty = interactive mode)
+	Output     string // path for observer JSON output
+	Verbose    bool   // include full detail in JSON output (headless mode only)
+	ResultsDir string // directory to save intermediate results (virtual metrics parquet); defaults to the scenario directory
 }
 
 func main() {
@@ -47,6 +49,7 @@ func main() {
 	headless := flag.String("headless", "", "Run scenario in headless mode (no HTTP server) and exit")
 	output := flag.String("output", "", "Path for eval JSON output (headless mode only)")
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
+	resultsDir := flag.String("results-dir", "", "Directory to save intermediate results (virtual metrics parquet); defaults to the scenario directory in headless mode")
 	flag.Parse()
 
 	overrides := make(map[string]bool)
@@ -83,12 +86,13 @@ func main() {
 			LogParams:    log.ForOneShot("", "off", true),
 		}),
 		fx.Supply(CLIParams{
-			ScenariosDir:      *scenariosDir,
-			HTTPAddr:          *httpAddr,
-			EnableOverrides:   overrides,
-			Headless:          *headless,
-			Output:            *output,
-			Verbose:           *verbose,
+			ScenariosDir:    *scenariosDir,
+			HTTPAddr:        *httpAddr,
+			EnableOverrides: overrides,
+			Headless:        *headless,
+			Output:          *output,
+			Verbose:         *verbose,
+			ResultsDir:      *resultsDir,
 		}),
 	)
 	if err != nil {
@@ -112,6 +116,19 @@ func run(recorder recorderdef.Component, params CLIParams) error {
 
 	// Headless mode: run scenario, write output, exit (no HTTP server)
 	if params.Headless != "" {
+		// Enable saving of intermediate results (virtual metrics parquet).
+		// Defaults to the scenario directory so results land alongside the input parquet files.
+		// This only initializes the virtual metrics writer — raw input data (metrics, logs,
+		// traces) is never re-recorded.
+		resultsDir := params.ResultsDir
+		if resultsDir == "" {
+			resultsDir = filepath.Join(params.ScenariosDir, params.Headless)
+		}
+		if err := recorder.EnableResultsSaving(resultsDir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to enable results saving to %s: %v\n", resultsDir, err)
+		} else {
+			fmt.Printf("Results saving enabled: virtual metrics → %s\n", resultsDir)
+		}
 		return tb.RunHeadless(params.Headless, params.Output, params.Verbose)
 	}
 

--- a/comp/anomalydetection/recorder/def/component.go
+++ b/comp/anomalydetection/recorder/def/component.go
@@ -45,6 +45,28 @@ type Component interface {
 	// ReadAllTraceStats reads all APM trace stats from parquet files and returns them as a slice.
 	// Each element corresponds to one aggregated stat group (ClientGroupedStats).
 	ReadAllTraceStats(inputDir string) ([]TraceStatsData, error)
+
+	// RecordVirtualMetric records a log-derived virtual metric to the dedicated
+	// virtual metrics parquet file (observer-virtualmetrics-*.parquet).
+	// Virtual metrics are computed by log detectors and stored with a "_virtual." prefix.
+	// This is a no-op when neither recording nor results saving is enabled.
+	RecordVirtualMetric(source, name string, value float64, tags []string, timestamp int64)
+
+	// FlushVirtualMetrics forces an immediate flush of buffered virtual metrics to disk.
+	// The testbench calls this after running log detectors to ensure results are persisted
+	// before the process exits or the scenario is unloaded.
+	// In the live observer, virtual metrics are also flushed on the regular periodic interval.
+	FlushVirtualMetrics()
+
+	// EnableResultsSaving initializes the virtual metrics writer to save computed results
+	// to the given output directory. Intended for headless mode: it enables saving only
+	// the derived/computed data (virtual metrics) without re-recording the raw input
+	// observations (metrics, logs, traces) that were loaded from parquet files.
+	//
+	// If the virtual metrics writer was already initialized (e.g. because full recording
+	// is enabled via observer.recording.enabled), this call is a no-op.
+	// Returns an error if the output directory cannot be created or the writer fails to start.
+	EnableResultsSaving(outputDir string) error
 }
 
 // MetricData represents a single metric read from parquet files.

--- a/comp/anomalydetection/recorder/def/component.go
+++ b/comp/anomalydetection/recorder/def/component.go
@@ -46,25 +46,32 @@ type Component interface {
 	// Each element corresponds to one aggregated stat group (ClientGroupedStats).
 	ReadAllTraceStats(inputDir string) ([]TraceStatsData, error)
 
-	// RecordVirtualMetric records a log-derived virtual metric to the dedicated
-	// virtual metrics parquet file (observer-virtualmetrics-*.parquet).
+	// RecordVirtualMetric records a log-derived virtual metric into the results metrics
+	// parquet file (observer-resultsmetrics-*.parquet).
 	// Virtual metrics are computed by log detectors and stored with a "_virtual." prefix.
 	// This is a no-op when neither recording nor results saving is enabled.
 	RecordVirtualMetric(source, name string, value float64, tags []string, timestamp int64)
 
-	// FlushVirtualMetrics forces an immediate flush of buffered virtual metrics to disk.
-	// The testbench calls this after running log detectors to ensure results are persisted
-	// before the process exits or the scenario is unloaded.
-	// In the live observer, virtual metrics are also flushed on the regular periodic interval.
-	FlushVirtualMetrics()
+	// RecordTelemetryMetric records a detector telemetry metric into the results metrics
+	// parquet file (observer-resultsmetrics-*.parquet).
+	// Telemetry metrics are emitted by anomaly detectors to expose their internal state
+	// and stored under the "telemetry.<detectorName>.<metricName>" naming convention.
+	// This is a no-op when neither recording nor results saving is enabled.
+	RecordTelemetryMetric(source, name string, value float64, tags []string, timestamp int64)
 
-	// EnableResultsSaving initializes the virtual metrics writer to save computed results
-	// to the given output directory. Intended for headless mode: it enables saving only
-	// the derived/computed data (virtual metrics) without re-recording the raw input
-	// observations (metrics, logs, traces) that were loaded from parquet files.
+	// FlushResultsMetrics forces an immediate flush of buffered results metrics to disk.
+	// The testbench calls this after running detectors to ensure all results are persisted
+	// before the process exits or the scenario is unloaded.
+	// In the live observer, results metrics are also flushed on the regular periodic interval.
+	FlushResultsMetrics()
+
+	// EnableResultsSaving initializes the results metrics writer to save computed intermediate
+	// data to the given output directory. Intended for headless mode: it enables saving only
+	// the derived/computed data (virtual metrics, telemetry metrics) without re-recording the
+	// raw input observations (metrics, logs, traces) that were loaded from parquet files.
 	//
-	// If the virtual metrics writer was already initialized (e.g. because full recording
-	// is enabled via observer.recording.enabled), this call is a no-op.
+	// If the results writer was already initialized (e.g. because full recording is enabled
+	// via observer.recording.enabled), this call is a no-op.
 	// Returns an error if the output directory cannot be created or the writer fails to start.
 	EnableResultsSaving(outputDir string) error
 }

--- a/comp/anomalydetection/recorder/def/component.go
+++ b/comp/anomalydetection/recorder/def/component.go
@@ -75,6 +75,17 @@ type Component interface {
 	// FlushResultsLogs forces an immediate flush of buffered results logs to disk.
 	FlushResultsLogs()
 
+	// RecordCorrelation records a correlator output into the results correlations parquet file
+	// (observer-resultscorrelations-*.parquet). Each call adds one ActiveCorrelation row
+	// with its member series, metric names, and embedded anomaly details as parallel lists.
+	// This is a no-op when neither recording nor results saving is enabled.
+	RecordCorrelation(data CorrelationData)
+
+	// FlushResultsCorrelations forces an immediate flush of buffered correlation results to disk.
+	// RunHeadless calls this after the correlator goroutine completes so that all rows are
+	// written before the process exits.
+	FlushResultsCorrelations()
+
 	// EnableResultsSaving initializes the results metrics writer to save computed intermediate
 	// data to the given output directory. Intended for headless mode: it enables saving only
 	// the derived/computed data (virtual metrics, telemetry metrics) without re-recording the
@@ -183,6 +194,24 @@ type TraceStatsData struct {
 	OkSummary         []byte   // DDSketch encoded latency distribution for ok spans
 	ErrorSummary      []byte   // DDSketch encoded latency distribution for error spans
 	PeerTags          []string // Peer entity tags (e.g., "db.hostname:...")
+}
+
+// CorrelationData represents a single correlator output written to the results correlations
+// parquet file. Member series, metric names, and anomaly details are stored as parallel lists
+// so the full correlation can be reconstructed from a single row without joins.
+type CorrelationData struct {
+	Pattern     string // pattern name, e.g. "kernel_bottleneck"
+	Title       string // display title, e.g. "Correlated: Kernel network bottleneck"
+	FirstSeen   int64  // unix seconds
+	LastUpdated int64  // unix seconds
+	// Member series and metric names participating in this correlation
+	MemberSeriesIDs []string
+	MetricNames     []string
+	// Anomaly details as parallel lists (one entry per triggering anomaly)
+	AnomalyTimestamps []int64
+	AnomalySources    []string
+	AnomalySeriesIDs  []string
+	AnomalyDetectors  []string
 }
 
 // LogData represents a log entry read from parquet files.

--- a/comp/anomalydetection/recorder/def/component.go
+++ b/comp/anomalydetection/recorder/def/component.go
@@ -59,11 +59,21 @@ type Component interface {
 	// This is a no-op when neither recording nor results saving is enabled.
 	RecordTelemetryMetric(source, name string, value float64, tags []string, timestamp int64)
 
+	// RecordTelemetryLog records a detector telemetry log into the results logs parquet
+	// file (observer-resultslogs-*.parquet).
+	// Telemetry logs are emitted by anomaly detectors to expose structured diagnostic
+	// information about their internal processing.
+	// This is a no-op when neither recording nor results saving is enabled.
+	RecordTelemetryLog(source string, content []byte, status, hostname string, tags []string, timestampMs int64)
+
 	// FlushResultsMetrics forces an immediate flush of buffered results metrics to disk.
 	// The testbench calls this after running detectors to ensure all results are persisted
 	// before the process exits or the scenario is unloaded.
 	// In the live observer, results metrics are also flushed on the regular periodic interval.
 	FlushResultsMetrics()
+
+	// FlushResultsLogs forces an immediate flush of buffered results logs to disk.
+	FlushResultsLogs()
 
 	// EnableResultsSaving initializes the results metrics writer to save computed intermediate
 	// data to the given output directory. Intended for headless mode: it enables saving only

--- a/comp/anomalydetection/recorder/impl/parquet_correlation_writer.go
+++ b/comp/anomalydetection/recorder/impl/parquet_correlation_writer.go
@@ -1,0 +1,233 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package recorderimpl
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/array"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/apache/arrow-go/v18/parquet"
+	"github.com/apache/arrow-go/v18/parquet/compress"
+
+	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// correlationParquetWriter writes correlator output to parquet files.
+// Each row represents one ActiveCorrelation with its member series and embedded anomaly
+// details stored as parallel lists, enabling full reconstruction without joining other files.
+// Files are only created when there is data to write; empty files are never produced.
+type correlationParquetWriter struct {
+	parquetWriter
+	typedBuilder *correlationBatchBuilder
+}
+
+// newResultsCorrelationParquetWriter creates a writer for correlator output
+// (observer-resultscorrelations-*.parquet).
+func newResultsCorrelationParquetWriter(outputDir string, flushInterval, retentionDuration time.Duration) (*correlationParquetWriter, error) {
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating output directory: %w", err)
+	}
+
+	schema := arrow.NewSchema(
+		[]arrow.Field{
+			{Name: "Pattern", Type: arrow.BinaryTypes.String},
+			{Name: "Title", Type: arrow.BinaryTypes.String},
+			{Name: "FirstSeen", Type: arrow.PrimitiveTypes.Int64},   // unix seconds
+			{Name: "LastUpdated", Type: arrow.PrimitiveTypes.Int64}, // unix seconds
+			// Member series and metric names participating in this correlation
+			{Name: "MemberSeriesIDs", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+			{Name: "MetricNames", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+			// Anomaly details as parallel lists (one entry per triggering anomaly)
+			{Name: "AnomalyTimestamps", Type: arrow.ListOf(arrow.PrimitiveTypes.Int64)},
+			{Name: "AnomalySources", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+			{Name: "AnomalySeriesIDs", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+			{Name: "AnomalyDetectors", Type: arrow.ListOf(arrow.BinaryTypes.String)},
+		},
+		nil,
+	)
+
+	props := parquet.NewWriterProperties(
+		parquet.WithVersion(parquet.V2_LATEST),
+		parquet.WithCompression(compress.Codecs.Zstd),
+		parquet.WithBloomFilterEnabledFor("Pattern", true),
+		parquet.WithBloomFilterFPPFor("Pattern", 0.01),
+	)
+
+	builder := newCorrelationBatchBuilder(schema)
+	cw := &correlationParquetWriter{
+		parquetWriter: parquetWriter{
+			outputDir:         outputDir,
+			filePrefix:        "observer-resultscorrelations",
+			schema:            schema,
+			writerProps:       props,
+			builder:           builder,
+			flushInterval:     flushInterval,
+			retentionDuration: retentionDuration,
+			stopCh:            make(chan struct{}),
+		},
+		typedBuilder: builder,
+	}
+	cw.start()
+
+	pkglog.Infof("Correlation parquet writer initialized: dir=%s flush=%v retention=%v", outputDir, flushInterval, retentionDuration)
+	return cw, nil
+}
+
+// WriteCorrelation adds a correlation to the batch (will be flushed on interval or explicit flush).
+func (cw *correlationParquetWriter) WriteCorrelation(data recorderdef.CorrelationData) {
+	cw.mu.Lock()
+	defer cw.mu.Unlock()
+	cw.typedBuilder.add(data)
+}
+
+// correlationBatchBuilder accumulates correlation rows into Arrow record batches.
+type correlationBatchBuilder struct {
+	schema *arrow.Schema
+
+	patterns    []string
+	titles      []string
+	firstSeens  []int64
+	lastUpdates []int64
+
+	memberSeriesIDs [][]string
+	metricNames     [][]string
+
+	anomalyTimestamps [][]int64
+	anomalySources    [][]string
+	anomalySeriesIDs  [][]string
+	anomalyDetectors  [][]string
+}
+
+func newCorrelationBatchBuilder(schema *arrow.Schema) *correlationBatchBuilder {
+	return &correlationBatchBuilder{schema: schema}
+}
+
+func (b *correlationBatchBuilder) add(data recorderdef.CorrelationData) {
+	b.patterns = append(b.patterns, data.Pattern)
+	b.titles = append(b.titles, data.Title)
+	b.firstSeens = append(b.firstSeens, data.FirstSeen)
+	b.lastUpdates = append(b.lastUpdates, data.LastUpdated)
+
+	memberCopy := make([]string, len(data.MemberSeriesIDs))
+	copy(memberCopy, data.MemberSeriesIDs)
+	b.memberSeriesIDs = append(b.memberSeriesIDs, memberCopy)
+
+	metricCopy := make([]string, len(data.MetricNames))
+	copy(metricCopy, data.MetricNames)
+	b.metricNames = append(b.metricNames, metricCopy)
+
+	tsCopy := make([]int64, len(data.AnomalyTimestamps))
+	copy(tsCopy, data.AnomalyTimestamps)
+	b.anomalyTimestamps = append(b.anomalyTimestamps, tsCopy)
+
+	srcCopy := make([]string, len(data.AnomalySources))
+	copy(srcCopy, data.AnomalySources)
+	b.anomalySources = append(b.anomalySources, srcCopy)
+
+	sidCopy := make([]string, len(data.AnomalySeriesIDs))
+	copy(sidCopy, data.AnomalySeriesIDs)
+	b.anomalySeriesIDs = append(b.anomalySeriesIDs, sidCopy)
+
+	detCopy := make([]string, len(data.AnomalyDetectors))
+	copy(detCopy, data.AnomalyDetectors)
+	b.anomalyDetectors = append(b.anomalyDetectors, detCopy)
+}
+
+func (b *correlationBatchBuilder) build() arrow.Record {
+	if len(b.patterns) == 0 {
+		return nil
+	}
+
+	rb := array.NewRecordBuilder(memory.DefaultAllocator, b.schema)
+
+	patternBuilder := rb.Field(0).(*array.StringBuilder)
+	titleBuilder := rb.Field(1).(*array.StringBuilder)
+	firstSeenBuilder := rb.Field(2).(*array.Int64Builder)
+	lastUpdatedBuilder := rb.Field(3).(*array.Int64Builder)
+
+	memberSeriesBuilder := rb.Field(4).(*array.ListBuilder)
+	memberSeriesValueBuilder := memberSeriesBuilder.ValueBuilder().(*array.StringBuilder)
+
+	metricNamesBuilder := rb.Field(5).(*array.ListBuilder)
+	metricNamesValueBuilder := metricNamesBuilder.ValueBuilder().(*array.StringBuilder)
+
+	anomalyTsBuilder := rb.Field(6).(*array.ListBuilder)
+	anomalyTsValueBuilder := anomalyTsBuilder.ValueBuilder().(*array.Int64Builder)
+
+	anomalySrcBuilder := rb.Field(7).(*array.ListBuilder)
+	anomalySrcValueBuilder := anomalySrcBuilder.ValueBuilder().(*array.StringBuilder)
+
+	anomalySidBuilder := rb.Field(8).(*array.ListBuilder)
+	anomalySidValueBuilder := anomalySidBuilder.ValueBuilder().(*array.StringBuilder)
+
+	anomalyDetBuilder := rb.Field(9).(*array.ListBuilder)
+	anomalyDetValueBuilder := anomalyDetBuilder.ValueBuilder().(*array.StringBuilder)
+
+	for _, v := range b.patterns {
+		patternBuilder.Append(v)
+	}
+	for _, v := range b.titles {
+		titleBuilder.Append(v)
+	}
+	firstSeenBuilder.AppendValues(b.firstSeens, nil)
+	lastUpdatedBuilder.AppendValues(b.lastUpdates, nil)
+
+	for _, list := range b.memberSeriesIDs {
+		memberSeriesBuilder.Append(true)
+		for _, v := range list {
+			memberSeriesValueBuilder.Append(v)
+		}
+	}
+	for _, list := range b.metricNames {
+		metricNamesBuilder.Append(true)
+		for _, v := range list {
+			metricNamesValueBuilder.Append(v)
+		}
+	}
+	for _, list := range b.anomalyTimestamps {
+		anomalyTsBuilder.Append(true)
+		anomalyTsValueBuilder.AppendValues(list, nil)
+	}
+	for _, list := range b.anomalySources {
+		anomalySrcBuilder.Append(true)
+		for _, v := range list {
+			anomalySrcValueBuilder.Append(v)
+		}
+	}
+	for _, list := range b.anomalySeriesIDs {
+		anomalySidBuilder.Append(true)
+		for _, v := range list {
+			anomalySidValueBuilder.Append(v)
+		}
+	}
+	for _, list := range b.anomalyDetectors {
+		anomalyDetBuilder.Append(true)
+		for _, v := range list {
+			anomalyDetValueBuilder.Append(v)
+		}
+	}
+
+	record := rb.NewRecord()
+	rb.Release()
+
+	b.patterns = nil
+	b.titles = nil
+	b.firstSeens = nil
+	b.lastUpdates = nil
+	b.memberSeriesIDs = nil
+	b.metricNames = nil
+	b.anomalyTimestamps = nil
+	b.anomalySources = nil
+	b.anomalySeriesIDs = nil
+	b.anomalyDetectors = nil
+
+	return record
+}

--- a/comp/anomalydetection/recorder/impl/parquet_log_writer.go
+++ b/comp/anomalydetection/recorder/impl/parquet_log_writer.go
@@ -26,13 +26,23 @@ type logParquetWriter struct {
 	typedBuilder *logBatchBuilder
 }
 
-// newLogParquetWriter creates a writer for log data.
+// newLogParquetWriter creates a writer for raw observed logs (observer-logs-*.parquet).
 func newLogParquetWriter(outputDir string, flushInterval, retentionDuration time.Duration) (*logParquetWriter, error) {
+	return newLogParquetWriterWithPrefix(outputDir, "observer-logs", flushInterval, retentionDuration)
+}
+
+// newResultsLogParquetWriter creates a writer for computed result logs
+// (observer-resultslogs-*.parquet). This file holds telemetry logs emitted by detectors.
+func newResultsLogParquetWriter(outputDir string, flushInterval, retentionDuration time.Duration) (*logParquetWriter, error) {
+	return newLogParquetWriterWithPrefix(outputDir, "observer-resultslogs", flushInterval, retentionDuration)
+}
+
+// newLogParquetWriterWithPrefix creates a log parquet writer with the given file prefix.
+func newLogParquetWriterWithPrefix(outputDir, filePrefix string, flushInterval, retentionDuration time.Duration) (*logParquetWriter, error) {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating output directory: %w", err)
 	}
 
-	// Schema for logs
 	schema := arrow.NewSchema(
 		[]arrow.Field{
 			{Name: "RunID", Type: arrow.BinaryTypes.String},
@@ -56,7 +66,7 @@ func newLogParquetWriter(outputDir string, flushInterval, retentionDuration time
 	lw := &logParquetWriter{
 		parquetWriter: parquetWriter{
 			outputDir:         outputDir,
-			filePrefix:        "observer-logs",
+			filePrefix:        filePrefix,
 			schema:            schema,
 			writerProps:       props,
 			builder:           builder,
@@ -68,7 +78,7 @@ func newLogParquetWriter(outputDir string, flushInterval, retentionDuration time
 	}
 	lw.start()
 
-	pkglog.Infof("Log parquet writer initialized: dir=%s flush=%v retention=%v", outputDir, flushInterval, retentionDuration)
+	pkglog.Infof("Log parquet writer initialized: prefix=%s dir=%s flush=%v retention=%v", filePrefix, outputDir, flushInterval, retentionDuration)
 	return lw, nil
 }
 

--- a/comp/anomalydetection/recorder/impl/parquet_metric_reader.go
+++ b/comp/anomalydetection/recorder/impl/parquet_metric_reader.go
@@ -109,8 +109,15 @@ func (r *parquetMetricReader) EndTime() int64 {
 // minParquetFileSize is the minimum valid size for a parquet file
 const minParquetFileSize = 20
 
+// observerResultsPrefix is the filename prefix shared by all observer result artifacts
+// (virtual/telemetry metrics, telemetry logs, correlations). Files with this prefix are
+// written by EnableResultsSaving and must never be read back as scenario inputs.
+const observerResultsPrefix = "observer-results"
+
 // findParquetFiles recursively finds all .parquet files in a directory,
-// skipping files that are too small to be valid parquet files.
+// skipping files that are too small to be valid parquet files and skipping
+// observer result artifacts (observer-results*.parquet) so they are never
+// ingested as detector inputs on subsequent runs.
 func findParquetFiles(dirPath string) ([]string, error) {
 	var files []string
 	err := filepath.Walk(dirPath, func(path string, info os.FileInfo, err error) error {
@@ -118,6 +125,11 @@ func findParquetFiles(dirPath string) ([]string, error) {
 			return err
 		}
 		if !info.IsDir() && strings.HasSuffix(path, ".parquet") {
+			baseName := filepath.Base(path)
+			if strings.HasPrefix(baseName, observerResultsPrefix) {
+				fmt.Printf("[parquet-reader] Skipping %s: observer results artifact (not a scenario input)\n", path)
+				return nil
+			}
 			if info.Size() < minParquetFileSize {
 				fmt.Printf("[parquet-reader] Skipping %s: file too small (%d bytes)\n", path, info.Size())
 				return nil

--- a/comp/anomalydetection/recorder/impl/parquet_metric_writer.go
+++ b/comp/anomalydetection/recorder/impl/parquet_metric_writer.go
@@ -27,11 +27,23 @@ type metricParquetWriter struct {
 	typedBuilder *metricBatchBuilder
 }
 
-// newMetricParquetWriter creates a writer that rotates parquet files at the flush interval.
+// newMetricParquetWriter creates a writer for raw observed metrics (observer-metrics-*.parquet).
+func newMetricParquetWriter(outputDir string, flushInterval, retentionDuration time.Duration) (*metricParquetWriter, error) {
+	return newMetricParquetWriterWithPrefix(outputDir, "observer-metrics", flushInterval, retentionDuration)
+}
+
+// newVirtualMetricParquetWriter creates a writer for log-derived virtual metrics
+// (observer-virtualmetrics-*.parquet). Uses the same schema as the raw metrics writer.
+func newVirtualMetricParquetWriter(outputDir string, flushInterval, retentionDuration time.Duration) (*metricParquetWriter, error) {
+	return newMetricParquetWriterWithPrefix(outputDir, "observer-virtualmetrics", flushInterval, retentionDuration)
+}
+
+// newMetricParquetWriterWithPrefix creates a metric parquet writer with the given file prefix.
 // outputDir: directory where parquet files will be written
+// filePrefix: prefix for file names (e.g. "observer-metrics", "observer-virtualmetrics")
 // flushInterval: how often to rotate files (e.g., 60s creates a new file every minute)
 // retentionDuration: how long to keep old files (0 = no cleanup)
-func newMetricParquetWriter(outputDir string, flushInterval, retentionDuration time.Duration) (*metricParquetWriter, error) {
+func newMetricParquetWriterWithPrefix(outputDir, filePrefix string, flushInterval, retentionDuration time.Duration) (*metricParquetWriter, error) {
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating output directory: %w", err)
 	}
@@ -65,7 +77,7 @@ func newMetricParquetWriter(outputDir string, flushInterval, retentionDuration t
 	pw := &metricParquetWriter{
 		parquetWriter: parquetWriter{
 			outputDir:         outputDir,
-			filePrefix:        "observer-metrics",
+			filePrefix:        filePrefix,
 			schema:            schema,
 			writerProps:       props,
 			builder:           builder,
@@ -77,7 +89,7 @@ func newMetricParquetWriter(outputDir string, flushInterval, retentionDuration t
 	}
 	pw.start()
 
-	pkglog.Infof("Parquet writer initialized: dir=%s flush=%v retention=%v", outputDir, flushInterval, retentionDuration)
+	pkglog.Infof("Parquet writer initialized: prefix=%s dir=%s flush=%v retention=%v", filePrefix, outputDir, flushInterval, retentionDuration)
 	return pw, nil
 }
 

--- a/comp/anomalydetection/recorder/impl/parquet_metric_writer.go
+++ b/comp/anomalydetection/recorder/impl/parquet_metric_writer.go
@@ -32,15 +32,16 @@ func newMetricParquetWriter(outputDir string, flushInterval, retentionDuration t
 	return newMetricParquetWriterWithPrefix(outputDir, "observer-metrics", flushInterval, retentionDuration)
 }
 
-// newVirtualMetricParquetWriter creates a writer for log-derived virtual metrics
-// (observer-virtualmetrics-*.parquet). Uses the same schema as the raw metrics writer.
-func newVirtualMetricParquetWriter(outputDir string, flushInterval, retentionDuration time.Duration) (*metricParquetWriter, error) {
-	return newMetricParquetWriterWithPrefix(outputDir, "observer-virtualmetrics", flushInterval, retentionDuration)
+// newResultsMetricParquetWriter creates a writer for computed result metrics
+// (observer-resultsmetrics-*.parquet). This single file holds both virtual metrics
+// (derived by log detectors) and telemetry metrics (emitted by anomaly detectors).
+func newResultsMetricParquetWriter(outputDir string, flushInterval, retentionDuration time.Duration) (*metricParquetWriter, error) {
+	return newMetricParquetWriterWithPrefix(outputDir, "observer-resultsmetrics", flushInterval, retentionDuration)
 }
 
 // newMetricParquetWriterWithPrefix creates a metric parquet writer with the given file prefix.
 // outputDir: directory where parquet files will be written
-// filePrefix: prefix for file names (e.g. "observer-metrics", "observer-virtualmetrics")
+// filePrefix: prefix for file names (e.g. "observer-metrics", "observer-resultsmetrics")
 // flushInterval: how often to rotate files (e.g., 60s creates a new file every minute)
 // retentionDuration: how long to keep old files (0 = no cleanup)
 func newMetricParquetWriterWithPrefix(outputDir, filePrefix string, flushInterval, retentionDuration time.Duration) (*metricParquetWriter, error) {

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -31,75 +31,97 @@ type Provides struct {
 func NewComponent(req Requires) (Provides, error) {
 	r := &recorderImpl{}
 
-	// Check if recording is enabled
-	if !req.Config.GetBool("observer.recording.enabled") {
-		pkglog.Debug("Recorder disabled (observer.recording.enabled=false)")
+	recordingEnabled := req.Config.GetBool("observer.recording.enabled")
+
+	// --- Raw observation recording ---
+	// When enabled, all incoming observations (metrics, logs, traces, profiles, trace stats)
+	// are written to parquet files as they arrive via the handle middleware.
+	var recordingDir string
+	var flushInterval time.Duration
+	var retentionDuration time.Duration
+
+	if recordingEnabled {
+		recordingDir = req.Config.GetString("observer.recording.parquet_output_dir")
+		if recordingDir == "" {
+			return Provides{Comp: r}, errors.New("observer.recording.parquet_output_dir not set")
+		}
+
+		flushInterval = req.Config.GetDuration("observer.recording.parquet_flush_interval")
+		if flushInterval == 0 {
+			flushInterval = 60 * time.Second
+		}
+
+		retentionDuration = req.Config.GetDuration("observer.recording.parquet_retention")
+		if retentionDuration <= 0 {
+			retentionDuration = 24 * time.Hour
+		}
+
+		writer, err := newMetricParquetWriter(recordingDir, flushInterval, retentionDuration)
+		if err != nil {
+			return Provides{Comp: r}, pkglog.Errorf("Failed to create metrics parquet writer: %v", err)
+		}
+		r.metricParquetWriter = writer
+
+		traceWriter, err := newTraceParquetWriter(recordingDir, flushInterval, retentionDuration)
+		if err != nil {
+			return Provides{Comp: r}, pkglog.Errorf("Failed to create trace parquet writer: %v", err)
+		}
+		r.traceParquetWriter = traceWriter
+
+		profileWriter, err := newProfileParquetWriter(recordingDir, flushInterval, retentionDuration)
+		if err != nil {
+			return Provides{Comp: r}, pkglog.Errorf("Failed to create profile parquet writer: %v", err)
+		}
+		r.profileParquetWriter = profileWriter
+
+		logWriter, err := newLogParquetWriter(recordingDir, flushInterval, retentionDuration)
+		if err != nil {
+			return Provides{Comp: r}, pkglog.Errorf("Failed to create log parquet writer: %v", err)
+		}
+		r.logParquetWriter = logWriter
+
+		traceStatsWriter, err := newTraceStatsParquetWriter(recordingDir, flushInterval, retentionDuration)
+		if err != nil {
+			return Provides{Comp: r}, pkglog.Errorf("Failed to create trace stats parquet writer: %v", err)
+		}
+		r.traceStatsParquetWriter = traceStatsWriter
+
+		pkglog.Infof("Recorder started: dir=%s flush=%v retention=%v", recordingDir, flushInterval, retentionDuration)
+	} else {
 		r.recordingDisabled = true
-		return Provides{Comp: r}, nil
+		pkglog.Debug("Recorder disabled (observer.recording.enabled=false)")
 	}
 
-	parquetDir := req.Config.GetString("observer.recording.parquet_output_dir")
-	if parquetDir == "" {
-		return Provides{Comp: r}, errors.New("observer.recording.parquet_output_dir not set")
-	}
+	// --- Results saving ---
+	// Writes computed intermediate data (virtual metrics from log detectors).
+	// Enabled by default when recording is on; can be enabled independently.
+	// The output directory defaults to the recording directory when unset.
+	resultsEnabled := recordingEnabled || req.Config.GetBool("observer.results.enabled")
+	fmt.Printf("[cc] resultsEnabled: %t\n", resultsEnabled)
+	if resultsEnabled {
+		resultsDir := req.Config.GetString("observer.results.output_dir")
+		if resultsDir == "" {
+			resultsDir = recordingDir // falls back to recording dir (may be empty if recording is off)
+		}
+		if resultsDir == "" {
+			pkglog.Warn("observer.results.enabled is true but no output directory configured; set observer.results.output_dir or observer.recording.parquet_output_dir")
+		} else {
+			// Reuse recording flush settings when available; fall back to sensible defaults.
+			resultsFlush := flushInterval
+			if resultsFlush == 0 {
+				resultsFlush = 60 * time.Second
+			}
+			resultsRetention := retentionDuration
 
-	flushInterval := req.Config.GetDuration("observer.recording.parquet_flush_interval")
-	if flushInterval == 0 {
-		flushInterval = 60 * time.Second
+			fmt.Printf("[cc] resultsDir: %s\n", resultsDir)
+			virtualWriter, err := newVirtualMetricParquetWriter(resultsDir, resultsFlush, resultsRetention)
+			if err != nil {
+				return Provides{Comp: r}, pkglog.Errorf("Failed to create virtual metrics parquet writer: %v", err)
+			}
+			r.virtualMetricParquetWriter = virtualWriter
+			pkglog.Infof("Results saving enabled: virtual metrics → %s", resultsDir)
+		}
 	}
-
-	retentionDuration := req.Config.GetDuration("observer.recording.parquet_retention")
-	if retentionDuration <= 0 {
-		retentionDuration = 24 * time.Hour
-	}
-
-	// Initialize metrics writer (always enabled when recording is on)
-	writer, err := newMetricParquetWriter(parquetDir, flushInterval, retentionDuration)
-	if err != nil {
-		return Provides{Comp: r}, pkglog.Errorf("Failed to create metrics parquet writer: %v", err)
-	}
-	r.metricParquetWriter = writer
-	pkglog.Infof("Recorder metrics writer started: dir=%s", parquetDir)
-
-	// Initialize virtual metrics writer for log-derived metrics
-	virtualMetricWriter, err := newVirtualMetricParquetWriter(parquetDir, flushInterval, retentionDuration)
-	if err != nil {
-		return Provides{Comp: r}, pkglog.Errorf("Failed to create virtual metrics parquet writer: %v", err)
-	}
-	r.virtualMetricParquetWriter = virtualMetricWriter
-	pkglog.Infof("Recorder virtual metrics writer started: dir=%s", parquetDir)
-
-	// Initialize traces writer (always enabled when recording is on)
-	traceWriter, err := newTraceParquetWriter(parquetDir, flushInterval, retentionDuration)
-	if err != nil {
-		return Provides{Comp: r}, pkglog.Errorf("Failed to create trace parquet writer: %v", err)
-	}
-	r.traceParquetWriter = traceWriter
-	pkglog.Infof("Recorder trace writer started: dir=%s", parquetDir)
-
-	// Initialize profiles writer (always enabled when recording is on)
-	profileWriter, err := newProfileParquetWriter(parquetDir, flushInterval, retentionDuration)
-	if err != nil {
-		return Provides{Comp: r}, pkglog.Errorf("Failed to create profile parquet writer: %v", err)
-	}
-	r.profileParquetWriter = profileWriter
-	pkglog.Infof("Recorder profile writer started: dir=%s", parquetDir)
-
-	// Initialize logs writer (always enabled when recording is on)
-	logWriter, err := newLogParquetWriter(parquetDir, flushInterval, retentionDuration)
-	if err != nil {
-		return Provides{Comp: r}, pkglog.Errorf("Failed to create log parquet writer: %v", err)
-	}
-	r.logParquetWriter = logWriter
-	pkglog.Infof("Recorder log writer started: dir=%s", parquetDir)
-
-	// Initialize trace stats writer (always enabled when recording is on)
-	traceStatsWriter, err := newTraceStatsParquetWriter(parquetDir, flushInterval, retentionDuration)
-	if err != nil {
-		return Provides{Comp: r}, pkglog.Errorf("Failed to create trace stats parquet writer: %v", err)
-	}
-	r.traceStatsParquetWriter = traceStatsWriter
-	pkglog.Infof("Recorder trace stats writer started: dir=%s", parquetDir)
 
 	return Provides{Comp: r}, nil
 }

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -61,6 +61,14 @@ func NewComponent(req Requires) (Provides, error) {
 	r.metricParquetWriter = writer
 	pkglog.Infof("Recorder metrics writer started: dir=%s", parquetDir)
 
+	// Initialize virtual metrics writer for log-derived metrics
+	virtualMetricWriter, err := newVirtualMetricParquetWriter(parquetDir, flushInterval, retentionDuration)
+	if err != nil {
+		return Provides{Comp: r}, pkglog.Errorf("Failed to create virtual metrics parquet writer: %v", err)
+	}
+	r.virtualMetricParquetWriter = virtualMetricWriter
+	pkglog.Infof("Recorder virtual metrics writer started: dir=%s", parquetDir)
+
 	// Initialize traces writer (always enabled when recording is on)
 	traceWriter, err := newTraceParquetWriter(parquetDir, flushInterval, retentionDuration)
 	if err != nil {
@@ -98,12 +106,13 @@ func NewComponent(req Requires) (Provides, error) {
 
 // recorderImpl implements the recorder component
 type recorderImpl struct {
-	recordingDisabled       bool
-	metricParquetWriter     *metricParquetWriter
-	traceParquetWriter      *traceParquetWriter
-	profileParquetWriter    *profileParquetWriter
-	logParquetWriter        *logParquetWriter
-	traceStatsParquetWriter *traceStatsParquetWriter
+	recordingDisabled          bool
+	metricParquetWriter        *metricParquetWriter
+	virtualMetricParquetWriter *metricParquetWriter
+	traceParquetWriter         *traceParquetWriter
+	profileParquetWriter       *profileParquetWriter
+	logParquetWriter           *logParquetWriter
+	traceStatsParquetWriter    *traceStatsParquetWriter
 }
 
 // GetHandle wraps the provided HandleFunc with recording capability.
@@ -237,6 +246,41 @@ func (r *recorderImpl) ReadAllLogs(inputDir string) ([]recorderdef.LogData, erro
 
 	pkglog.Infof("ReadAllLogs: loaded %d logs", len(logs))
 	return logs, nil
+}
+
+// EnableResultsSaving initializes the virtual metrics writer for headless mode.
+// It creates only the virtual metrics parquet writer, leaving raw observation writers
+// (metrics, logs, traces, profiles) uninitialized so that loaded input data is never
+// re-recorded. Safe to call multiple times; subsequent calls are no-ops.
+func (r *recorderImpl) EnableResultsSaving(outputDir string) error {
+	if r.virtualMetricParquetWriter != nil {
+		return nil // already initialized (either via full recording or a previous call)
+	}
+	// Use a very long flush interval: the testbench drives flushing explicitly via
+	// FlushVirtualMetrics(), so periodic flushing is not needed.
+	writer, err := newVirtualMetricParquetWriter(outputDir, 365*24*time.Hour, 0)
+	if err != nil {
+		return fmt.Errorf("creating virtual metrics parquet writer: %w", err)
+	}
+	r.virtualMetricParquetWriter = writer
+	pkglog.Infof("Results saving enabled: virtual metrics will be written to %s", outputDir)
+	return nil
+}
+
+// RecordVirtualMetric writes a log-derived virtual metric to the virtual metrics parquet file.
+func (r *recorderImpl) RecordVirtualMetric(source, name string, value float64, tags []string, timestamp int64) {
+	if r.virtualMetricParquetWriter == nil {
+		return
+	}
+	r.virtualMetricParquetWriter.WriteMetric(source, name, value, tags, timestamp)
+}
+
+// FlushVirtualMetrics forces an immediate flush of buffered virtual metrics to disk.
+func (r *recorderImpl) FlushVirtualMetrics() {
+	if r.virtualMetricParquetWriter == nil {
+		return
+	}
+	r.virtualMetricParquetWriter.flush()
 }
 
 // recordingHandle wraps an observer handle to record observations.

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -117,7 +117,14 @@ func NewComponent(req Requires) (Provides, error) {
 				return Provides{Comp: r}, pkglog.Errorf("Failed to create results metrics parquet writer: %v", err)
 			}
 			r.resultsMetricParquetWriter = resultsWriter
-			pkglog.Infof("Results saving enabled: results metrics → %s", resultsDir)
+
+			resultsLogWriter, err := newResultsLogParquetWriter(resultsDir, resultsFlush, resultsRetention)
+			if err != nil {
+				return Provides{Comp: r}, pkglog.Errorf("Failed to create results logs parquet writer: %v", err)
+			}
+			r.resultsLogParquetWriter = resultsLogWriter
+
+			pkglog.Infof("Results saving enabled: results metrics + logs → %s", resultsDir)
 		}
 	}
 
@@ -128,7 +135,8 @@ func NewComponent(req Requires) (Provides, error) {
 type recorderImpl struct {
 	recordingDisabled          bool
 	metricParquetWriter        *metricParquetWriter
-	resultsMetricParquetWriter *metricParquetWriter // observer-resultsmetrics-*.parquet (virtual + telemetry)
+	resultsMetricParquetWriter *metricParquetWriter // observer-resultsmetrics-*.parquet (virtual + telemetry metrics)
+	resultsLogParquetWriter    *logParquetWriter    // observer-resultslogs-*.parquet (telemetry logs)
 	traceParquetWriter         *traceParquetWriter
 	profileParquetWriter       *profileParquetWriter
 	logParquetWriter           *logParquetWriter
@@ -268,22 +276,29 @@ func (r *recorderImpl) ReadAllLogs(inputDir string) ([]recorderdef.LogData, erro
 	return logs, nil
 }
 
-// EnableResultsSaving initializes the results metrics writer for headless mode.
-// It creates only the results parquet writer, leaving raw observation writers
-// (metrics, logs, traces, profiles) uninitialized so that loaded input data is never
-// re-recorded. Safe to call multiple times; subsequent calls are no-ops.
+// EnableResultsSaving initializes the results writers for headless mode.
+// It creates only the results parquet writers (metrics + logs), leaving raw observation
+// writers (metrics, logs, traces, profiles) uninitialized so that loaded input data is
+// never re-recorded. Safe to call multiple times; subsequent calls are no-ops.
 func (r *recorderImpl) EnableResultsSaving(outputDir string) error {
 	if r.resultsMetricParquetWriter != nil {
 		return nil // already initialized (either via full recording or a previous call)
 	}
 	// Use a very long flush interval: the testbench drives flushing explicitly via
-	// FlushResultsMetrics(), so periodic flushing is not needed.
-	writer, err := newResultsMetricParquetWriter(outputDir, 365*24*time.Hour, 0)
+	// FlushResultsMetrics() / FlushResultsLogs(), so periodic flushing is not needed.
+	metricWriter, err := newResultsMetricParquetWriter(outputDir, 365*24*time.Hour, 0)
 	if err != nil {
 		return fmt.Errorf("creating results metrics parquet writer: %w", err)
 	}
-	r.resultsMetricParquetWriter = writer
-	pkglog.Infof("Results saving enabled: results metrics will be written to %s", outputDir)
+	r.resultsMetricParquetWriter = metricWriter
+
+	logWriter, err := newResultsLogParquetWriter(outputDir, 365*24*time.Hour, 0)
+	if err != nil {
+		return fmt.Errorf("creating results logs parquet writer: %w", err)
+	}
+	r.resultsLogParquetWriter = logWriter
+
+	pkglog.Infof("Results saving enabled: metrics + logs will be written to %s", outputDir)
 	return nil
 }
 
@@ -310,6 +325,22 @@ func (r *recorderImpl) FlushResultsMetrics() {
 		return
 	}
 	r.resultsMetricParquetWriter.flush()
+}
+
+// RecordTelemetryLog writes a detector telemetry log to the results logs parquet file.
+func (r *recorderImpl) RecordTelemetryLog(source string, content []byte, status, hostname string, tags []string, timestampMs int64) {
+	if r.resultsLogParquetWriter == nil {
+		return
+	}
+	r.resultsLogParquetWriter.WriteLog(source, content, status, hostname, tags, timestampMs)
+}
+
+// FlushResultsLogs forces an immediate flush of buffered results logs to disk.
+func (r *recorderImpl) FlushResultsLogs() {
+	if r.resultsLogParquetWriter == nil {
+		return
+	}
+	r.resultsLogParquetWriter.flush()
 }
 
 // recordingHandle wraps an observer handle to record observations.

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -38,7 +38,11 @@ func NewComponent(req Requires) (Provides, error) {
 	// are written to parquet files as they arrive via the handle middleware.
 	var recordingDir string
 	var flushInterval time.Duration
-	var retentionDuration time.Duration
+
+	retentionDuration := req.Config.GetDuration("observer.recording.parquet_retention")
+	if retentionDuration <= 0 {
+		retentionDuration = 24 * time.Hour
+	}
 
 	if recordingEnabled {
 		recordingDir = req.Config.GetString("observer.recording.parquet_output_dir")
@@ -49,11 +53,6 @@ func NewComponent(req Requires) (Provides, error) {
 		flushInterval = req.Config.GetDuration("observer.recording.parquet_flush_interval")
 		if flushInterval == 0 {
 			flushInterval = 60 * time.Second
-		}
-
-		retentionDuration = req.Config.GetDuration("observer.recording.parquet_retention")
-		if retentionDuration <= 0 {
-			retentionDuration = 24 * time.Hour
 		}
 
 		writer, err := newMetricParquetWriter(recordingDir, flushInterval, retentionDuration)

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -97,7 +97,6 @@ func NewComponent(req Requires) (Provides, error) {
 	// Enabled by default when recording is on; can be enabled independently.
 	// The output directory defaults to the recording directory when unset.
 	resultsEnabled := recordingEnabled || req.Config.GetBool("observer.results.enabled")
-	fmt.Printf("[cc] resultsEnabled: %t\n", resultsEnabled)
 	if resultsEnabled {
 		resultsDir := req.Config.GetString("observer.results.output_dir")
 		if resultsDir == "" {
@@ -113,13 +112,12 @@ func NewComponent(req Requires) (Provides, error) {
 			}
 			resultsRetention := retentionDuration
 
-			fmt.Printf("[cc] resultsDir: %s\n", resultsDir)
-			virtualWriter, err := newVirtualMetricParquetWriter(resultsDir, resultsFlush, resultsRetention)
+			resultsWriter, err := newResultsMetricParquetWriter(resultsDir, resultsFlush, resultsRetention)
 			if err != nil {
-				return Provides{Comp: r}, pkglog.Errorf("Failed to create virtual metrics parquet writer: %v", err)
+				return Provides{Comp: r}, pkglog.Errorf("Failed to create results metrics parquet writer: %v", err)
 			}
-			r.virtualMetricParquetWriter = virtualWriter
-			pkglog.Infof("Results saving enabled: virtual metrics → %s", resultsDir)
+			r.resultsMetricParquetWriter = resultsWriter
+			pkglog.Infof("Results saving enabled: results metrics → %s", resultsDir)
 		}
 	}
 
@@ -130,7 +128,7 @@ func NewComponent(req Requires) (Provides, error) {
 type recorderImpl struct {
 	recordingDisabled          bool
 	metricParquetWriter        *metricParquetWriter
-	virtualMetricParquetWriter *metricParquetWriter
+	resultsMetricParquetWriter *metricParquetWriter // observer-resultsmetrics-*.parquet (virtual + telemetry)
 	traceParquetWriter         *traceParquetWriter
 	profileParquetWriter       *profileParquetWriter
 	logParquetWriter           *logParquetWriter
@@ -270,39 +268,48 @@ func (r *recorderImpl) ReadAllLogs(inputDir string) ([]recorderdef.LogData, erro
 	return logs, nil
 }
 
-// EnableResultsSaving initializes the virtual metrics writer for headless mode.
-// It creates only the virtual metrics parquet writer, leaving raw observation writers
+// EnableResultsSaving initializes the results metrics writer for headless mode.
+// It creates only the results parquet writer, leaving raw observation writers
 // (metrics, logs, traces, profiles) uninitialized so that loaded input data is never
 // re-recorded. Safe to call multiple times; subsequent calls are no-ops.
 func (r *recorderImpl) EnableResultsSaving(outputDir string) error {
-	if r.virtualMetricParquetWriter != nil {
+	if r.resultsMetricParquetWriter != nil {
 		return nil // already initialized (either via full recording or a previous call)
 	}
 	// Use a very long flush interval: the testbench drives flushing explicitly via
-	// FlushVirtualMetrics(), so periodic flushing is not needed.
-	writer, err := newVirtualMetricParquetWriter(outputDir, 365*24*time.Hour, 0)
+	// FlushResultsMetrics(), so periodic flushing is not needed.
+	writer, err := newResultsMetricParquetWriter(outputDir, 365*24*time.Hour, 0)
 	if err != nil {
-		return fmt.Errorf("creating virtual metrics parquet writer: %w", err)
+		return fmt.Errorf("creating results metrics parquet writer: %w", err)
 	}
-	r.virtualMetricParquetWriter = writer
-	pkglog.Infof("Results saving enabled: virtual metrics will be written to %s", outputDir)
+	r.resultsMetricParquetWriter = writer
+	pkglog.Infof("Results saving enabled: results metrics will be written to %s", outputDir)
 	return nil
 }
 
-// RecordVirtualMetric writes a log-derived virtual metric to the virtual metrics parquet file.
+// RecordVirtualMetric writes a log-derived virtual metric to the results metrics parquet file.
 func (r *recorderImpl) RecordVirtualMetric(source, name string, value float64, tags []string, timestamp int64) {
-	if r.virtualMetricParquetWriter == nil {
+	if r.resultsMetricParquetWriter == nil {
 		return
 	}
-	r.virtualMetricParquetWriter.WriteMetric(source, name, value, tags, timestamp)
+	r.resultsMetricParquetWriter.WriteMetric(source, name, value, tags, timestamp)
 }
 
-// FlushVirtualMetrics forces an immediate flush of buffered virtual metrics to disk.
-func (r *recorderImpl) FlushVirtualMetrics() {
-	if r.virtualMetricParquetWriter == nil {
+// RecordTelemetryMetric writes a detector telemetry metric to the results metrics parquet file.
+// Telemetry metrics share the file with virtual metrics (observer-resultsmetrics-*.parquet).
+func (r *recorderImpl) RecordTelemetryMetric(source, name string, value float64, tags []string, timestamp int64) {
+	if r.resultsMetricParquetWriter == nil {
 		return
 	}
-	r.virtualMetricParquetWriter.flush()
+	r.resultsMetricParquetWriter.WriteMetric(source, name, value, tags, timestamp)
+}
+
+// FlushResultsMetrics forces an immediate flush of buffered results metrics to disk.
+func (r *recorderImpl) FlushResultsMetrics() {
+	if r.resultsMetricParquetWriter == nil {
+		return
+	}
+	r.resultsMetricParquetWriter.flush()
 }
 
 // recordingHandle wraps an observer handle to record observations.

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -124,7 +124,13 @@ func NewComponent(req Requires) (Provides, error) {
 			}
 			r.resultsLogParquetWriter = resultsLogWriter
 
-			pkglog.Infof("Results saving enabled: results metrics + logs → %s", resultsDir)
+			correlationWriter, err := newResultsCorrelationParquetWriter(resultsDir, resultsFlush, resultsRetention)
+			if err != nil {
+				return Provides{Comp: r}, pkglog.Errorf("Failed to create results correlations parquet writer: %v", err)
+			}
+			r.resultsCorrelationParquetWriter = correlationWriter
+
+			pkglog.Infof("Results saving enabled: results metrics + logs + correlations → %s", resultsDir)
 		}
 	}
 
@@ -133,14 +139,15 @@ func NewComponent(req Requires) (Provides, error) {
 
 // recorderImpl implements the recorder component
 type recorderImpl struct {
-	recordingDisabled          bool
-	metricParquetWriter        *metricParquetWriter
-	resultsMetricParquetWriter *metricParquetWriter // observer-resultsmetrics-*.parquet (virtual + telemetry metrics)
-	resultsLogParquetWriter    *logParquetWriter    // observer-resultslogs-*.parquet (telemetry logs)
-	traceParquetWriter         *traceParquetWriter
-	profileParquetWriter       *profileParquetWriter
-	logParquetWriter           *logParquetWriter
-	traceStatsParquetWriter    *traceStatsParquetWriter
+	recordingDisabled               bool
+	metricParquetWriter             *metricParquetWriter
+	resultsMetricParquetWriter      *metricParquetWriter      // observer-resultsmetrics-*.parquet (virtual + telemetry metrics)
+	resultsLogParquetWriter         *logParquetWriter         // observer-resultslogs-*.parquet (telemetry logs)
+	resultsCorrelationParquetWriter *correlationParquetWriter // observer-resultscorrelations-*.parquet (correlator output)
+	traceParquetWriter              *traceParquetWriter
+	profileParquetWriter            *profileParquetWriter
+	logParquetWriter                *logParquetWriter
+	traceStatsParquetWriter         *traceStatsParquetWriter
 }
 
 // GetHandle wraps the provided HandleFunc with recording capability.
@@ -298,7 +305,13 @@ func (r *recorderImpl) EnableResultsSaving(outputDir string) error {
 	}
 	r.resultsLogParquetWriter = logWriter
 
-	pkglog.Infof("Results saving enabled: metrics + logs will be written to %s", outputDir)
+	corrWriter, err := newResultsCorrelationParquetWriter(outputDir, 365*24*time.Hour, 0)
+	if err != nil {
+		return fmt.Errorf("creating results correlations parquet writer: %w", err)
+	}
+	r.resultsCorrelationParquetWriter = corrWriter
+
+	pkglog.Infof("Results saving enabled: metrics + logs + correlations will be written to %s", outputDir)
 	return nil
 }
 
@@ -341,6 +354,22 @@ func (r *recorderImpl) FlushResultsLogs() {
 		return
 	}
 	r.resultsLogParquetWriter.flush()
+}
+
+// RecordCorrelation writes a correlator output row to the results correlations parquet file.
+func (r *recorderImpl) RecordCorrelation(data recorderdef.CorrelationData) {
+	if r.resultsCorrelationParquetWriter == nil {
+		return
+	}
+	r.resultsCorrelationParquetWriter.WriteCorrelation(data)
+}
+
+// FlushResultsCorrelations forces an immediate flush of buffered correlation results to disk.
+func (r *recorderImpl) FlushResultsCorrelations() {
+	if r.resultsCorrelationParquetWriter == nil {
+		return
+	}
+	r.resultsCorrelationParquetWriter.flush()
 }
 
 // recordingHandle wraps an observer handle to record observations.

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"unicode"
 
+	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
@@ -41,6 +42,19 @@ func (a *LogMetricsExtractor) Process(log observer.LogView) observer.LogDetectio
 				Name:  "celian.is.the.best.questionmark",
 				Value: 1,
 				Tags:  log.GetTags(),
+			},
+		},
+		Telemetry: []observer.ObserverTelemetry{
+			{
+				Log: &logDataView{
+					data: &recorderdef.LogData{
+						Content:     []byte("Hello"),
+						Status:      log.GetStatus(),
+						Tags:        log.GetTags(),
+						TimestampMs: log.GetTimestampMs(),
+						Hostname:    log.GetHostname(),
+					},
+				},
 			},
 		},
 	}

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -34,27 +34,38 @@ type LogMetricsExtractor struct {
 func (a *LogMetricsExtractor) Name() string { return "log_metrics_extractor" }
 
 func (a *LogMetricsExtractor) Process(log observer.LogView) observer.LogDetectionResult {
-	content := log.GetContent()
-	tags := log.GetTags()
-
-	// Always emit pattern frequency metric for all logs
-	patternSig := logSignature(content, a.MaxEvalBytes)
-	if patternSig == "" {
-		return observer.LogDetectionResult{}
+	// TODO A
+	return observer.LogDetectionResult{
+		Metrics: []observer.MetricOutput{
+			{
+				Name:  "celian.is.the.best.questionmark",
+				Value: 1,
+				Tags:  log.GetTags(),
+			},
+		},
 	}
 
-	metrics := []observer.MetricOutput{{
-		Name:  patternCountMetricName(patternSig),
-		Value: 1,
-		Tags:  tags,
-	}}
+	// content := log.GetContent()
+	// tags := log.GetTags()
 
-	// For JSON logs, also extract numeric field metrics
-	if isJSONObject(content) {
-		metrics = append(metrics, a.extractJSONFieldMetrics(content, tags)...)
-	}
+	// // Always emit pattern frequency metric for all logs
+	// patternSig := logSignature(content, a.MaxEvalBytes)
+	// if patternSig == "" {
+	// 	return observer.LogDetectionResult{}
+	// }
 
-	return observer.LogDetectionResult{Metrics: metrics}
+	// metrics := []observer.MetricOutput{{
+	// 	Name:  patternCountMetricName(patternSig),
+	// 	Value: 1,
+	// 	Tags:  tags,
+	// }}
+
+	// // For JSON logs, also extract numeric field metrics
+	// if isJSONObject(content) {
+	// 	metrics = append(metrics, a.extractJSONFieldMetrics(content, tags)...)
+	// }
+
+	// return observer.LogDetectionResult{Metrics: metrics}
 }
 
 func isJSONObject(b []byte) bool {

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"unicode"
 
-	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
@@ -35,51 +34,27 @@ type LogMetricsExtractor struct {
 func (a *LogMetricsExtractor) Name() string { return "log_metrics_extractor" }
 
 func (a *LogMetricsExtractor) Process(log observer.LogView) observer.LogDetectionResult {
-	// TODO A
-	return observer.LogDetectionResult{
-		Metrics: []observer.MetricOutput{
-			{
-				Name:  "celian.is.the.best.questionmark",
-				Value: 1,
-				Tags:  log.GetTags(),
-			},
-		},
-		Telemetry: []observer.ObserverTelemetry{
-			{
-				Log: &logDataView{
-					data: &recorderdef.LogData{
-						Content:     []byte("Hello"),
-						Status:      log.GetStatus(),
-						Tags:        log.GetTags(),
-						TimestampMs: log.GetTimestampMs(),
-						Hostname:    log.GetHostname(),
-					},
-				},
-			},
-		},
+	content := log.GetContent()
+	tags := log.GetTags()
+
+	// Always emit pattern frequency metric for all logs
+	patternSig := logSignature(content, a.MaxEvalBytes)
+	if patternSig == "" {
+		return observer.LogDetectionResult{}
 	}
 
-	// content := log.GetContent()
-	// tags := log.GetTags()
+	metrics := []observer.MetricOutput{{
+		Name:  patternCountMetricName(patternSig),
+		Value: 1,
+		Tags:  tags,
+	}}
 
-	// // Always emit pattern frequency metric for all logs
-	// patternSig := logSignature(content, a.MaxEvalBytes)
-	// if patternSig == "" {
-	// 	return observer.LogDetectionResult{}
-	// }
+	// For JSON logs, also extract numeric field metrics
+	if isJSONObject(content) {
+		metrics = append(metrics, a.extractJSONFieldMetrics(content, tags)...)
+	}
 
-	// metrics := []observer.MetricOutput{{
-	// 	Name:  patternCountMetricName(patternSig),
-	// 	Value: 1,
-	// 	Tags:  tags,
-	// }}
-
-	// // For JSON logs, also extract numeric field metrics
-	// if isJSONObject(content) {
-	// 	metrics = append(metrics, a.extractJSONFieldMetrics(content, tags)...)
-	// }
-
-	// return observer.LogDetectionResult{Metrics: metrics}
+	return observer.LogDetectionResult{Metrics: metrics}
 }
 
 func isJSONObject(b []byte) bool {

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -230,6 +230,7 @@ func NewComponent(deps Requires) Provides {
 
 	if recorder, ok := deps.Recorder.Get(); ok {
 		obs.handleFunc = recorder.GetHandle(obs.handleFunc)
+		obs.recorder = recorder
 	}
 
 	go obs.run()
@@ -361,7 +362,8 @@ type observerImpl struct {
 	reporters      []observerdef.Reporter
 	storage        *timeSeriesStorage
 	obsCh          chan observation
-	handleFunc observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	handleFunc     observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	recorder       recorderdef.Component  // Optional: for recording virtual metrics from log detectors
 
 	// Raw anomaly tracking for test bench display
 	rawAnomalies     []observerdef.Anomaly
@@ -374,7 +376,7 @@ type observerImpl struct {
 	fetcher              *observerFetcher
 	totalAnomalyCount    int                             // total count of all anomalies ever detected (no cap)
 	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
-	lastAnalyzedDataTime int64 // data timestamp up to which we've analyzed
+	lastAnalyzedDataTime int64                           // data timestamp up to which we've analyzed
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -408,7 +410,11 @@ func (o *observerImpl) processLog(source string, l *logObs) {
 		result := detector.Process(view)
 		for _, m := range result.Metrics {
 			// Virtual metrics coming from logs starts with _virtual.
-			o.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
+			virtualName := "_virtual." + m.Name
+			o.storage.Add(source, virtualName, m.Value, l.timestampMs/1000, m.Tags)
+			if o.recorder != nil {
+				o.recorder.RecordVirtualMetric(source, virtualName, m.Value, m.Tags, l.timestampMs/1000)
+			}
 		}
 		// Route directly emitted anomalies through the standard pipeline
 		for _, anomaly := range result.Anomalies {

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -449,10 +449,34 @@ func (o *observerImpl) runDetectorsUpTo(upTo int64) {
 			o.captureRawAnomaly(anomaly)
 			o.processAnomaly(anomaly)
 		}
-		// TODO: handle result.Telemetry in live observer (currently only used by testbench)
+		o.recordTelemetry(result.Telemetry, detector.Name(), upTo)
 	}
 
 	o.flushAndReport()
+}
+
+// recordTelemetry records telemetry emitted by a detector to the results metrics parquet file.
+// Telemetry is not added to the observer's main storage to avoid polluting anomaly detection.
+func (o *observerImpl) recordTelemetry(telemetry []observerdef.ObserverTelemetry, detectorName string, baseTimestamp int64) {
+	if o.recorder == nil || len(telemetry) == 0 {
+		return
+	}
+	for _, t := range telemetry {
+		if t.DetectorName == "" {
+			t.DetectorName = detectorName
+		}
+		if t.Metric != nil {
+			ts := int64(t.Metric.GetTimestamp())
+			if ts == 0 {
+				ts = baseTimestamp
+			}
+			name := "telemetry." + t.DetectorName + "." + t.Metric.GetName()
+			o.recorder.RecordTelemetryMetric("telemetry", name, t.Metric.GetValue(), t.Metric.GetRawTags(), ts)
+		}
+		if t.Log != nil {
+			// TODO(results-logs): record telemetry logs to a results logs parquet file
+		}
+	}
 }
 
 // metricsDetectorAdapter wraps a stateless MetricsDetector to implement MultiSeriesDetector.

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -474,7 +474,16 @@ func (o *observerImpl) recordTelemetry(telemetry []observerdef.ObserverTelemetry
 			o.recorder.RecordTelemetryMetric("telemetry", name, t.Metric.GetValue(), t.Metric.GetRawTags(), ts)
 		}
 		if t.Log != nil {
-			// TODO(results-logs): record telemetry logs to a results logs parquet file
+			ts := t.Log.GetTimestampMs()
+			if ts == 0 {
+				ts = baseTimestamp * 1000
+			}
+			status := t.Log.GetStatus()
+			if status == "" {
+				status = "info"
+			}
+			tags := append(t.Log.GetTags(), "detector:"+t.DetectorName, "telemetry:true")
+			o.recorder.RecordTelemetryLog("telemetry", t.Log.GetContent(), status, t.Log.GetHostname(), tags, ts)
 		}
 	}
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -774,6 +774,43 @@ func (tb *TestBench) rerunDetectorsLocked() {
 			tb.correlations = append(tb.correlations, corr)
 		}
 
+		// Record finalized correlations to parquet (observer-resultscorrelations-*.parquet).
+		// Flushing is done separately in RunHeadless after this goroutine completes.
+		if recorder := tb.config.Recorder; recorder != nil {
+			for _, corr := range tb.correlations {
+				anomalyTimestamps := make([]int64, len(corr.Anomalies))
+				anomalySources := make([]string, len(corr.Anomalies))
+				anomalySeriesIDs := make([]string, len(corr.Anomalies))
+				anomalyDetectors := make([]string, len(corr.Anomalies))
+				for i, a := range corr.Anomalies {
+					anomalyTimestamps[i] = a.Timestamp
+					anomalySources[i] = string(a.Source)
+					anomalySeriesIDs[i] = string(a.SourceSeriesID)
+					anomalyDetectors[i] = a.DetectorName
+				}
+				memberIDs := make([]string, len(corr.MemberSeriesIDs))
+				for i, id := range corr.MemberSeriesIDs {
+					memberIDs[i] = string(id)
+				}
+				metricNames := make([]string, len(corr.MetricNames))
+				for i, n := range corr.MetricNames {
+					metricNames[i] = string(n)
+				}
+				recorder.RecordCorrelation(recorderdef.CorrelationData{
+					Pattern:           corr.Pattern,
+					Title:             corr.Title,
+					FirstSeen:         corr.FirstSeen,
+					LastUpdated:       corr.LastUpdated,
+					MemberSeriesIDs:   memberIDs,
+					MetricNames:       metricNames,
+					AnomalyTimestamps: anomalyTimestamps,
+					AnomalySources:    anomalySources,
+					AnomalySeriesIDs:  anomalySeriesIDs,
+					AnomalyDetectors:  anomalyDetectors,
+				})
+			}
+		}
+
 		tb.correlatorsProcessing = false
 		tb.correlatorsDone.Broadcast()
 	}()
@@ -1083,6 +1120,11 @@ func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) erro
 		tb.correlatorsDone.Wait()
 	}
 	tb.mu.RUnlock()
+
+	// Flush correlation results now that the goroutine has finished recording.
+	if tb.config.Recorder != nil {
+		tb.config.Recorder.FlushResultsCorrelations()
+	}
 
 	// Write structured JSON output.
 	if outputPath != "" {

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -612,10 +612,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 		fmt.Printf("  Warning: failed to run log detectors: %v\n", err)
 	}
 	if tb.config.Recorder != nil {
-		fmt.Printf("[cc] Flushing virtual metrics...\n")
-		tb.config.Recorder.FlushVirtualMetrics()
-	} else {
-		fmt.Printf("[cc] No recorder found, skipping flush of virtual metrics...\n")
+		tb.config.Recorder.FlushResultsMetrics()
 	}
 
 	// --- Metrics ---
@@ -781,22 +778,26 @@ func (tb *TestBench) rerunDetectorsLocked() {
 // It includes metrics and logs.
 func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, detectorName string, baseTimestampMs int64) {
 	for _, telemetryEvent := range telemetry {
-		// Generate missing fields if needed
+		if telemetryEvent.DetectorName == "" {
+			telemetryEvent.DetectorName = detectorName
+		}
+
 		if telemetryEvent.Metric != nil {
-			metric := &metricObs{
-				name:      telemetryEvent.Metric.GetName(),
-				value:     telemetryEvent.Metric.GetValue(),
-				tags:      telemetryEvent.Metric.GetRawTags(),
-				timestamp: int64(telemetryEvent.Metric.GetTimestamp()),
+			ts := int64(telemetryEvent.Metric.GetTimestamp())
+			if ts == 0 {
+				ts = baseTimestampMs / 1000
 			}
-			if metric.timestamp == 0 {
-				metric.timestamp = baseTimestampMs / 1000
+			name := "telemetry." + telemetryEvent.DetectorName + "." + telemetryEvent.Metric.GetName()
+			tags := telemetryEvent.Metric.GetRawTags()
+			value := telemetryEvent.Metric.GetValue()
+
+			// Store for UI display
+			tb.storage.Add("telemetry", name, value, ts, tags)
+
+			// Record to results metrics parquet file (observer-resultsmetrics-*.parquet)
+			if tb.config.Recorder != nil {
+				tb.config.Recorder.RecordTelemetryMetric("telemetry", name, value, tags, ts)
 			}
-			if telemetryEvent.DetectorName == "" {
-				telemetryEvent.DetectorName = detectorName
-			}
-			// Save this for UI
-			tb.storage.Add("telemetry", "telemetry."+telemetryEvent.DetectorName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
 		}
 
 		if telemetryEvent.Log != nil {
@@ -819,11 +820,9 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 			if log.Status == "" {
 				log.Status = "info"
 			}
-			if telemetryEvent.DetectorName == "" {
-				telemetryEvent.DetectorName = detectorName
-			}
-			// Save this for UI
+			// Store for UI display
 			tb.rawLogs = append(tb.rawLogs, &logDataView{data: &log})
+			// TODO(results-logs): record telemetry logs to a results logs parquet file
 		}
 	}
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -502,7 +502,11 @@ func (tb *TestBench) runLogDetectors() error {
 			result := detector.Process(log)
 			ts := log.GetTimestampMs()
 			for _, m := range result.Metrics {
-				tb.storage.Add("logs", "_virtual."+m.Name, m.Value, ts/1000, m.Tags)
+				virtualName := "_virtual." + m.Name
+				tb.storage.Add("logs", virtualName, m.Value, ts/1000, m.Tags)
+				if tb.config.Recorder != nil {
+					tb.config.Recorder.RecordVirtualMetric("logs", virtualName, m.Value, m.Tags, ts/1000)
+				}
 			}
 			for _, anomaly := range result.Anomalies {
 				// Fill in fields the detector may not have set
@@ -606,6 +610,12 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// We want to process logs first in case they produce metrics that are used by other detectors.
 	if err := tb.runLogDetectors(); err != nil {
 		fmt.Printf("  Warning: failed to run log detectors: %v\n", err)
+	}
+	if tb.config.Recorder != nil {
+		fmt.Printf("[cc] Flushing virtual metrics...\n")
+		tb.config.Recorder.FlushVirtualMetrics()
+	} else {
+		fmt.Printf("[cc] No recorder found, skipping flush of virtual metrics...\n")
 	}
 
 	// --- Metrics ---

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -611,9 +611,6 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	if err := tb.runLogDetectors(); err != nil {
 		fmt.Printf("  Warning: failed to run log detectors: %v\n", err)
 	}
-	if tb.config.Recorder != nil {
-		tb.config.Recorder.FlushResultsMetrics()
-	}
 
 	// --- Metrics ---
 	// Clear existing results
@@ -687,6 +684,14 @@ func (tb *TestBench) rerunDetectorsLocked() {
 			}
 		}
 		tb.handleTelemetry(multiResult.Telemetry, detector.Name(), dataTime)
+	}
+
+	// Flush results (virtual metrics, telemetry metrics, telemetry logs) now that all
+	// sync detector phases are done. This ensures headless runs capture everything
+	// including telemetry from metric detectors, not just from log detectors.
+	if tb.config.Recorder != nil {
+		tb.config.Recorder.FlushResultsMetrics()
+		tb.config.Recorder.FlushResultsLogs()
 	}
 
 	// --- Correlations ---
@@ -822,7 +827,11 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 			}
 			// Store for UI display
 			tb.rawLogs = append(tb.rawLogs, &logDataView{data: &log})
-			// TODO(results-logs): record telemetry logs to a results logs parquet file
+
+			// Record to results logs parquet file (observer-resultslogs-*.parquet)
+			if tb.config.Recorder != nil {
+				tb.config.Recorder.RecordTelemetryLog("telemetry", log.Content, log.Status, log.Hostname, log.Tags, log.TimestampMs)
+			}
 		}
 	}
 }

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -355,6 +355,13 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.recording.parquet_flush_interval", 60*time.Second)          // File rotation interval
 	config.BindEnvAndSetDefault("observer.recording.parquet_retention", 24*time.Hour)                 // Cleanup after 24 hours
 
+	// Observer results saving: writes computed intermediate data (virtual metrics from log detectors)
+	// Enabled by default whenever recording is on; can be enabled independently of recording.
+	// observer.results.enabled=true enables saving without full raw-observation recording.
+	// observer.results.output_dir defaults to observer.recording.parquet_output_dir when unset.
+	config.BindEnvAndSetDefault("observer.results.enabled", false)
+	config.BindEnvAndSetDefault("observer.results.output_dir", "")
+
 	// Observer component configuration for anomaly detection
 	config.BindEnvAndSetDefault("observer.analysis.enabled", true)
 	config.BindEnvAndSetDefault("observer.traces.fetch_interval", 5*time.Second)

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -12,6 +12,7 @@ def build_testbench(ctx):
     Builds the observer-testbench binary.
     """
     ctx.run("go build -o bin/observer-testbench ./cmd/observer-testbench")
+    print(color_message('Testbench built successfully!', Color.GREEN))
 
 
 @task
@@ -57,10 +58,13 @@ def deploy_k8s_agent(ctx, cluster_name: str = ""):
         uninstall_k8s_agent(ctx)
         ctx.run('helm install datadog-agent -f /tmp/datadog-values.yaml datadog/datadog')
 
+    print(color_message('Datadog Agent deployed successfully!', Color.GREEN))
+
 
 @task
 def uninstall_k8s_agent(ctx):
     ctx.run('helm uninstall datadog-agent')
+    print(color_message('Datadog Agent uninstalled successfully!', Color.GREEN))
 
 
 @task
@@ -86,7 +90,7 @@ def build_k8s_image(ctx, devenv_id: str = ""):
     ctx.run(
         "limactl shell --workdir '/home/lima.linux' gadget-k8s-host -- kind load docker-image observer-agent:latest --name gadget-dev"
     )
-    print(color_message('Done!', Color.GREEN))
+    print(color_message('Observer-agent image built and loaded into Kind successfully!', Color.GREEN))
 
 
 @task
@@ -103,4 +107,4 @@ def fetch_k8s_observer_parquet(ctx, dest: str = "/tmp/k8s-observer-metrics"):
 
     ctx.run(f"kubectl cp {datadog_agent_pod}:/tmp/observer-metrics {dest}")
 
-    print(color_message(f"Fetched observer parquet files to {dest}", Color.GREEN))
+    print(color_message(f"Fetched observer parquet files to {dest} successfully!", Color.GREEN))


### PR DESCRIPTION
### What does this PR do?

This adds config in the observer and testbench headless mode to save all intermediate results into parquet files.
This includes:
- Virtual metrics (metrics created by detectors)
- Telemetry (metrics / logs created by detectors for debugging)
- Correlators data

### Motivation

It will be useful to obtain results directly from gensim or from staging using the observer and not the testbench (we can compare both results).
Also, it will be faster to load only this without running the whole pipeline from the testbench UI (coming in a future PR).

### Describe how you validated your changes

Tried on my future PR to load everything.

### Additional Notes

Should we update the config and have a single flag in headless mode for the result json + all the parquet files?
