### PR TITLE
fix(ci): Prevent script failure retry on static_quality_gates

### DIFF
--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -1,4 +1,6 @@
 static_quality_gates:
+  inherit:
+    default: false
   stage: functional_test
   rules:
     - !reference [.except_coverage_pipeline] # Coverage pipeline creates a special artifact that will not pass the quality gate


### PR DESCRIPTION
### What does this PR do?

Adds `inherit: default: false` to the `static_quality_gates` job to prevent the global `default: retry: max: 1, when: always` from applying to this job.

The job already has its own `retry` block that only retries on infrastructure failures (runner_system_failure, stuck_or_timeout_failure, etc.) and exit code 42. However, the global default retry was also applying, causing the job to be retried once on script failures — which is undesirable as it delays merge queue feedback without adding value.

### Motivation

In pipeline 100828567, `static_quality_gates` failed with a script failure and was automatically retried due to the default `retry: max: 1, when: always`. This wastes CI time and delays merge queue results. The job should only retry on genuine infrastructure failures.

### Describe how you validated your changes

Reviewed the GitLab CI `default:` block — `retry` is the only setting defined there, so `inherit: default: false` has no side effects beyond disabling the default retry.

### Additional Notes

The `.retry_only_infra_failure` template (used by many other jobs) has the same retry config. Those jobs may also be affected by the default retry leaking through on script failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)