### PR TITLE
ci(dependencies): Prevent dependabot auto rebase

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: /
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go
@@ -41,6 +42,7 @@ updates:
           - patch
   - package-ecosystem: gomod
     directory: /pkg/trace
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go
@@ -62,6 +64,7 @@ updates:
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/gohai
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go
@@ -80,6 +83,7 @@ updates:
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/obfuscate
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go
@@ -98,6 +102,7 @@ updates:
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/security/secl
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go
@@ -114,6 +119,7 @@ updates:
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /internal/tools
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go
@@ -133,6 +139,7 @@ updates:
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /pkg/networkdevice/profile
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go
@@ -149,6 +156,7 @@ updates:
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /test/new-e2e
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go
@@ -180,6 +188,7 @@ updates:
     open-pull-requests-limit: 100
   - package-ecosystem: gomod
     directory: /test/fakeintake
+    rebase-strategy: disabled
     labels:
       - dependencies
       - dependencies-go


### PR DESCRIPTION
### What does this PR do?

Adds `rebase-strategy: disabled` to all 9 gomod entries in `.github/dependabot.yaml`. This prevents Dependabot from automatically rebasing its open PRs whenever the base branch is updated.

### Motivation

Dependabot's default behavior is to rebase open PRs mid-week whenever `main` moves forward. This creates unnecessary CI churn and noise. Disabling auto-rebase keeps PRs stable until their scheduled update day, reducing wasted CI resources and making the PR queue easier to manage.

This is a preparatory step for the Dependabot → Renovate migration.

### Describe how you validated your changes

Configuration-only change — validated YAML syntax. No functional code changes.

### Additional Notes

Only the `gomod` ecosystem entries are affected. The `github-actions`, `docker`, and `maven` entries were not modified as they have fewer open PRs and lower rebase churn.