### PR TITLE
feat(disco): Include sd-agent in hacky dev image build

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -552,7 +552,10 @@ def hacky_dev_image_build(
         build_dir = get_ebpf_build_dir(build_arch)
         runtime_dir = get_ebpf_runtime_dir()
 
-        copy_extra_agents += "COPY bin/system-probe/system-probe /opt/datadog-agent/embedded/bin/system-probe\n"
+        copy_extra_agents += (
+            "COPY bin/system-probe/system-probe /opt/datadog-agent/embedded/bin/system-probe\n"
+            "COPY pkg/discovery/module/rust/embedded/bin/sd-agent /opt/datadog-agent/embedded/bin/sd-agent\n"
+        )
         copy_ebpf_assets = f"""
 RUN mkdir -p /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/
 RUN mkdir -p /opt/datadog-agent/embedded/share/system-probe/ebpf/runtime/


### PR DESCRIPTION
### What does this PR do?

Adds a `COPY` instruction to the `hacky-dev-image-build` Dockerfile to include the `sd-agent` binary in the image when building with `--system-probe`.

The binary is copied from `pkg/discovery/module/rust/embedded/bin/sd-agent` (where `build_rust_binaries()` installs it) to `/opt/datadog-agent/embedded/bin/sd-agent` in the container.

### Motivation

The `sd-agent` binary was not included in the hacky dev image, making it unavailable for testing service discovery in dev environments.

### Describe how you validated your changes

Ran `dda inv agent.hacky-dev-image-build --base-image=datadog/agent-dev:nightly-main-py3 --system-probe` and confirmed the Docker build succeeds and the binary is present at `/opt/datadog-agent/embedded/bin/sd-agent` in the resulting image.