### PR TITLE
feat(ci): Migrate docker ecosystem from Dependabot to Renovate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -217,18 +217,6 @@ updates:
       - dependency-name: golang.org/x/*
       # OpenTelemetry packages need to be updated with `dda inv` rather than dependabot
       - dependency-name: go.opentelemetry.io/*
-  - package-ecosystem: docker
-    directory: /test/fakeintake
-    labels:
-      - dependencies
-      - team/agent-e2e-test
-      - changelog/no-changelog
-      - qa/no-code-change
-      - dev/testing
-    schedule:
-      interval: weekly
-      day: saturday
-    open-pull-requests-limit: 100
   - package-ecosystem: maven
     directory: Dockerfiles/agent/bouncycastle-fips
     labels:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "enabledManagers": ["custom.regex", "pre-commit", "github-actions"],
+    "enabledManagers": ["custom.regex", "pre-commit", "github-actions", "dockerfile"],
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
     "platformCommit": "enabled",
@@ -32,6 +32,11 @@
       {
         "matchManagers": ["github-actions"],
         "labels": ["dependencies", "dependencies-github-actions", "changelog/no-changelog", "qa/no-code-change"],
+        "schedule": ["on saturday"]
+      },
+      {
+        "matchManagers": ["dockerfile"],
+        "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
         "schedule": ["on saturday"]
       }
     ],


### PR DESCRIPTION
### What does this PR do?

Phase 2 of the Dependabot → Renovate migration: migrates the `docker` ecosystem to Renovate.

**Changes:**
- **`renovate.json`**: Added `dockerfile` to `enabledManagers` with Saturday schedule and standard labels
- **`.github/dependabot.yaml`**: Removed the `docker` ecosystem section for `/test/fakeintake`

### Motivation

Continuation of the Dependabot → Renovate migration started in #47179 (Phase 1: github-actions).

Renovate's `dockerfile` manager will automatically discover all Dockerfiles in the repo (16 files) and manage base image updates (e.g. `golang`, `alpine` versions in `test/fakeintake/Dockerfile`). This replaces the Dependabot docker config which only covered `test/fakeintake/`.

### Describe how you validated your changes

- Pre-commit hooks pass
- Renovate config follows the [Renovate docs schema](https://docs.renovatebot.com/renovate-schema.json)
- Verified all 16 Dockerfiles in the repo have CODEOWNERS coverage

### Additional Notes

This is Phase 2 of a 5-phase migration. Next phases will migrate `maven` and `gomod` ecosystems, then delete `dependabot.yaml` entirely.

Predecessor: https://github.com/DataDog/datadog-agent/commit/e87e9f635b1a96e13ae5005ac97084f29e2172c7