### PR TITLE
fix(fleet): Make SetPackageVersion idempotent to preserve extensions list

### DIFF
--- a/pkg/fleet/installer/packages/extensions/db.go
+++ b/pkg/fleet/installer/packages/extensions/db.go
@@ -135,6 +135,12 @@ func (p *extensionsDB) SetPackageVersion(pkg string, version string, isExperimen
 		if b == nil {
 			return errors.New("bucket not found")
 		}
+		if existing := b.Get(getKey(pkg, isExperiment)); len(existing) > 0 {
+			var existingPkg dbPackage
+			if err := json.Unmarshal(existing, &existingPkg); err == nil && existingPkg.Version == version {
+				return nil
+			}
+		}
 		dbPkg := dbPackage{
 			Name:    pkg,
 			Version: version,

--- a/pkg/fleet/installer/packages/extensions/extensions_test.go
+++ b/pkg/fleet/installer/packages/extensions/extensions_test.go
@@ -82,6 +82,55 @@ func TestPackageKeyDifferentiation(t *testing.T) {
 	assert.NotContains(t, experiment.Extensions, "python", "experiment should not have stable extensions")
 }
 
+// TestSetPackageVersionIdempotent verifies that calling SetPackageVersion with the same
+// pkg, version, and isExperiment does not wipe the extensions list.
+func TestSetPackageVersionIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := newExtensionsDB(filepath.Join(tmpDir, "extensions.db"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	pkg := dbPackage{
+		Name:       "datadog-agent",
+		Version:    "7.50.0",
+		Extensions: map[string]struct{}{"python": {}, "ruby": {}},
+	}
+	err = db.SetPackage(pkg, false)
+	require.NoError(t, err)
+
+	err = db.SetPackageVersion("datadog-agent", "7.50.0", false)
+	require.NoError(t, err)
+
+	got, err := db.GetPackage("datadog-agent", false)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]struct{}{"python": {}, "ruby": {}}, got.Extensions, "extensions should be preserved after idempotent SetPackageVersion")
+}
+
+// TestSetPackageVersionWipesExtensionsOnVersionChange verifies that calling SetPackageVersion
+// with a new version resets the extensions list (intentional behavior).
+func TestSetPackageVersionWipesExtensionsOnVersionChange(t *testing.T) {
+	tmpDir := t.TempDir()
+	db, err := newExtensionsDB(filepath.Join(tmpDir, "extensions.db"))
+	require.NoError(t, err)
+	defer db.Close()
+
+	pkg := dbPackage{
+		Name:       "datadog-agent",
+		Version:    "7.50.0",
+		Extensions: map[string]struct{}{"python": {}},
+	}
+	err = db.SetPackage(pkg, false)
+	require.NoError(t, err)
+
+	err = db.SetPackageVersion("datadog-agent", "7.51.0", false)
+	require.NoError(t, err)
+
+	got, err := db.GetPackage("datadog-agent", false)
+	require.NoError(t, err)
+	assert.Equal(t, "7.51.0", got.Version)
+	assert.Empty(t, got.Extensions, "extensions should be wiped on version change")
+}
+
 // TestHookErrorPropagation verifies that hook failures are properly propagated
 // as errors rather than being silently ignored.
 //


### PR DESCRIPTION
### What does this PR do?

Makes `SetPackageVersion` in `extensionsDB` idempotent: if the existing DB entry already has the same package name, version, and experiment flag, the function returns early without writing, preserving the extensions list.

Previously, calling `SetPackageVersion` a second time with the same arguments would overwrite the entry with a fresh `dbPackage` (no extensions), silently wiping all registered extensions for that package.

### Motivation

`SetPackageVersion` is called to record which version of a package is installed. If it is called again (e.g. on agent restart or retry), it should be a no-op when nothing changed. The previous behavior caused extensions to be lost on any redundant call.

### Describe how you validated your changes

Added two unit tests:
- `TestSetPackageVersionIdempotent`: sets a package with extensions, calls `SetPackageVersion` again with the same version, and asserts the extensions are still present.
- `TestSetPackageVersionWipesExtensionsOnVersionChange`: verifies the existing behavior is preserved when the version actually changes (extensions are intentionally reset).

Both tests pass.

### Additional Notes

The fix reads the existing DB entry inside the same bbolt write transaction before deciding whether to proceed, so there is no TOCTOU race.