### PR TITLE
Send an event with testbench

### DIFF
--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -105,12 +105,14 @@ func main() {
 	}
 }
 
-func run(recorder recorderdef.Component, params CLIParams) error {
+func run(recorder recorderdef.Component, cfg config.Component, logger log.Component, params CLIParams) error {
 	// Create the test bench
 	tb, err := observerimpl.NewTestBench(observerimpl.TestBenchConfig{
 		ScenariosDir:    params.ScenariosDir,
 		HTTPAddr:        params.HTTPAddr,
 		Recorder:        recorder,
+		Cfg:             cfg,
+		Logger:          logger,
 		EnableOverrides: params.EnableOverrides,
 	})
 	if err != nil {

--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -37,6 +37,10 @@ type CLIParams struct {
 	Headless string // scenario name to run (empty = interactive mode)
 	Output   string // path for observer JSON output
 	Verbose  bool   // include full detail in JSON output (headless mode only)
+
+	// SendAnomalyEvent mode: run scenario and send one Datadog event per correlation
+	SendAnomalyEvent string // scenario name to run (empty = disabled)
+	DryRun           bool   // print events to stdout instead of sending them
 }
 
 func main() {
@@ -47,6 +51,8 @@ func main() {
 	headless := flag.String("headless", "", "Run scenario in headless mode (no HTTP server) and exit")
 	output := flag.String("output", "", "Path for eval JSON output (headless mode only)")
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
+	sendAnomalyEvent := flag.String("send-anomaly-event", "", "Run scenario and send one Datadog event per correlation, then exit")
+	dryRun := flag.Bool("dry-run", false, "Print events to stdout instead of sending them (use with --send-anomaly-event)")
 	flag.Parse()
 
 	overrides := make(map[string]bool)
@@ -83,12 +89,14 @@ func main() {
 			LogParams:    log.ForOneShot("", "off", true),
 		}),
 		fx.Supply(CLIParams{
-			ScenariosDir:      *scenariosDir,
-			HTTPAddr:          *httpAddr,
-			EnableOverrides:   overrides,
-			Headless:          *headless,
-			Output:            *output,
-			Verbose:           *verbose,
+			ScenariosDir:     *scenariosDir,
+			HTTPAddr:         *httpAddr,
+			EnableOverrides:  overrides,
+			Headless:         *headless,
+			Output:           *output,
+			Verbose:          *verbose,
+			SendAnomalyEvent: *sendAnomalyEvent,
+			DryRun:           *dryRun,
 		}),
 	)
 	if err != nil {
@@ -108,6 +116,11 @@ func run(recorder recorderdef.Component, params CLIParams) error {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create test bench: %v\n", err)
 		return err
+	}
+
+	// SendAnomalyEvent mode: run scenario and send one Datadog event per correlation, then exit.
+	if params.SendAnomalyEvent != "" {
+		return tb.RunSendAnomalyEvents(params.SendAnomalyEvent, params.DryRun)
 	}
 
 	// Headless mode: run scenario, write output, exit (no HTTP server)

--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -40,7 +40,6 @@ type CLIParams struct {
 
 	// SendAnomalyEvent mode: run scenario and send one Datadog event per correlation
 	SendAnomalyEvent string // scenario name to run (empty = disabled)
-	DryRun           bool   // print events to stdout instead of sending them
 }
 
 func main() {
@@ -52,7 +51,6 @@ func main() {
 	output := flag.String("output", "", "Path for eval JSON output (headless mode only)")
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
 	sendAnomalyEvent := flag.String("send-anomaly-event", "", "Run scenario and send one Datadog event per correlation, then exit")
-	dryRun := flag.Bool("dry-run", false, "Print events to stdout instead of sending them (use with --send-anomaly-event)")
 	flag.Parse()
 
 	overrides := make(map[string]bool)
@@ -96,7 +94,6 @@ func main() {
 			Output:           *output,
 			Verbose:          *verbose,
 			SendAnomalyEvent: *sendAnomalyEvent,
-			DryRun:           *dryRun,
 		}),
 	)
 	if err != nil {
@@ -122,7 +119,7 @@ func run(recorder recorderdef.Component, cfg config.Component, logger log.Compon
 
 	// SendAnomalyEvent mode: run scenario and send one Datadog event per correlation, then exit.
 	if params.SendAnomalyEvent != "" {
-		return tb.RunSendAnomalyEvents(params.SendAnomalyEvent, params.DryRun)
+		return tb.RunSendAnomalyEvents(params.SendAnomalyEvent)
 	}
 
 	// Headless mode: run scenario, write output, exit (no HTTP server)

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -9,32 +9,33 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
-	"os"
 	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 
+	config "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
 // eventSender formats and dispatches one Datadog event per correlation.
 // When api is nil, send prints to stdout (dry-run mode) instead of calling the API.
 type eventSender struct {
-	api *datadogV2.EventsApi
-	ctx context.Context
+	api    *datadogV2.EventsApi
+	ctx    context.Context
+	logger log.Component
 }
 
 // newEventSender creates an eventSender. When dryRun is true, api is left nil.
-func newEventSender(dryRun bool) (*eventSender, error) {
+func newEventSender(cfg config.Component, logger log.Component, dryRun bool) (*eventSender, error) {
 	if dryRun {
-		return &eventSender{}, nil
+		return &eventSender{logger: logger}, nil
 	}
-	apiKey := os.Getenv("DD_API_KEY")
+	apiKey := cfg.GetString("api_key")
 	if apiKey == "" {
-		return nil, fmt.Errorf("DD_API_KEY environment variable is not set")
+		return nil, fmt.Errorf("api_key is not set in configuration")
 	}
 	ctx := context.WithValue(
 		datadog.NewDefaultContext(context.Background()),
@@ -42,8 +43,9 @@ func newEventSender(dryRun bool) (*eventSender, error) {
 		map[string]datadog.APIKey{"apiKeyAuth": {Key: apiKey}},
 	)
 	return &eventSender{
-		api: datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
-		ctx: ctx,
+		api:    datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
+		ctx:    ctx,
+		logger: logger,
 	}, nil
 }
 
@@ -80,7 +82,7 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 	text := correlationMessage(c)
 	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
 
-	log.Printf("[observer] sending event: pattern=%s title=%q timestamp=%s\n%s\n", c.Pattern, c.Title, ts, text)
+	s.logger.Infof("[observer] sending event: pattern=%s title=%q timestamp=%s\n%s\n", c.Pattern, c.Title, ts, text)
 
 	if s.api == nil {
 		fmt.Printf("[dry-run] pattern=%s title=%q timestamp=%s\n%s\n\n", c.Pattern, c.Title, ts, text)
@@ -107,15 +109,15 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 		body, readErr := io.ReadAll(httpResp.Body)
 		httpResp.Body.Close()
 		if readErr == nil {
-			log.Printf("[observer] API error response (HTTP %d): %s", httpResp.StatusCode, string(body))
+			s.logger.Errorf("[observer] API error response (HTTP %d): %s", httpResp.StatusCode, string(body))
 		}
 	}
 	return err
 }
 
 // sendCorrelationEvents creates a sender and dispatches one event per correlation.
-func sendCorrelationEvents(correlations []observerdef.ActiveCorrelation, dryRun bool) error {
-	sender, err := newEventSender(dryRun)
+func sendCorrelationEvents(correlations []observerdef.ActiveCorrelation, cfg config.Component, logger log.Component, dryRun bool) error {
+	sender, err := newEventSender(cfg, logger, dryRun)
 	if err != nil {
 		return err
 	}

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -8,6 +8,8 @@ package observerimpl
 import (
 	"context"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -45,17 +47,40 @@ func newEventSender(dryRun bool) (*eventSender, error) {
 	}, nil
 }
 
-// send formats a correlation into an event and either prints or posts it.
-func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
-	var lines []string
+// correlationMessage builds the event message body for a correlation.
+func correlationMessage(c observerdef.ActiveCorrelation) string {
+	var metricLines, logLines []string
 	for _, a := range c.Anomalies {
-		if a.Description != "" {
-			lines = append(lines, "- "+a.Description)
+		if a.Description == "" {
+			continue
+		}
+		if a.Type == observerdef.AnomalyTypeLog {
+			logLines = append(logLines, "- "+a.Description)
+		} else {
+			metricLines = append(metricLines, "- "+a.Description)
 		}
 	}
-	intro := fmt.Sprintf("The following %d metric anomalies were detected and are likely related:", len(lines))
-	text := intro + "\n" + strings.Join(lines, "\n")
+	var sections []string
+	if len(metricLines) > 0 {
+		sections = append(sections, fmt.Sprintf("Metric anomalies (%d):\n%s", len(metricLines), strings.Join(metricLines, "\n")))
+	}
+	if len(logLines) > 0 {
+		sections = append(sections, fmt.Sprintf("Log anomalies (%d):\n%s", len(logLines), strings.Join(logLines, "\n")))
+	}
+	const maxLen = 4000
+	text := "The following anomalies were detected and are likely related:\n\n" + strings.Join(sections, "\n\n")
+	if len(text) > maxLen {
+		text = text[:maxLen-3] + "..."
+	}
+	return text
+}
+
+// send formats a correlation into an event and either prints or posts it.
+func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
+	text := correlationMessage(c)
 	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
+
+	log.Printf("[observer] sending event: pattern=%s title=%q timestamp=%s\n%s\n", c.Pattern, c.Title, ts, text)
 
 	if s.api == nil {
 		fmt.Printf("[dry-run] pattern=%s title=%q timestamp=%s\n%s\n\n", c.Pattern, c.Title, ts, text)
@@ -77,7 +102,14 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 			},
 		},
 	}
-	_, _, err := s.api.CreateEvent(s.ctx, payload)
+	_, httpResp, err := s.api.CreateEvent(s.ctx, payload)
+	if err != nil && httpResp != nil {
+		body, readErr := io.ReadAll(httpResp.Body)
+		httpResp.Body.Close()
+		if readErr == nil {
+			log.Printf("[observer] API error response (HTTP %d): %s", httpResp.StatusCode, string(body))
+		}
+	}
 	return err
 }
 

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// eventSender formats and dispatches one Datadog event per correlation.
+// When api is nil, send prints to stdout (dry-run mode) instead of calling the API.
+type eventSender struct {
+	api *datadogV2.EventsApi
+	ctx context.Context
+}
+
+// newEventSender creates an eventSender. When dryRun is true, api is left nil.
+func newEventSender(dryRun bool) (*eventSender, error) {
+	if dryRun {
+		return &eventSender{}, nil
+	}
+	apiKey := os.Getenv("DD_API_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("DD_API_KEY environment variable is not set")
+	}
+	ctx := context.WithValue(
+		datadog.NewDefaultContext(context.Background()),
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{"apiKeyAuth": {Key: apiKey}},
+	)
+	return &eventSender{
+		api: datadogV2.NewEventsApi(datadog.NewAPIClient(datadog.NewConfiguration())),
+		ctx: ctx,
+	}, nil
+}
+
+// send formats a correlation into an event and either prints or posts it.
+func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
+	var lines []string
+	for _, a := range c.Anomalies {
+		if a.Description != "" {
+			lines = append(lines, "- "+a.Description)
+		}
+	}
+	intro := fmt.Sprintf("The following %d metric anomalies were detected and are likely related:", len(lines))
+	text := intro + "\n" + strings.Join(lines, "\n")
+	ts := time.Unix(c.FirstSeen, 0).UTC().Format(time.RFC3339)
+
+	if s.api == nil {
+		fmt.Printf("[dry-run] pattern=%s title=%q timestamp=%s\n%s\n\n", c.Pattern, c.Title, ts, text)
+		return nil
+	}
+
+	attrs := datadogV2.AlertEventCustomAttributesAsEventPayloadAttributes(
+		datadogV2.NewAlertEventCustomAttributes(datadogV2.ALERTEVENTCUSTOMATTRIBUTESSTATUS_ERROR),
+	)
+	payload := datadogV2.EventCreateRequestPayload{
+		Data: datadogV2.EventCreateRequest{
+			Type: datadogV2.EVENTCREATEREQUESTTYPE_EVENT,
+			Attributes: datadogV2.EventPayload{
+				Title:      c.Title,
+				Message:    datadog.PtrString(text),
+				Category:   datadogV2.EVENTCATEGORY_ALERT,
+				Tags:       []string{"source:agent-q-branch-observer", "pattern:" + c.Pattern},
+				Attributes: attrs,
+			},
+		},
+	}
+	_, _, err := s.api.CreateEvent(s.ctx, payload)
+	return err
+}
+
+// sendCorrelationEvents creates a sender and dispatches one event per correlation.
+func sendCorrelationEvents(correlations []observerdef.ActiveCorrelation, dryRun bool) error {
+	sender, err := newEventSender(dryRun)
+	if err != nil {
+		return err
+	}
+	for _, c := range correlations {
+		if err := sender.send(c); err != nil {
+			return fmt.Errorf("sending event for pattern %q: %w", c.Pattern, err)
+		}
+	}
+	return nil
+}

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -115,14 +115,10 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 	return err
 }
 
-// sendCorrelationEvents creates a sender and dispatches one event per correlation.
-func sendCorrelationEvents(correlations []observerdef.ActiveCorrelation, cfg config.Component, logger log.Component, dryRun bool) error {
-	sender, err := newEventSender(cfg, logger, dryRun)
-	if err != nil {
-		return err
-	}
+// sendCorrelationEvents dispatches one event per correlation.
+func (s *eventSender) sendCorrelationEvents(correlations []observerdef.ActiveCorrelation) error {
 	for _, c := range correlations {
-		if err := sender.send(c); err != nil {
+		if err := s.send(c); err != nil {
 			return fmt.Errorf("sending event for pattern %q: %w", c.Pattern, err)
 		}
 	}

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -28,9 +28,10 @@ type eventSender struct {
 	logger log.Component
 }
 
-// newEventSender creates an eventSender. When dryRun is true, api is left nil.
-func newEventSender(cfg config.Component, logger log.Component, dryRun bool) (*eventSender, error) {
-	if dryRun {
+// newEventSender creates an eventSender. It reads observer.event_reporter.sending_enabled
+// from cfg; when false, api is left nil and events are only logged (dry-run mode).
+func newEventSender(cfg config.Component, logger log.Component) (*eventSender, error) {
+	if !cfg.GetBool("observer.event_reporter.sending_enabled") {
 		return &eventSender{logger: logger}, nil
 	}
 	apiKey := cfg.GetString("api_key")
@@ -109,18 +110,17 @@ func (s *eventSender) send(c observerdef.ActiveCorrelation) error {
 		body, readErr := io.ReadAll(httpResp.Body)
 		httpResp.Body.Close()
 		if readErr == nil {
-			s.logger.Errorf("[observer] API error response (HTTP %d): %s", httpResp.StatusCode, string(body))
+			return fmt.Errorf("API error (HTTP %d): %s", httpResp.StatusCode, string(body))
 		}
 	}
 	return err
 }
 
-// sendCorrelationEvents dispatches one event per correlation.
-func (s *eventSender) sendCorrelationEvents(correlations []observerdef.ActiveCorrelation) error {
+// sendCorrelationEvents sends one event per correlation.
+func (s *eventSender) sendCorrelationEvents(correlations []observerdef.ActiveCorrelation) {
 	for _, c := range correlations {
 		if err := s.send(c); err != nil {
-			return fmt.Errorf("sending event for pattern %q: %w", c.Pattern, err)
+			s.logger.Errorf("[observer] failed to send event for pattern %s: %v", c.Pattern, err)
 		}
 	}
-	return nil
 }

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
+	config "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
@@ -28,6 +30,9 @@ type Requires struct {
 	// AgentInternalLogTap provides optional overrides for capturing agent-internal logs.
 	// When fields are nil, values are read from configuration defaults.
 	AgentInternalLogTap AgentInternalLogTapConfig
+
+	Config config.Component
+	Log    log.Component
 
 	// Recorder is an optional component for transparent metric recording.
 	// If provided, all handles will be wrapped to record metrics to parquet files.
@@ -209,11 +214,9 @@ func NewComponent(deps Requires) Provides {
 		correlators: []observerdef.Correlator{
 			correlator,
 		},
-		reporters: []observerdef.Reporter{
-			reporter,
-		},
-		storage: newTimeSeriesStorage(),
-		obsCh:   make(chan observation, 1000),
+		reporters: []observerdef.Reporter{reporter},
+		storage:   newTimeSeriesStorage(),
+		obsCh:     make(chan observation, 1000),
 	}
 
 	cfg := pkgconfigsetup.Datadog()
@@ -230,6 +233,17 @@ func NewComponent(deps Requires) Provides {
 
 	if recorder, ok := deps.Recorder.Get(); ok {
 		obs.handleFunc = recorder.GetHandle(obs.handleFunc)
+	}
+
+	// Optionally add the event reporter when sending is enabled via config.
+	if deps.Config.GetBool("observer.event_reporter.sending_enabled") {
+		if sender, err := newEventSender(deps.Config, deps.Log); err != nil {
+			deps.Log.Warnf("[observer] event_reporter disabled: %v", err)
+		} else {
+			eventReporter := &EventReporter{sender: sender, logger: deps.Log}
+			eventReporter.SetCorrelationState(correlator)
+			obs.reporters = append(obs.reporters, eventReporter)
+		}
 	}
 
 	go obs.run()
@@ -361,7 +375,7 @@ type observerImpl struct {
 	reporters      []observerdef.Reporter
 	storage        *timeSeriesStorage
 	obsCh          chan observation
-	handleFunc observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
+	handleFunc     observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
 
 	// Raw anomaly tracking for test bench display
 	rawAnomalies     []observerdef.Anomaly
@@ -374,7 +388,7 @@ type observerImpl struct {
 	fetcher              *observerFetcher
 	totalAnomalyCount    int                             // total count of all anomalies ever detected (no cap)
 	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
-	lastAnalyzedDataTime int64 // data timestamp up to which we've analyzed
+	lastAnalyzedDataTime int64                           // data timestamp up to which we've analyzed
 }
 
 // run is the main dispatch loop, processing all observations sequentially.

--- a/comp/observer/impl/reporter_event.go
+++ b/comp/observer/impl/reporter_event.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// EventReporter sends Datadog events for new correlations via eventSender.
+// It tracks seen correlations and only fires when a correlation first appears.
+type EventReporter struct {
+	sender           *eventSender
+	logger           log.Component
+	correlationState observerdef.CorrelationState
+	seenCorrelations map[string]bool // pattern -> reported
+}
+
+// Name returns the reporter name.
+func (r *EventReporter) Name() string {
+	return "event_reporter"
+}
+
+// SetCorrelationState sets the correlation state source for the reporter.
+func (r *EventReporter) SetCorrelationState(state observerdef.CorrelationState) {
+	r.correlationState = state
+	r.seenCorrelations = make(map[string]bool)
+}
+
+// Report checks for new correlations and sends an event for each one.
+func (r *EventReporter) Report(_ observerdef.ReportOutput) {
+	if r.correlationState == nil {
+		return
+	}
+
+	activeCorrelations := r.correlationState.ActiveCorrelations()
+
+	// Build the set of currently active patterns.
+	currentlyActive := make(map[string]bool, len(activeCorrelations))
+	for _, ac := range activeCorrelations {
+		currentlyActive[ac.Pattern] = true
+	}
+
+	// Send an event for each newly-seen correlation.
+	for _, ac := range activeCorrelations {
+		if !r.seenCorrelations[ac.Pattern] {
+			if err := r.sender.send(ac); err != nil {
+				r.logger.Errorf("[observer] failed to send event for pattern %s: %v", ac.Pattern, err)
+			}
+			r.seenCorrelations[ac.Pattern] = true
+		}
+	}
+
+	// Remove correlations that are no longer active so they can fire again if they recur.
+	for pattern := range r.seenCorrelations {
+		if !currentlyActive[pattern] {
+			delete(r.seenCorrelations, pattern)
+		}
+	}
+}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1094,7 +1094,11 @@ func (tb *TestBench) RunSendAnomalyEvents(scenario string, dryRun bool) error {
 	for tb.correlatorsProcessing {
 		tb.correlatorsDone.Wait()
 	}
-	return sendCorrelationEvents(tb.correlations, tb.config.Cfg, tb.config.Logger, dryRun)
+	sender, err := newEventSender(tb.config.Cfg, tb.config.Logger, dryRun)
+	if err != nil {
+		return err
+	}
+	return sender.sendCorrelationEvents(tb.correlations)
 }
 
 // ToggleComponent toggles a component's enabled state and re-runs analyses if needed.

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
+	config "github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
@@ -82,6 +84,8 @@ type TestBenchConfig struct {
 	ScenariosDir string
 	HTTPAddr     string
 	Recorder     recorderdef.Component // Optional: for loading parquet scenarios
+	Cfg          config.Component
+	Logger       log.Component
 
 	// EnableOverrides controls which components are enabled at startup.
 	// Keys are component names (e.g. "cusum", "lead_lag").
@@ -1090,7 +1094,7 @@ func (tb *TestBench) RunSendAnomalyEvents(scenario string, dryRun bool) error {
 	for tb.correlatorsProcessing {
 		tb.correlatorsDone.Wait()
 	}
-	return sendCorrelationEvents(tb.correlations, dryRun)
+	return sendCorrelationEvents(tb.correlations, tb.config.Cfg, tb.config.Logger, dryRun)
 }
 
 // ToggleComponent toggles a component's enabled state and re-runs analyses if needed.

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1077,6 +1077,22 @@ func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) erro
 	return nil
 }
 
+// RunSendAnomalyEvents loads a scenario, waits for correlators to finish, then
+// delegates to notify.go to send one Datadog event per correlation.
+// When dryRun is true, events are printed to stdout instead of being sent.
+func (tb *TestBench) RunSendAnomalyEvents(scenario string, dryRun bool) error {
+	if err := tb.LoadScenario(scenario); err != nil {
+		return fmt.Errorf("loading scenario %q: %w", scenario, err)
+	}
+
+	tb.mu.RLock()
+	defer tb.mu.RUnlock()
+	for tb.correlatorsProcessing {
+		tb.correlatorsDone.Wait()
+	}
+	return sendCorrelationEvents(tb.correlations, dryRun)
+}
+
 // ToggleComponent toggles a component's enabled state and re-runs analyses if needed.
 func (tb *TestBench) ToggleComponent(name string) error {
 	tb.mu.Lock()

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1083,8 +1083,8 @@ func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) erro
 
 // RunSendAnomalyEvents loads a scenario, waits for correlators to finish, then
 // delegates to notify.go to send one Datadog event per correlation.
-// When dryRun is true, events are printed to stdout instead of being sent.
-func (tb *TestBench) RunSendAnomalyEvents(scenario string, dryRun bool) error {
+// Whether events are actually sent is controlled by observer.event_reporter.sending_enabled in cfg.
+func (tb *TestBench) RunSendAnomalyEvents(scenario string) error {
 	if err := tb.LoadScenario(scenario); err != nil {
 		return fmt.Errorf("loading scenario %q: %w", scenario, err)
 	}
@@ -1094,11 +1094,12 @@ func (tb *TestBench) RunSendAnomalyEvents(scenario string, dryRun bool) error {
 	for tb.correlatorsProcessing {
 		tb.correlatorsDone.Wait()
 	}
-	sender, err := newEventSender(tb.config.Cfg, tb.config.Logger, dryRun)
+	sender, err := newEventSender(tb.config.Cfg, tb.config.Logger)
 	if err != nil {
 		return err
 	}
-	return sender.sendCorrelationEvents(tb.correlations)
+	sender.sendCorrelationEvents(tb.correlations)
+	return nil
 }
 
 // ToggleComponent toggles a component's enabled state and re-runs analyses if needed.

--- a/go.mod
+++ b/go.mod
@@ -482,7 +482,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/buf v0.76.0-devel // indirect
 	github.com/DataDog/datadog-agent/pkg/util/statstracker v0.64.0-rc.3 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/system/socket v0.76.0-devel
-	github.com/DataDog/datadog-api-client-go/v2 v2.54.0 // indirect
+	github.com/DataDog/datadog-api-client-go/v2 v2.54.0
 	github.com/DataDog/go-tuf v1.1.1-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/gostackparse v0.7.0 // indirect

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -363,6 +363,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.profiles.max_fetch_batch", 50)
 	config.BindEnvAndSetDefault("observer.metrics.enabled", false)
 	config.BindEnvAndSetDefault("observer.metrics.high_frequency_interval", 0*time.Second) // 0 = disabled
+	config.BindEnvAndSetDefault("observer.event_reporter.sending_enabled", false)
 
 	// Auto exit configuration
 	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)


### PR DESCRIPTION
## Summary
- Adds `--send-anomaly-event <scenario>` flag to the observer testbench that runs a scenario and sends one Datadog event per active correlation via the Datadog Events v2 API
- Introduces `comp/observer/impl/notify.go` with an `eventSender` that formats correlation data into event payloads and dispatches them; whether events are actually sent is controlled by the `observer.event_reporter.sending_enabled` config key (when false, events are logged to stdout as dry-run)
- Adds `comp/observer/impl/reporter_event.go` with an `EventReporter` that plugs into the agent component system — it tracks seen correlations and fires one event per new correlation when the observer is running inside the agent
- The observer component (`NewComponent`) now conditionally wires up the `EventReporter` when `observer.event_reporter.sending_enabled` is true, using the injected `config.Component` and `log.Component` deps
- Removes the now-redundant `--dry-run` CLI flag; dry-run behaviour is instead controlled by the config key above

<img width="1251" height="651" alt="Screenshot 2026-03-05 at 22 30 47" src="https://github.com/user-attachments/assets/6ad61712-2fb5-47ea-b6a0-613f9bb02f3f" />