### PR TITLE
Revert "Revert "fix(fleet): set DD_CONFD_PATH in experiment agent systemd unit""

### DIFF
--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent.service.tmpl
@@ -22,6 +22,7 @@ Environment="DD_FLEET_POLICIES_DIR={{.FleetPoliciesDir}}"
 {{- if not .Stable}}
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
+Environment="DD_CONFD_PATH={{.EtcDir}}/conf.d"
 {{- end}}
 RuntimeDirectory=datadog
 StartLimitInterval=10

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-exp.service
@@ -14,6 +14,7 @@ EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
+Environment="DD_CONFD_PATH=/etc/datadog-agent-exp/conf.d"
 RuntimeDirectory=datadog
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-exp.service
@@ -14,6 +14,7 @@ EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
+Environment="DD_CONFD_PATH=/etc/datadog-agent-exp/conf.d"
 RuntimeDirectory=datadog
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-exp.service
@@ -14,6 +14,7 @@ EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
+Environment="DD_CONFD_PATH=/etc/datadog-agent-exp/conf.d"
 RuntimeDirectory=datadog
 StartLimitInterval=10
 StartLimitBurst=5

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-exp.service
@@ -14,6 +14,7 @@ EnvironmentFile=-/etc/datadog-agent-exp/environment
 Environment="DD_FLEET_POLICIES_DIR=/etc/datadog-agent-exp/managed/datadog-agent/stable"
 Environment="DD_INVENTORIES_FIRST_RUN_DELAY=5"
 Environment="EXPERIMENT_TIMEOUT=3000s"
+Environment="DD_CONFD_PATH=/etc/datadog-agent-exp/conf.d"
 RuntimeDirectory=datadog
 StartLimitInterval=10
 StartLimitBurst=5

--- a/test/new-e2e/tests/fleet/agent/agent.go
+++ b/test/new-e2e/tests/fleet/agent/agent.go
@@ -1076,12 +1076,10 @@ type Status struct {
 		OrgEnabled   string `json:"orgEnabled"`
 	} `json:"remoteConfiguration"`
 	RunnerStats struct {
-		Checks struct {
-		} `json:"Checks"`
-		Running struct {
-		} `json:"Running"`
-		RunningChecks int `json:"RunningChecks"`
-		Runs          int `json:"Runs"`
+		Checks        map[string]interface{} `json:"Checks"`
+		Running       map[string]interface{} `json:"Running"`
+		RunningChecks int                    `json:"RunningChecks"`
+		Runs          int                    `json:"Runs"`
 		Workers       struct {
 			Count int `json:"Count"`
 		} `json:"Workers"`

--- a/test/new-e2e/tests/fleet/config_test.go
+++ b/test/new-e2e/tests/fleet/config_test.go
@@ -296,6 +296,48 @@ func (s *configSuite) TestSystemProbeConfig() {
 	require.NotEmpty(s.T(), status.AgentMetadata.AgentVersion, "agent version should be available after promotion")
 }
 
+// TestExperimentIntegrationLoaded verifies that an integration config deployed
+// via the config experiment flow is picked up by the experiment agent before promotion.
+func (s *configSuite) TestExperimentIntegrationLoaded() {
+	if s.Env().RemoteHost.OSFamily == e2eos.WindowsFamily {
+		s.T().Skip("Skipping on Windows: experiment agent config paths are Linux-specific")
+	}
+
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+
+	nginxConfig := `{"init_config": {}, "instances": [{"nginx_status_url": "http://localhost:8080/nginx_status"}]}`
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID: "integration-loaded-test",
+		FileOperations: []backend.FileOperation{
+			{
+				FileOperationType: backend.FileOperationMergePatch,
+				FilePath:          "/datadog.yaml",
+				Patch:             []byte(`{}`),
+			},
+			{
+				FileOperationType: backend.FileOperationMergePatch,
+				FilePath:          "/conf.d/nginx.yaml",
+				Patch:             []byte(nginxConfig),
+			},
+		},
+	}, nil)
+	require.NoError(s.T(), err)
+
+	status, err := s.Agent.Status()
+	require.NoError(s.T(), err)
+	_, nginxLoaded := status.RunnerStats.Checks["nginx"]
+	assert.True(s.T(), nginxLoaded, "nginx check should be loaded from the experiment conf.d directory")
+
+	err = s.Backend.PromoteConfigExperiment()
+	require.NoError(s.T(), err)
+
+	status, err = s.Agent.Status()
+	require.NoError(s.T(), err)
+	_, nginxLoaded = status.RunnerStats.Checks["nginx"]
+	assert.True(s.T(), nginxLoaded, "nginx check should still be loaded after promotion")
+}
+
 // TestConfigRollbackDeploymentID tests that rolling back a config experiment
 // correctly preserves the stable_config_version and does not overwrite it
 // with the experiment deployment ID.

--- a/test/new-e2e/tests/fleet/config_test.go
+++ b/test/new-e2e/tests/fleet/config_test.go
@@ -282,18 +282,22 @@ func (s *configSuite) TestSystemProbeConfig() {
 	require.NoError(s.T(), err)
 
 	// Check agent is alive during experiment
-	status, err := s.Agent.Status()
-	require.NoError(s.T(), err, "agent should be running during experiment")
-	require.NotEmpty(s.T(), status.AgentMetadata.AgentVersion, "agent version should be available during experiment")
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		status, err := s.Agent.Status()
+		require.NoError(c, err, "agent should be running during experiment")
+		require.NotEmpty(c, status.AgentMetadata.AgentVersion, "agent version should be available during experiment")
+	}, 60*time.Second, 5*time.Second)
 
 	// Promote the experiment
 	err = s.Backend.PromoteConfigExperiment()
 	require.NoError(s.T(), err)
 
 	// Check agent is alive after promotion to stable
-	status, err = s.Agent.Status()
-	require.NoError(s.T(), err, "agent should be running after promotion to stable")
-	require.NotEmpty(s.T(), status.AgentMetadata.AgentVersion, "agent version should be available after promotion")
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		status, err := s.Agent.Status()
+		require.NoError(c, err, "agent should be running after promotion to stable")
+		require.NotEmpty(c, status.AgentMetadata.AgentVersion, "agent version should be available after promotion")
+	}, 60*time.Second, 5*time.Second)
 }
 
 // TestExperimentIntegrationLoaded verifies that an integration config deployed
@@ -324,18 +328,22 @@ func (s *configSuite) TestExperimentIntegrationLoaded() {
 	}, nil)
 	require.NoError(s.T(), err)
 
-	status, err := s.Agent.Status()
-	require.NoError(s.T(), err)
-	_, nginxLoaded := status.RunnerStats.Checks["nginx"]
-	assert.True(s.T(), nginxLoaded, "nginx check should be loaded from the experiment conf.d directory")
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		status, err := s.Agent.Status()
+		require.NoError(c, err)
+		_, nginxLoaded := status.RunnerStats.Checks["nginx"]
+		assert.True(c, nginxLoaded, "nginx check should be loaded from the experiment conf.d directory")
+	}, 60*time.Second, 5*time.Second)
 
 	err = s.Backend.PromoteConfigExperiment()
 	require.NoError(s.T(), err)
 
-	status, err = s.Agent.Status()
-	require.NoError(s.T(), err)
-	_, nginxLoaded = status.RunnerStats.Checks["nginx"]
-	assert.True(s.T(), nginxLoaded, "nginx check should still be loaded after promotion")
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		status, err := s.Agent.Status()
+		require.NoError(c, err)
+		_, nginxLoaded := status.RunnerStats.Checks["nginx"]
+		assert.True(c, nginxLoaded, "nginx check should still be loaded after promotion")
+	}, 60*time.Second, 5*time.Second)
 }
 
 // TestConfigRollbackDeploymentID tests that rolling back a config experiment


### PR DESCRIPTION
Reverts DataDog/datadog-agent#47518, and fixes the test issue