### PR TITLE
perf(ci): Download pre-built binaries for Go tools on macOS CI runners

### DIFF
--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -1,7 +1,10 @@
 import os
 import platform
+import re
 import sys
+import tempfile
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from invoke import Context, Exit, task
@@ -41,6 +44,126 @@ TOOLS = {
 }
 
 
+@dataclass
+class PrebuiltTool:
+    """Describes how to download a pre-built binary from GitHub Releases."""
+
+    repo: str  # GitHub repo (e.g. 'bazelbuild/bazelisk')
+    binary_name: str  # Name of the binary to place in GOBIN
+    # Asset filename pattern. Placeholders: {version} (without 'v' prefix), {os}, {arch}
+    asset_pattern: str
+    is_archive: bool = True  # If False, asset is a raw binary (not tar.gz)
+    # Path to binary inside the archive (empty = binary at archive root)
+    archive_binary_path: str = ""
+    # go.mod module path used to look up the pinned version
+    go_mod_module: str = ""
+
+
+# Tools that should be downloaded as pre-built binaries instead of `go install`.
+# These are the slowest to compile from source and all provide darwin/arm64 binaries.
+PREBUILT_TOOLS: dict[str, PrebuiltTool] = {
+    'github.com/bazelbuild/bazelisk': PrebuiltTool(
+        repo='bazelbuild/bazelisk',
+        binary_name='bazelisk',
+        asset_pattern='bazelisk-{os}-{arch}',
+        is_archive=False,
+        go_mod_module='github.com/bazelbuild/bazelisk',
+    ),
+    'github.com/golangci/golangci-lint/v2/cmd/golangci-lint': PrebuiltTool(
+        repo='golangci/golangci-lint',
+        binary_name='golangci-lint',
+        asset_pattern='golangci-lint-{version}-{os}-{arch}.tar.gz',
+        archive_binary_path='golangci-lint-{version}-{os}-{arch}/golangci-lint',
+        go_mod_module='github.com/golangci/golangci-lint/v2',
+    ),
+    'gotest.tools/gotestsum': PrebuiltTool(
+        repo='gotestyourself/gotestsum',
+        binary_name='gotestsum',
+        asset_pattern='gotestsum_{version}_{os}_{arch}.tar.gz',
+        go_mod_module='gotest.tools/gotestsum',
+    ),
+    'github.com/vektra/mockery/v3': PrebuiltTool(
+        repo='vektra/mockery',
+        binary_name='mockery',
+        # mockery uses capitalized OS name (Darwin, Linux)
+        asset_pattern='mockery_{version}_{Os}_{arch}.tar.gz',
+        go_mod_module='github.com/vektra/mockery/v3',
+    ),
+}
+
+# Map of go.mod dir -> parsed module versions, lazily populated
+_go_mod_versions_cache: dict[str, dict[str, str]] = {}
+
+
+def _parse_go_mod_versions(go_mod_path: str) -> dict[str, str]:
+    """Parse a go.mod file and return a dict of module -> version."""
+    versions = {}
+    with open(go_mod_path) as f:
+        for line in f:
+            m = re.match(r'\s+(\S+)\s+(v\S+)', line)
+            if m:
+                versions[m.group(1)] = m.group(2)
+    return versions
+
+
+def _get_tool_version(tool_import: str, go_mod_dir: str) -> str:
+    """Get the pinned version of a tool from its go.mod."""
+    if go_mod_dir not in _go_mod_versions_cache:
+        _go_mod_versions_cache[go_mod_dir] = _parse_go_mod_versions(os.path.join(go_mod_dir, 'go.mod'))
+    versions = _go_mod_versions_cache[go_mod_dir]
+    prebuilt = PREBUILT_TOOLS[tool_import]
+    mod = prebuilt.go_mod_module
+    if mod in versions:
+        return versions[mod]
+    raise Exit(f"Could not find version for {mod} in {go_mod_dir}/go.mod", code=1)
+
+
+def _format_asset_fields(pattern: str, version: str, os_name: str, arch: str) -> str:
+    """Format an asset pattern with version/os/arch, supporting {Os} for capitalized OS."""
+    return pattern.format(
+        version=version,
+        os=os_name,
+        Os=os_name.capitalize(),
+        arch=arch,
+    )
+
+
+def _install_prebuilt_tool(ctx: Context, tool_import: str, gobin: str, go_mod_dir: str):
+    """Download a pre-built binary from GitHub Releases and place it in GOBIN."""
+    prebuilt = PREBUILT_TOOLS[tool_import]
+    version = _get_tool_version(tool_import, go_mod_dir)
+    version_no_v = version.lstrip('v')
+    dest = os.path.join(gobin, prebuilt.binary_name)
+
+    os_name = 'darwin' if sys.platform.startswith('darwin') else 'linux'
+    arch = 'arm64' if platform.machine() in ('arm64', 'aarch64') else 'amd64'
+
+    asset = _format_asset_fields(prebuilt.asset_pattern, version_no_v, os_name, arch)
+    url = f"https://github.com/{prebuilt.repo}/releases/download/{version}/{asset}"
+
+    print(f"Downloading {prebuilt.binary_name} {version} from {url}")
+
+    if not prebuilt.is_archive:
+        # Raw binary download
+        ctx.run(f'curl -fsSL --retry 4 -o {dest} {url}')
+        ctx.run(f'chmod +x {dest}')
+    else:
+        # Archive: extract the binary
+        binary_in_archive = prebuilt.binary_name
+        if prebuilt.archive_binary_path:
+            binary_in_archive = _format_asset_fields(prebuilt.archive_binary_path, version_no_v, os_name, arch)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            archive_path = os.path.join(tmpdir, 'archive.tar.gz')
+            ctx.run(f'curl -fsSL --retry 4 -o {archive_path} {url}')
+            ctx.run(f'tar xzf {archive_path} -C {tmpdir} {binary_in_archive}')
+            extracted = os.path.join(tmpdir, binary_in_archive)
+            ctx.run(f'mv {extracted} {dest}')
+            ctx.run(f'chmod +x {dest}')
+
+    print(f"Installed {prebuilt.binary_name} {version} to {dest}")
+
+
 @task
 def download_tools(ctx):
     """Download all Go tools for testing."""
@@ -50,9 +173,18 @@ def download_tools(ctx):
 
 
 @task
-def install_tools(ctx: Context, max_retry: int = 3):
-    """Install all Go tools for testing."""
+def install_tools(ctx: Context, max_retry: int = 3, use_prebuilt: bool = True):
+    """Install all Go tools for testing.
+
+    Args:
+        max_retry: Number of retries for go install commands.
+        use_prebuilt: Download pre-built binaries for supported tools instead of
+            compiling from source with ``go install``. Defaults to True.
+    """
     with gitlab_section("Installing Go tools", collapsed=True):
+        gobin = get_gobin(ctx)
+        os.makedirs(gobin, exist_ok=True)
+
         env = {'GO111MODULE': 'on'}
         if os.getenv('DD_CC'):
             env['CC'] = os.getenv('DD_CC')
@@ -62,8 +194,11 @@ def install_tools(ctx: Context, max_retry: int = 3):
             for path, tools in TOOLS.items():
                 with ctx.cd(path):
                     for tool in tools:
-                        run_command_with_retry(ctx, f"go install {tool}", max_retry=max_retry)
-        for bazelisk in Path(get_gobin(ctx)).glob('bazelisk*'):
+                        if use_prebuilt and tool in PREBUILT_TOOLS:
+                            _install_prebuilt_tool(ctx, tool, gobin, path)
+                        else:
+                            run_command_with_retry(ctx, f"go install {tool}", max_retry=max_retry)
+        for bazelisk in Path(gobin).glob('bazelisk*'):
             link_or_copy(bazelisk, bazelisk.with_stem(bazelisk.stem.replace('isk', '')))
 
 

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -57,6 +57,8 @@ class PrebuiltTool:
     archive_binary_path: str = ""
     # go.mod module path used to look up the pinned version
     go_mod_module: str = ""
+    # Override arch names when they differ from Go conventions (amd64/arm64)
+    arch_map: dict[str, str] | None = None
 
 
 # Tools that should be downloaded as pre-built binaries instead of `go install`.
@@ -85,9 +87,10 @@ PREBUILT_TOOLS: dict[str, PrebuiltTool] = {
     'github.com/vektra/mockery/v3': PrebuiltTool(
         repo='vektra/mockery',
         binary_name='mockery',
-        # mockery uses capitalized OS name (Darwin, Linux)
+        # mockery uses capitalized OS name and x86_64 instead of amd64
         asset_pattern='mockery_{version}_{Os}_{arch}.tar.gz',
         go_mod_module='github.com/vektra/mockery/v3',
+        arch_map={'amd64': 'x86_64'},
     ),
 }
 
@@ -137,6 +140,8 @@ def _install_prebuilt_tool(ctx: Context, tool_import: str, gobin: str, go_mod_di
 
     os_name = 'darwin' if sys.platform.startswith('darwin') else 'linux'
     arch = 'arm64' if platform.machine() in ('arm64', 'aarch64') else 'amd64'
+    if prebuilt.arch_map and arch in prebuilt.arch_map:
+        arch = prebuilt.arch_map[arch]
 
     asset = _format_asset_fields(prebuilt.asset_pattern, version_no_v, os_name, arch)
     url = f"https://github.com/{prebuilt.repo}/releases/download/{version}/{asset}"

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -199,7 +199,7 @@ def install_tools(ctx: Context, max_retry: int = 3, use_prebuilt: bool = True):
             for path, tools in TOOLS.items():
                 with ctx.cd(path):
                     for tool in tools:
-                        if use_prebuilt and tool in PREBUILT_TOOLS:
+                        if use_prebuilt and tool in PREBUILT_TOOLS and sys.platform != 'win32':
                             _install_prebuilt_tool(ctx, tool, gobin, path)
                         else:
                             run_command_with_retry(ctx, f"go install {tool}", max_retry=max_retry)


### PR DESCRIPTION
### What does this PR do?

Replaces `go install` with pre-built binary downloads for the 4 slowest-to-compile Go tools in `install-tools`:

- **bazelisk** (raw binary from GitHub Releases)
- **golangci-lint** (tar.gz archive)
- **gotestsum** (tar.gz archive)
- **mockery** (tar.gz archive)

These tools are the main source of duration variance in the `tests_macos_gitlab_arm64` CI job. On a cold Go build cache (fresh macOS runner), `go install bazelisk` alone can take **41 minutes**. With pre-built binaries, all 4 tools install in **~10 seconds**.

The remaining 13 tools continue to use `go install` — they compile in 1-2 seconds each and aren't worth optimizing.

Versions are read from `internal/tools/go.mod`, so there's a single source of truth — no separate version file to maintain. A `--no-use-prebuilt` flag is available as an escape hatch to revert to the old `go install` behavior.

### Motivation

Analysis of the `tests_macos_gitlab_arm64` job over the last 3 months showed:

| Period | Avg (main) | P95 (main) | Runs |
|---|---|---|---|
| Dec–Jan | 24.9 min | 36.4 min | 569 |
| Jan–Feb | 24.4 min | 32.3 min | 842 |
| Feb–Mar | 26.9 min | 38.6 min | 1,084 |

The root cause of extreme outliers (up to 96 min) is **cold Go build caches on ephemeral macOS EC2 runners**. The `go_deps` artifact provides module sources but not compiled objects, so `go install` recompiles everything from scratch on fresh runners.

### Describe how you validated your changes

- Verified all 4 GitHub Release asset URLs exist and match the expected naming conventions
- End-to-end tested all 4 binary downloads on darwin/arm64:
  - `bazelisk version` → `Bazelisk version: v1.28.1`
  - `golangci-lint version` → `v2.9.0`
  - `gotestsum --version` → `1.12.3`
  - `mockery --version` → works
- Verified go.mod version parsing produces correct URLs
- `py_compile` passes

### Additional Notes

- Only `tasks/install_tasks.py` is modified
- The `PrebuiltTool` dataclass makes it easy to add more tools in the future if they start publishing pre-built binaries
- `{Os}` placeholder handles mockery's capitalized OS name (`Darwin` vs `darwin`)