### PR TITLE
feat(ci): Add docker-compose manager to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "enabledManagers": ["custom.regex", "pre-commit", "github-actions", "dockerfile"],
+    "enabledManagers": ["custom.regex", "pre-commit", "github-actions", "dockerfile", "docker-compose"],
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
     "platformCommit": "enabled",
@@ -42,6 +42,16 @@
         "matchManagers": ["dockerfile"],
         "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
         "schedule": ["on saturday"]
+      },
+      {
+        "matchManagers": ["docker-compose"],
+        "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
+        "schedule": ["on saturday"]
+      },
+      {
+        "matchManagers": ["docker-compose"],
+        "matchFileNames": ["**/testdata/**", "**/fixtures/**", "**/testfixtures/**", "pkg/collector/corechecks/oracle/compose/**"],
+        "enabled": false
       }
     ],
     "pre-commit": {


### PR DESCRIPTION
### What does this PR do?

Adds `docker-compose` manager to Renovate.

**Changes to `renovate.json`:**
- Added `docker-compose` to `enabledManagers`
- Added package rules with Saturday schedule and standard labels
- Added a disable rule for docker-compose files in testdata/fixtures paths to avoid churn on test infrastructure

**Managed docker-compose files (8):**
- `cmd/host-profiler/docker-compose.yml`
- `test/e2e-framework/components/datadog/apps/*/docker-compose*.yaml` (6 files)
- `test/fakeintake/docker-compose.yaml`

**Excluded docker-compose files (21):** all files under `**/testdata/**`, `**/fixtures/**`, `**/testfixtures/**`, and `pkg/collector/corechecks/oracle/compose/**`

### Motivation

Part of the Dependabot → Renovate migration. The `docker-compose` manager is a new addition — Dependabot never managed docker-compose files.

### Describe how you validated your changes

- Pre-commit hooks pass
- Renovate config follows the [Renovate docs schema](https://docs.renovatebot.com/renovate-schema.json)
- Confirmed the 21 testdata/fixtures docker-compose files are correctly excluded

### Additional Notes

Predecessor PRs:
- Phase 1 (github-actions): https://github.com/DataDog/datadog-agent/commit/e87e9f635b1a96e13ae5005ac97084f29e2172c7
- Phase 2 (docker/dependabot removal): #47512