### PR TITLE
dyninst: use uprobe_multi for batch attachment when available

### DIFF
--- a/pkg/dyninst/dyninsttest/util.go
+++ b/pkg/dyninst/dyninsttest/util.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/cilium/ebpf/link"
 	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
@@ -158,41 +157,4 @@ func StartProcess(ctx context.Context, t *testing.T, tempDir string, binPath str
 
 	require.NoError(t, err)
 	return proc, sampleStdin
-}
-
-// AttachBPFProbes attaches the BPF program to the running process.
-func AttachBPFProbes(
-	t *testing.T,
-	binPath string,
-	obj object.File,
-	pid int,
-	program *loader.Program,
-) func() {
-	sampleLink, err := link.OpenExecutable(binPath)
-	require.NoError(t, err)
-	textSection := obj.Section(".text")
-	require.NotNil(t, textSection)
-
-	var allAttached []link.Link
-	for _, attachpoint := range program.Attachpoints {
-		// Despite the name, Uprobe expects an offset in the object file, and not the virtual address.
-		addr := attachpoint.PC - textSection.Addr + textSection.Offset
-		attached, err := sampleLink.Uprobe(
-			"",
-			program.BpfProgram,
-			&link.UprobeOptions{
-				PID:     pid,
-				Address: addr,
-				Offset:  0,
-				Cookie:  attachpoint.Cookie,
-			},
-		)
-		require.NoError(t, err)
-		allAttached = append(allAttached, attached)
-	}
-	return func() {
-		for _, a := range allAttached {
-			require.NoError(t, a.Close())
-		}
-	}
 }

--- a/pkg/dyninst/ebpfbench/main.go
+++ b/pkg/dyninst/ebpfbench/main.go
@@ -10,7 +10,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,7 +17,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/ringbuf"
 
 	"github.com/DataDog/datadog-agent/pkg/dyninst/compiler"
@@ -27,7 +25,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/object"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/output"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/process"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uprobe"
 )
 
 func getSampleBinaryPath() (string, error) {
@@ -101,11 +101,6 @@ func runBenchmark() error {
 	}
 	defer func() { program.Close() }()
 
-	sampleLink, err := link.OpenExecutable(binPath)
-	if err != nil {
-		return err
-	}
-
 	// Launch the sample service, inject the BPF program and collect the output.
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
@@ -121,36 +116,14 @@ func runBenchmark() error {
 	if err != nil {
 		return err
 	}
-
-	textSection := obj.Section(".text")
-	if textSection == nil {
-		return errors.New("no .text section found")
-	}
-	var allAttached []link.Link
-	for _, attachpoint := range program.Attachpoints {
-		// Despite the name, Uprobe expects an offset in the object file, and not the virtual address.
-		addr := attachpoint.PC - textSection.Addr + textSection.Offset
-		fmt.Printf("attaching @0x%x cookie=%d\n", addr, attachpoint.Cookie)
-		attached, err := sampleLink.Uprobe(
-			"",
-			program.BpfProgram,
-			&link.UprobeOptions{
-				PID:     sampleProc.Process.Pid,
-				Address: addr,
-				Offset:  0,
-				Cookie:  attachpoint.Cookie,
-			},
-		)
-		if err != nil {
-			return err
-		}
-		allAttached = append(allAttached, attached)
+	pid := process.ID{PID: int32(sampleProc.Process.Pid)}
+	attached, err := uprobe.Attach(program, process.Executable{Path: binPath}, pid)
+	if err != nil {
+		return err
 	}
 	defer func() {
-		for _, a := range allAttached {
-			if err := a.Close(); err != nil {
-				fmt.Printf("error closing link: %v\n", err)
-			}
+		if err := attached.Detach(nil); err != nil {
+			fmt.Printf("error detaching: %v\n", err)
 		}
 	}()
 

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -124,13 +124,6 @@ func testDyninst(
 	t.Cleanup(testServer.s.Close)
 	cfg, err := module.NewConfig(nil)
 	require.NoError(t, err)
-	// In short mode (which never runs in CI), use uprobe_multi attachment to
-	// speed up integration tests on hosts that support it. Kernel feature
-	// detection is unreliable, so we opt in explicitly rather than
-	// auto-detecting in the loader.
-	if testing.Short() {
-		cfg.UseMultiAttach = true
-	}
 	loaderOpts := []loader.Option{
 		loader.WithAdditionalSerializer(&compiler.DebugSerializer{
 			Out: codeDump,
@@ -241,6 +234,8 @@ func testDyninst(
 		t, assertProbesInstalled, 180*time.Second, 100*time.Millisecond,
 		"diagnostics should indicate that the probes are installed",
 	)
+	time.Sleep(10 * time.Second)
+	t.Logf("slept for 10 seconds")
 
 	// Trigger the function calls, receive the events, and wait for the process
 	// to exit.

--- a/pkg/dyninst/loader/loader.go
+++ b/pkg/dyninst/loader/loader.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 // Loader is responsible for loading the eBPF, making it ready to attach.
@@ -67,14 +69,6 @@ func WithAdditionalSerializer(serializer compiler.CodeSerializer) Option {
 	return additionalSerializerOption{serializer}
 }
 
-// WithUseMultiAttach configures the loader to load programs for attachment
-// via the uprobe_multi link type (BPF_LINK_TYPE_UPROBE_MULTI). The caller is
-// responsible for ensuring the running kernel supports this link type
-// (Linux 6.6+); the loader does not probe for support.
-func WithUseMultiAttach(enabled bool) Option {
-	return useMultiAttachOption(enabled)
-}
-
 // NewLoader creates a new Loader.
 func NewLoader(opts ...Option) (*Loader, error) {
 	l := &Loader{}
@@ -114,7 +108,8 @@ func (l *Loader) Load(program compiler.Program) (*Program, error) {
 	}
 	ringbufMapSpec.MaxEntries = uint32(l.config.ringBufSize)
 
-	if l.config.useMultiAttach {
+	useMultiAttach := canUseMultiAttach()
+	if useMultiAttach {
 		progSpec, ok := spec.Programs["probe_run_with_cookie"]
 		if !ok {
 			return nil, errors.New("probe_run_with_cookie program not found in eBPF spec")
@@ -144,9 +139,32 @@ func (l *Loader) Load(program compiler.Program) (*Program, error) {
 		Collection:     collection,
 		BpfProgram:     bpfProgram,
 		Attachpoints:   serialized.bpfAttachPoints,
-		UseMultiAttach: l.config.useMultiAttach,
+		UseMultiAttach: useMultiAttach,
 	}, nil
 }
+
+// canUseMultiAttach reports whether the running kernel supports
+// uprobe_multi attachment with a working PID filter.
+//
+// Linux 6.6 introduced BPF_LINK_TYPE_UPROBE_MULTI, but its PID filter
+// was buggy until 6.10: uprobe_prog_run() compared `current` against the
+// per-link task_struct pointer rather than its mm, so probes only fired
+// for the single thread looked up at attach time. Go programs run
+// goroutines across many OS threads, so most events were silently dropped.
+// The fix is upstream commit 46ba0e49b642 ("bpf: fix multi-uprobe PID
+// filtering logic"), present in 6.10+ and backported to 6.9.9, but never
+// to linux-6.8.y — so Ubuntu 24.04's stock 6.8 kernel is permanently
+// affected. Gate on 6.10 to be safe.
+var canUseMultiAttach = sync.OnceValue(func() bool {
+	if features.HaveBPFLinkUprobeMulti() != nil {
+		return false
+	}
+	v, err := kernel.HostVersion()
+	if err != nil {
+		return false
+	}
+	return v >= kernel.VersionCode(6, 10, 0)
+})
 
 // stripRelocations removes the relocation metadata from the instructions.
 // These are not needed for pt_regs as long as we're not trying to build
@@ -292,8 +310,6 @@ type config struct {
 	dyninstDebugLevel   uint8
 	dyninstDebugEnabled bool
 
-	useMultiAttach bool
-
 	additionalSerializer compiler.CodeSerializer
 }
 
@@ -327,12 +343,6 @@ type additionalSerializerOption struct {
 
 func (o additionalSerializerOption) apply(c *config) {
 	c.additionalSerializer = o
-}
-
-type useMultiAttachOption bool
-
-func (o useMultiAttachOption) apply(c *config) {
-	c.useMultiAttach = bool(o)
 }
 
 func (l *Loader) init(opts ...Option) error {

--- a/pkg/dyninst/module/config.go
+++ b/pkg/dyninst/module/config.go
@@ -54,14 +54,6 @@ type Config struct {
 	// ActuatorConfig is the configuration for the actuator.
 	ActuatorConfig actuator.Config
 
-	// UseMultiAttach causes the loader to use the uprobe_multi link type
-	// (BPF_LINK_TYPE_UPROBE_MULTI) when attaching probes. This batches
-	// many attachments into a single bpf_link_create call and is much
-	// faster for programs with many attachpoints, but requires kernel
-	// support (Linux 6.6+). The caller is responsible for only enabling
-	// this on supported kernels.
-	UseMultiAttach bool
-
 	TestingKnobs struct {
 		LoaderOptions             []loader.Option
 		IRGeneratorOverride       func(IRGenerator) IRGenerator

--- a/pkg/dyninst/module/module.go
+++ b/pkg/dyninst/module/module.go
@@ -254,9 +254,6 @@ func makeRealDependencies(
 	if config.TestingKnobs.LoaderOptions != nil {
 		loaderOpts = config.TestingKnobs.LoaderOptions
 	}
-	if config.UseMultiAttach {
-		loaderOpts = append(loaderOpts, loader.WithUseMultiAttach(true))
-	}
 	ret.loader, err = loader.NewLoader(loaderOpts...)
 	if err != nil {
 		return ret, fmt.Errorf("error creating loader: %w", err)

--- a/pkg/dyninst/throttler_test.go
+++ b/pkg/dyninst/throttler_test.go
@@ -20,7 +20,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dyninst/ir"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/irgen"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/loader"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/process"
 	"github.com/DataDog/datadog-agent/pkg/dyninst/testprogs"
+	"github.com/DataDog/datadog-agent/pkg/dyninst/uprobe"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 func TestThrottler(t *testing.T) {
@@ -48,7 +51,7 @@ func enforcesBudget(t *testing.T, busyloopPath string) {
 
 	// Load the binary and generate the IR.
 	t.Logf("loading binary")
-	obj, irp := dyninsttest.GenerateIr(
+	_, irp := dyninsttest.GenerateIr(
 		t, tempDir, busyloopPath, "busyloop", irgen.WithSkipReturnEvents(true),
 	)
 
@@ -76,10 +79,13 @@ func enforcesBudget(t *testing.T, busyloopPath string) {
 		ctx, t, tempDir, busyloopPath,
 		"1" /*round_cnt*/, "20" /*round_sec*/, "3", /*concurrency*/
 	)
-	cleanup = dyninsttest.AttachBPFProbes(
-		t, busyloopPath, obj, sampleProc.Process.Pid, program,
-	)
-	defer cleanup()
+
+	pid := process.ID{PID: int32(sampleProc.Process.Pid)}
+	exe, err := process.ResolveExecutable(kernel.ProcFSRoot(), pid.PID)
+	require.NoError(t, err)
+	attached, err := uprobe.Attach(program, exe, pid)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, attached.Detach(nil)) }()
 	defer func() {
 		sampleProc.Process.Kill()
 		sampleProc.Wait()
@@ -129,7 +135,7 @@ func refreshesBudget(t *testing.T, busyloopPath string) {
 
 	// Load the binary and generate the IR.
 	t.Logf("loading binary")
-	obj, irp := dyninsttest.GenerateIr(
+	_, irp := dyninsttest.GenerateIr(
 		t, tempDir, busyloopPath, "busyloop", irgen.WithSkipReturnEvents(true),
 	)
 
@@ -155,8 +161,12 @@ func refreshesBudget(t *testing.T, busyloopPath string) {
 		ctx, t, tempDir, busyloopPath,
 		"1" /*round_cnt*/, "20" /*round_sec*/, "3", /*concurrency*/
 	)
-	cleanup = dyninsttest.AttachBPFProbes(t, busyloopPath, obj, sampleProc.Process.Pid, program)
-	defer cleanup()
+	pid := process.ID{PID: int32(sampleProc.Process.Pid)}
+	exe, err := process.ResolveExecutable(kernel.ProcFSRoot(), pid.PID)
+	require.NoError(t, err)
+	attached, err := uprobe.Attach(program, exe, pid)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, attached.Detach(nil)) }()
 	defer func() {
 		sampleProc.Process.Kill()
 		sampleProc.Wait()


### PR DESCRIPTION
### What does this PR do?

Use the uprobe_multi link type (BPF_LINK_TYPE_UPROBE_MULTI) for attaching dyninst probes when the kernel supports it.

In the loader, we now probe features.HaveBPFLinkUprobeMulti() at load time. If supported, we set AttachTraceUprobeMulti on the program spec before loading and flag the Program for multi-attach. At attachment time, the uprobe package checks this flag: if set, it collects all addresses and cookies into slices and calls Executable.UprobeMulti in one shot; otherwise it falls back to the original per-address Executable.Uprobe loop for older kernels.

### Motivation

In real workloads and in our integration tests, a single dyninst program can have hundreds of attachment points. Previously each one required its own Uprobe syscall, which is slow — the kernel has to set up a separate ftrace/uprobe registration per address. With uprobe_multi, all addresses are passed in a single bpf_link_create call, letting the kernel batch the work.

For our integration tests this reduces attachment time from ~90s to ~22s.


### Describe how you validated your changes

Ran the tests.

### Additional Notes

Fixes https://datadoghq.atlassian.net/browse/DEBUG-4772