### PR TITLE
remove flake marker from startstop tests

### DIFF
--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -80,27 +80,18 @@ type onServiceStateMismatch func(host *components.RemoteHost, serviceName, actua
 
 // TestServiceBehaviorAgentCommandNoFIM tests the service behavior when controlled by Agent commands
 func TestNoFIMServiceBehaviorAgentCommand(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &agentServiceCommandSuite{}
 	run(t, s, systemProbeNoFIMConfig, agentConfig, securityAgentConfig)
 }
 
 // TestServiceBehaviorPowerShellNoFIM tests the service behavior when controlled by PowerShell commands
 func TestNoFIMServiceBehaviorPowerShell(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &powerShellServiceCommandSuite{}
 	run(t, s, systemProbeNoFIMConfig, agentConfig, securityAgentConfig)
 }
 
 // TestServiceBehaviorAgentCommand tests the service behavior when controlled by Agent commands
 func TestServiceBehaviorAgentCommand(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &agentServiceCommandSuite{}
 	run(t, s, systemProbeConfig, agentConfig, securityAgentConfig)
 }
@@ -139,9 +130,6 @@ func (s *agentServiceCommandSuite) SetupSuite() {
 
 // TestServiceBehaviorAgentCommand tests the service behavior when controlled by PowerShell commands
 func TestServiceBehaviorPowerShell(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &powerShellServiceCommandSuite{}
 	run(t, s, systemProbeConfig, agentConfig, securityAgentConfig)
 }
@@ -289,9 +277,6 @@ type agentServiceDisabledSuite struct {
 
 // TestServiceBehaviorWhenDisabled tests the service behavior when disabled in the configuration
 func TestServiceBehaviorWhenDisabledSystemProbe(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &agentServiceDisabledSystemProbeSuite{}
 	s.disabledServices = []string{
 		"datadog-security-agent",
@@ -308,9 +293,6 @@ type agentServiceDisabledSystemProbeSuite struct {
 
 // TestServiceBehaviorWhenDisabledProcessAgent tests the service behavior when disabled in the configuration
 func TestServiceBehaviorWhenDisabledProcessAgent(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &agentServiceDisabledProcessAgentSuite{}
 	s.disabledServices = []string{
 		"datadog-process-agent",
@@ -327,9 +309,6 @@ type agentServiceDisabledProcessAgentSuite struct {
 }
 
 func TestServiceBehaviorWhenDisabledTraceAgent(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &agentServiceDisabledTraceAgentSuite{}
 	s.disabledServices = []string{
 		"datadog-trace-agent",
@@ -342,9 +321,6 @@ type agentServiceDisabledTraceAgentSuite struct {
 }
 
 func TestServiceBehaviorWhenDisabledInstaller(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &agentServiceDisabledInstallerSuite{}
 	s.disabledServices = []string{
 		"Datadog Installer",
@@ -959,9 +935,6 @@ type dvAgentServiceDisabledInstallerSuite struct {
 // TestDriverVerifierOnServiceBehaviorAgentCommand tests the same as TestServiceBehaviorAgentCommand
 // with driver verifier enabled.
 func TestDriverVerifierOnServiceBehaviorAgentCommand(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &dvAgentServiceCommandSuite{}
 	s.enableDriverVerifier = true
 	s.timeoutScale = driverVerifierTimeoutScale
@@ -971,9 +944,6 @@ func TestDriverVerifierOnServiceBehaviorAgentCommand(t *testing.T) {
 // TestDriverVerifierOnServiceBehaviorPowerShell tests the the same as TestServiceBehaviorPowerShell
 // with driver verifier enabled.
 func TestDriverVerifierOnServiceBehaviorPowerShell(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &dvPowerShellServiceCommandSuite{}
 	s.enableDriverVerifier = true
 	s.timeoutScale = driverVerifierTimeoutScale
@@ -983,9 +953,6 @@ func TestDriverVerifierOnServiceBehaviorPowerShell(t *testing.T) {
 // TestDriverVerifierOnServiceBehaviorWhenDisabledSystemProbe tests the same as TestServiceBehaviorWhenDisabledSystemProbe
 // with driver verifier enabled.
 func TestDriverVerifierOnServiceBehaviorWhenDisabledSystemProbe(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &dvAgentServiceDisabledSystemProbeSuite{}
 	s.disabledServices = []string{
 		"datadog-security-agent",
@@ -1001,9 +968,6 @@ func TestDriverVerifierOnServiceBehaviorWhenDisabledSystemProbe(t *testing.T) {
 // TestDriverVerifierOnServiceBehaviorWhenDisabledProcessAgent tests the same as TestServiceBehaviorWhenDisabledProcessAgent
 // with driver verifier enabled.
 func TestDriverVerifierOnServiceBehaviorWhenDisabledProcessAgent(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &dvAgentServiceDisabledProcessAgentSuite{}
 	s.disabledServices = []string{
 		"datadog-process-agent",
@@ -1020,9 +984,6 @@ func TestDriverVerifierOnServiceBehaviorWhenDisabledProcessAgent(t *testing.T) {
 // TestDriverVerifierOnServiceBehaviorWhenDisabledTraceAgent tests the same as TestServiceBehaviorWhenDisabledTraceAgent
 // with driver verifier enabled.
 func TestDriverVerifierOnServiceBehaviorWhenDisabledTraceAgent(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &dvAgentServiceDisabledTraceAgentSuite{}
 	s.disabledServices = []string{
 		"datadog-trace-agent",
@@ -1035,9 +996,6 @@ func TestDriverVerifierOnServiceBehaviorWhenDisabledTraceAgent(t *testing.T) {
 // TestDriverVerifierOnServiceBehaviorWhenDisabledInstaller tests the same as TestServiceBehaviorWhenDisabledInstaller
 // with driver verifier enabled.
 func TestDriverVerifierOnServiceBehaviorWhenDisabledInstaller(t *testing.T) {
-	// TODO(windows-products): Fix flakiness and re-enable this test
-	flake.Mark(t)
-
 	s := &dvAgentServiceDisabledInstallerSuite{}
 	s.disabledServices = []string{
 		"Datadog Installer",


### PR DESCRIPTION
### What does this PR do?
remove flake.Mark from Windows service startstop tests

### Motivation
we're not aware of any flaky behavior and CI history is clear