### PR TITLE
bump retry and remove flake

### DIFF
--- a/test/new-e2e/tests/agent-platform/common/agent_integration.go
+++ b/test/new-e2e/tests/agent-platform/common/agent_integration.go
@@ -14,14 +14,12 @@ import (
 	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/util/testutil/flake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client/agentclient"
 )
 
 // CheckIntegrationInstall run test to test installation of integrations
 func CheckIntegrationInstall(t *testing.T, client *TestClient) {
 	t.Run("integration", func(tt *testing.T) {
-		flake.Mark(tt)
 		requirementIntegrationPath := client.Helper.GetInstallFolder() + "requirements-agent-release.txt"
 
 		ciliumRegex := regexp.MustCompile(`datadog-cilium==.*`)
@@ -84,7 +82,7 @@ func installIntegration(t *testing.T, client *TestClient, integration string) {
 	// Their release pipeline runs at least once a day at 5AM CET and can run during working hours if they need to release something.
 
 	interval := 30 * time.Second
-	maxRetries := 6
+	maxRetries := 30
 
 	_, err := backoff.Retry(context.Background(), func() (any, error) {
 		_, err := client.AgentClient.IntegrationWithError(agentclient.WithArgs([]string{"install", "--unsafe-disable-verification", "-r", integration}))


### PR DESCRIPTION
### What does this PR do?
remove flake and bump retry count in integration install subtests

### Motivation
makes our flaky report hard to read because this subtest is used in many places and they're all reported individually

test still [flakes](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40test.agent_is_marked_flaky%3Atrue%20%40test.name%3A%2A%2Fagent_runtime_behavior%2Fintegration%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&top_n=250&top_o=top&viz=stream&x_missing=true&start=1765056632634&end=1772832632634&paused=false) occasionally so the retry must not be long enough