### PR TITLE
Extract waitForExperimentMSIRollback helper

### DIFF
--- a/test/new-e2e/tests/installer/windows/suites/agent-package/persisting_extensions_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/persisting_extensions_test.go
@@ -18,7 +18,6 @@ import (
 	installer "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/unix"
 	installerwindows "github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/windows/consts"
-	windowscommon "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common"
 	windowsagent "github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent"
 )
 
@@ -31,7 +30,7 @@ const (
 )
 
 type testExtensionsSuite struct {
-	installerwindows.BaseSuite
+	testAgentUpgradeSuite
 }
 
 // TestExtensionPersistence tests Agent extension persistence behaviour on Windows.
@@ -191,19 +190,9 @@ func (s *testExtensionsSuite) TestExtensionRestoredOnMSIRollback() {
 		s.removeExtension("datadog-agent", "ddot")
 	}()
 	s.verifyDDOTRunning(s.StableAgentVersion().Version())
+	s.setExperimentMSIArgs([]string{"WIXFAILWHENDEFERRED=1"})
 
-	err := windowscommon.SetRegistryMultiString(s.Env().RemoteHost,
-		`HKLM:SOFTWARE\Datadog\Datadog Agent`, "StartExperimentMSIArgs",
-		[]string{"WIXFAILWHENDEFERRED=1"})
-	s.Require().NoError(err)
-
-	s.WaitForDaemonToStop(func() {
-		_, err := s.StartExperimentCurrentVersion()
-		s.Require().NoError(err, "daemon should stop cleanly")
-	})
-
-	err = s.WaitForInstallerService("Running")
-	s.Require().NoError(err)
+	s.waitForExperimentMSIRollback()
 
 	s.Require().Host(s.Env().RemoteHost).
 		HasDatadogInstaller().

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -442,28 +442,7 @@ func (s *testAgentUpgradeSuite) TestExperimentMSIRollbackMaintainsCustomUserAndA
 	s.setExperimentMSIArgs([]string{"WIXFAILWHENDEFERRED=1"})
 
 	// Act
-	s.WaitForDaemonToStop(func() {
-		_, err := s.StartExperimentCurrentVersion()
-		s.Require().NoError(err, "daemon should stop cleanly")
-		// This returns while the upgrade is still running, so we need to wait for the service to stop
-		// We can't use WaitForInstallerService here because it can be racy with MSI rollback,
-		// the service could stop and then restart before we check the status again.
-	}, backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)), backoff.WithMaxTries(100))
-
-	// wait for upgrade to restart the service
-	// this is racy, we'll either catch the new service running briefly before MSI rollback
-	// triggers, or we'll catch the previous service running after MSI rollback completes
-	// The next set of checks quiesce the race.
-	err := s.WaitForInstallerService("Running")
-	s.Require().NoError(err)
-
-	// Now that the service is running, we know that the stable version has been removed,
-	// so we can wait for the stable version to be placed on disk once again via MSI rollback
-	err = s.waitForInstallerVersion(s.StableAgentVersion().Version())
-	s.Require().NoError(err)
-	// and wait again to ensure the stable service is running
-	err = s.WaitForInstallerService("Running")
-	s.Require().NoError(err)
+	s.waitForExperimentMSIRollback()
 
 	// Assert
 
@@ -901,6 +880,34 @@ func (s *testAgentUpgradeFromGASuite) createStableAgent() (*installerwindows.Age
 	s.Require().NoError(err, "Stable agent version was in an incorrect format")
 
 	return agent, nil
+}
+
+// waitForExperimentMSIRollback starts an experiment and waits for the MSI to roll back
+// and the stable version to be restored. It handles the race conditions inherent in
+// MSI rollback by waiting for the service to restart and the stable version to appear on disk.
+func (s *testAgentUpgradeSuite) waitForExperimentMSIRollback() {
+	s.WaitForDaemonToStop(func() {
+		_, err := s.StartExperimentCurrentVersion()
+		s.Require().NoError(err, "daemon should stop cleanly")
+		// This returns while the upgrade is still running, so we need to wait for the service to stop
+		// We can't use WaitForInstallerService here because it can be racy with MSI rollback,
+		// the service could stop and then restart before we check the status again.
+	}, backoff.WithBackOff(backoff.NewConstantBackOff(5*time.Second)), backoff.WithMaxTries(100))
+
+	// wait for upgrade to restart the service
+	// this is racy, we'll either catch the new service running briefly before MSI rollback
+	// triggers, or we'll catch the previous service running after MSI rollback completes
+	// The next set of checks quiesce the race.
+	err := s.WaitForInstallerService("Running")
+	s.Require().NoError(err)
+
+	// Now that the service is running, we know that the stable version has been removed,
+	// so we can wait for the stable version to be placed on disk once again via MSI rollback
+	err = s.waitForInstallerVersion(s.StableAgentVersion().Version())
+	s.Require().NoError(err)
+	// and wait again to ensure the stable service is running
+	err = s.WaitForInstallerService("Running")
+	s.Require().NoError(err)
 }
 
 // setExperimentMSIArgs stores a list of MSI options for the installer to provide to the MSI when starting an experiment.


### PR DESCRIPTION
### What does this PR do?

Extracts the MSI rollback wait logic into a shared `waitForExperimentMSIRollback` helper on `testAgentUpgradeSuite`, deduplicating it from `upgrade_test.go` and `persisting_extensions_test.go`.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2442
fix flaky race condition