### PR TITLE
Suppress spurious service-not-found warning on fresh installs

### DIFF
--- a/pkg/fleet/installer/packages/datadog_agent_windows.go
+++ b/pkg/fleet/installer/packages/datadog_agent_windows.go
@@ -630,7 +630,9 @@ func getenv() *env.Env {
 	if env.MsiParams.AgentUserName == "" {
 		user, err := windowsuser.GetAgentUserFromService()
 		if err != nil {
-			log.Warnf("Could not read Agent user from service: %v", err)
+			if !errors.Is(err, windows.ERROR_SERVICE_DOES_NOT_EXIST) {
+				log.Warnf("Could not read Agent user from service: %v", err)
+			}
 		} else {
 			env.MsiParams.AgentUserName = user
 		}

--- a/pkg/fleet/installer/paths/installer_paths_windows.go
+++ b/pkg/fleet/installer/paths/installer_paths_windows.go
@@ -562,7 +562,7 @@ func getProgramDataDirForProduct(product string) (path string, err error) {
 	defer k.Close()
 	val, _, err := k.GetStringValue("ConfigRoot")
 	if err != nil {
-		log.Warnf("Windows installation key config not found, using default program data dir")
+		log.Debugf("Windows installation key config not found, using default program data dir")
 		return filepath.Join(res, "Datadog"), nil
 	}
 	path = val
@@ -589,7 +589,7 @@ func getProgramFilesDirForProduct(product string) (path string, err error) {
 	defer k.Close()
 	val, _, err := k.GetStringValue("InstallPath")
 	if err != nil {
-		log.Warnf("Windows installation key config not found, using default program data dir")
+		log.Debugf("Windows installation key config not found, using default program data dir")
 		return filepath.Join(res, "Datadog", product), nil
 	}
 	path = val

--- a/pkg/util/defaultpaths/path_windows.go
+++ b/pkg/util/defaultpaths/path_windows.go
@@ -80,7 +80,7 @@ func fetchInstallPath() string {
 		defer k.Close()
 		s, _, err := k.GetStringValue("InstallPath")
 		if err != nil {
-			log.Warnf("Installpath not found in registry: %s", err)
+			log.Debugf("Installpath not found in registry: %s", err)
 		} else if s != "" {
 			return s
 		}

--- a/pkg/util/winutil/shutil.go
+++ b/pkg/util/winutil/shutil.go
@@ -44,7 +44,7 @@ func GetProgramDataDirForProduct(product string) (path string, err error) {
 	defer k.Close()
 	val, _, err := k.GetStringValue("ConfigRoot")
 	if err != nil {
-		log.Warnf("Windows installation key config not found, using default program data dir")
+		log.Debugf("Windows installation key config not found, using default program data dir")
 		return getDefaultProgramDataDir()
 	}
 	path = val
@@ -66,7 +66,7 @@ func GetProgramFilesDirForProduct(product string) (path string, err error) {
 	defer k.Close()
 	val, _, err := k.GetStringValue("InstallPath")
 	if err != nil {
-		log.Warnf("Windows installation key config not found, using default program data dir")
+		log.Debugf("Windows installation key config not found, using default program data dir")
 		return getDefaultProgramFilesDir()
 	}
 	path = val

--- a/pkg/util/winutil/users.go
+++ b/pkg/util/winutil/users.go
@@ -89,7 +89,7 @@ func GetServiceUserSID(service string) (*windows.SID, error) {
 	// get config for datadogagent service
 	user, err := GetServiceUser(service)
 	if err != nil {
-		return nil, fmt.Errorf("could not get datadogagent service user: %s", err)
+		return nil, fmt.Errorf("could not get datadogagent service user: %w", err)
 	}
 
 	username, err := getUserFromServiceUser(user)


### PR DESCRIPTION
### What does this PR do?

Suppresses a noisy `Could not read Agent user from service` warning on fresh installs where the `datadogagent` service doesn't exist yet. Also fixes error wrapping in `GetServiceUserSID` (`%s` to `%w`) so callers can use `errors.Is` to detect the underlying Windows error.

### Motivation

After #46910 landed, `log.Warnf` calls are emitted to stdout for non-daemon invocations, making this previously-silent warning visible on every fresh install.