### PR TITLE
[CNM-5109] fix flaky TestDNSCacheTelemetry by closing leaked cache goroutines

### DIFF
--- a/pkg/network/dns/cache_test.go
+++ b/pkg/network/dns/cache_test.go
@@ -32,6 +32,7 @@ func TestMultipleIPsForSameName(t *testing.T) {
 	datadogIPs.add(datadog2, 1*time.Minute)
 
 	cache := newReverseDNSCache(100, disableAutomaticExpiration)
+	defer cache.Close()
 	cache.Add(datadogIPs)
 
 	localhost := util.AddressFromString("127.0.0.1")
@@ -50,6 +51,7 @@ func TestMultipleIPsForSameName(t *testing.T) {
 
 func TestMultipleNamesForSameIP(t *testing.T) {
 	cache := newReverseDNSCache(100, disableAutomaticExpiration)
+	defer cache.Close()
 
 	raddr := util.AddressFromString("172.022.116.123")
 	tr1 := newTranslation("i-03e46c9ff42db4abc")
@@ -74,6 +76,7 @@ func TestMultipleNamesForSameIP(t *testing.T) {
 func TestDNSCacheExpiration(t *testing.T) {
 	ttl := 100 * time.Millisecond
 	cache := newReverseDNSCache(1000, disableAutomaticExpiration)
+	defer cache.Close()
 	t1 := time.Now()
 
 	laddr1 := util.AddressFromString("127.0.0.1")
@@ -148,6 +151,7 @@ func TestDNSCacheTelemetry(t *testing.T) {
 	cacheTelemetry.oversized.Delete()
 	ttl := 100 * time.Millisecond
 	cache := newReverseDNSCache(1000, disableAutomaticExpiration)
+	defer cache.Close()
 	t1 := time.Now()
 
 	translation := newTranslation("host-a")
@@ -209,6 +213,7 @@ func validateTelemetry(t *testing.T, expected map[string]int64) {
 func TestDNSCacheMerge(t *testing.T) {
 	ttl := 100 * time.Millisecond
 	cache := newReverseDNSCache(1000, disableAutomaticExpiration)
+	defer cache.Close()
 
 	conns := map[util.Address]struct{}{
 		util.AddressFromString("127.0.0.1"):   {},
@@ -237,6 +242,7 @@ func TestDNSCacheMerge(t *testing.T) {
 func TestDNSCacheMerge_MixedCaseNames(t *testing.T) {
 	ttl := 100 * time.Millisecond
 	cache := newReverseDNSCache(1000, disableAutomaticExpiration)
+	defer cache.Close()
 
 	conns := map[util.Address]struct{}{
 		util.AddressFromString("192.168.0.1"): {},
@@ -260,6 +266,7 @@ func TestDNSCacheMerge_MixedCaseNames(t *testing.T) {
 
 func TestGetOversizedDNS(t *testing.T) {
 	cache := newReverseDNSCache(1000, time.Minute)
+	defer cache.Close()
 	cache.maxDomainsPerIP = 10
 	addr := util.AddressFromString("192.168.0.1")
 	exp := time.Now().Add(1 * time.Hour)
@@ -299,6 +306,7 @@ func BenchmarkDNSCacheGet(b *testing.B) {
 		added   = make([]util.Address, 0, numIPs)
 		addrGen = randomAddressGen()
 	)
+	b.Cleanup(func() { cache.Close() })
 	for i := 0; i < numIPs; i++ {
 		address := addrGen()
 		added = append(added, address)


### PR DESCRIPTION
Tests creating reverseDNSCache instances were not calling Close(), leaking background Expire() goroutines. TestGetOversizedDNS (with a time.Minute ticker) was the primary culprit — in CI where test suites take >1 min, its goroutine would overwrite the global cacheTelemetry.length gauge during TestDNSCacheTelemetry assertions.

Add defer cache.Close() to all tests and b.Cleanup to the benchmark.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
