### PR TITLE
log invalid json

### DIFF
--- a/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_installer_asserts.go
+++ b/test/new-e2e/tests/installer/windows/remote-host-assertions/remote_windows_installer_asserts.go
@@ -31,7 +31,10 @@ func (d *RemoteWindowsInstallerAssertions) Status() *RemoteWindowsInstallerStatu
 	output, err := d.execute("status --json")
 	d.require.NoError(err)
 	status, err := parseStatusOutput(output)
-	d.require.NoError(err)
+	if err != nil {
+		d.context.T().Logf("Failed to parse status output: %s", output)
+		d.require.NoError(err)
+	}
 	return &RemoteWindowsInstallerStatusAssertions{
 		RemoteWindowsInstallerAssertions: d,
 		status:                           status,


### PR DESCRIPTION
### What does this PR do?
log invalid json on error

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2282
seeing flakes with invalid JSON but can't see the JSON, only the unmarshal error
```
invalid character 'i' in literal false (expecting 'l')
```
https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1468689829/raw