### PR TITLE
fix(ci): pin install-dda action to install branch for Renovate

### DIFF
--- a/.github/actions/install-dda/action.yml
+++ b/.github/actions/install-dda/action.yml
@@ -22,7 +22,7 @@ runs:
     shell: bash
 
   - name: Install dda
-    uses: DataDog/datadog-agent-dev@00e4a423088309efce1d5ba6b8c5366eef648710
+    uses: DataDog/datadog-agent-dev@00e4a423088309efce1d5ba6b8c5366eef648710 # install
     with:
       version: ${{ inputs.version || steps.set-version.outputs.version }}
       features: ${{ inputs.features }}


### PR DESCRIPTION
### What does this PR do?

Adds a `# install` branch comment to the `DataDog/datadog-agent-dev` digest pin in `.github/actions/install-dda/action.yml`.

This tells Renovate to track the `install` branch when resolving digest updates for this action, instead of the default branch.

### Motivation

Renovate's `github-actions` manager resolves digest updates from the default branch of a repository. However, the reusable action in `DataDog/datadog-agent-dev` is defined on the `install` branch. This caused PR #47543 to propose a digest from the wrong branch.

Adding the `# install` comment is a [documented Renovate feature](https://docs.renovatebot.com/modules/manager/github-actions/) that tells it which branch/tag to use when looking up the latest digest.

### Describe how you validated your changes

Renovate documentation confirms that a comment after a digest pin is used as the branch/tag ref for digest lookups.

### Additional Notes

Related: #47543