### PR TITLE
[static_quality_gates] Adjust for DCA

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -47,11 +47,11 @@ static_quality_gate_docker_agent_jmx_arm64:
   max_on_disk_size: 999.17 MiB
   max_on_wire_size: 324.39 MiB
 static_quality_gate_docker_cluster_agent_amd64:
-  max_on_disk_size: 204.27 MiB
-  max_on_wire_size: 71.92 MiB
+  max_on_disk_size: 206.27 MiB
+  max_on_wire_size: 72.92 MiB
 static_quality_gate_docker_cluster_agent_arm64:
-  max_on_disk_size: 218.0 MiB
-  max_on_wire_size: 67.22 MiB
+  max_on_disk_size: 220.0 MiB
+  max_on_wire_size: 68.22 MiB
 static_quality_gate_docker_cws_instrumentation_amd64:
   max_on_disk_size: 7.18 MiB
   max_on_wire_size: 3.33 MiB


### PR DESCRIPTION
### What does this PR do?

Increases max allowed size for DCA. Currently DCA PRs are blocked because we're at the limit for arm64 on disk.
I increased all of them because there isn't much remaining in the others either. For simplicity, I chose 2MB for the on disk ones to have some room and 1MB for the on wire size (they should need less).

As agreed with @wdhif 
