### PR TITLE
[ACTP] Render PAR config for DCA

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4578,7 +4578,7 @@ api_key:
 ## @param private_action_runner - custom object - optional
 ## Configuration for the Private Action Runner.
 ## The Private Action Runner allows executing actions within your infrastructure.
-## See https://docs.datadoghq.com/fr/actions/private_actions/ for more information.
+## See https://docs.datadoghq.com/actions/private_actions/ for more information.
 #
 # private_action_runner:
 

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -94,6 +94,7 @@ func mkContext(buildType string, osName string) context {
 			KubeApiServer:       true,
 			ClusterChecks:       true,
 			AdmissionController: true,
+			PrivateActionRunner: true,
 		}
 	case "dcacf":
 		return context{


### PR DESCRIPTION
### What does this PR do?
As the title said

### Motivation
The Private Action Runner has been enabled in the DCA for a while now https://github.com/DataDog/datadog-agent/pull/45997

### Describe how you validated your changes

### Additional Notes
