### PR TITLE
omnibus: remove a leftover dbus header

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -60,6 +60,7 @@ build do
             # Delete the leftovers of static linking.
             delete "#{install_dir}/embedded/lib/libdbus-1.a"
             delete "#{install_dir}/embedded/include/dbus-1.0"
+            delete "#{install_dir}/embedded/lib/dbus-1.0/include"
         end
 
         # TODO: Rather than move these, let's install them to the right place to start


### PR DESCRIPTION
### What does this PR do?

Remove a leftover dbus header that was meant to be removed.

### Motivation

Ensure no dbus header are installed with the agent.
This is mostly in preparation for https://github.com/DataDog/datadog-agent/pull/47511 which shows this file as missing.
Since we know it wasn't meant to be installed, move the cleanup in a dedicated PR.

### Describe how you validated your changes

### Additional Notes
