### PR TITLE
fix(testutil): Switch docker-compose to docker compose CLI v2

### DIFF
--- a/pkg/util/testutil/docker/config.go
+++ b/pkg/util/testutil/docker/config.go
@@ -31,9 +31,8 @@ var EmptyEnv []string
 type commandType string
 
 const (
-	dockerCommand commandType = "docker"
-	// we are using old v1 docker-compose command because our CI doesn't support docker cli v2 yet
-	composeCommand commandType = "docker-compose"
+	dockerCommand  commandType = "docker"
+	composeCommand commandType = "compose"
 	runCommand     commandType = "run"
 	removeCommand  commandType = "rm"
 )
@@ -158,15 +157,15 @@ type composeConfig struct {
 }
 
 func (c composeConfig) command() string {
-	return string(composeCommand)
+	return string(dockerCommand)
 }
 
 func (c composeConfig) commandArgs(t subCommandType) []string {
 	switch t {
 	case start:
-		return []string{"-f", c.File, "up", "--remove-orphans", "-V"}
+		return []string{string(composeCommand), "-f", c.File, "up", "--remove-orphans", "-V"}
 	case kill:
-		return []string{"-f", c.File, "down", "--remove-orphans", "--volumes"}
+		return []string{string(composeCommand), "-f", c.File, "down", "--remove-orphans", "--volumes"}
 	default:
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?

Switches the test utility docker compose helper from the legacy `docker-compose` v1 standalone CLI to the `docker compose` v2 CLI plugin (i.e., `docker compose ...` instead of `docker-compose ...`).

### Motivation

The old `docker-compose` v1 standalone CLI is deprecated since 2023. The comment in the code explicitly stated this was using v1 because CI didn't support v2 yet, but CI passes with this change so that's not true anymore.

### Describe how you validated your changes

CI