### PR TITLE
Fix data race on lastLine in integration downloader

### DIFF
--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 
 	"go.uber.org/fx"
 
@@ -576,23 +575,24 @@ func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType st
 	if err := downloaderCmd.Start(); err != nil {
 		return "", fmt.Errorf("error running command: %v", err)
 	}
-	var wg sync.WaitGroup
-	lastLine := ""
-	wg.Go(func() {
+	// Buffered so the goroutine can send even if we return early on error.
+	lastLineCh := make(chan string, 1)
+	go func() {
+		var last string
 		in := bufio.NewScanner(stdout)
 		for in.Scan() {
-			lastLine = in.Text()
-			fmt.Println(lastLine)
+			last = in.Text()
+			fmt.Println(last)
 		}
-	})
+		lastLineCh <- last
+	}()
 
 	if err := downloaderCmd.Wait(); err != nil {
 		return "", fmt.Errorf("error running command: %v", err)
 	}
-	wg.Wait()
 
 	// The path to the wheel will be at the last line of the output
-	wheelPath := lastLine
+	wheelPath := <-lastLineCh
 
 	// Verify the availability of the wheel file
 	if _, err := os.Stat(wheelPath); err != nil {

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"go.uber.org/fx"
 
@@ -575,8 +576,11 @@ func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType st
 	if err := downloaderCmd.Start(); err != nil {
 		return "", fmt.Errorf("error running command: %v", err)
 	}
+	var wg sync.WaitGroup
 	lastLine := ""
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		in := bufio.NewScanner(stdout)
 		for in.Scan() {
 			lastLine = in.Text()
@@ -587,6 +591,7 @@ func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType st
 	if err := downloaderCmd.Wait(); err != nil {
 		return "", fmt.Errorf("error running command: %v", err)
 	}
+	wg.Wait()
 
 	// The path to the wheel will be at the last line of the output
 	wheelPath := lastLine

--- a/cmd/agent/subcommands/integrations/command.go
+++ b/cmd/agent/subcommands/integrations/command.go
@@ -578,15 +578,13 @@ func downloadWheel(cliParams *cliParams, integration, version, rootLayoutType st
 	}
 	var wg sync.WaitGroup
 	lastLine := ""
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		in := bufio.NewScanner(stdout)
 		for in.Scan() {
 			lastLine = in.Text()
 			fmt.Println(lastLine)
 		}
-	}()
+	})
 
 	if err := downloaderCmd.Wait(); err != nil {
 		return "", fmt.Errorf("error running command: %v", err)


### PR DESCRIPTION
### What does this PR do?

Fix a data race on `lastLine` in the integration downloader. The variable is written inside a goroutine and read on the main goroutine after `cmd.Wait()`. Since `cmd.Wait()` only closes the stdout pipe but does not wait for the scanning goroutine to finish, there is no happens-before guarantee. A `sync.WaitGroup` is added to synchronize goroutine exit before reading `lastLine`.

### Motivation

Fixes a data race that the Go race detector would flag, and that could produce a torn or stale read of the last output line of the downloader command.

### Describe how you validated your changes

CI.

### Additional Notes

This bug was found by Claude.