### PR TITLE
Fix data race writing upToDate under read lock in RemoteConfigProvider

### DIFF
--- a/comp/core/autodiscovery/providers/remote_config.go
+++ b/comp/core/autodiscovery/providers/remote_config.go
@@ -51,8 +51,8 @@ func NewRemoteConfigProvider() *RemoteConfigProvider {
 
 // Collect retrieves integrations from the remote-config, builds Config objects and returns them
 func (rc *RemoteConfigProvider) Collect(_ context.Context) ([]integration.Config, error) {
-	rc.mu.RLock()
-	defer rc.mu.RUnlock()
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
 
 	rc.upToDate = true
 


### PR DESCRIPTION
### What does this PR do?

Fix a data race in `RemoteConfigProvider.Collect()`. The method acquires `rc.mu.RLock()` then writes `rc.upToDate = true`. Multiple goroutines can hold a read lock simultaneously, so concurrent `Collect()` calls produce concurrent writes to `upToDate`. Additionally, `IsUpToDate()` reads `upToDate` under `RLock`, which races with the write in `Collect()`. The fix upgrades the lock in `Collect()` from `RLock` to `Lock`.

### Motivation

Fixes a data race.

### Describe how you validated your changes

CI.

### Additional Notes

This bug was found by Claude.