### PR TITLE
Fix data race on configErrors in KubeServiceConfigProvider

### DIFF
--- a/comp/core/autodiscovery/providers/kube_services.go
+++ b/comp/core/autodiscovery/providers/kube_services.go
@@ -168,7 +168,7 @@ func valuesDiffer(first, second map[string]string, prefix string) bool {
 func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Service, ddConf model.Config) ([]integration.Config, error) {
 	var configs []integration.Config
 
-	newErrors := make(map[string]types.ErrorMsgSet)
+	setServiceIDs := map[string]struct{}{}
 
 	for _, svc := range services {
 		if svc == nil || svc.ObjectMeta.UID == "" {
@@ -177,6 +177,7 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		}
 
 		serviceID := apiserver.EntityForService(svc)
+		setServiceIDs[serviceID] = struct{}{}
 		svcConf, errors := utils.ExtractTemplatesFromAnnotations(serviceID, svc.Annotations, kubeServiceID)
 		if len(errors) > 0 {
 			errMsgSet := make(types.ErrorMsgSet)
@@ -184,7 +185,13 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 				log.Errorf("Cannot parse service template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 				errMsgSet[err.Error()] = struct{}{}
 			}
-			newErrors[serviceID] = errMsgSet
+			k.mu.Lock()
+			k.configErrors[serviceID] = errMsgSet
+			k.mu.Unlock()
+		} else {
+			k.mu.Lock()
+			delete(k.configErrors, serviceID)
+			k.mu.Unlock()
 		}
 
 		ignoreAdForHybridScenariosTags := ignoreADTagsFromAnnotations(svc.GetAnnotations(), kubeServiceAnnotationPrefix)
@@ -201,14 +208,33 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		configs = append(configs, svcConf...)
 	}
 
-	k.mu.Lock()
-	k.configErrors = newErrors
+	k.cleanErrorsOfDeletedServices(setServiceIDs)
+
 	if k.telemetryStore != nil {
-		k.telemetryStore.Errors.Set(float64(len(k.configErrors)), names.KubeServices)
+		k.mu.RLock()
+		n := len(k.configErrors)
+		k.mu.RUnlock()
+		k.telemetryStore.Errors.Set(float64(n), names.KubeServices)
 	}
-	k.mu.Unlock()
 
 	return configs, nil
+}
+
+func (k *KubeServiceConfigProvider) cleanErrorsOfDeletedServices(setCurrentServiceIDs map[string]struct{}) {
+	setServiceIDsWithErrors := map[string]struct{}{}
+
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	for serviceID := range k.configErrors {
+		setServiceIDsWithErrors[serviceID] = struct{}{}
+	}
+
+	for serviceID := range setServiceIDsWithErrors {
+		if _, exists := setCurrentServiceIDs[serviceID]; !exists {
+			delete(k.configErrors, serviceID)
+		}
+	}
 }
 
 // GetConfigErrors returns a map of configuration errors for each Kubernetes service

--- a/comp/core/autodiscovery/providers/kube_services.go
+++ b/comp/core/autodiscovery/providers/kube_services.go
@@ -10,6 +10,7 @@ package providers
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 
@@ -215,9 +216,5 @@ func (k *KubeServiceConfigProvider) GetConfigErrors() map[string]types.ErrorMsgS
 	k.mu.RLock()
 	defer k.mu.RUnlock()
 
-	errors := make(map[string]types.ErrorMsgSet, len(k.configErrors))
-	for k2, v := range k.configErrors {
-		errors[k2] = v
-	}
-	return errors
+	return maps.Clone(k.configErrors)
 }

--- a/comp/core/autodiscovery/providers/kube_services.go
+++ b/comp/core/autodiscovery/providers/kube_services.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"go.uber.org/atomic"
 	v1 "k8s.io/api/core/v1"
@@ -38,6 +39,7 @@ const (
 type KubeServiceConfigProvider struct {
 	lister         listersv1.ServiceLister
 	upToDate       *atomic.Bool
+	mu             sync.RWMutex
 	configErrors   map[string]types.ErrorMsgSet
 	telemetryStore *telemetry.Store
 }
@@ -165,7 +167,7 @@ func valuesDiffer(first, second map[string]string, prefix string) bool {
 func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Service, ddConf model.Config) ([]integration.Config, error) {
 	var configs []integration.Config
 
-	setServiceIDs := map[string]struct{}{}
+	newErrors := make(map[string]types.ErrorMsgSet)
 
 	for _, svc := range services {
 		if svc == nil || svc.ObjectMeta.UID == "" {
@@ -174,7 +176,6 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		}
 
 		serviceID := apiserver.EntityForService(svc)
-		setServiceIDs[serviceID] = struct{}{}
 		svcConf, errors := utils.ExtractTemplatesFromAnnotations(serviceID, svc.Annotations, kubeServiceID)
 		if len(errors) > 0 {
 			errMsgSet := make(types.ErrorMsgSet)
@@ -182,9 +183,7 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 				log.Errorf("Cannot parse service template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 				errMsgSet[err.Error()] = struct{}{}
 			}
-			k.configErrors[serviceID] = errMsgSet
-		} else {
-			delete(k.configErrors, serviceID)
+			newErrors[serviceID] = errMsgSet
 		}
 
 		ignoreAdForHybridScenariosTags := ignoreADTagsFromAnnotations(svc.GetAnnotations(), kubeServiceAnnotationPrefix)
@@ -201,29 +200,24 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		configs = append(configs, svcConf...)
 	}
 
-	k.cleanErrorsOfDeletedServices(setServiceIDs)
-
+	k.mu.Lock()
+	k.configErrors = newErrors
 	if k.telemetryStore != nil {
 		k.telemetryStore.Errors.Set(float64(len(k.configErrors)), names.KubeServices)
 	}
+	k.mu.Unlock()
 
 	return configs, nil
 }
 
-func (k *KubeServiceConfigProvider) cleanErrorsOfDeletedServices(setCurrentServiceIDs map[string]struct{}) {
-	setServiceIDsWithErrors := map[string]struct{}{}
-	for serviceID := range k.configErrors {
-		setServiceIDsWithErrors[serviceID] = struct{}{}
-	}
-
-	for serviceID := range setServiceIDsWithErrors {
-		if _, exists := setCurrentServiceIDs[serviceID]; !exists {
-			delete(k.configErrors, serviceID)
-		}
-	}
-}
-
 // GetConfigErrors returns a map of configuration errors for each Kubernetes service
 func (k *KubeServiceConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
-	return k.configErrors
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	errors := make(map[string]types.ErrorMsgSet, len(k.configErrors))
+	for k2, v := range k.configErrors {
+		errors[k2] = v
+	}
+	return errors
 }

--- a/comp/core/autodiscovery/providers/kube_services.go
+++ b/comp/core/autodiscovery/providers/kube_services.go
@@ -40,7 +40,7 @@ const (
 type KubeServiceConfigProvider struct {
 	lister         listersv1.ServiceLister
 	upToDate       *atomic.Bool
-	mu             sync.RWMutex
+	configErrorsMu sync.RWMutex
 	configErrors   map[string]types.ErrorMsgSet
 	telemetryStore *telemetry.Store
 }
@@ -201,20 +201,20 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		configs = append(configs, svcConf...)
 	}
 
-	k.mu.Lock()
+	k.configErrorsMu.Lock()
 	k.configErrors = newErrors
 	if k.telemetryStore != nil {
 		k.telemetryStore.Errors.Set(float64(len(k.configErrors)), names.KubeServices)
 	}
-	k.mu.Unlock()
+	k.configErrorsMu.Unlock()
 
 	return configs, nil
 }
 
 // GetConfigErrors returns a map of configuration errors for each Kubernetes service
 func (k *KubeServiceConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
-	k.mu.RLock()
-	defer k.mu.RUnlock()
+	k.configErrorsMu.RLock()
+	defer k.configErrorsMu.RUnlock()
 
 	return maps.Clone(k.configErrors)
 }

--- a/comp/core/autodiscovery/providers/kube_services.go
+++ b/comp/core/autodiscovery/providers/kube_services.go
@@ -168,7 +168,7 @@ func valuesDiffer(first, second map[string]string, prefix string) bool {
 func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Service, ddConf model.Config) ([]integration.Config, error) {
 	var configs []integration.Config
 
-	setServiceIDs := map[string]struct{}{}
+	newErrors := make(map[string]types.ErrorMsgSet)
 
 	for _, svc := range services {
 		if svc == nil || svc.ObjectMeta.UID == "" {
@@ -177,7 +177,6 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		}
 
 		serviceID := apiserver.EntityForService(svc)
-		setServiceIDs[serviceID] = struct{}{}
 		svcConf, errors := utils.ExtractTemplatesFromAnnotations(serviceID, svc.Annotations, kubeServiceID)
 		if len(errors) > 0 {
 			errMsgSet := make(types.ErrorMsgSet)
@@ -185,13 +184,7 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 				log.Errorf("Cannot parse service template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 				errMsgSet[err.Error()] = struct{}{}
 			}
-			k.mu.Lock()
-			k.configErrors[serviceID] = errMsgSet
-			k.mu.Unlock()
-		} else {
-			k.mu.Lock()
-			delete(k.configErrors, serviceID)
-			k.mu.Unlock()
+			newErrors[serviceID] = errMsgSet
 		}
 
 		ignoreAdForHybridScenariosTags := ignoreADTagsFromAnnotations(svc.GetAnnotations(), kubeServiceAnnotationPrefix)
@@ -208,33 +201,14 @@ func (k *KubeServiceConfigProvider) parseServiceAnnotations(services []*v1.Servi
 		configs = append(configs, svcConf...)
 	}
 
-	k.cleanErrorsOfDeletedServices(setServiceIDs)
-
+	k.mu.Lock()
+	k.configErrors = newErrors
 	if k.telemetryStore != nil {
-		k.mu.RLock()
-		n := len(k.configErrors)
-		k.mu.RUnlock()
-		k.telemetryStore.Errors.Set(float64(n), names.KubeServices)
+		k.telemetryStore.Errors.Set(float64(len(k.configErrors)), names.KubeServices)
 	}
+	k.mu.Unlock()
 
 	return configs, nil
-}
-
-func (k *KubeServiceConfigProvider) cleanErrorsOfDeletedServices(setCurrentServiceIDs map[string]struct{}) {
-	setServiceIDsWithErrors := map[string]struct{}{}
-
-	k.mu.Lock()
-	defer k.mu.Unlock()
-
-	for serviceID := range k.configErrors {
-		setServiceIDsWithErrors[serviceID] = struct{}{}
-	}
-
-	for serviceID := range setServiceIDsWithErrors {
-		if _, exists := setCurrentServiceIDs[serviceID]; !exists {
-			delete(k.configErrors, serviceID)
-		}
-	}
 }
 
 // GetConfigErrors returns a map of configuration errors for each Kubernetes service


### PR DESCRIPTION
### What does this PR do?

Fix a data race on `configErrors` in `KubeServiceConfigProvider`. Each provider has a dedicated polling goroutine (in `config_poller.go`) that periodically calls `Collect()` → `parseServiceAnnotations()`, which writes to `configErrors`. Concurrently, `GetConfigErrors()` is called from `GetAutodiscoveryErrors()` on arbitrary HTTP handler goroutines — triggered by `agent status`, the GUI endpoint, or `/config-check`. Since `configErrors` has no synchronization, a concurrent map read+write can occur when a status request lands while a poll is in progress.

The fix adds a `sync.RWMutex` to the struct. `parseServiceAnnotations` now builds errors into a local map and replaces `configErrors` atomically under a write lock. `GetConfigErrors` returns a copy under a read lock. The now-unnecessary `cleanErrorsOfDeletedServices` method is removed since rebuilding from scratch on each `Collect` call is equivalent.

### Motivation

Fixes a data race that the Go race detector would flag. The window is narrow (poll in progress while a status request arrives) which explains why it has not been observed in practice, but it is a real race under Go's memory model.

### Describe how you validated your changes

CI.

### Additional Notes

This bug was found by Claude.