### PR TITLE
feat(logs): add logs_agent_profile config key for named performance p…

### DIFF
--- a/comp/logs/agent/agentimpl/agent_core_init.go
+++ b/comp/logs/agent/agentimpl/agent_core_init.go
@@ -103,7 +103,7 @@ func buildHTTPEndpointsForRestart(coreConfig model.Reader) (*config.Endpoints, e
 // buildPipelineProvider builds a new pipeline provider with the given configuration
 func buildPipelineProvider(a *logAgent, processingRules []*config.ProcessingRule, diagnosticMessageReceiver *diagnostic.BufferedMessageReceiver, destinationsCtx *client.DestinationsContext) pipeline.Provider {
 	pipelineProvider := pipeline.NewProvider(
-		a.config.GetInt("logs_config.pipelines"),
+		config.PipelinesCount(a.config),
 		a.auditor,
 		diagnosticMessageReceiver,
 		processingRules,

--- a/comp/logs/agent/agentimpl/status_templates/logsagent.tmpl
+++ b/comp/logs/agent/agentimpl/status_templates/logsagent.tmpl
@@ -46,6 +46,16 @@
   {{- end }}
 {{- end }}
 
+{{- if .PipelineHealth }}
+
+  ===============
+  Pipeline Health
+  ===============
+  {{- range $line := .PipelineHealth }}
+  {{$line}}
+  {{- end }}
+{{- end }}
+
 {{- if .Integrations }}
   ============
   Integrations

--- a/comp/logs/agent/agentimpl/status_templates/logsagentHTML.tmpl
+++ b/comp/logs/agent/agentimpl/status_templates/logsagentHTML.tmpl
@@ -34,6 +34,16 @@
       {{- end }}
       </span>
     {{- end}}
+    {{- if .PipelineHealth }}
+      <span class="stat_subtitle">Pipeline Health</span>
+      <span class="stat_subdata">
+        <table style="font-family:monospace;border-collapse:collapse">
+        {{- range $line := .PipelineHealth }}
+          <tr><td style="white-space:pre">{{$line}}</td></tr>
+        {{- end }}
+        </table>
+      </span>
+    {{- end }}
     {{- range .Integrations }}
       <span class="stat_subtitle">{{ .Name }}</span>
       <span class="stat_subdata">

--- a/comp/logs/agent/config/config_keys.go
+++ b/comp/logs/agent/config/config_keys.go
@@ -133,6 +133,12 @@ func (l *LogsConfigKeys) compressionKind() string {
 		}
 	}
 
+	if !l.config.IsConfigured(configKey) {
+		if p := getActiveProfile(l.config); p != nil && p.compressionKind != nil {
+			return *p.compressionKind
+		}
+	}
+
 	if compressionKind == ZstdCompressionKind || compressionKind == GzipCompressionKind {
 		return compressionKind
 	}
@@ -143,14 +149,26 @@ func (l *LogsConfigKeys) compressionKind() string {
 
 func (l *LogsConfigKeys) compressionLevel() int {
 	if l.compressionKind() == ZstdCompressionKind {
-		level := l.getConfig().GetInt(l.getConfigKey("zstd_compression_level"))
+		key := l.getConfigKey("zstd_compression_level")
+		if !l.config.IsConfigured(key) {
+			if p := getActiveProfile(l.config); p != nil && p.zstdCompressionLevel != nil {
+				return *p.zstdCompressionLevel
+			}
+		}
+		level := l.getConfig().GetInt(key)
 		if strings.HasPrefix(l.prefix, "logs_config.") {
 			log.Debugf("Logs pipeline is using compression zstd at level: %d", level)
 		}
 		return level
 	}
 
-	level := l.getConfig().GetInt(l.getConfigKey("compression_level"))
+	key := l.getConfigKey("compression_level")
+	if !l.config.IsConfigured(key) {
+		if p := getActiveProfile(l.config); p != nil && p.gzipCompressionLevel != nil {
+			return *p.gzipCompressionLevel
+		}
+	}
+	level := l.getConfig().GetInt(key)
 	if strings.HasPrefix(l.prefix, "logs_config.") {
 		log.Debugf("Logs pipeline is using compression gzip atlevel: %d", level)
 	}
@@ -158,7 +176,14 @@ func (l *LogsConfigKeys) compressionLevel() int {
 }
 
 func (l *LogsConfigKeys) useCompression() bool {
-	return l.getConfig().GetBool(l.getConfigKey("use_compression"))
+	key := l.getConfigKey("use_compression")
+	if l.config.IsConfigured(key) {
+		return l.config.GetBool(key)
+	}
+	if p := getActiveProfile(l.config); p != nil && p.useCompression != nil {
+		return *p.useCompression
+	}
+	return l.config.GetBool(key)
 }
 
 func (l *LogsConfigKeys) hasAdditionalEndpoints() bool {
@@ -225,6 +250,11 @@ func (l *LogsConfigKeys) batchMaxConcurrentSend() int {
 	if batchMaxConcurrentSend < 0 {
 		log.Warnf("Invalid %s: %v should be >= 0, fallback on %v", key, batchMaxConcurrentSend, pkgconfigsetup.DefaultBatchMaxConcurrentSend)
 		return pkgconfigsetup.DefaultBatchMaxConcurrentSend
+	}
+	if !l.config.IsConfigured(key) {
+		if p := getActiveProfile(l.config); p != nil && p.batchMaxConcurrentSend != nil {
+			return *p.batchMaxConcurrentSend
+		}
 	}
 	return batchMaxConcurrentSend
 }

--- a/comp/logs/agent/config/profiles.go
+++ b/comp/logs/agent/config/profiles.go
@@ -1,0 +1,120 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"runtime"
+
+	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// logsAgentProfile holds optional overrides for logs agent tuning settings.
+// A nil pointer field means "no override; use the system default."
+type logsAgentProfile struct {
+	pipelines              *int
+	batchMaxConcurrentSend *int
+	useCompression         *bool
+	compressionKind        *string
+	gzipCompressionLevel   *int
+	zstdCompressionLevel   *int
+	messageChannelSize     *int
+	payloadChannelSize     *int
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// profiles is the registry of named performance profiles.
+// Fields left as nil fall through to the system default.
+var profiles = map[string]*logsAgentProfile{
+	// balanced: all defaults — present for self-documenting explicitness.
+	"balanced": {},
+
+	// wan_optimized: more concurrent HTTP requests to hide WAN latency.
+	"wan_optimized": {
+		batchMaxConcurrentSend: ptr(20),
+	},
+
+	// max_throughput: adds no-compression to wan_optimized; CPU freed, relies on fast network.
+	"max_throughput": {
+		batchMaxConcurrentSend: ptr(20),
+		useCompression:         ptr(false),
+	},
+
+	// low_resource: single pipeline, halved channel buffers; saves goroutines + memory.
+	"low_resource": {
+		pipelines:          ptr(1),
+		messageChannelSize: ptr(50),
+		payloadChannelSize: ptr(5),
+	},
+
+	// bandwidth_saver: gzip level 9 maximises compression ratio (trades CPU for bandwidth).
+	"bandwidth_saver": {
+		compressionKind:      ptr(GzipCompressionKind),
+		gzipCompressionLevel: ptr(9),
+	},
+
+	// performance: all CPUs as pipelines + high send concurrency; for high-ingestion hosts.
+	"performance": {
+		pipelines:              ptr(runtime.GOMAXPROCS(0)),
+		batchMaxConcurrentSend: ptr(20),
+	},
+}
+
+// getActiveProfile returns the profile selected by logs_config.logs_agent_profile, or nil
+// when the profile is empty/unset ("" or "balanced" both result in no overrides).
+// An unknown profile name emits a warning and returns nil.
+func getActiveProfile(cfg pkgconfigmodel.Reader) *logsAgentProfile {
+	name := cfg.GetString("logs_config.logs_agent_profile")
+	if name == "" {
+		return nil
+	}
+	p, ok := profiles[name]
+	if !ok {
+		log.Warnf("Unknown logs_agent_profile %q; ignoring. Valid values: balanced, wan_optimized, max_throughput, low_resource, bandwidth_saver, performance", name)
+		return nil
+	}
+	return p
+}
+
+// PipelinesCount returns the number of log processing pipelines to use.
+// The active profile is consulted when the user has not explicitly set the key.
+func PipelinesCount(cfg pkgconfigmodel.Reader) int {
+	const key = "logs_config.pipelines"
+	if cfg.IsConfigured(key) {
+		return cfg.GetInt(key)
+	}
+	if p := getActiveProfile(cfg); p != nil && p.pipelines != nil {
+		return *p.pipelines
+	}
+	return cfg.GetInt(key)
+}
+
+// MessageChannelSize returns the size of the per-pipeline message channel.
+// The active profile is consulted when the user has not explicitly set the key.
+func MessageChannelSize(cfg pkgconfigmodel.Reader) int {
+	const key = "logs_config.message_channel_size"
+	if cfg.IsConfigured(key) {
+		return cfg.GetInt(key)
+	}
+	if p := getActiveProfile(cfg); p != nil && p.messageChannelSize != nil {
+		return *p.messageChannelSize
+	}
+	return cfg.GetInt(key)
+}
+
+// PayloadChannelSize returns the size of the payload channel used by senders.
+// The active profile is consulted when the user has not explicitly set the key.
+func PayloadChannelSize(cfg pkgconfigmodel.Reader) int {
+	const key = "logs_config.payload_channel_size"
+	if cfg.IsConfigured(key) {
+		return cfg.GetInt(key)
+	}
+	if p := getActiveProfile(cfg); p != nil && p.payloadChannelSize != nil {
+		return *p.payloadChannelSize
+	}
+	return cfg.GetInt(key)
+}

--- a/comp/logs/agent/config/profiles_test.go
+++ b/comp/logs/agent/config/profiles_test.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	coreconfig "github.com/DataDog/datadog-agent/comp/core/config"
+)
+
+func newMockCfg(t *testing.T) coreconfig.Component {
+	t.Helper()
+	return coreconfig.NewMockWithOverrides(t, map[string]any{"api_key": "test"})
+}
+
+// 1. No profile → system default returned for PipelinesCount.
+func TestNoProfile_PipelinesCount(t *testing.T) {
+	cfg := newMockCfg(t)
+	// System default is min(4, GOMAXPROCS). Don't pin the exact value; just confirm no panic
+	// and that the result matches cfg.GetInt directly.
+	assert.Equal(t, cfg.GetInt("logs_config.pipelines"), PipelinesCount(cfg))
+}
+
+// 2. low_resource, no user override → pipelines=1, channels halved.
+func TestLowResource_Defaults(t *testing.T) {
+	cfg := newMockCfg(t)
+	cfg.SetWithoutSource("logs_config.logs_agent_profile", "low_resource")
+
+	assert.Equal(t, 1, PipelinesCount(cfg))
+	assert.Equal(t, 50, MessageChannelSize(cfg))
+	assert.Equal(t, 5, PayloadChannelSize(cfg))
+}
+
+// 3. low_resource + explicit pipelines=3 → user wins.
+func TestLowResource_ExplicitPipelines(t *testing.T) {
+	cfg := newMockCfg(t)
+	cfg.SetWithoutSource("logs_config.logs_agent_profile", "low_resource")
+	cfg.SetWithoutSource("logs_config.pipelines", 3)
+
+	assert.Equal(t, 3, PipelinesCount(cfg))
+	// channel sizes still come from profile since user didn't override them
+	assert.Equal(t, 50, MessageChannelSize(cfg))
+	assert.Equal(t, 5, PayloadChannelSize(cfg))
+}
+
+// 4. wan_optimized → batchMaxConcurrentSend=20.
+func TestWanOptimized_BatchMaxConcurrentSend(t *testing.T) {
+	cfg := newMockCfg(t)
+	cfg.SetWithoutSource("logs_config.logs_agent_profile", "wan_optimized")
+
+	lck := defaultLogsConfigKeys(cfg)
+	assert.Equal(t, 20, lck.batchMaxConcurrentSend())
+}
+
+// 5. wan_optimized + explicit batch_max_concurrent_send=5 → 5.
+func TestWanOptimized_ExplicitBatchMaxConcurrentSend(t *testing.T) {
+	cfg := newMockCfg(t)
+	cfg.SetWithoutSource("logs_config.logs_agent_profile", "wan_optimized")
+	cfg.SetWithoutSource("logs_config.batch_max_concurrent_send", 5)
+
+	lck := defaultLogsConfigKeys(cfg)
+	assert.Equal(t, 5, lck.batchMaxConcurrentSend())
+}
+
+// 6. Unknown profile name → system default + no panic (warning logged).
+func TestUnknownProfile_FallsThrough(t *testing.T) {
+	cfg := newMockCfg(t)
+	cfg.SetWithoutSource("logs_config.logs_agent_profile", "does_not_exist")
+
+	assert.Equal(t, cfg.GetInt("logs_config.pipelines"), PipelinesCount(cfg))
+	assert.Equal(t, cfg.GetInt("logs_config.message_channel_size"), MessageChannelSize(cfg))
+	assert.Equal(t, cfg.GetInt("logs_config.payload_channel_size"), PayloadChannelSize(cfg))
+}
+
+// 7. bandwidth_saver → gzip kind, level 9.
+func TestBandwidthSaver_CompressionKindAndLevel(t *testing.T) {
+	cfg := newMockCfg(t)
+	cfg.SetWithoutSource("logs_config.logs_agent_profile", "bandwidth_saver")
+
+	lck := defaultLogsConfigKeys(cfg)
+	assert.Equal(t, GzipCompressionKind, lck.compressionKind())
+	assert.Equal(t, 9, lck.compressionLevel())
+}
+
+// 8. max_throughput → useCompression=false.
+func TestMaxThroughput_UseCompression(t *testing.T) {
+	cfg := newMockCfg(t)
+	cfg.SetWithoutSource("logs_config.logs_agent_profile", "max_throughput")
+
+	lck := defaultLogsConfigKeys(cfg)
+	assert.False(t, lck.useCompression())
+}
+
+// 9. performance → pipelines=GOMAXPROCS.
+func TestPerformance_Pipelines(t *testing.T) {
+	cfg := newMockCfg(t)
+	cfg.SetWithoutSource("logs_config.logs_agent_profile", "performance")
+
+	assert.Equal(t, runtime.GOMAXPROCS(0), PipelinesCount(cfg))
+}

--- a/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
+++ b/comp/otelcol/otlp/components/exporter/datadogexporter/host_metadata_test.go
@@ -60,7 +60,7 @@ func (*mockProvider) Stop()                                   {}
 func (*mockProvider) NextPipelineChan() chan *message.Message { return make(chan *message.Message, 10) }
 func (*mockProvider) GetOutputChan() chan *message.Message    { return make(chan *message.Message, 10) }
 func (*mockProvider) NextPipelineChanWithMonitor() (chan *message.Message, *metrics.CapacityMonitor) {
-	return make(chan *message.Message), metrics.NewCapacityMonitor("test", "test-instance")
+	return make(chan *message.Message), metrics.NewCapacityMonitor("test", "test-instance", 0)
 }
 func (*mockProvider) Flush(_ context.Context) {}
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -2085,6 +2085,11 @@ func logsagent(config pkgconfigmodel.Setup) {
 	logsPipelines := min(4, runtime.GOMAXPROCS(0))
 	config.BindEnvAndSetDefault("logs_config.pipelines", logsPipelines)
 
+	// Named performance profile for the logs agent. Valid values: "", "balanced", "wan_optimized",
+	// "max_throughput", "low_resource", "bandwidth_saver", "performance". Empty string (default)
+	// means no profile is applied. Any explicitly-set granular setting takes precedence over the profile.
+	config.BindEnvAndSetDefault("logs_config.logs_agent_profile", "")
+
 	// If true, the agent looks for container logs in the location used by podman, rather
 	// than docker.  This is a temporary configuration parameter to support podman logs until
 	// a more substantial refactor of autodiscovery is made to determine this automatically.

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -260,6 +260,7 @@ func (d *Destination) sendAndRetry(payload *message.Payload, output chan *messag
 			metrics.RetryTimeSpent.Add(int64(backoffDuration))
 			metrics.RetryCount.Add(1)
 			metrics.TlmRetryCount.Add(1)
+			metrics.GlobalSaturationHistory.RecordRetry()
 		}
 
 		start := time.Now()

--- a/pkg/logs/metrics/capacity_monitor.go
+++ b/pkg/logs/metrics/capacity_monitor.go
@@ -14,32 +14,37 @@ import (
 // CapacityMonitor samples the average capacity of a component over a given interval.
 // Capacity is calculated as the difference between the ingress and egress of a payload.
 // Because data moves very quickly through components, we need to sample and aggregate this value over time.
+// When channelCapacity > 0, the monitor also computes a fill percentage and records it to
+// GlobalSaturationHistory for bottleneck detection and profile recommendation.
 type CapacityMonitor struct {
 	sync.Mutex
-	ingress      int64
-	ingressBytes int64
-	egress       int64
-	egressBytes  int64
-	avgItems     float64
-	avgBytes     float64
-	name         string
-	instance     string
-	tickChan     <-chan time.Time
+	ingress         int64
+	ingressBytes    int64
+	egress          int64
+	egressBytes     int64
+	avgItems        float64
+	avgBytes        float64
+	name            string
+	instance        string
+	channelCapacity int // 0 means capacity unknown; no fill % computed
+	tickChan        <-chan time.Time
 }
 
-// NewCapacityMonitor creates a new CapacityMonitor
-func NewCapacityMonitor(name, instance string) *CapacityMonitor {
-	return newCapacityMonitorWithTick(name, instance, time.NewTicker(1*time.Second).C)
+// NewCapacityMonitor creates a new CapacityMonitor. channelCapacity is the size of the
+// upstream channel feeding this component; pass 0 if unknown.
+func NewCapacityMonitor(name, instance string, channelCapacity int) *CapacityMonitor {
+	return newCapacityMonitorWithTick(name, instance, channelCapacity, time.NewTicker(1*time.Second).C)
 }
 
 // newCapacityMonitorWithTick is used for testing.
-func newCapacityMonitorWithTick(name, instance string, tickChan <-chan time.Time) *CapacityMonitor {
+func newCapacityMonitorWithTick(name, instance string, channelCapacity int, tickChan <-chan time.Time) *CapacityMonitor {
 	return &CapacityMonitor{
-		name:     name,
-		instance: instance,
-		avgItems: 0,
-		avgBytes: 0,
-		tickChan: tickChan,
+		name:            name,
+		instance:        instance,
+		channelCapacity: channelCapacity,
+		avgItems:        0,
+		avgBytes:        0,
+		tickChan:        tickChan,
 	}
 }
 
@@ -91,4 +96,12 @@ func (i *CapacityMonitor) report() {
 	}
 	TlmUtilizationItems.Set(i.avgItems, i.name, i.instance)
 	TlmUtilizationBytes.Set(i.avgBytes, i.name, i.instance)
+	if i.channelCapacity > 0 {
+		fillPct := i.avgItems / float64(i.channelCapacity)
+		if fillPct > 1.0 {
+			fillPct = 1.0
+		}
+		TlmUtilizationFillPct.Set(fillPct*100, i.name, i.instance)
+		GlobalSaturationHistory.RecordFill(i.name, fillPct)
+	}
 }

--- a/pkg/logs/metrics/capacity_monitor_test.go
+++ b/pkg/logs/metrics/capacity_monitor_test.go
@@ -27,7 +27,7 @@ func (m mockPayload) Count() int64 {
 func TestCapacityMonitor(t *testing.T) {
 
 	tickChan := make(chan time.Time, 1)
-	m := newCapacityMonitorWithTick("test", "test", tickChan)
+	m := newCapacityMonitorWithTick("test", "test", 0, tickChan)
 
 	assert.Equal(t, m.avgItems, 0.0)
 	assert.Equal(t, m.avgBytes, 0.0)

--- a/pkg/logs/metrics/metrics.go
+++ b/pkg/logs/metrics/metrics.go
@@ -96,6 +96,17 @@ var (
 	TlmUtilizationItems = telemetry.NewGauge("logs_component_utilization", "items", []string{"name", "instance"}, "Gauge of the number of items currently held in a component and its buffers")
 	// TlmUtilizationBytes is the capacity of a component by number of bytes
 	TlmUtilizationBytes = telemetry.NewGauge("logs_component_utilization", "bytes", []string{"name", "instance"}, "Gauge of the number of bytes currently held in a component and its buffers")
+	// TlmUtilizationFillPct is the fill percentage of a component's input queue (0-100).
+	// Only emitted for stages where channel capacity is known (processor, strategy).
+	TlmUtilizationFillPct = telemetry.NewGauge("logs_component_utilization", "fill_pct", []string{"name", "instance"}, "Fill percentage (0-100) of the component's input queue")
+
+	// TlmStageSaturation is 1 when a pipeline stage is currently saturated (fill > 70% or high retry rate), 0 otherwise.
+	TlmStageSaturation = telemetry.NewGauge("logs", "stage_saturation", []string{"stage"}, "1 when a pipeline stage is saturated, 0 otherwise")
+
+	// TlmProfileRecommendationActive is 1 when a profile change is recommended based on observed bottlenecks.
+	// Tagged with the current and suggested profile names.
+	TlmProfileRecommendationActive = telemetry.NewGauge("logs", "profile_recommendation_active", []string{"current_profile", "suggested_profile"}, "1 when a profile change is recommended based on observed pipeline bottlenecks")
+
 	// TlmDestNumWorkers is the number of destination workers in use.
 	TlmDestNumWorkers = telemetry.NewGauge("logs_destination", "destination_workers", []string{"instance"}, "Gauge of the number of destination workers in use")
 	// TlmDestVirtualLatency is a moving average of the destination's latency.

--- a/pkg/logs/metrics/pipeline_monitor.go
+++ b/pkg/logs/metrics/pipeline_monitor.go
@@ -37,6 +37,9 @@ type PipelineMonitor interface {
 	ReportComponentIngress(size MeasurablePayload, name string, instanceID string)
 	ReportComponentEgress(size MeasurablePayload, name string, instanceID string)
 	MakeUtilizationMonitor(name string, instanceID string) UtilizationMonitor
+	// SetStageCapacity registers the channel capacity for a named stage so that
+	// fill-percentage metrics and saturation history can be computed.
+	SetStageCapacity(name string, capacity int)
 }
 
 // NoopPipelineMonitor is a no-op implementation of PipelineMonitor.
@@ -70,18 +73,32 @@ func (n *NoopPipelineMonitor) MakeUtilizationMonitor(_ string, _ string) Utiliza
 	return &NoopUtilizationMonitor{}
 }
 
+// SetStageCapacity does nothing.
+func (n *NoopPipelineMonitor) SetStageCapacity(_ string, _ int) {}
+
 // TelemetryPipelineMonitor is a PipelineMonitor that reports capacity metrics to telemetry
 type TelemetryPipelineMonitor struct {
-	monitors map[string]*CapacityMonitor
-	lock     sync.RWMutex
+	monitors   map[string]*CapacityMonitor
+	capacities map[string]int // keyed by stage name; set via SetStageCapacity
+	lock       sync.RWMutex
 }
 
-// NewTelemetryPipelineMonitor creates a new pipeline monitort that reports capacity and utiilization metrics as telemetry
+// NewTelemetryPipelineMonitor creates a new pipeline monitor that reports capacity and utilization metrics as telemetry
 func NewTelemetryPipelineMonitor() *TelemetryPipelineMonitor {
 	return &TelemetryPipelineMonitor{
-		monitors: make(map[string]*CapacityMonitor),
-		lock:     sync.RWMutex{},
+		monitors:   make(map[string]*CapacityMonitor),
+		capacities: make(map[string]int),
+		lock:       sync.RWMutex{},
 	}
+}
+
+// SetStageCapacity registers the channel capacity for a named pipeline stage so that
+// fill-percentage metrics and saturation history can be computed.
+// Must be called before the stage's CapacityMonitor is first used.
+func (c *TelemetryPipelineMonitor) SetStageCapacity(name string, capacity int) {
+	c.lock.Lock()
+	c.capacities[name] = capacity
+	c.lock.Unlock()
 }
 
 func (c *TelemetryPipelineMonitor) getMonitor(name string, instanceID string) *CapacityMonitor {
@@ -94,7 +111,8 @@ func (c *TelemetryPipelineMonitor) getMonitor(name string, instanceID string) *C
 	if !exists {
 		c.lock.Lock()
 		if c.monitors[key] == nil {
-			c.monitors[key] = NewCapacityMonitor(name, instanceID)
+			capacity := c.capacities[name] // 0 if not registered — fill % won't be computed
+			c.monitors[key] = NewCapacityMonitor(name, instanceID, capacity)
 		}
 		monitor = c.monitors[key]
 		c.lock.Unlock()

--- a/pkg/logs/metrics/saturation_history.go
+++ b/pkg/logs/metrics/saturation_history.go
@@ -1,0 +1,336 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// saturationHighThreshold is the fill percentage above which a stage is considered saturated.
+	saturationHighThreshold = 0.70
+	// saturationLowThreshold is the fill percentage below which a saturated stage is considered recovered.
+	// The gap between high and low provides hysteresis to prevent rapid state flapping.
+	saturationLowThreshold = 0.30
+	// saturationMinDuration is the minimum sustained saturation duration before an event is recorded.
+	saturationMinDuration = 10 * time.Second
+	// maxSaturationEvents is the maximum number of events retained in the ring buffer.
+	maxSaturationEvents = 50
+
+	// retryRateWindow is the sliding window over which transport retries are counted.
+	retryRateWindow = 30 * time.Second
+	// retryRateThreshold is the number of retries within retryRateWindow that marks transport as saturated.
+	retryRateThreshold = 3
+)
+
+// SaturationEvent records a single episode where a pipeline stage was saturated.
+type SaturationEvent struct {
+	// Stage is the pipeline stage name (ProcessorTlmName, StrategyTlmName, SenderTlmName).
+	Stage string
+	// StartTime is when saturation began.
+	StartTime time.Time
+	// EndTime is when saturation ended; zero means the event is still ongoing.
+	EndTime time.Time
+	// PeakFill is the highest fill percentage observed during the event (0.0–1.0).
+	// For the sender stage this is a normalised retry rate, not a channel fill.
+	PeakFill float64
+	// Suggestion is the profile name recommended to address this bottleneck.
+	Suggestion string
+}
+
+// Duration returns how long the event lasted, or the elapsed time if still ongoing.
+func (e SaturationEvent) Duration() time.Duration {
+	if e.EndTime.IsZero() {
+		return time.Since(e.StartTime)
+	}
+	return e.EndTime.Sub(e.StartTime)
+}
+
+// Ongoing reports whether the saturation event is still active.
+func (e SaturationEvent) Ongoing() bool { return e.EndTime.IsZero() }
+
+// SaturationSummary is a point-in-time snapshot returned by SaturationHistory.Summary.
+type SaturationSummary struct {
+	// MaxFill5m / MaxFill30m / MaxFill2h are the per-stage maximum fill percentages
+	// observed in the last 5 minutes, 30 minutes, and 2 hours respectively.
+	// Keys are the stage TlmName constants.
+	MaxFill5m  map[string]float64
+	MaxFill30m map[string]float64
+	MaxFill2h  map[string]float64
+	// SuggestedProfile is the profile name recommended based on the 5-minute window.
+	// Empty string means no recommendation.
+	SuggestedProfile string
+	// RecentEvents contains the most recent saturation events, newest first.
+	RecentEvents []SaturationEvent
+}
+
+// ---------- internal types ----------
+
+type stageSaturationState struct {
+	saturated bool
+	startTime time.Time
+	peakFill  float64
+}
+
+type rollingWindow struct {
+	duration  time.Duration
+	maxFill   map[string]float64
+	lastReset time.Time
+}
+
+func newRollingWindow(d time.Duration, now time.Time) rollingWindow {
+	return rollingWindow{
+		duration:  d,
+		maxFill:   make(map[string]float64),
+		lastReset: now,
+	}
+}
+
+func (w *rollingWindow) record(stage string, fill float64, now time.Time) {
+	if now.Sub(w.lastReset) >= w.duration {
+		w.maxFill = make(map[string]float64)
+		w.lastReset = now
+	}
+	if fill > w.maxFill[stage] {
+		w.maxFill[stage] = fill
+	}
+}
+
+func (w *rollingWindow) max(stage string) float64 {
+	return w.maxFill[stage]
+}
+
+// ---------- SaturationHistory ----------
+
+// SaturationHistory tracks historical saturation events across the logs pipeline.
+// It is driven by CapacityMonitor sample ticks (for processor / strategy fill %)
+// and by RecordRetry calls from the HTTP destination (for transport pressure).
+// Access to the singleton is via GlobalSaturationHistory.
+type SaturationHistory struct {
+	mu      sync.Mutex
+	states  map[string]*stageSaturationState // keyed by stage TlmName
+	events  []SaturationEvent                // ring buffer, oldest first
+	windows [3]rollingWindow                 // indices: 0=5m, 1=30m, 2=2h
+
+	// retryTimestamps is a sliding window of recent retry event times.
+	retryTimestamps []time.Time
+
+	// currentProfile is the logs_agent_profile value set at startup (or via RC).
+	currentProfile string
+
+	// now is injectable for testing.
+	now func() time.Time
+}
+
+// GlobalSaturationHistory is the package-level singleton.
+// CapacityMonitor and the HTTP destination write to it; the status builder reads from it.
+var GlobalSaturationHistory = NewSaturationHistory()
+
+// SetCurrentProfile stores the active profile name so that recommendation telemetry
+// can be tagged with the current setting. Call this at agent startup and on RC updates.
+func SetCurrentProfile(name string) {
+	GlobalSaturationHistory.mu.Lock()
+	GlobalSaturationHistory.currentProfile = name
+	GlobalSaturationHistory.mu.Unlock()
+}
+
+// NewSaturationHistory creates a new SaturationHistory.
+func NewSaturationHistory() *SaturationHistory {
+	now := time.Now()
+	h := &SaturationHistory{
+		states:          make(map[string]*stageSaturationState),
+		events:          make([]SaturationEvent, 0, maxSaturationEvents),
+		retryTimestamps: make([]time.Time, 0, 64),
+		now:             time.Now,
+	}
+	h.windows[0] = newRollingWindow(5*time.Minute, now)
+	h.windows[1] = newRollingWindow(30*time.Minute, now)
+	h.windows[2] = newRollingWindow(2*time.Hour, now)
+	return h
+}
+
+// RecordFill records the current fill percentage for a pipeline stage.
+// Called by CapacityMonitor on each sample tick when channel capacity is known.
+// fill must be in [0.0, 1.0].
+func (h *SaturationHistory) RecordFill(stage string, fill float64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	now := h.now()
+	for i := range h.windows {
+		h.windows[i].record(stage, fill, now)
+	}
+	h.updateState(stage, fill, now)
+	h.emitTelemetry()
+}
+
+// RecordRetry records a transport-layer retry event.
+// Called by the HTTP destination on every retry attempt.
+func (h *SaturationHistory) RecordRetry() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	now := h.now()
+
+	// Prune timestamps outside the sliding window.
+	cutoff := now.Add(-retryRateWindow)
+	n := 0
+	for _, t := range h.retryTimestamps {
+		if t.After(cutoff) {
+			h.retryTimestamps[n] = t
+			n++
+		}
+	}
+	h.retryTimestamps = append(h.retryTimestamps[:n], now)
+
+	// Normalise retry count to a [0, 1] fill-equivalent so it fits the same state machine.
+	rate := float64(len(h.retryTimestamps))
+	fillEquiv := rate / float64(retryRateThreshold+1)
+	if fillEquiv > 1.0 {
+		fillEquiv = 1.0
+	}
+
+	for i := range h.windows {
+		h.windows[i].record(SenderTlmName, fillEquiv, now)
+	}
+	h.updateState(SenderTlmName, fillEquiv, now)
+	h.emitTelemetry()
+}
+
+// updateState runs the per-stage saturation state machine and appends events on recovery.
+// Must be called with h.mu held.
+func (h *SaturationHistory) updateState(stage string, fill float64, now time.Time) {
+	state, ok := h.states[stage]
+	if !ok {
+		state = &stageSaturationState{}
+		h.states[stage] = state
+	}
+
+	if !state.saturated && fill >= saturationHighThreshold {
+		state.saturated = true
+		state.startTime = now
+		state.peakFill = fill
+	} else if state.saturated {
+		if fill > state.peakFill {
+			state.peakFill = fill
+		}
+		if fill < saturationLowThreshold {
+			// Recovered. Record the event only if it lasted long enough to be meaningful.
+			if now.Sub(state.startTime) >= saturationMinDuration {
+				h.appendEvent(SaturationEvent{
+					Stage:      stage,
+					StartTime:  state.startTime,
+					EndTime:    now,
+					PeakFill:   state.peakFill,
+					Suggestion: suggestionForStage(stage),
+				})
+			}
+			state.saturated = false
+			state.peakFill = 0
+		}
+	}
+}
+
+func (h *SaturationHistory) appendEvent(e SaturationEvent) {
+	if len(h.events) >= maxSaturationEvents {
+		copy(h.events, h.events[1:])
+		h.events = h.events[:len(h.events)-1]
+	}
+	h.events = append(h.events, e)
+}
+
+// emitTelemetry fires stage-saturation and profile-recommendation metrics.
+// Must be called with h.mu held.
+func (h *SaturationHistory) emitTelemetry() {
+	knownStages := []string{ProcessorTlmName, StrategyTlmName, SenderTlmName}
+	for _, stage := range knownStages {
+		v := 0.0
+		if s, ok := h.states[stage]; ok && s.saturated {
+			v = 1.0
+		}
+		TlmStageSaturation.Set(v, stage)
+	}
+
+	suggestion := h.computeSuggestion()
+	currentProfile := h.currentProfile
+	if currentProfile == "" {
+		currentProfile = "balanced"
+	}
+	if suggestion != "" && suggestion != currentProfile {
+		TlmProfileRecommendationActive.Set(1.0, currentProfile, suggestion)
+	} else {
+		TlmProfileRecommendationActive.Set(0.0, currentProfile, "none")
+	}
+}
+
+// computeSuggestion returns the recommended profile based on the 5-minute rolling max.
+// Using the 5-minute window avoids spurious recommendations from sub-second spikes.
+// Must be called with h.mu held.
+func (h *SaturationHistory) computeSuggestion() string {
+	strategyFill := h.windows[0].max(StrategyTlmName)
+	transportFill := h.windows[0].max(SenderTlmName)
+	processorFill := h.windows[0].max(ProcessorTlmName)
+
+	switch {
+	case strategyFill >= saturationHighThreshold:
+		return "max_throughput"
+	case transportFill >= saturationHighThreshold:
+		return "wan_optimized"
+	case processorFill >= saturationHighThreshold:
+		return "performance"
+	default:
+		return ""
+	}
+}
+
+// Summary returns a snapshot of the current saturation state for the status page.
+func (h *SaturationHistory) Summary() SaturationSummary {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	stages := []string{ProcessorTlmName, StrategyTlmName, SenderTlmName}
+	s := SaturationSummary{
+		MaxFill5m:  make(map[string]float64, len(stages)),
+		MaxFill30m: make(map[string]float64, len(stages)),
+		MaxFill2h:  make(map[string]float64, len(stages)),
+	}
+	for _, stage := range stages {
+		s.MaxFill5m[stage] = h.windows[0].max(stage)
+		s.MaxFill30m[stage] = h.windows[1].max(stage)
+		s.MaxFill2h[stage] = h.windows[2].max(stage)
+	}
+	s.SuggestedProfile = h.computeSuggestion()
+
+	// Return events newest-first.
+	s.RecentEvents = make([]SaturationEvent, len(h.events))
+	for i, e := range h.events {
+		s.RecentEvents[len(h.events)-1-i] = e
+	}
+	return s
+}
+
+// suggestionForStage returns the profile name that addresses a bottleneck at the given stage.
+func suggestionForStage(stage string) string {
+	switch stage {
+	case ProcessorTlmName:
+		return "performance"
+	case StrategyTlmName:
+		return "max_throughput"
+	case SenderTlmName:
+		return "wan_optimized"
+	default:
+		return ""
+	}
+}
+
+func init() {
+	// Initialise all stage saturation gauges to 0 so they exist in Prometheus
+	// even before any events are recorded.
+	TlmStageSaturation.Set(0.0, ProcessorTlmName)
+	TlmStageSaturation.Set(0.0, StrategyTlmName)
+	TlmStageSaturation.Set(0.0, SenderTlmName)
+}

--- a/pkg/logs/metrics/saturation_history.go
+++ b/pkg/logs/metrics/saturation_history.go
@@ -55,6 +55,9 @@ func (e SaturationEvent) Ongoing() bool { return e.EndTime.IsZero() }
 
 // SaturationSummary is a point-in-time snapshot returned by SaturationHistory.Summary.
 type SaturationSummary struct {
+	// CurrentFill is the most recently recorded fill percentage per stage (0.0–1.0).
+	// Updated on every CapacityMonitor sample tick (approximately once per second).
+	CurrentFill map[string]float64
 	// MaxFill5m / MaxFill30m / MaxFill2h are the per-stage maximum fill percentages
 	// observed in the last 5 minutes, 30 minutes, and 2 hours respectively.
 	// Keys are the stage TlmName constants.
@@ -116,6 +119,9 @@ type SaturationHistory struct {
 	events  []SaturationEvent                // ring buffer, oldest first
 	windows [3]rollingWindow                 // indices: 0=5m, 1=30m, 2=2h
 
+	// currentFill is the most recently sampled fill value per stage.
+	currentFill map[string]float64
+
 	// retryTimestamps is a sliding window of recent retry event times.
 	retryTimestamps []time.Time
 
@@ -144,6 +150,7 @@ func NewSaturationHistory() *SaturationHistory {
 	h := &SaturationHistory{
 		states:          make(map[string]*stageSaturationState),
 		events:          make([]SaturationEvent, 0, maxSaturationEvents),
+		currentFill:     make(map[string]float64),
 		retryTimestamps: make([]time.Time, 0, 64),
 		now:             time.Now,
 	}
@@ -159,6 +166,8 @@ func NewSaturationHistory() *SaturationHistory {
 func (h *SaturationHistory) RecordFill(stage string, fill float64) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+
+	h.currentFill[stage] = fill
 
 	now := h.now()
 	for i := range h.windows {
@@ -189,6 +198,7 @@ func (h *SaturationHistory) RecordRetry() {
 
 	// Normalise retry count to a [0, 1] fill-equivalent so it fits the same state machine.
 	rate := float64(len(h.retryTimestamps))
+	h.currentFill[SenderTlmName] = rate / float64(retryRateThreshold+1)
 	fillEquiv := rate / float64(retryRateThreshold+1)
 	if fillEquiv > 1.0 {
 		fillEquiv = 1.0
@@ -294,11 +304,13 @@ func (h *SaturationHistory) Summary() SaturationSummary {
 
 	stages := []string{ProcessorTlmName, StrategyTlmName, SenderTlmName}
 	s := SaturationSummary{
-		MaxFill5m:  make(map[string]float64, len(stages)),
-		MaxFill30m: make(map[string]float64, len(stages)),
-		MaxFill2h:  make(map[string]float64, len(stages)),
+		CurrentFill: make(map[string]float64, len(stages)),
+		MaxFill5m:   make(map[string]float64, len(stages)),
+		MaxFill30m:  make(map[string]float64, len(stages)),
+		MaxFill2h:   make(map[string]float64, len(stages)),
 	}
 	for _, stage := range stages {
+		s.CurrentFill[stage] = h.currentFill[stage]
 		s.MaxFill5m[stage] = h.windows[0].max(stage)
 		s.MaxFill30m[stage] = h.windows[1].max(stage)
 		s.MaxFill2h[stage] = h.windows[2].max(stage)

--- a/pkg/logs/metrics/saturation_history_test.go
+++ b/pkg/logs/metrics/saturation_history_test.go
@@ -1,0 +1,175 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestHistory() *SaturationHistory {
+	now := time.Now()
+	h := &SaturationHistory{
+		states:          make(map[string]*stageSaturationState),
+		events:          make([]SaturationEvent, 0, maxSaturationEvents),
+		retryTimestamps: make([]time.Time, 0, 16),
+		now:             func() time.Time { return now },
+	}
+	h.windows[0] = newRollingWindow(5*time.Minute, now)
+	h.windows[1] = newRollingWindow(30*time.Minute, now)
+	h.windows[2] = newRollingWindow(2*time.Hour, now)
+	return h
+}
+
+func TestNoSaturation_NilSuggestion(t *testing.T) {
+	h := newTestHistory()
+	h.RecordFill(ProcessorTlmName, 0.10)
+	h.RecordFill(StrategyTlmName, 0.10)
+
+	s := h.Summary()
+	assert.Empty(t, s.SuggestedProfile)
+	assert.Empty(t, s.RecentEvents)
+}
+
+func TestStrategySaturation_SuggestsMaxThroughput(t *testing.T) {
+	h := newTestHistory()
+	h.RecordFill(StrategyTlmName, 0.85)
+
+	s := h.Summary()
+	assert.Equal(t, "max_throughput", s.SuggestedProfile)
+	assert.InDelta(t, 0.85, s.MaxFill5m[StrategyTlmName], 0.01)
+}
+
+func TestProcessorSaturation_SuggestsPerformance(t *testing.T) {
+	h := newTestHistory()
+	h.RecordFill(ProcessorTlmName, 0.80)
+
+	s := h.Summary()
+	assert.Equal(t, "performance", s.SuggestedProfile)
+}
+
+func TestTransportSaturation_SuggestsWanOptimized(t *testing.T) {
+	h := newTestHistory()
+	// Push enough retries to exceed the threshold.
+	for i := 0; i < retryRateThreshold+2; i++ {
+		h.RecordRetry()
+	}
+
+	s := h.Summary()
+	assert.Equal(t, "wan_optimized", s.SuggestedProfile)
+}
+
+// Strategy saturated at the same time as transport → compression wins (it's upstream).
+func TestStrategyTakesPriorityOverTransport(t *testing.T) {
+	h := newTestHistory()
+	h.RecordFill(StrategyTlmName, 0.90)
+	for i := 0; i < retryRateThreshold+2; i++ {
+		h.RecordRetry()
+	}
+
+	s := h.Summary()
+	assert.Equal(t, "max_throughput", s.SuggestedProfile)
+}
+
+func TestSaturationEvent_RecordedOnRecovery(t *testing.T) {
+	var now time.Time
+	h := newTestHistory()
+	h.now = func() time.Time { return now }
+
+	now = time.Now()
+	h.RecordFill(StrategyTlmName, 0.85) // enter saturated
+
+	now = now.Add(saturationMinDuration + 1*time.Second)
+	h.RecordFill(StrategyTlmName, 0.10) // recover
+
+	s := h.Summary()
+	require.Len(t, s.RecentEvents, 1)
+	assert.Equal(t, StrategyTlmName, s.RecentEvents[0].Stage)
+	assert.Equal(t, "max_throughput", s.RecentEvents[0].Suggestion)
+	assert.InDelta(t, 0.85, s.RecentEvents[0].PeakFill, 0.01)
+	assert.False(t, s.RecentEvents[0].Ongoing())
+}
+
+func TestShortSpike_NotRecordedAsEvent(t *testing.T) {
+	var now time.Time
+	h := newTestHistory()
+	h.now = func() time.Time { return now }
+
+	now = time.Now()
+	h.RecordFill(ProcessorTlmName, 0.80) // enter saturated
+
+	// Recover immediately — below minimum duration.
+	now = now.Add(2 * time.Second)
+	h.RecordFill(ProcessorTlmName, 0.10)
+
+	s := h.Summary()
+	assert.Empty(t, s.RecentEvents)
+}
+
+func TestRollingWindowReset(t *testing.T) {
+	var now time.Time
+	h := newTestHistory()
+	h.now = func() time.Time { return now }
+
+	now = time.Now()
+	h.RecordFill(StrategyTlmName, 0.90)
+	assert.InDelta(t, 0.90, h.Summary().MaxFill5m[StrategyTlmName], 0.01)
+
+	// Advance past the 5-minute window.
+	now = now.Add(5*time.Minute + 1*time.Second)
+	h.RecordFill(StrategyTlmName, 0.10) // record something low to trigger reset
+
+	assert.InDelta(t, 0.10, h.Summary().MaxFill5m[StrategyTlmName], 0.01)
+	// 30m window should still hold the old peak.
+	assert.InDelta(t, 0.90, h.Summary().MaxFill30m[StrategyTlmName], 0.01)
+}
+
+func TestEventRingBuffer_BoundedAtMax(t *testing.T) {
+	var now time.Time
+	h := newTestHistory()
+	h.now = func() time.Time { return now }
+
+	now = time.Now()
+	for i := 0; i < maxSaturationEvents+5; i++ {
+		now = now.Add(1 * time.Second)
+		h.RecordFill(StrategyTlmName, 0.90) // enter
+		now = now.Add(saturationMinDuration + 1*time.Second)
+		h.RecordFill(StrategyTlmName, 0.10) // recover + record event
+	}
+
+	s := h.Summary()
+	assert.LessOrEqual(t, len(s.RecentEvents), maxSaturationEvents)
+}
+
+func TestRecentEvents_NewestFirst(t *testing.T) {
+	var now time.Time
+	h := newTestHistory()
+	h.now = func() time.Time { return now }
+
+	now = time.Now()
+	t0 := now
+
+	// First event: processor
+	h.RecordFill(ProcessorTlmName, 0.80)
+	now = now.Add(saturationMinDuration + 1*time.Second)
+	h.RecordFill(ProcessorTlmName, 0.10)
+
+	// Second event: strategy
+	now = now.Add(1 * time.Second)
+	h.RecordFill(StrategyTlmName, 0.85)
+	now = now.Add(saturationMinDuration + 1*time.Second)
+	h.RecordFill(StrategyTlmName, 0.10)
+
+	s := h.Summary()
+	require.Len(t, s.RecentEvents, 2)
+	// Newest (strategy) first.
+	assert.Equal(t, StrategyTlmName, s.RecentEvents[0].Stage)
+	assert.Equal(t, ProcessorTlmName, s.RecentEvents[1].Stage)
+	_ = t0
+}

--- a/pkg/logs/metrics/saturation_history_test.go
+++ b/pkg/logs/metrics/saturation_history_test.go
@@ -18,6 +18,7 @@ func newTestHistory() *SaturationHistory {
 	h := &SaturationHistory{
 		states:          make(map[string]*stageSaturationState),
 		events:          make([]SaturationEvent, 0, maxSaturationEvents),
+		currentFill:     make(map[string]float64),
 		retryTimestamps: make([]time.Time, 0, 16),
 		now:             func() time.Time { return now },
 	}

--- a/pkg/logs/metrics/saturation_info_provider.go
+++ b/pkg/logs/metrics/saturation_info_provider.go
@@ -1,0 +1,180 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// pipelineStages defines the three bottleneck stages in pipeline order,
+// from first-to-process to last-to-send. Backpressure propagates in reverse.
+var pipelineStages = []struct {
+	key   string // TlmName constant
+	label string // human-readable label for status display
+}{
+	{ProcessorTlmName, "Processor (rules)"},
+	{StrategyTlmName, "Compression"},
+	{SenderTlmName, "Transport"},
+}
+
+// profileRationale describes the effect of each recommended profile in one line.
+var profileRationale = map[string]string{
+	"max_throughput": "disables compression, freeing CPU at the cost of ~2-4x more network bandwidth",
+	"wan_optimized":  "increases concurrent HTTP sends to hide WAN / intake latency",
+	"performance":    "uses all CPU cores as parallel pipelines to speed up rule evaluation",
+}
+
+// SaturationInfoProvider formats pipeline health data for the agent status page.
+// It implements the InfoKey/Info pattern used by the logs agent status system.
+type SaturationInfoProvider struct{}
+
+// InfoKey returns the section heading used by the status page.
+func (s SaturationInfoProvider) InfoKey() string { return "Pipeline Health" }
+
+// Info returns pre-formatted status lines for the pipeline health section.
+//
+// Output layout (each string is one printed line; template prepends 2 spaces):
+//
+//	Stage              Now  [-- Fill --]   5m    30m     2h
+//	----------------------------------------------------------------
+//	Processor (rules)   8%  [=         ]   12%    12%    45%
+//	Compression        91%  [=========!]  100%   100%   100%  << saturated
+//	Transport           3%  [          ]    5%     5%     5%
+//	----------------------------------------------------------------
+//	Backpressure flows upstream:  Transport -> Compression -> Processor
+//
+//	!! Compression is saturated (5m peak: 100%)
+//	   Suggested profile: max_throughput
+//	   Effect: disables compression, freeing CPU ...
+//
+//	Recent saturation events:
+//	  14:23:15  Compression  peak 91%  3m 12s  -> max_throughput
+func (s SaturationInfoProvider) Info() []string {
+	sum := GlobalSaturationHistory.Summary()
+	var out []string
+
+	const (
+		labelW = 22 // stage label column width
+		barW   = 10 // fill-bar inner width (chars between [ and ])
+		divLen = 68 // separator line length
+	)
+
+	// Column header
+	// %5s for "Now" aligns with the %4.0f%% data column (4-wide number + "%" = 5 chars).
+	out = append(out,
+		fmt.Sprintf("%-*s  %5s  %-*s  %5s  %6s  %6s",
+			labelW, "Stage", "Now", barW+2, "[-- Fill --]", "5m", "30m", "2h"))
+	out = append(out, strings.Repeat("-", divLen))
+
+	// One row per stage in pipeline order.
+	anySaturated := false
+	for _, st := range pipelineStages {
+		curr := sum.CurrentFill[st.key]
+		m5 := sum.MaxFill5m[st.key]
+		m30 := sum.MaxFill30m[st.key]
+		m2h := sum.MaxFill2h[st.key]
+
+		bar := fillBar(curr, barW)
+
+		// Mark the stage as saturated if the 5-minute max is above the threshold —
+		// this catches stages that were saturated recently, not just right now.
+		saturatedRecently := m5 >= saturationHighThreshold
+		if saturatedRecently {
+			anySaturated = true
+		}
+
+		// Replace the last bar char with '!' when currently saturated so the bar
+		// itself signals urgency without relying on colour.
+		if curr >= saturationHighThreshold {
+			bar = bar[:len(bar)-2] + "!]"
+		}
+
+		marker := ""
+		if saturatedRecently {
+			marker = "  << saturated"
+		}
+
+		out = append(out, fmt.Sprintf("%-*s  %4.0f%%  %s  %5.0f%%  %6.0f%%  %6.0f%%%s",
+			labelW, st.label, curr*100, bar, m5*100, m30*100, m2h*100, marker))
+	}
+
+	out = append(out, strings.Repeat("-", divLen))
+
+	// Backpressure direction note — helps users understand which direction to look.
+	out = append(out, "Backpressure flows upstream:  Transport -> Compression -> Processor")
+
+	// Suggestion block.
+	if sum.SuggestedProfile != "" {
+		rationale := profileRationale[sum.SuggestedProfile]
+		out = append(out, "")
+		out = append(out, fmt.Sprintf("!! Bottleneck detected. Suggested profile: %s", sum.SuggestedProfile))
+		out = append(out, fmt.Sprintf("   Set:    logs_config.logs_agent_profile: %s", sum.SuggestedProfile))
+		if rationale != "" {
+			out = append(out, fmt.Sprintf("   Effect: %s", rationale))
+		}
+	} else if !anySaturated {
+		out = append(out, "   No bottleneck detected.")
+	}
+
+	// Recent saturation events (newest first, max 5 shown).
+	if len(sum.RecentEvents) > 0 {
+		out = append(out, "")
+		out = append(out, "Recent saturation events:")
+		for i, e := range sum.RecentEvents {
+			if i >= 5 {
+				break
+			}
+			durationStr := "ongoing"
+			if !e.Ongoing() {
+				durationStr = formatDuration(e.Duration())
+			}
+			label := stageLabelFor(e.Stage)
+			out = append(out, fmt.Sprintf("  %s  %-18s  peak %3.0f%%  %8s  -> %s",
+				e.StartTime.Local().Format("15:04:05"),
+				label, e.PeakFill*100, durationStr, e.Suggestion))
+		}
+	}
+
+	return out
+}
+
+// fillBar returns an ASCII fill bar of the form "[===       ]".
+// fill is in [0.0, 1.0]; width is the number of inner characters.
+func fillBar(fill float64, width int) string {
+	filled := int(fill * float64(width))
+	if filled > width {
+		filled = width
+	}
+	return "[" + strings.Repeat("=", filled) + strings.Repeat(" ", width-filled) + "]"
+}
+
+// formatDuration returns a compact duration string: "3m 12s", "45s", "1h 02m".
+func formatDuration(d time.Duration) string {
+	d = d.Round(time.Second)
+	h := int(d.Hours())
+	m := int(d.Minutes()) % 60
+	s := int(d.Seconds()) % 60
+	switch {
+	case h > 0:
+		return fmt.Sprintf("%dh %02dm", h, m)
+	case m > 0:
+		return fmt.Sprintf("%dm %02ds", m, s)
+	default:
+		return fmt.Sprintf("%ds", s)
+	}
+}
+
+// stageLabelFor returns the human-readable label for a stage TlmName constant.
+func stageLabelFor(stage string) string {
+	for _, st := range pipelineStages {
+		if st.key == stage {
+			return st.label
+		}
+	}
+	return stage
+}

--- a/pkg/logs/metrics/saturation_info_provider.go
+++ b/pkg/logs/metrics/saturation_info_provider.go
@@ -112,10 +112,10 @@ func (s SaturationInfoProvider) Info() []string {
 	if sum.SuggestedProfile != "" {
 		rationale := profileRationale[sum.SuggestedProfile]
 		out = append(out, "")
-		out = append(out, fmt.Sprintf("!! Bottleneck detected. Suggested profile: %s", sum.SuggestedProfile))
-		out = append(out, fmt.Sprintf("   Set:    logs_config.logs_agent_profile: %s", sum.SuggestedProfile))
+		out = append(out, "!! Bottleneck detected. Suggested profile: "+sum.SuggestedProfile)
+		out = append(out, "   Set:    logs_config.logs_agent_profile: "+sum.SuggestedProfile)
 		if rationale != "" {
-			out = append(out, fmt.Sprintf("   Effect: %s", rationale))
+			out = append(out, "   Effect: "+rationale)
 		}
 	} else if !anySaturated {
 		out = append(out, "   No bottleneck detected.")

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -42,7 +42,7 @@ func NewPipeline(
 	compression logscompression.Component,
 	instanceID string,
 ) *Pipeline {
-	strategyInput := make(chan *message.Message, cfg.GetInt("logs_config.message_channel_size"))
+	strategyInput := make(chan *message.Message, config.MessageChannelSize(cfg))
 	flushChan := make(chan struct{})
 
 	var encoder processor.Encoder
@@ -57,7 +57,7 @@ func NewPipeline(
 	}
 	strategy := getStrategy(strategyInput, senderImpl.In(), flushChan, endpoints, serverlessMeta, senderImpl.PipelineMonitor(), compression, instanceID)
 
-	inputChan := make(chan *message.Message, cfg.GetInt("logs_config.message_channel_size"))
+	inputChan := make(chan *message.Message, config.MessageChannelSize(cfg))
 
 	processor := processor.New(cfg, inputChan, strategyInput, processingRules,
 		encoder, diagnosticMessageReceiver, hostname, senderImpl.PipelineMonitor(), instanceID)

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -42,7 +42,13 @@ func NewPipeline(
 	compression logscompression.Component,
 	instanceID string,
 ) *Pipeline {
-	strategyInput := make(chan *message.Message, config.MessageChannelSize(cfg))
+	msgChanSize := config.MessageChannelSize(cfg)
+	// Register channel capacities so CapacityMonitor can compute fill percentages
+	// and feed SaturationHistory for bottleneck detection.
+	senderImpl.PipelineMonitor().SetStageCapacity(metrics.ProcessorTlmName, msgChanSize)
+	senderImpl.PipelineMonitor().SetStageCapacity(metrics.StrategyTlmName, msgChanSize)
+
+	strategyInput := make(chan *message.Message, msgChanSize)
 	flushChan := make(chan struct{})
 
 	var encoder processor.Encoder
@@ -57,7 +63,7 @@ func NewPipeline(
 	}
 	strategy := getStrategy(strategyInput, senderImpl.In(), flushChan, endpoints, serverlessMeta, senderImpl.PipelineMonitor(), compression, instanceID)
 
-	inputChan := make(chan *message.Message, config.MessageChannelSize(cfg))
+	inputChan := make(chan *message.Message, msgChanSize)
 
 	processor := processor.New(cfg, inputChan, strategyInput, processingRules,
 		encoder, diagnosticMessageReceiver, hostname, senderImpl.PipelineMonitor(), instanceID)

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -141,7 +141,7 @@ func tcpSender(
 	return tcpSenderFactory(
 		cfg,
 		sink,
-		cfg.GetInt("logs_config.payload_channel_size"),
+		config.PayloadChannelSize(cfg),
 		serverlessMeta,
 		endpoints,
 		destinationsContext,
@@ -193,7 +193,7 @@ func httpSender(
 	return httpSenderFactory(
 		cfg,
 		sink,
-		cfg.GetInt("logs_config.payload_channel_size"),
+		config.PayloadChannelSize(cfg),
 		serverlessMeta,
 		endpoints,
 		destinationsContext,

--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -218,6 +218,9 @@ func newProvider(
 	serverlessMeta sender.ServerlessMeta,
 	senderImpl sender.PipelineComponent,
 ) Provider {
+	// Register the active profile so saturation history can tag recommendation metrics.
+	metrics.SetCurrentProfile(cfg.GetString("logs_config.logs_agent_profile"))
+
 	return &provider{
 		numberOfPipelines:         numberOfPipelines,
 		diagnosticMessageReceiver: diagnosticMessageReceiver,

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/DataDog/datadog-agent/comp/logs/agent/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	sourcesPkg "github.com/DataDog/datadog-agent/pkg/logs/sources"
 	status "github.com/DataDog/datadog-agent/pkg/logs/status/utils"
 	"github.com/DataDog/datadog-agent/pkg/logs/tailers"
@@ -51,7 +52,7 @@ func (b *Builder) BuildStatus(verbose bool) Status {
 	if verbose {
 		tailers = b.getTailers()
 	}
-	return Status{
+	s := Status{
 		IsRunning:        b.getIsRunning(),
 		Endpoints:        b.getEndpoints(),
 		Integrations:     b.getIntegrations(),
@@ -62,6 +63,10 @@ func (b *Builder) BuildStatus(verbose bool) Status {
 		Errors:           b.getErrors(),
 		UseHTTP:          b.getUseHTTP(),
 	}
+	if s.IsRunning {
+		s.PipelineHealth = metrics.SaturationInfoProvider{}.Info()
+	}
+	return s
 }
 
 // getIsRunning returns true if the agent is running,

--- a/pkg/logs/status/status.go
+++ b/pkg/logs/status/status.go
@@ -82,6 +82,10 @@ type Status struct {
 	Errors           []string          `json:"errors"`
 	Warnings         []string          `json:"warnings"`
 	UseHTTP          bool              `json:"use_http"`
+	// PipelineHealth contains pre-formatted lines describing per-stage fill
+	// percentages, historical maximums, bottleneck identification, and any
+	// profile-change suggestion. Only populated when the agent is running.
+	PipelineHealth []string `json:"pipeline_health,omitempty"`
 }
 
 // SetCurrentTransport sets the current transport used by the log agent.


### PR DESCRIPTION
…resets

Introduces logs_config.logs_agent_profile, a string key that lets users select a named profile (wan_optimized, max_throughput, low_resource, bandwidth_saver, performance) which pre-configures pipeline tuning knobs. Explicit per-key settings always take precedence over the active profile.

Profiles control: pipelines count, batch_max_concurrent_send, use_compression, compression_kind/level, and channel sizes.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
