### PR TITLE
[tagger] Fix outdated comments

### DIFF
--- a/comp/core/tagger/impl-noop/tagger.go
+++ b/comp/core/tagger/impl-noop/tagger.go
@@ -3,13 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package tagger implements the Tagger component. The Tagger is the central
-// source of truth for client-side entity tagging. It subscribes to workloadmeta
-// to get updates for all the entity kinds (containers, kubernetes pods,
-// kubernetes nodes, etc.) and extracts the tags for each of them. Tags are then
-// stored in memory (by the TagStore) and can be queried by the tagger.Tag()
-// method.
-
 // Package noopimpl provides a noop implementation for the tagger component
 package noopimpl
 

--- a/comp/core/tagger/impl/tagger.go
+++ b/comp/core/tagger/impl/tagger.go
@@ -384,9 +384,6 @@ func (t *localTagger) GlobalTags(cardinality types.TagCardinality) ([]string, er
 // NOTE(remy): it is not needed to sort/dedup the tags anymore since after the
 // enrichment, the metric and its tags is sent to the context key generator, which
 // is taking care of deduping the tags while generating the context key.
-// This function is dupliacted in the remote tagger `impl-remote`.
-// When modifying this function make sure to update the copy `impl-remote` as well.
-// TODO: extract this function to a share function so it can be used in both implementations
 func (t *localTagger) EnrichTags(tb tagset.TagsAccumulator, originInfo taggertypes.OriginInfo) {
 	cardinality := taggerCardinality(originInfo.Cardinality, t.datadogConfig.dogstatsdCardinality, t.log)
 


### PR DESCRIPTION
### What does this PR do?

This PR is a small cleanup. It simply deletes a couple of incorrect or stale comments from the tagger code: the noop implementation included the description of the standard implementation, and `EnrichTags` mentions that it's duplicated when it's not the case.

