### PR TITLE
feat(ask-review): personalize Slack review messages per team

### DIFF
--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 
 from invoke.tasks import task
 
-from tasks.libs.ciproviders.github_api import GithubAPI
-from tasks.libs.owners.parsing import search_owners
+from tasks.libs.ciproviders.github_api import GithubAPI, get_pr_size
+from tasks.libs.owners.parsing import read_owners, search_owners
 from tasks.libs.pipeline.notifications import (
     DEFAULT_SLACK_CHANNEL,
     GITHUB_SLACK_REVIEW_MAP,
@@ -31,18 +31,17 @@ def ask_reviews(_, pr_id, action, team_slugs):
         print("No requested teams provided, skipping.")
         return
 
-    cleaned = []
+    requested = []
     for slug in team_slugs:
         slug = (slug or "").strip()
         slug = slug.removeprefix("@datadog/").removeprefix("@DataDog/")  # tolerate callers passing full team handles
         if slug:
-            cleaned.append(slug)
-    if not cleaned:
+            requested.append(slug)
+    if not requested:
         print("No requested teams provided, skipping.")
         return
 
-    reviewers = [f"@datadog/{slug}" for slug in cleaned]
-    print(f"Reviewers: {reviewers}")
+    print(f"Requested reviewers: {requested}")
 
     from slack_sdk import WebClient
 
@@ -50,35 +49,56 @@ def ask_reviews(_, pr_id, action, team_slugs):
     emojis = client.emoji_list()
     waves = [emoji for emoji in emojis.data['emoji'] if 'wave' in emoji and 'microwave' not in emoji]
 
+    # Compute per-team file counts and PR size
+    file_counts = _get_team_file_counts(pr, requested)
+    size = get_pr_size(pr)
+    max_files = max(file_counts.values()) if file_counts else 0
+
+    actor = pr.user.name or pr.user.login
+    stop_updating = ""
+    if (pr.user.login == "renovate[bot]" or pr.user.login == "mend[bot]") and pr.title.startswith(
+        "chore(deps): update integrations-core"
+    ):
+        stop_updating = "Add the `stop-updating` label before trying to merge this PR, to prevent it from being updated by Renovate.\n"
+
     channels = defaultdict(list)
-    for reviewer in reviewers:
+    for slug in requested:
+        reviewer = f"@datadog/{slug}"
         channel = next(
             (chan for team, chan in GITHUB_SLACK_REVIEW_MAP.items() if team.casefold() == reviewer.casefold()),
             DEFAULT_SLACK_CHANNEL,
         )
-        channels[channel].append(reviewer)
+        channels[channel].append(slug)
 
-    actor = pr.user.name or pr.user.login
-    for channel, reviewers in channels.items():
-        stop_updating = ""
-        if (pr.user.login == "renovate[bot]" or pr.user.login == "mend[bot]") and pr.title.startswith(
-            "chore(deps): update integrations-core"
-        ):
-            stop_updating = "Add the `stop-updating` label before trying to merge this PR, to prevent it from being updated by Renovate.\n"
-        message = f'Hello :{random.choice(waves)}:!\n*{actor}* is asking review for PR <{pr.html_url}/s|{pr.title}>.\nCould you please have a look?\n{stop_updating}Thanks in advance!\n'
+    for channel, slugs in channels.items():
         if channel == DEFAULT_SLACK_CHANNEL:
-            missing = ", ".join(reviewers)
+            missing_teams = ", ".join(f"@datadog/{s}" for s in slugs)
             message = (
                 f'Hello :{random.choice(waves)}:!\n'
-                f'A review channel is missing for {missing}, can you please ask them to update '
+                f'A review channel is missing for {missing_teams}, can you please ask them to update '
                 '`github_slack_review_map.yaml` and transfer them this review '
                 f'<{pr.html_url}/s|{pr.title}>?\n Thanks in advance!'
             )
+        else:
+            team_lines = []
+            for slug in slugs:
+                nb_files = file_counts.get(slug, 0)
+                role = "primary" if (max_files > 0 and nb_files == max_files) else "secondary"
+                team_lines.append(f'{slug} has {nb_files} file(s) to review, as a {role} contributor.')
+            team_info = '\n'.join(team_lines)
+            message = (
+                f'Hello :{random.choice(waves)}:!\n'
+                f'*{actor}* is asking review for PR <{pr.html_url}/s|{pr.title}>.\n'
+                f'This is a `{size}` PR.\n'
+                f'{team_info}\n'
+                f'{stop_updating}Could you please have a look? Thanks in advance!\n'
+            )
+
         try:
             client.chat_postMessage(channel=channel, text=message)
         except Exception as e:
-            message = f"An error occurred while sending a review message from {actor} for PR <{pr.html_url}/s|{pr.title}> to channel {channel}. Error: {e}"
-            client.chat_postMessage(channel=DEFAULT_SLACK_CHANNEL, text=message)
+            error_message = f"An error occurred while sending a review message from {actor} for PR <{pr.html_url}/s|{pr.title}> to channel {channel}. Error: {e}"
+            client.chat_postMessage(channel=DEFAULT_SLACK_CHANNEL, text=error_message)
 
 
 def _is_revert(pr) -> bool:
@@ -90,6 +110,20 @@ def _is_revert(pr) -> bool:
     if re.match(r"^Revert \"(.*)\"\n\nThis reverts commit (\w+).", commits[0].commit.message):
         return True
     return False
+
+
+def _get_team_file_counts(pr, team_slugs, owners_file='.github/CODEOWNERS'):
+    """Return a dict mapping each team slug to the number of PR files it owns."""
+    owners = read_owners(owners_file)
+    counts = {slug: 0 for slug in team_slugs}
+    for f in pr.get_files():
+        file_owners = owners.of(f.filename)
+        for _kind, owner_handle in file_owners:
+            normalized = owner_handle.casefold().removeprefix("@datadog/")
+            for slug in team_slugs:
+                if slug.casefold() == normalized:
+                    counts[slug] += 1
+    return counts
 
 
 @task

--- a/tasks/libs/ciproviders/github_api.py
+++ b/tasks/libs/ciproviders/github_api.py
@@ -611,27 +611,13 @@ class GithubAPI:
         Get the complexity of the code review for a given PR, taking into account the number of files, lines and comments.
         """
         pr = self._repository.get_pull(pr_id)
-        # Criteria are defined with the average of PR attributes (files, lines, comments) so that:
-        # - easy PRs are merged in less than 1 day
-        # - hard PRs are merged in more than 1 week
-        # More details about criteria definition: https://datadoghq.atlassian.net/wiki/spaces/agent/pages/4271079846/Code+Review+Experience+Improvement#Complexity-label
-        criteria = {
-            'easy': {'files': 4, 'lines': 150, 'comments': 2},
-            'hard': {'files': 12, 'lines': 650, 'comments': 9},
+        size = get_pr_size(pr)
+        size_to_label = {
+            'small': 'short review',
+            'medium': 'medium review',
+            'large': 'long review',
         }
-        if (
-            pr.changed_files < criteria['easy']['files']
-            and pr.additions + pr.deletions < criteria['easy']['lines']
-            and pr.review_comments < criteria['easy']['comments']
-        ):
-            return 'short review'
-        elif (
-            pr.changed_files > criteria['hard']['files']
-            or pr.additions + pr.deletions > criteria['hard']['lines']
-            or pr.review_comments > criteria['hard']['comments']
-        ):
-            return 'long review'
-        return 'medium review'
+        return size_to_label[size]
 
     def find_teams(self, obj, exclude_teams=None, exclude_permissions=None, depth=None):
         """Get teams from a Github object (repository or team)"""
@@ -778,3 +764,29 @@ def generate_local_github_token(ctx):
         token = ctx.run('ddtool auth github token', hide=True).stdout.strip()
 
         return token
+
+
+def get_pr_size(pr) -> str:
+    """Return 'small', 'medium', or 'large' based on PR stats."""
+    # Criteria are defined with the average of PR attributes (files, lines, comments) so that:
+    # - easy PRs are merged in less than 1 day
+    # - hard PRs are merged in more than 1 week
+    # More details: https://datadoghq.atlassian.net/wiki/spaces/agent/pages/4271079846/Code+Review+Experience+Improvement#Complexity-label
+    _SIZE_CRITERIA = {
+        'easy': {'files': 4, 'lines': 150, 'comments': 2},
+        'hard': {'files': 12, 'lines': 650, 'comments': 9},
+    }
+
+    if (
+        pr.changed_files < _SIZE_CRITERIA['easy']['files']
+        and pr.additions + pr.deletions < _SIZE_CRITERIA['easy']['lines']
+        and pr.review_comments < _SIZE_CRITERIA['easy']['comments']
+    ):
+        return 'small'
+    if (
+        pr.changed_files > _SIZE_CRITERIA['hard']['files']
+        or pr.additions + pr.deletions > _SIZE_CRITERIA['hard']['lines']
+        or pr.review_comments > _SIZE_CRITERIA['hard']['comments']
+    ):
+        return 'large'
+    return 'medium'

--- a/tasks/unit_tests/issue_tests.py
+++ b/tasks/unit_tests/issue_tests.py
@@ -4,7 +4,14 @@ from unittest.mock import MagicMock, patch
 
 from invoke.context import MockContext, Result
 
-from tasks.issue import DEFAULT_SLACK_CHANNEL, GITHUB_SLACK_REVIEW_MAP, add_reviewers, ask_reviews
+from tasks.issue import (
+    DEFAULT_SLACK_CHANNEL,
+    GITHUB_SLACK_REVIEW_MAP,
+    _get_team_file_counts,
+    add_reviewers,
+    ask_reviews,
+)
+from tasks.libs.ciproviders.github_api import get_pr_size
 
 
 class TestAddReviewers(unittest.TestCase):
@@ -145,7 +152,9 @@ class TestAskReviews(unittest.TestCase):
     )
     @patch('tasks.issue.GithubAPI')
     @patch('slack_sdk.WebClient')
-    def test_label_with_ask_review(self, slack_mock, gh_mock, print_mock):
+    @patch('tasks.issue.get_pr_size', new=MagicMock(return_value='medium'))
+    @patch('tasks.issue._get_team_file_counts')
+    def test_label_with_ask_review(self, file_counts_mock, slack_mock, gh_mock, print_mock):
         pr_mock = MagicMock()
         pr_mock.title = "This is a revert"
         pr_mock.base.ref = "main"
@@ -163,6 +172,8 @@ class TestAskReviews(unittest.TestCase):
         gh_instance.repo.get_pull.return_value = pr_mock
         gh_mock.return_value = gh_instance
 
+        file_counts_mock.return_value = {'team1': 3, 'team2': 2}
+
         emoji_list = {'emoji': {'wave': 'url1', 'waves': 'url2', 'microwave': 'urlx'}}
         slack_client = MagicMock()
         slack_client.emoji_list.return_value = types.SimpleNamespace(data=emoji_list)
@@ -177,7 +188,12 @@ class TestAskReviews(unittest.TestCase):
         channels = [call.kwargs['channel'] for call in slack_client.chat_postMessage.mock_calls]
         self.assertIn('channel1', channels)
         self.assertIn('channel2', channels)
-        self.assertEqual(len(slack_client.chat_postMessage.mock_calls), 2)  # 2 teams
+        self.assertEqual(len(slack_client.chat_postMessage.mock_calls), 2)  # 2 channels
+        # Verify personalized messages
+        for call in slack_client.chat_postMessage.mock_calls:
+            text = call.kwargs['text']
+            self.assertIn('`medium` PR', text)
+            self.assertIn('file(s) to review', text)
 
     @patch('builtins.print')
     @patch(
@@ -304,7 +320,9 @@ class TestAskReviews(unittest.TestCase):
     )
     @patch('tasks.issue.GithubAPI')
     @patch('slack_sdk.WebClient')
-    def test_default_channel(self, slack_mock, gh_mock, print_mock):
+    @patch('tasks.issue.get_pr_size', new=MagicMock(return_value='small'))
+    @patch('tasks.issue._get_team_file_counts', return_value={'newteam1': 0, 'newteam2': 0})
+    def test_default_channel(self, file_counts_mock, slack_mock, gh_mock, print_mock):
         pr_mock = MagicMock()
         pr_mock.title = "Title"
         pr_mock.base.ref = "main"
@@ -327,11 +345,11 @@ class TestAskReviews(unittest.TestCase):
         GITHUB_SLACK_REVIEW_MAP.clear()
         ask_reviews(MockContext(), 7, "review_requested", team_slugs=["newteam1", "newteam2"])
 
-        # Only one message because all reviewers fall back to DEFAULT_SLACK_CHANNEL
+        # One message because both reviewers fall back to DEFAULT_SLACK_CHANNEL (grouped)
         slack_client.chat_postMessage.assert_called_once()
         args, kwargs = slack_client.chat_postMessage.call_args
-        assert kwargs['channel'] == DEFAULT_SLACK_CHANNEL
-        assert "A review channel is missing" in kwargs['text']
+        self.assertEqual(kwargs['channel'], DEFAULT_SLACK_CHANNEL)
+        self.assertIn("A review channel is missing", kwargs['text'])
 
     @patch('builtins.print')
     @patch(
@@ -340,7 +358,9 @@ class TestAskReviews(unittest.TestCase):
     )
     @patch('tasks.issue.GithubAPI')
     @patch('slack_sdk.WebClient')
-    def test_same_slack_channel(self, slack_mock, gh_mock, print_mock):
+    @patch('tasks.issue.get_pr_size', new=MagicMock(return_value='small'))
+    @patch('tasks.issue._get_team_file_counts', return_value={'teamx': 5, 'teamy': 3})
+    def test_same_slack_channel(self, file_counts_mock, slack_mock, gh_mock, print_mock):
         pr_mock = MagicMock()
         pr_mock.title = "Some PR"
         pr_mock.base.ref = "main"
@@ -365,11 +385,16 @@ class TestAskReviews(unittest.TestCase):
 
         ask_reviews(MockContext(), 8, "review_requested", team_slugs=["teamx", "teamy"])
 
-        # Only one message because both reviewers map to the same channel
+        # One message because both teams map to the same channel
         slack_client.chat_postMessage.assert_called_once()
         args, kwargs = slack_client.chat_postMessage.call_args
         self.assertEqual(kwargs['channel'], 'chan-shared')
         self.assertIn("actorlogin", kwargs['text'])
+        # Both teams have per-team lines
+        self.assertIn("teamx has 5 file(s) to review", kwargs['text'])
+        self.assertIn("teamy has 3 file(s) to review", kwargs['text'])
+        self.assertIn("primary", kwargs['text'])
+        self.assertIn("secondary", kwargs['text'])
 
     @patch('builtins.print')
     @patch(
@@ -378,7 +403,9 @@ class TestAskReviews(unittest.TestCase):
     )
     @patch('tasks.issue.GithubAPI')
     @patch('slack_sdk.WebClient')
-    def test_review_request_one_team(self, slack_mock, gh_mock, print_mock):
+    @patch('tasks.issue.get_pr_size', new=MagicMock(return_value='large'))
+    @patch('tasks.issue._get_team_file_counts', return_value={'team1': 10})
+    def test_review_request_one_team(self, file_counts_mock, slack_mock, gh_mock, print_mock):
         """Test that when a specific team is requested (review_request event), only that team is notified"""
         pr_mock = MagicMock()
         pr_mock.title = "This is a feature"
@@ -412,3 +439,112 @@ class TestAskReviews(unittest.TestCase):
         args, kwargs = slack_client.chat_postMessage.call_args
         self.assertEqual(kwargs['channel'], 'channel1')
         self.assertIn("actorname", kwargs['text'])
+        self.assertIn("`large` PR", kwargs['text'])
+        self.assertIn("team1 has 10 file(s) to review", kwargs['text'])
+        self.assertIn("primary", kwargs['text'])
+
+    @patch('builtins.print')
+    @patch(
+        'os.environ',
+        {'SLACK_DATADOG_AGENT_BOT_TOKEN': 'fake-token'},
+    )
+    @patch('tasks.issue.GithubAPI')
+    @patch('slack_sdk.WebClient')
+    @patch('tasks.issue.get_pr_size', new=MagicMock(return_value='small'))
+    @patch('tasks.issue._get_team_file_counts', return_value={'team1': 5, 'team2': 0})
+    def test_team_zero_owned_files(self, file_counts_mock, slack_mock, gh_mock, print_mock):
+        """Test that a team with 0 owned files gets a secondary role"""
+        pr_mock = MagicMock()
+        pr_mock.title = "Some PR"
+        pr_mock.base.ref = "main"
+        pr_mock.get_labels.return_value = [types.SimpleNamespace(name='ask-review')]
+        pr_mock.get_commits.return_value = [MagicMock(commit=MagicMock(message="This is a feature"))]
+        pr_mock.user.login = "actorlogin"
+        pr_mock.user.name = "actorname"
+        pr_mock.html_url = "http://foo"
+
+        gh_instance = MagicMock()
+        gh_instance.repo.get_pull.return_value = pr_mock
+        gh_mock.return_value = gh_instance
+
+        emoji_list = {'emoji': {'wave': 'url1'}}
+        slack_client = MagicMock()
+        slack_client.emoji_list.return_value = types.SimpleNamespace(data=emoji_list)
+        slack_mock.return_value = slack_client
+
+        GITHUB_SLACK_REVIEW_MAP.clear()
+        GITHUB_SLACK_REVIEW_MAP['@datadog/team1'] = 'channel1'
+        GITHUB_SLACK_REVIEW_MAP['@datadog/team2'] = 'channel2'
+
+        ask_reviews(MockContext(), 10, "labeled", team_slugs=["team1", "team2"])
+
+        self.assertEqual(len(slack_client.chat_postMessage.mock_calls), 2)
+        # Find the message for each channel
+        messages = {call.kwargs['channel']: call.kwargs['text'] for call in slack_client.chat_postMessage.mock_calls}
+        self.assertIn("team1 has 5 file(s) to review", messages['channel1'])
+        self.assertIn("primary", messages['channel1'])
+        self.assertIn("team2 has 0 file(s) to review", messages['channel2'])
+        self.assertIn("secondary", messages['channel2'])
+
+
+class TestGetTeamFileCounts(unittest.TestCase):
+    def test_basic_counts(self):
+        pr_mock = MagicMock()
+        pr_mock.get_files.return_value = [
+            types.SimpleNamespace(filename='pkg/network/foo.go'),
+            types.SimpleNamespace(filename='pkg/network/bar.go'),
+            types.SimpleNamespace(filename='pkg/debugger/baz.go'),
+        ]
+        with patch('tasks.issue.read_owners') as owners_mock:
+            co_mock = MagicMock()
+
+            def of_side_effect(filename):
+                if filename.startswith('pkg/network'):
+                    return [('TEAM', '@DataDog/network-team')]
+                if filename.startswith('pkg/debugger'):
+                    return [('TEAM', '@DataDog/debugger-team')]
+                return []
+
+            co_mock.of.side_effect = of_side_effect
+            owners_mock.return_value = co_mock
+
+            counts = _get_team_file_counts(pr_mock, ['network-team', 'debugger-team'])
+
+        self.assertEqual(counts['network-team'], 2)
+        self.assertEqual(counts['debugger-team'], 1)
+
+    def test_no_matching_teams(self):
+        pr_mock = MagicMock()
+        pr_mock.get_files.return_value = [
+            types.SimpleNamespace(filename='pkg/other/foo.go'),
+        ]
+        with patch('tasks.issue.read_owners') as owners_mock:
+            co_mock = MagicMock()
+            co_mock.of.return_value = [('TEAM', '@DataDog/other-team')]
+            owners_mock.return_value = co_mock
+
+            counts = _get_team_file_counts(pr_mock, ['network-team'])
+
+        self.assertEqual(counts['network-team'], 0)
+
+
+class TestGetPrSize(unittest.TestCase):
+    def test_small(self):
+        pr = types.SimpleNamespace(changed_files=2, additions=50, deletions=30, review_comments=1)
+        self.assertEqual(get_pr_size(pr), 'small')
+
+    def test_medium(self):
+        pr = types.SimpleNamespace(changed_files=6, additions=200, deletions=100, review_comments=3)
+        self.assertEqual(get_pr_size(pr), 'medium')
+
+    def test_large_by_files(self):
+        pr = types.SimpleNamespace(changed_files=15, additions=10, deletions=5, review_comments=0)
+        self.assertEqual(get_pr_size(pr), 'large')
+
+    def test_large_by_lines(self):
+        pr = types.SimpleNamespace(changed_files=1, additions=600, deletions=100, review_comments=0)
+        self.assertEqual(get_pr_size(pr), 'large')
+
+    def test_large_by_comments(self):
+        pr = types.SimpleNamespace(changed_files=1, additions=10, deletions=5, review_comments=10)
+        self.assertEqual(get_pr_size(pr), 'large')


### PR DESCRIPTION
### What does this PR do?

Personalizes the `ask_reviews` Slack messages with per-team context:
- Each message now shows how many files the team owns in the PR (via CODEOWNERS)
- Includes the overall PR size (`small`, `medium`, or `large`)
- Assigns each team a role (`primary` for the team(s) with the most owned files, `secondary` for others)

When multiple teams share the same Slack channel, a single message is sent with one line per team showing their individual file counts and roles.

Extracts a shared `get_pr_size(pr)` function in `github_api.py` and refactors `get_codereview_complexity` to use it.

### Motivation

Give reviewers immediate context about the scope of their review — how many files they own, the overall PR size, and whether they are the primary or secondary reviewer — so they can prioritize accordingly.

### Describe how you validated your changes

All 22 unit tests pass:
```
python -m pytest tasks/unit_tests/issue_tests.py -v
```

New tests added:
- `TestGetPrSize` — 5 tests covering small/medium/large thresholds
- `TestGetTeamFileCounts` — 2 tests for file ownership counting
- `test_team_zero_owned_files` — verifies secondary role for teams with 0 owned files
- Updated `test_same_slack_channel` to verify per-team lines in grouped messages

### Additional Notes

Files changed:
- `tasks/issue.py` — added `_get_team_file_counts` helper, rewrote message loop
- `tasks/libs/ciproviders/github_api.py` — extracted `get_pr_size()`, refactored `get_codereview_complexity`
- `tasks/unit_tests/issue_tests.py` — updated and added tests