### PR TITLE
fix(discovery): fall back to exe name when language detector returns None

### DIFF
--- a/pkg/discovery/module/rust/src/service_name.rs
+++ b/pkg/discovery/module/rust/src/service_name.rs
@@ -107,35 +107,34 @@ pub fn get(
     exe = trim_symbols_from_exe(exe);
     exe = normalize_exe_name(exe);
 
-    // Fallback: use the exe basename, stripping the trailing file extension.
-    // Matches the Go fallback in usm.ExtractServiceMetadata
-    // (pkg/discovery/usm/service.go) which uses strings.LastIndex(exe, ".").
-    let fallback = || {
-        let name = match exe.rfind('.') {
-            Some(idx) if idx > 0 => exe.get(..idx),
-            _ => Some(exe),
-        }?;
-        Some(ServiceNameMetadata::new(
-            name,
-            ServiceNameSource::CommandLine,
-        ))
-    };
-
-    match exe {
-        "gunicorn" => Some(gunicorn::extract_name(cmdline, &ctx.envs)).or_else(fallback),
-        "puma" => rails::extract_name(cmdline, ctx).or_else(fallback),
-        "beam.smp" | "beam" => erlang::extract_name(cmdline).or_else(fallback),
-        "php" => php::extract_name(cmdline, ctx).or_else(fallback),
+    let metadata = match exe {
+        "gunicorn" => Some(gunicorn::extract_name(cmdline, &ctx.envs)),
+        "puma" => rails::extract_name(cmdline, ctx),
+        "beam.smp" | "beam" => erlang::extract_name(cmdline),
+        "php" => php::extract_name(cmdline, ctx),
         &_ => match language {
-            Language::Python => python::extract_name(cmdline, ctx).or_else(fallback),
-            Language::Ruby => ruby::extract_name(cmdline).or_else(fallback),
-            Language::Java => java::extract_name(cmdline, ctx).or_else(fallback),
-            Language::NodeJS => nodejs::extract_name(cmdline, ctx).or_else(fallback),
-            Language::DotNet => dotnet::extract_name(cmdline).or_else(fallback),
-            Language::PHP => php::extract_name(cmdline, ctx).or_else(fallback),
-            _ => fallback(),
+            Language::Python => python::extract_name(cmdline, ctx),
+            Language::Ruby => ruby::extract_name(cmdline),
+            Language::Java => java::extract_name(cmdline, ctx),
+            Language::NodeJS => nodejs::extract_name(cmdline, ctx),
+            Language::DotNet => dotnet::extract_name(cmdline),
+            Language::PHP => php::extract_name(cmdline, ctx),
+            _ => None,
         },
+    };
+    if metadata.is_some() {
+        return metadata;
     }
+
+    // Fallback: use the exe basename, stripping the trailing file extension.
+    let name = match exe.rfind('.') {
+        Some(idx) if idx > 0 => exe.get(..idx)?,
+        _ => exe,
+    };
+    Some(ServiceNameMetadata::new(
+        name,
+        ServiceNameSource::CommandLine,
+    ))
 }
 
 fn trim_at_sep_end(s: &str, sep: char) -> &str {
@@ -543,10 +542,6 @@ mod tests {
             ))
         );
     }
-
-    // Tests for fallback behavior: when a language-specific detector returns
-    // None, we fall back to using the exe basename (matching Go's
-    // usm.ExtractServiceMetadata fallback in pkg/discovery/usm/service.go).
 
     #[test]
     fn fallback_when_python_detector_fails() {

--- a/pkg/discovery/module/rust/src/service_name.rs
+++ b/pkg/discovery/module/rust/src/service_name.rs
@@ -107,28 +107,30 @@ pub fn get(
     exe = trim_symbols_from_exe(exe);
     exe = normalize_exe_name(exe);
 
+    let fallback = || {
+        let name = match exe.find('.') {
+            Some(idx) => exe.get(..idx),
+            None => Some(exe),
+        }?;
+        Some(ServiceNameMetadata::new(
+            name,
+            ServiceNameSource::CommandLine,
+        ))
+    };
+
     match exe {
         "gunicorn" => Some(gunicorn::extract_name(cmdline, &ctx.envs)),
         "puma" => rails::extract_name(cmdline, ctx),
         "beam.smp" | "beam" => erlang::extract_name(cmdline),
         "php" => php::extract_name(cmdline, ctx),
         &_ => match language {
-            Language::Python => python::extract_name(cmdline, ctx),
-            Language::Ruby => ruby::extract_name(cmdline),
-            Language::Java => java::extract_name(cmdline, ctx),
-            Language::NodeJS => nodejs::extract_name(cmdline, ctx),
-            Language::DotNet => dotnet::extract_name(cmdline),
-            Language::PHP => php::extract_name(cmdline, ctx),
-            _ => {
-                if let Some(idx) = exe.find('.') {
-                    exe = exe.get(..idx)?;
-                }
-
-                Some(ServiceNameMetadata::new(
-                    exe,
-                    ServiceNameSource::CommandLine,
-                ))
-            }
+            Language::Python => python::extract_name(cmdline, ctx).or_else(fallback),
+            Language::Ruby => ruby::extract_name(cmdline).or_else(fallback),
+            Language::Java => java::extract_name(cmdline, ctx).or_else(fallback),
+            Language::NodeJS => nodejs::extract_name(cmdline, ctx).or_else(fallback),
+            Language::DotNet => dotnet::extract_name(cmdline).or_else(fallback),
+            Language::PHP => php::extract_name(cmdline, ctx).or_else(fallback),
+            _ => fallback(),
         },
     }
 }

--- a/pkg/discovery/module/rust/src/service_name.rs
+++ b/pkg/discovery/module/rust/src/service_name.rs
@@ -122,10 +122,10 @@ pub fn get(
     };
 
     match exe {
-        "gunicorn" => Some(gunicorn::extract_name(cmdline, &ctx.envs)),
-        "puma" => rails::extract_name(cmdline, ctx),
-        "beam.smp" | "beam" => erlang::extract_name(cmdline),
-        "php" => php::extract_name(cmdline, ctx),
+        "gunicorn" => Some(gunicorn::extract_name(cmdline, &ctx.envs)).or_else(fallback),
+        "puma" => rails::extract_name(cmdline, ctx).or_else(fallback),
+        "beam.smp" | "beam" => erlang::extract_name(cmdline).or_else(fallback),
+        "php" => php::extract_name(cmdline, ctx).or_else(fallback),
         &_ => match language {
             Language::Python => python::extract_name(cmdline, ctx).or_else(fallback),
             Language::Ruby => ruby::extract_name(cmdline).or_else(fallback),
@@ -279,12 +279,21 @@ mod tests {
 
     #[test]
     fn test_integration_erlang_no_name() {
-        // Integration test: Erlang process without valid name returns None
+        // When the Erlang detector can't find a name, fall back to the exe
+        // basename with extension stripped: "beam.smp" -> "beam".
+        // Matches Go's ExtractServiceMetadata fallback
+        // (pkg/discovery/usm/service.go:340-347).
         let cmdline = cmdline!["beam.smp", "-smp", "auto", "-noinput"];
         let (envs, fs) = test_ctx();
         let mut ctx = DetectionContext::new(0, envs, &fs);
         let result = get_name(&Language::Unknown, &cmdline, &mut ctx);
-        assert_eq!(result, None);
+        assert_eq!(
+            result,
+            Some(ServiceNameMetadata::new(
+                "beam",
+                ServiceNameSource::CommandLine,
+            ))
+        );
     }
 
     #[test]

--- a/pkg/discovery/module/rust/src/service_name.rs
+++ b/pkg/discovery/module/rust/src/service_name.rs
@@ -107,10 +107,13 @@ pub fn get(
     exe = trim_symbols_from_exe(exe);
     exe = normalize_exe_name(exe);
 
+    // Fallback: use the exe basename, stripping the trailing file extension.
+    // Matches the Go fallback in usm.ExtractServiceMetadata
+    // (pkg/discovery/usm/service.go) which uses strings.LastIndex(exe, ".").
     let fallback = || {
-        let name = match exe.find('.') {
-            Some(idx) => exe.get(..idx),
-            None => Some(exe),
+        let name = match exe.rfind('.') {
+            Some(idx) if idx > 0 => exe.get(..idx),
+            _ => Some(exe),
         }?;
         Some(ServiceNameMetadata::new(
             name,
@@ -528,6 +531,93 @@ mod tests {
             Some(ServiceNameMetadata::new(
                 "myapp.asgi",
                 ServiceNameSource::CommandLine
+            ))
+        );
+    }
+
+    // Tests for fallback behavior: when a language-specific detector returns
+    // None, we fall back to using the exe basename (matching Go's
+    // usm.ExtractServiceMetadata fallback in pkg/discovery/usm/service.go).
+
+    #[test]
+    fn fallback_when_python_detector_fails() {
+        // A non-Python exe (sleep) with Language::Python should fall back to
+        // the exe name when the Python detector can't extract a name.
+        let (envs, fs) = test_ctx();
+        let mut ctx = DetectionContext::new(0, envs, &fs);
+        assert_eq!(
+            get_name(&Language::Python, &cmdline!["sleep", "1000"], &mut ctx),
+            Some(ServiceNameMetadata::new(
+                "sleep",
+                ServiceNameSource::CommandLine,
+            ))
+        );
+    }
+
+    #[test]
+    fn fallback_when_java_detector_fails() {
+        let (envs, fs) = test_ctx();
+        let mut ctx = DetectionContext::new(0, envs, &fs);
+        assert_eq!(
+            get_name(
+                &Language::Java,
+                &cmdline!["my-daemon", "--config", "/etc/foo.conf"],
+                &mut ctx
+            ),
+            Some(ServiceNameMetadata::new(
+                "my-daemon",
+                ServiceNameSource::CommandLine,
+            ))
+        );
+    }
+
+    #[test]
+    fn fallback_strips_last_extension() {
+        // Go uses strings.LastIndex(exe, ".") so "server.x86_64.bin"
+        // becomes "server.x86_64", not "server".
+        let (envs, fs) = test_ctx();
+        let mut ctx = DetectionContext::new(0, envs, &fs);
+        assert_eq!(
+            get_name(
+                &Language::Unknown,
+                &cmdline!["./server.x86_64.bin"],
+                &mut ctx
+            ),
+            Some(ServiceNameMetadata::new(
+                "server.x86_64",
+                ServiceNameSource::CommandLine,
+            ))
+        );
+    }
+
+    #[test]
+    fn fallback_no_extension() {
+        let (envs, fs) = test_ctx();
+        let mut ctx = DetectionContext::new(0, envs, &fs);
+        assert_eq!(
+            get_name(
+                &Language::Unknown,
+                &cmdline!["my-service", "--flag"],
+                &mut ctx
+            ),
+            Some(ServiceNameMetadata::new(
+                "my-service",
+                ServiceNameSource::CommandLine,
+            ))
+        );
+    }
+
+    #[test]
+    fn fallback_dotfile_exe() {
+        // An exe starting with '.' like ".hidden" should not be trimmed to
+        // empty — matches Go's `i > 0` guard.
+        let (envs, fs) = test_ctx();
+        let mut ctx = DetectionContext::new(0, envs, &fs);
+        assert_eq!(
+            get_name(&Language::Unknown, &cmdline![".hidden"], &mut ctx),
+            Some(ServiceNameMetadata::new(
+                ".hidden",
+                ServiceNameSource::CommandLine,
             ))
         );
     }


### PR DESCRIPTION
### What does this PR do?

Adds a fallback in the Rust service name detection logic so that when a language-specific detector returns `None`, the service name falls back to the executable basename (with trailing file extension stripped) instead of returning no name at all.

Previously, if a language detector (e.g. Python, Java, Erlang) couldn't determine a name, the code returned `None` for language-dispatched executables, while only the catch-all `_` arm had the exe-basename fallback. This meant processes like `beam.smp` or a Java daemon without a recognizable jar would get no service name.

### Motivation

The Go implementation (`pkg/discovery/usm/service.go:340-347`) already falls back to the exe basename when a detector fails. This change brings the Rust implementation to parity, ensuring all discovered services get a name.

### Describe how you validated your changes

Unit tests modified.

This is also needed to pass the `TestServicesTracerMetadataWithoutPorts` test when the existing Go tests are run against the Rust implementation in an upcoming PR.