### PR TITLE
Fix goroutine leak on flare provider timeout

### DIFF
--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -253,6 +253,7 @@ func (f *flare) runProviders(fb types.FlareBuilder, providerTimeout time.Duratio
 		f.log.Infof("Running flare provider %s with timeout %s", providerName, timeout)
 		_ = fb.Logf("Running flare provider %s with timeout %s", providerName, timeout)
 
+		// Buffered so the goroutine can send even if we already left via timeout.
 		done := make(chan struct{}, 1)
 		go func() {
 			startTime := time.Now()

--- a/comp/core/flare/flare.go
+++ b/comp/core/flare/flare.go
@@ -253,7 +253,7 @@ func (f *flare) runProviders(fb types.FlareBuilder, providerTimeout time.Duratio
 		f.log.Infof("Running flare provider %s with timeout %s", providerName, timeout)
 		_ = fb.Logf("Running flare provider %s with timeout %s", providerName, timeout)
 
-		done := make(chan struct{})
+		done := make(chan struct{}, 1)
 		go func() {
 			startTime := time.Now()
 			err := p.Callback(fb)


### PR DESCRIPTION
### What does this PR do?

When a flare provider exceeds its timeout, the `select` exits via the timeout branch and the loop moves on to the next provider. The goroutine running that provider is left blocked forever trying to send on `done`, an unbuffered channel that nobody is receiving from anymore. Each flare request with a slow provider leaks one goroutine permanently.

The fix makes `done` a buffered channel of size 1, so the goroutine can complete its send and exit regardless of whether the timeout already fired.

### Motivation

Fixes a goroutine leak that accumulates on every flare request with a slow or stuck provider.

### Describe how you validated your changes

CI.

### Additional Notes

This bug was found by Claude.