### PR TITLE
Fix goroutine leak in Python memory tracker

### DIFF
--- a/comp/collector/collector/collectorimpl/collector.go
+++ b/comp/collector/collector/collectorimpl/collector.go
@@ -212,6 +212,7 @@ func (c *collectorImpl) stop(_ context.Context) error {
 		c.runner.Stop()
 		c.runner = nil
 	}
+	python.StopMemoryTracker()
 	c.state.Store(stopped)
 	return nil
 }

--- a/pkg/collector/python/embed_nopy.go
+++ b/pkg/collector/python/embed_nopy.go
@@ -9,3 +9,6 @@ package python
 
 // InitPython is a no-op when the build tag is not set
 func InitPython(_ ...string) {}
+
+// StopMemoryTracker is a no-op when the build tag is not set
+func StopMemoryTracker() {}

--- a/pkg/collector/python/memory.go
+++ b/pkg/collector/python/memory.go
@@ -64,6 +64,13 @@ var TrackedCString = func(str string) *C.char {
 }
 
 var memoryTrackerInitializer sync.Once
+var memoryTrackerStop = make(chan struct{})
+
+// StopMemoryTracker stops the background memory tracking goroutine started by
+// InitMemoryTracker. It is a no-op if InitMemoryTracker was never called.
+func StopMemoryTracker() {
+	close(memoryTrackerStop)
+}
 
 func InitMemoryTracker() {
 	memoryTrackerInitializer.Do(func() {
@@ -85,13 +92,17 @@ func InitMemoryTracker() {
 			defer ticker.Stop()
 
 			for {
-				<-ticker.C
-				memoryStats := C.get_and_reset_memory_stats()
-				tlmAllocations.Add(float64(memoryStats.allocations))
-				tlmAllocatedBytes.Add(float64(memoryStats.allocated_bytes))
-				tlmFrees.Add(float64(memoryStats.frees))
-				tlmFreedBytes.Add(float64(memoryStats.freed_bytes))
-				tlmInuseBytes.Add(float64(memoryStats.inuse_bytes))
+				select {
+				case <-ticker.C:
+					memoryStats := C.get_and_reset_memory_stats()
+					tlmAllocations.Add(float64(memoryStats.allocations))
+					tlmAllocatedBytes.Add(float64(memoryStats.allocated_bytes))
+					tlmFrees.Add(float64(memoryStats.frees))
+					tlmFreedBytes.Add(float64(memoryStats.freed_bytes))
+					tlmInuseBytes.Add(float64(memoryStats.inuse_bytes))
+				case <-memoryTrackerStop:
+					return
+				}
 			}
 		}()
 	})


### PR DESCRIPTION
### What does this PR do?

The background goroutine started by `InitMemoryTracker` loops forever with no exit path — no `ctx.Done()`, no done channel. Since it is started inside a `sync.Once`, it runs for the entire process lifetime with no way to stop it.

The fix adds a package-level `memoryTrackerStop` channel and a `StopMemoryTracker` function. The goroutine selects on `memoryTrackerStop` alongside the ticker, so it exits cleanly when the collector stops. `StopMemoryTracker` is called from the collector's `OnStop` hook. A no-op stub is added to `embed_nopy.go` for non-Python builds.

### Motivation

Fixes a goroutine leak in the Python memory tracker that had no shutdown path.

### Describe how you validated your changes

CI.

### Additional Notes

This bug was found by Claude.