### PR TITLE
Fix NetFlow Stop not closing UDP listeners

### DIFF
--- a/comp/netflow/server/server.go
+++ b/comp/netflow/server/server.go
@@ -152,6 +152,7 @@ func (s *Server) Stop() {
 
 		go func() {
 			s.logger.Infof("Listener `%s` shutting down", listener.config.Addr())
+			listener.flowState.Shutdown()
 			close(stopped)
 		}()
 


### PR DESCRIPTION
### What does this PR do?

`Server.Stop()` iterates over listeners and spawns a goroutine per listener that only logs a message and closes a local `stopped` channel — it never calls any method on the listener itself. As a result, UDP sockets remain open after `Stop()` returns.

The fix calls `listener.flowState.Shutdown()` inside the goroutine before closing the `stopped` channel, so the underlying UDP socket is actually closed.

### Motivation

Fixes a resource leak where UDP sockets were never closed on server shutdown.

### Describe how you validated your changes

CI.

### Additional Notes

This bug was found by Claude.