### PR TITLE
Fix killQueue ticker resource leak in process killer

### DIFF
--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -621,6 +621,7 @@ func (p *ProcessKiller) Start(ctx context.Context, wg *sync.WaitGroup) {
 		killQueue := time.NewTicker(killQueueTicker)
 
 		defer ticker.Stop()
+		defer killQueue.Stop()
 		state := stopped
 		for {
 			switch state {


### PR DESCRIPTION
### What does this PR do?

Two tickers are created in the process killer goroutine: `ticker` and `killQueue`. Only `ticker` has a `defer Stop()` registered. When the goroutine exits via `ctx.Done()`, `killQueue` keeps firing indefinitely, leaking the underlying runtime timer.

The fix adds `defer killQueue.Stop()` alongside the existing `defer ticker.Stop()`.

### Motivation

Fixes a timer resource leak when the process killer goroutine exits.

### Describe how you validated your changes

CI.

### Additional Notes

This bug was found by Claude.