### PR TITLE
feat(gha): Move to supported action

### DIFF
--- a/.github/workflows/markdown-lint-check.yml
+++ b/.github/workflows/markdown-lint-check.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         persist-credentials: false
-    - uses: gaurav-nelson/github-action-markdown-link-check@3c3b66f1f7d0900e37b71eca45b63ea9eedfce31 # v1.0.17
+    - uses: tcort/github-action-markdown-link-check@e7c7a18363c842693fadde5d41a3bd3573a7a225 # v1.1.2
       with:
         use-quiet-mode: yes
         config-file: .markdown-link-check


### PR DESCRIPTION
### What does this PR do?
The initial repo was deprecated last year (https://github.com/gaurav-nelson/github-action-markdown-link-check).

### Motivation 
Maintained dependencies

### Describe how you validated your changes
n/a

### Additional Notes
This was causing an error in Renovate
<img width="941" height="190" alt="image" src="https://github.com/user-attachments/assets/914fa478-ef21-4031-9256-1688394d845b" />

