### PR TITLE
Fix HTTP response body leak in fleet local API client

### DIFF
--- a/pkg/fleet/daemon/local_api.go
+++ b/pkg/fleet/daemon/local_api.go
@@ -513,6 +513,7 @@ func (c *localAPIClientImpl) PromoteExperiment(pkg string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	var response APIResponse
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil {
@@ -521,7 +522,6 @@ func (c *localAPIClientImpl) PromoteExperiment(pkg string) error {
 	if response.Error != nil {
 		return fmt.Errorf("error promoting experiment: %s", response.Error.Message)
 	}
-	defer resp.Body.Close()
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

In one function of `localAPIClientImpl`, `defer resp.Body.Close()` was placed after early `return` statements for decode errors and response errors. On those paths the body was never closed, leaking the underlying HTTP connection and preventing it from being returned to the pool.

The fix moves `defer resp.Body.Close()` to immediately after the `client.Do` nil error check, consistent with every other function in the same file.

### Motivation

Fixes an HTTP connection leak on error paths in the fleet local API client.

### Describe how you validated your changes

CI.

### Additional Notes

This bug was found by Claude.