### PR TITLE
[kubernetes/metadata] Skip notifications when Delete is a no-op

### DIFF
--- a/pkg/clusteragent/api/v1/types.go
+++ b/pkg/clusteragent/api/v1/types.go
@@ -92,14 +92,22 @@ func (m NamespacesPodsStringsSet) Set(namespace, podName string, strings ...stri
 	m[namespace][podName].Insert(strings...)
 }
 
-// Delete deletes strings for a given namespace.
-func (m NamespacesPodsStringsSet) Delete(namespace string, strings ...string) {
+// Delete deletes strings for a given namespace. Returns true if any
+// modification was made.
+func (m NamespacesPodsStringsSet) Delete(namespace string, strings ...string) bool {
 	if _, ok := m[namespace]; !ok {
 		// Nothing to delete.
-		return
+		return false
 	}
+
+	modified := false
 	for podName, svcSet := range m[namespace] {
-		svcSet.Delete(strings...)
+		for _, s := range strings {
+			if svcSet.Has(s) {
+				svcSet.Delete(s)
+				modified = true
+			}
+		}
 
 		if svcSet.Len() == 0 {
 			delete(m[namespace], podName)
@@ -108,6 +116,8 @@ func (m NamespacesPodsStringsSet) Delete(namespace string, strings ...string) {
 	if len(m[namespace]) == 0 {
 		delete(m, namespace)
 	}
+
+	return modified
 }
 
 // MetadataResponseBundle maps pod names to associated metadata.

--- a/pkg/clusteragent/api/v1/types_test.go
+++ b/pkg/clusteragent/api/v1/types_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -82,6 +83,68 @@ func TestNamespacesPodsStringsSet_Copy(t *testing.T) {
 			if got := tt.m.DeepCopy(tt.old); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NamespacesPodsStringsSet.Copy() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestNamespacesPodsStringsSet_Delete(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialSet   NamespacesPodsStringsSet
+		namespace    string
+		services     []string
+		wantModified bool
+		wantResult   NamespacesPodsStringsSet
+	}{
+		{
+			name:         "non-existing namespace returns false",
+			initialSet:   NamespacesPodsStringsSet{},
+			namespace:    "ns1",
+			services:     []string{"svc1"},
+			wantModified: false,
+			wantResult:   NamespacesPodsStringsSet{},
+		},
+		{
+			name: "non-existing service returns false",
+			initialSet: NamespacesPodsStringsSet{
+				"ns1": map[string]sets.Set[string]{"pod1": sets.New("svc1")},
+			},
+			namespace:    "ns1",
+			services:     []string{"svc-other"},
+			wantModified: false,
+			wantResult: NamespacesPodsStringsSet{
+				"ns1": map[string]sets.Set[string]{"pod1": sets.New("svc1")},
+			},
+		},
+		{
+			name: "deleting existing service returns true",
+			initialSet: NamespacesPodsStringsSet{
+				"ns1": map[string]sets.Set[string]{"pod1": sets.New("svc1", "svc2")},
+			},
+			namespace:    "ns1",
+			services:     []string{"svc1"},
+			wantModified: true,
+			wantResult: NamespacesPodsStringsSet{
+				"ns1": map[string]sets.Set[string]{"pod1": sets.New("svc2")},
+			},
+		},
+		{
+			name: "deleting last service from a namespace also deletes the namespace",
+			initialSet: NamespacesPodsStringsSet{
+				"ns1": map[string]sets.Set[string]{"pod1": sets.New("svc1")},
+			},
+			namespace:    "ns1",
+			services:     []string{"svc1"},
+			wantModified: true,
+			wantResult:   NamespacesPodsStringsSet{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.initialSet.Delete(test.namespace, test.services...)
+			assert.Equal(t, test.wantModified, got)
+			assert.Equal(t, test.wantResult, test.initialSet)
 		})
 	}
 }

--- a/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/metadata_controller.go
@@ -512,8 +512,9 @@ func (m *metadataController) cleanupStaleNodes(namespace, serviceName string, af
 	for nodeName := range staleNodes {
 		log.Tracef("Cleaning up stale service metadata for Node %s and Service %s/%s", nodeName, namespace, serviceName)
 		metaBundle := m.store.getCopyOrNew(nodeName)
-		metaBundle.Services.Delete(namespace, serviceName)
-		m.store.set(nodeName, metaBundle)
+		if metaBundle.Services.Delete(namespace, serviceName) {
+			m.store.set(nodeName, metaBundle)
+		}
 	}
 
 	m.serviceToNodes[serviceName] = affectedNodes
@@ -559,9 +560,9 @@ func (m *metadataController) deleteService(namespace, svc string) error {
 		}
 		newMetaBundle := apiserver.NewMetadataMapperBundle()
 		newMetaBundle.DeepCopy(oldBundle)
-		newMetaBundle.Services.Delete(namespace, svc)
-
-		m.store.set(node.Name, newMetaBundle)
+		if newMetaBundle.Services.Delete(namespace, svc) {
+			m.store.set(node.Name, newMetaBundle)
+		}
 	}
 	return nil
 }

--- a/pkg/util/kubernetes/apiserver/services_test.go
+++ b/pkg/util/kubernetes/apiserver/services_test.go
@@ -28,11 +28,13 @@ func TestNamespacesPodsStringsSet(t *testing.T) {
 	require.Equal(t, 3, len(mapper["default"]))
 	assert.Equal(t, sets.New("svc1"), mapper["default"]["pod1"])
 
-	mapper.Delete("default", "svc1")
+	modified := mapper.Delete("default", "svc1")
+	assert.True(t, modified)
 	require.Equal(t, 1, len(mapper["default"]))
 	assert.Equal(t, sets.New("svc2"), mapper["default"]["pod3"])
 
-	mapper.Delete("default", "svc2")
+	modified = mapper.Delete("default", "svc2")
+	assert.True(t, modified)
 
 	// No more pods in default namespace.
 	_, ok := mapper["default"]


### PR DESCRIPTION
### What does this PR do?

Implements a small optimization discussed in https://github.com/DataDog/datadog-agent/pull/47025#discussion_r2892319879 with @gabedos 

This PR implements a change so that in a couple of functions in `pkg/util/kubernetes/apiserver/controllers/metadata_controller.go`, `store.set` is not called when the previous delete call doesn't delete anything. This avoids notifying grpc stream goroutines for nothing.


### Describe how you validated your changes

CI
