### PR TITLE
buildifier: centralize configuration & analyze our deps files

### DIFF
--- a/.buildifier.json
+++ b/.buildifier.json
@@ -1,0 +1,3 @@
+{
+  "warnings": "-module-docstring"
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,7 @@
 /bazel/configs/procmgrd.bazelrc              @DataDog/agent-runtimes
 /MODULE.bazel*                          @DataDog/agent-build
 /deps/                                  @DataDog/agent-build
+/.buildifier.json                       @DataDog/agent-build
 
 # The owner should really be to a team that does not exist yet. It would cover supply chain in general.
 # For now, agent-build are the experts in that.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -87,6 +87,7 @@ http_archive(
         "//bazel/patches:buildifier-build.patch",  # bazelbuild/buildtools#1398
         "//bazel/patches:buildifier-internal-factory.patch",  # bazelbuild/buildtools#1399
         "//bazel/patches:buildifier-runner-bat-template.patch",  # bazelbuild/buildtools#1400 bazelbuild/buildtools#1404
+        "//bazel/patches:buildifier-runner-bash-template.patch",  # bazelbuild/buildtools#1454
     ],
     sha256 = "f3b800e9f6ca60bdef3709440f393348f7c18a29f30814288a7326285c80aab9",
     strip_prefix = "buildtools-8.5.1",

--- a/bazel/buildifier/BUILD.bazel
+++ b/bazel/buildifier/BUILD.bazel
@@ -27,7 +27,6 @@ buildifier_test(
     buildifier = "@multitool//tools/buildifier",
     exclude_patterns = exclude_patterns,
     lint_mode = "warn",
-    lint_warnings = ["-module-docstring"],
     mode = "diff",
     no_sandbox = True,
     tags = ["manual"],  # not cacheable

--- a/bazel/patches/buildifier-runner-bash-template.patch
+++ b/bazel/patches/buildifier-runner-bash-template.patch
@@ -1,0 +1,25 @@
+From 8e4cf56287603160f66e982b798eb7d13c1367c0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Hugo=20Beauz=C3=A9e-Luyssen?= <hugo.beauzee@datadoghq.com>
+Date: Mon, 9 Mar 2026 15:04:08 +0100
+Subject: [PATCH] buildifier: add *.BUILD.bazel to the list of analyzed
+ patterns
+
+---
+ buildifier/runner.bash.template | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/buildifier/runner.bash.template b/buildifier/runner.bash.template
+index 06a969b..32f00f6 100644
+--- a/buildifier/runner.bash.template
++++ b/buildifier/runner.bash.template
+@@ -50,6 +50,7 @@ find . \
+     -o -name BUILD.bazel \
+     -o -name BUILD \
+     -o -name '*.BUILD' \
++    -o -name '*.BUILD.bazel' \
+     -o -name 'BUILD.*.bazel' \
+     -o -name 'BUILD.*.oss' \
+     -o -name MODULE.bazel \
+-- 
+2.43.0
+

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -1,12 +1,12 @@
-load("@//bazel/rules:foreign_cc_shared_wrapper.bzl", "foreign_cc_shared_wrapper")
 load("@@//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
+load("@//bazel/rules:foreign_cc_shared_wrapper.bzl", "foreign_cc_shared_wrapper")
 load("@//deps/openssl:version.bzl", "OPENSSL_VERSION")
 load("@bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@bazel_skylib//rules:select_file.bzl", "select_file")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "REMOVE_BASE_DIRECTORY", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files", "pkg_mklink")
 
 # Keep in sync with the ones on repos.MODULE.bazel
 python_externals = {

--- a/deps/libffi.BUILD.bazel
+++ b/deps/libffi.BUILD.bazel
@@ -272,4 +272,3 @@ cc_library(
     visibility = ["//visibility:public"],
     linkstatic = True,
 )
-

--- a/deps/lua/lua.BUILD.bazel
+++ b/deps/lua/lua.BUILD.bazel
@@ -1,10 +1,9 @@
-load("@rules_license//rules:license.bzl", "license")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
 
 package(
     default_package_metadata = [":license"],
-    default_visibility = ["//packages:__subpackages__"]
+    default_visibility = ["//packages:__subpackages__"],
 )
 
 license(

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -3,7 +3,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 
 package(
     default_package_metadata = [":license"],

--- a/deps/zstd.BUILD.bazel
+++ b/deps/zstd.BUILD.bazel
@@ -1,6 +1,4 @@
 load("@@//bazel/rules:so_symlink.bzl", "so_symlink")
-load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
-load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
 load("@rules_license//rules:license.bzl", "license")
 


### PR DESCRIPTION
### What does this PR do?

* Introduce a `.buildifier.json` settings file to centralize the buildifier settings
* Include `*.BUILD.bazel` to the list of patterns analyzed by `buildifier:test`
* Fix the warnings that would now be reported otherwise

### Motivation

The setting file is there to reduce the discrepancies between editors & our CI. In my case, my editor is very eager to reformat everything it can find, while our CI didn't complain about some of the lines that get changed.
Having a common config should improve the experience.

The patch to buildifier is there to ensure we analyze all bazel files present in the repository. Currently, all `*.BUILD.bazel` files were silently ignored

### Describe how you validated your changes

Local run with & without the changes to files in `/deps` to ensure they correctly were reported once the buildifier patch is applied, and not afterward so we don't introduce new failures.

### Additional Notes

My editor still ignores `.buildifier.json` but that's more of a "me" problem than an agent problem :sweat_smile: 