### PR TITLE
[AMCC-176][metric filterlist] Fix initialization with local config

### DIFF
--- a/comp/dogstatsd/server/filterlist_init_test.go
+++ b/comp/dogstatsd/server/filterlist_init_test.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer"
+	"github.com/DataDog/datadog-agent/comp/aggregator/demultiplexer/demultiplexerimpl"
+	configComponent "github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameimpl"
+	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/listeners"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/pidmap/pidmapimpl"
+	replay "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/def"
+	replaymock "github.com/DataDog/datadog-agent/comp/dogstatsd/replay/fx-mock"
+	serverdebug "github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug"
+	"github.com/DataDog/datadog-agent/comp/dogstatsd/serverDebug/serverdebugimpl"
+	filterlistimpl "github.com/DataDog/datadog-agent/comp/filterlist/impl"
+	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
+	metricscompression "github.com/DataDog/datadog-agent/comp/serializer/metricscompression/fx-mock"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
+)
+
+// depsWithoutFilterList is like depsWithoutServer but without the FilterList field,
+// so we can inject a real filterlist implementation manually.
+type depsWithoutFilterList struct {
+	fx.In
+
+	Config        configComponent.Component
+	Log           log.Component
+	Demultiplexer demultiplexer.FakeSamplerMock
+	Replay        replay.Component
+	PidMap        pidmap.Component
+	Debug         serverdebug.Component
+	WMeta         option.Option[workloadmeta.Component]
+	Telemetry     telemetry.Component
+	Hostname      hostnameinterface.Component
+}
+
+func TestWorkerFilterListInitializedFromLocalConfig(t *testing.T) {
+	cfg := map[string]interface{}{
+		"dogstatsd_port":    listeners.RandomPortName,
+		"metric_filterlist": []string{"filtered.metric"},
+	}
+
+	deps := fxutil.Test[depsWithoutFilterList](t, fx.Options(
+		fx.Provide(func() log.Component { return logmock.New(t) }),
+		fx.Provide(func() configComponent.Component { return configComponent.NewMockWithOverrides(t, cfg) }),
+		telemetryimpl.MockModule(),
+		hostnameimpl.MockModule(),
+		serverdebugimpl.MockModule(),
+		replaymock.MockModule(),
+		pidmapimpl.Module(),
+		demultiplexerimpl.FakeSamplerMockModule(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+		metricscompression.MockModule(),
+		logscompression.MockModule(),
+	))
+
+	fl := filterlistimpl.NewFilterList(deps.Log, deps.Config, deps.Telemetry)
+	s := newServerCompat(deps.Config, deps.Log, deps.Hostname, deps.Replay, deps.Debug, false, deps.Demultiplexer, deps.WMeta, deps.PidMap, deps.Telemetry, fl)
+
+	err := s.start(context.TODO())
+	require.NoError(t, err)
+	defer s.stop(context.TODO()) //nolint:errcheck
+
+	require.NotEmpty(t, s.workers, "server should have workers")
+	for i, worker := range s.workers {
+		require.NotNil(t, worker.filterList, "worker %d filterList should not be nil", i)
+		assert.True(t, worker.filterList.Test("filtered.metric"),
+			"worker %d should filter 'filtered.metric' from local config", i)
+		assert.False(t, worker.filterList.Test("unfiltered.metric"),
+			"worker %d should not filter 'unfiltered.metric'", i)
+	}
+}

--- a/comp/dogstatsd/server/server.go
+++ b/comp/dogstatsd/server/server.go
@@ -535,7 +535,7 @@ func (s *server) onFilterListUpdate(filterList utilstrings.Matcher, _ utilstring
 	defer s.startedMtx.RUnlock()
 
 	if !s.IsRunning() {
-		// The workers have stopped so can't receive updates.
+		// The server is not running, so workers can't receive updates.
 		return
 	}
 
@@ -571,13 +571,13 @@ func (s *server) handleMessages() {
 	s.log.Debug("DogStatsD will run", workersCount, "workers")
 
 	for i := 0; i < workersCount; i++ {
-		worker := newWorker(s, i, s.wmeta, s.packetsTelemetry, s.stringInternerTelemetry)
+		worker := newWorker(s, i, s.wmeta, s.packetsTelemetry, s.stringInternerTelemetry, s.filterList.GetMetricFilterList())
 		go worker.run()
 		s.workers = append(s.workers, worker)
 	}
 
 	// It is important to set this up after the workers are running so they receive
-	// the initial  filterlist and any updates.
+	// any updates.
 	s.filterList.OnUpdateMetricFilterList(s.onFilterListUpdate)
 }
 

--- a/comp/dogstatsd/server/server_worker.go
+++ b/comp/dogstatsd/server/server_worker.go
@@ -40,7 +40,7 @@ type worker struct {
 	filterList       utilstrings.Matcher
 }
 
-func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Component], packetsTelemetry *packets.TelemetryStore, stringInternerTelemetry *stringInternerTelemetry) *worker {
+func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Component], packetsTelemetry *packets.TelemetryStore, stringInternerTelemetry *stringInternerTelemetry, filterList utilstrings.Matcher) *worker {
 	var batcher *batcher
 	if s.ServerlessMode {
 		batcher = newServerlessBatcher(s.demultiplexer, s.tlmChannel)
@@ -55,6 +55,7 @@ func newWorker(s *server, workerNum int, wmeta option.Option[workloadmeta.Compon
 		samples:          make(metrics.MetricSampleBatch, 0, defaultSampleSize),
 		packetsTelemetry: packetsTelemetry,
 		FilterListUpdate: make(chan utilstrings.Matcher),
+		filterList:       filterList,
 	}
 }
 

--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -172,6 +172,8 @@ func (fl *FilterList) GetTagFilterList() filterlist.TagMatcher {
 
 // GetMetricFilterList returns the current metric filterlist.
 func (fl *FilterList) GetMetricFilterList() utilstrings.Matcher {
+	fl.updateMetricMtx.RLock()
+	defer fl.updateMetricMtx.RUnlock()
 	return fl.filterList
 }
 


### PR DESCRIPTION
### What does this PR do?

1eccec1 broke the initialization logic of the filterlist when configured with the local config, because the commit moved the initial `onFilterListUpdate` call to _before_ the dogstatsd server is running (i.e. before `s.IsRunning()` returns `true`), which made the initial call to `onFilterListUpdate` a no-op (instead of initializing the filter list to the locally-configured list).

This commit fixes this by explicitly passing the locally-configured filterlist to the dogstatsd workers upon initialization.

### Motivation

Fix metric filterlist configured via local config.

### Describe how you validated your changes

* Added a unit test
* Validated that with the following local `datadog.yaml` config, for an Agent that's not connected to RC (otherwise the RC-polled filterlist would take precedence):
```
metric_filterlist:
- "test.metric.olivielpeau"
```
and the following metric submission:
```
echo "test.metric.olivielpeau:1|c" | nc -w 1 -u 127.0.0.1 8125
```

7.66.0 does not filter the metric, whereas this PR does.

### Additional Notes

Filterlists configured via RC should not be affected by the regression that the present PR fixes: by the time the filter lists from RC are pulled, the dogstatsd server _should_ be fully running, and therefore `onFilterListUpdate` should be called and actually set the RC-configured filter list. Note that I don't think the current code provides strong guarantees about this order of operation for RC-configured filter lists but in practice I think it's highly unlikely that an RC-configured filter list is pulled before the dogstatsd server is fully running. I'll try to follow up with a separate PR to provide strong guarantees for this.