### PR TITLE
fix(fleet): Remove ConditionPathExists from system-probe service units

### DIFF
--- a/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-sysprobe.service.tmpl
+++ b/pkg/fleet/installer/packages/embedded/tmpl/datadog-agent-sysprobe.service.tmpl
@@ -6,8 +6,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-sysprobe-exp.service
-ConditionPathExists=|{{.EtcDir}}/system-probe.yaml
-ConditionPathExists=|{{.FleetPoliciesDir}}/system-probe.yaml
 {{- else}}
 Description=Datadog System Probe Experiment
 Requires=sys-kernel-debug.mount
@@ -15,8 +13,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
-ConditionPathExists=|{{.EtcDir}}/system-probe.yaml
-ConditionPathExists=|{{.FleetPoliciesDir}}/system-probe.yaml
 {{- end}}
 
 [Service]

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe-exp.service
@@ -5,8 +5,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
-ConditionPathExists=|/etc/datadog-agent-exp/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm-nocap/datadog-agent-sysprobe.service
@@ -5,8 +5,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-sysprobe-exp.service
-ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe-exp.service
@@ -5,8 +5,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
-ConditionPathExists=|/etc/datadog-agent-exp/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-sysprobe.service
@@ -5,8 +5,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-sysprobe-exp.service
-ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe-exp.service
@@ -5,8 +5,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
-ConditionPathExists=|/etc/datadog-agent-exp/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci-nocap/datadog-agent-sysprobe.service
@@ -5,8 +5,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-sysprobe-exp.service
-ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe-exp.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe-exp.service
@@ -5,8 +5,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent-exp.service
 Conflicts=datadog-agent.service datadog-agent-sysprobe.service
-ConditionPathExists=|/etc/datadog-agent-exp/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent-exp/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe.service
+++ b/pkg/fleet/installer/packages/embedded/tmpl/gen/oci/datadog-agent-sysprobe.service
@@ -5,8 +5,6 @@ Before=datadog-agent.service datadog-agent-exp.service
 After=network.target sys-kernel-debug.mount
 BindsTo=datadog-agent.service
 Conflicts=datadog-agent-exp.service datadog-agent-sysprobe-exp.service
-ConditionPathExists=|/etc/datadog-agent/system-probe.yaml
-ConditionPathExists=|/etc/datadog-agent/managed/datadog-agent/stable/system-probe.yaml
 
 [Service]
 Type=simple

--- a/releasenotes/notes/sp-remove-condition-cd72bdced3d67ed1.yaml
+++ b/releasenotes/notes/sp-remove-condition-cd72bdced3d67ed1.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    With systemd, the system-probe service now checks environment variables for
+    configuration even if ``system-probe.yaml`` does not exist.

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -11,9 +11,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/stretchr/testify/assert"
+
 	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
-	"github.com/stretchr/testify/assert"
 
 	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
 	"github.com/DataDog/datadog-agent/test/new-e2e/tests/installer/host"
@@ -52,7 +53,7 @@ func (s *packageAgentSuite) TestInstall() {
 	defer s.Purge()
 	s.host.AssertPackageInstalledByPackageManager("datadog-agent")
 	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit)
-	s.host.WaitForUnitExited(s.T(), 0, processUnit, dataPlaneUnit)
+	s.host.WaitForUnitExited(s.T(), 0, processUnit, dataPlaneUnit, probeUnit)
 
 	state := s.host.State()
 	s.assertUnits(state, true)
@@ -83,10 +84,10 @@ func (s *packageAgentSuite) assertUnits(state host.State, oldUnits bool) {
 	state.AssertUnitsLoaded(agentUnit, traceUnit, processUnit, probeUnit, securityUnit, dataPlaneUnit)
 	state.AssertUnitsEnabled(agentUnit)
 
-	// we cannot assert here on process-agent/agent-data-plane being either running or dead due to timing issues,
+	// we cannot assert here on process-agent/agent-data-plane/system-probe being either running or dead due to timing issues,
 	// so it has to be checked prior (i.e., using WaitForUnitExited)
 	state.AssertUnitsRunning(agentUnit, traceUnit)
-	state.AssertUnitsDead(probeUnit, securityUnit)
+	state.AssertUnitsDead(securityUnit)
 
 	systemdPath := "/etc/systemd/system"
 	if oldUnits || s.installMethod == InstallMethodAnsible {
@@ -508,7 +509,7 @@ func (s *packageAgentSuite) TestInstallFips() {
 	defer s.Purge()
 	s.host.AssertPackageInstalledByPackageManager("datadog-fips-agent")
 	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit)
-	s.host.WaitForUnitExited(s.T(), 0, processUnit, dataPlaneUnit)
+	s.host.WaitForUnitExited(s.T(), 0, processUnit, dataPlaneUnit, probeUnit)
 
 	// Important: the installer daemon shouldn't start if FIPS is enabled. Remote Config will be disabled and the unit will exit with code 255.
 	s.host.WaitForUnitExited(s.T(), 255, installerUnit)

--- a/test/new-e2e/tests/installer/unix/package_ddot_test.go
+++ b/test/new-e2e/tests/installer/unix/package_ddot_test.go
@@ -132,8 +132,8 @@ func (s *packageDDOTSuite) TestInstallDDOTInstaller() {
 func (s *packageDDOTSuite) assertCoreUnits(state host.State, oldUnits bool) {
 	state.AssertUnitsLoaded(agentUnit, traceUnit, processUnit, probeUnit, securityUnit)
 	state.AssertUnitsEnabled(agentUnit)
-	state.AssertUnitsRunning(agentUnit, traceUnit) //cannot assert process-agent because it may be running or dead based on timing
-	state.AssertUnitsDead(probeUnit, securityUnit)
+	state.AssertUnitsRunning(agentUnit, traceUnit) //cannot assert process-agent and system-probe because they may be running or dead based on timing
+	state.AssertUnitsDead(securityUnit)
 
 	systemdPath := "/etc/systemd/system"
 	if oldUnits {


### PR DESCRIPTION
### What does this PR do?

Removes the `ConditionPathExists=[...]/system-probe.yaml` directives from the system-probe systemd service unit.

### Motivation

Currently, the system-probe service requires the existence of `system-probe.yaml` to start. This condition causes the following problems:

- system-probe can also be configured via environment variables, and the system-probe service file references `/etc/datadog-agent/environment` via an `EnvironmentFile` directive. However, if an environment variable to enable some system-probe module is present in the file, system-probe won't run unless `system-probe.yaml` (even an empty) exists, so the environment variables don't work in that case.

- The options `compliance.enabled` along with `compliance.run_in_system_probe` in the `datadog.yaml` (not `system-probe.yaml`) are supposed to enable the system-probe module, but these option don't work unless a system-probe.yaml (even an empty one) exists.

Not that even before this PR, the existence of the file does not mean that system-probe is enabled, system-probe still checks on startup to see if it is enabled and exits cleanly if it is not. So remove the condition and let system-probe itself properly determine if it needs to run or not. 

Note that this condition was originally introduced way back in https://github.com/DataDog/datadog-agent/pull/4883 to "avoid running anything as root" when system-probe is not enabled. Things have changed since then and we already have another default service (`datadog-agent-installer`) which starts as root and there will be more in the future (`procmgrd`) so that argument no longer holds.

### Describe how you validated your changes

CI.

Also installed the agent from this CI pipeline on a Linux VM with the install script and checked that system-probe exits cleanly after checking its config with the default settings.