### PR TITLE
use mirrored versions of kmt docker images

### DIFF
--- a/pkg/discovery/module/testdata/docker-compose.yml
+++ b/pkg/discovery/module/testdata/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   one:
     # Just some image that has python.  mysql chosen since it is already used
     # from another test.
-    image: mysql:8.0.32
+    image: mysql:8.0.34
     # Symlink binary to allow easier identification of processes from test
     command: >
       sh -c "echo

--- a/pkg/network/protocols/amqp/testdata/docker-compose.yml
+++ b/pkg/network/protocols/amqp/testdata/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 name: amqp
 services:
   rabbitmq:
-    image: rabbitmq:3-management-alpine
+    image: rabbitmq:3.12.7-management-alpine
     ports:
       - ${AMQP_ADDR:-127.0.0.1}:${AMQP_PORT:-5672}:${AMQP_PORT:-5672}
       - ${AMQP_ADDR:-127.0.0.1}:15672:15672

--- a/pkg/network/protocols/kafka/testdata/docker-compose.yml
+++ b/pkg/network/protocols/kafka/testdata/docker-compose.yml
@@ -4,7 +4,7 @@
 name: kafka
 services:
   zookeeper:
-    image: bitnamilegacy/zookeeper:3.9
+    image: bitnamilegacy/zookeeper:3.9.2-debian-12-r11
     ports:
       - "2181:2181"
     environment:

--- a/pkg/network/protocols/mysql/testdata/docker-compose.yml
+++ b/pkg/network/protocols/mysql/testdata/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 name: mysql
 services:
   mysql:
-    image: mysql:8.0.32
+    image: mysql:8.0.34
     entrypoint: /runner.sh
     command: --default-authentication-plugin=mysql_native_password ${MYSQL_TLS_ARGS}
     restart: always

--- a/pkg/network/protocols/postgres/testdata/docker-compose.yml
+++ b/pkg/network/protocols/postgres/testdata/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 name: postgres
 services:
   postgres:
-    image: postgres:15-alpine
+    image: postgres:15.4-alpine
     restart: always
     entrypoint: /v/runner.sh
     command: postgres -l -c ssl=${ENCRYPTION_MODE} -c ssl_cert_file=/postgres-test/server.crt -c ssl_key_file=/postgres-test/server.key -c config_file=/postgres-test/postgres.conf

--- a/pkg/network/protocols/redis/testdata/docker-compose.yml
+++ b/pkg/network/protocols/redis/testdata/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 name: redis
 services:
   redis:
-    image: redis:7-alpine
+    image: redis:7.0.14-alpine
     entrypoint: /runner.sh
     command: --ignore-warnings ARM64-COW-BUG ${REDIS_ARGS}
     ports:

--- a/pkg/network/tracer/testdata/dnsworkload/docker-compose.yml
+++ b/pkg/network/tracer/testdata/dnsworkload/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 name: dnsworkload
 services:
   coredns:
-    image: coredns/coredns:1.13.1
+    image: coredns/coredns:1.11.3
     command: -conf /etc/coredns/Corefile
     ports:
       - 127.0.0.1:53:53/udp

--- a/pkg/network/usm/testdata/musl/docker-compose.yml
+++ b/pkg/network/usm/testdata/musl/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   alpine:
-    image: dwdraju/alpine-curl-jq:latest
+    image: byrnedo/alpine-curl:3.17
     stdin_open: true
     tty: true
     # No server, the container only needs to be running for the test to get

--- a/pkg/network/usm/testdata/musl/docker-compose.yml
+++ b/pkg/network/usm/testdata/musl/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   alpine:
-    image: byrnedo/alpine-curl:3.17
+    image: dwdraju/alpine-curl-jq:latest
     stdin_open: true
     tty: true
     # No server, the container only needs to be running for the test to get

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1927,17 +1927,17 @@ def save_test_dockers(ctx, output_dir, arch, use_crane=False):
     for vmconfig_path in vmconfig_paths:
         with open(vmconfig_path) as vmconfig:
             vmjson = json.load(vmconfig)
-            if not "vmsets" in vmjson:
+            if "vmsets" not in vmjson:
                 continue
 
             for vmset in vmjson["vmsets"]:
-                if not "disks" in vmset:
+                if "disks" not in vmset:
                     continue
                 if vmset["arch"] != arch:
                     continue
 
                 for disk in vmset["disks"]:
-                    if not "source" in disk:
+                    if "source" not in disk:
                         continue
 
                     root = disk["source"].removesuffix(f"/docker-{arch}.qcow2.xz")
@@ -1956,8 +1956,8 @@ def save_test_dockers(ctx, output_dir, arch, use_crane=False):
 
             docker_ls.add(
                 line.removeprefix("public.ecr.aws/docker/library/")
-                    .removeprefix("registry.ddbuild.io/images/mirror/library/")
-                    .removeprefix("registry.ddbuild.io/images/mirror/")
+                .removeprefix("registry.ddbuild.io/images/mirror/library/")
+                .removeprefix("registry.ddbuild.io/images/mirror/")
             )
 
     images = _test_docker_image_list()

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1915,24 +1915,59 @@ def save_test_dockers(ctx, output_dir, arch, use_crane=False):
         return
 
     # crane does not accept 'x86_64' as a valid architecture
+    crane_arch = arch
     if arch == "x86_64":
-        arch = "amd64"
+        crane_arch = "amd64"
 
-    # only download images not present in preprepared vm disk
-    resp = requests.get('https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker.ls')
+    vmconfig_paths = [
+        "test/new-e2e/system-probe/config/vmconfig-system-probe.json",
+        "test/new-e2e/system-probe/config/vmconfig-security-agent.json",
+    ]
+    urls = set()
+    for vmconfig_path in vmconfig_paths:
+        with open(vmconfig_path) as vmconfig:
+            vmjson = json.load(vmconfig)
+            if not "vmsets" in vmjson:
+                continue
 
-    # remove the public.ecr.aws/docker/library/ prefix as we might be downloading official images
-    # from the AWS mirror instead of dockerhub to avoid rate limits
-    docker_ls = {line.removeprefix("public.ecr.aws/docker/library/") for line in resp.text.split('\n') if line.strip()}
+            for vmset in vmjson["vmsets"]:
+                if not "disks" in vmset:
+                    continue
+                if vmset["arch"] != arch:
+                    continue
+
+                for disk in vmset["disks"]:
+                    if not "source" in disk:
+                        continue
+
+                    root = disk["source"].removesuffix(f"/docker-{arch}.qcow2.xz")
+                    urls.add(f"{root}/docker.ls")
+
+    docker_ls = set()
+    for u in urls:
+        # only download images not present in preprepared vm disk
+        resp = requests.get(u)
+
+        # remove mirror prefixes as we might be downloading official images
+        # from the AWS or DD mirror instead of dockerhub to avoid rate limits
+        for line in resp.text.split('\n'):
+            if not line.strip():
+                continue
+
+            docker_ls.add(
+                line.removeprefix("public.ecr.aws/docker/library/")
+                    .removeprefix("registry.ddbuild.io/images/mirror/library/")
+                    .removeprefix("registry.ddbuild.io/images/mirror/")
+            )
 
     images = _test_docker_image_list()
     for image in images - docker_ls:
         output_path = image.translate(str.maketrans('', '', string.punctuation))
         output_file = f"{os.path.join(output_dir, output_path)}.tar"
         if use_crane:
-            ctx.run(f"crane pull --platform linux/{arch} {image} {output_file}")
+            ctx.run(f"crane pull --platform linux/{crane_arch} {image} {output_file}")
         else:
-            ctx.run(f"docker pull --platform linux/{arch} {image}")
+            ctx.run(f"docker pull --platform linux/{crane_arch} {image}")
             ctx.run(f"docker save {image} > {output_file}")
 
 
@@ -1964,7 +1999,7 @@ def _test_docker_image_list():
     images.remove("public.ecr.aws/b1o7r7e0/usm-team/go-httpbin:https")
 
     # Add images used in docker run commands
-    images.add("public.ecr.aws/docker/library/alpine:3.20.3")
+    images.add("alpine:3.20.3")
 
     return images
 

--- a/test/new-e2e/system-probe/config/vmconfig-security-agent.json
+++ b/test/new-e2e/system-probe/config/vmconfig-security-agent.json
@@ -11,7 +11,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-x86_64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/use-more-mirror/docker-x86_64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-x86_64.qcow2",
                     "type": "default"
                 }
@@ -29,7 +29,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-arm64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/use-more-mirror/docker-arm64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-arm64.qcow2",
                     "type": "default"
                 }

--- a/test/new-e2e/system-probe/config/vmconfig-security-agent.json
+++ b/test/new-e2e/system-probe/config/vmconfig-security-agent.json
@@ -11,7 +11,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/use-more-mirror/docker-x86_64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/20260310_e40b46ce/docker-x86_64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-x86_64.qcow2",
                     "type": "default"
                 }
@@ -29,7 +29,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/use-more-mirror/docker-arm64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/20260310_e40b46ce/docker-arm64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-arm64.qcow2",
                     "type": "default"
                 }

--- a/test/new-e2e/system-probe/config/vmconfig-system-probe.json
+++ b/test/new-e2e/system-probe/config/vmconfig-system-probe.json
@@ -11,7 +11,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-x86_64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/use-more-mirror/docker-x86_64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-x86_64.qcow2",
                     "type": "default"
                 }
@@ -29,7 +29,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/master/docker-arm64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/use-more-mirror/docker-arm64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-arm64.qcow2",
                     "type": "default"
                 }

--- a/test/new-e2e/system-probe/config/vmconfig-system-probe.json
+++ b/test/new-e2e/system-probe/config/vmconfig-system-probe.json
@@ -11,7 +11,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/use-more-mirror/docker-x86_64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/20260310_e40b46ce/docker-x86_64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-x86_64.qcow2",
                     "type": "default"
                 }
@@ -29,7 +29,7 @@
             "disks": [
                 {
                     "mount_point": "/mnt/docker",
-                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/bryce.kahle/use-more-mirror/docker-arm64.qcow2.xz",
+                    "source": "https://dd-agent-omnibus.s3.amazonaws.com/kernel-version-testing/rootfs/20260310_e40b46ce/docker-arm64.qcow2.xz",
                     "target": "%KMTDIR%/rootfs/docker-arm64.qcow2",
                     "type": "default"
                 }


### PR DESCRIPTION
### What does this PR do?

Changes KMT tests to use versions of docker images that are mirrored. This is often just being more specific about the version.

### Motivation

Avoid rate limiting when building the docker disk.

### Describe how you validated your changes

### Additional Notes
