### PR TITLE
[Backport 7.77.x] fix forwarder diverging on refreshed api key

### DIFF
--- a/comp/forwarder/defaultforwarder/forwarder_health.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"regexp"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -45,7 +46,7 @@ var (
 
 	// domainURLRegexp determines if an URL belongs to Datadog or not. If the URL belongs to Datadog it's prefixed
 	// with 'api.' (see computeDomainURLAPIKeyMap).
-	domainURLRegexp = regexp.MustCompile(`([a-z]{2,}\d{1,2}\.)?(datadoghq\.[a-z]+|ddog-gov\.com)$`)
+	domainURLRegexp = regexp.MustCompile(`([a-z]{2,}\d{1,2}\.)?(datadoghq\.[a-z]+|ddog-gov\.com)\.?$`)
 )
 
 func init() {
@@ -201,7 +202,9 @@ func (fh *forwarderHealth) UpdateAPIKeys(domain string, old []string, new []stri
 
 func getAPIDomain(domain string) string {
 	if domainURLRegexp.MatchString(domain) {
-		return "https://api." + domainURLRegexp.FindString(domain)
+		match := domainURLRegexp.FindString(domain)
+		match = strings.TrimSuffix(match, ".")
+		return "https://api." + match
 	}
 
 	return domain

--- a/comp/forwarder/defaultforwarder/forwarder_health_test.go
+++ b/comp/forwarder/defaultforwarder/forwarder_health_test.go
@@ -487,3 +487,43 @@ func TestHealthInvalidAPIKeyTriggersSecretRefresh(t *testing.T) {
 
 	assert.True(t, triggered, "secrets.Refresh(false) should be called when API key is invalid")
 }
+
+// TestUpdateAPIKeyAfterSetBaseDomain verifies health cache correctness after key rotation with a mutated resolver domain.
+func TestUpdateAPIKeyAfterSetBaseDomain(t *testing.T) {
+	originalDomain := "https://app.datadoghq.com."
+
+	keysPerDomains := map[string][]utils.APIKeys{
+		originalDomain: {utils.NewAPIKeys("api_key", "old_key")},
+	}
+	resolvers, err := resolver.NewSingleDomainResolvers(keysPerDomains)
+	require.NoError(t, err)
+
+	log := logmock.New(t)
+	cfg := configmock.New(t)
+	secrets := secretsmock.New(t)
+	fh := forwarderHealth{log: log, config: cfg, secrets: secrets, domainResolvers: resolvers}
+	fh.init()
+
+	// mock mutate the resolver's base domain like default forwarder does
+	resolvers[originalDomain].SetBaseDomain("https://mock-mutated-app.agent.datadoghq.com.")
+
+	resolvers[originalDomain].SetForwarderHealth(&fh)
+	resolver.OnUpdateConfig(resolvers[originalDomain], log, cfg)
+
+	// seed the config so the next SetWithoutSource has a valid oldValue
+	cfg.SetWithoutSource("api_key", "old_key")
+
+	// trigger rotation rotation through the real config update path
+	cfg.SetWithoutSource("api_key", "new_key")
+
+	// health cache should contain only new_key
+	fh.keyMapMutex.Lock()
+	var allKeys []string
+	for _, keys := range fh.keysPerAPIEndpoint {
+		allKeys = append(allKeys, keys...)
+	}
+	fh.keyMapMutex.Unlock()
+
+	assert.Contains(t, allKeys, "new_key", "new_key should be in health cache")
+	assert.NotContains(t, allKeys, "old_key", "old_key should have been removed from health cache")
+}

--- a/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
+++ b/comp/forwarder/defaultforwarder/resolver/domain_resolver.go
@@ -94,7 +94,7 @@ func OnUpdateConfig(resolver DomainResolver, log log.Component, config config.Co
 			resolver.UpdateAPIKey(setting, oldAPIKey, newAPIKey)
 
 			if health := resolver.GetForwarderHealth(); health != nil {
-				health.UpdateAPIKeys(resolver.GetBaseDomain(), []string{oldAPIKey}, []string{newAPIKey})
+				health.UpdateAPIKeys(resolver.GetConfigName(), []string{oldAPIKey}, []string{newAPIKey})
 			}
 
 			log.Infof("rotating API key for '%s': %s -> %s",
@@ -136,7 +136,7 @@ func updateAdditionalEndpoints(resolver DomainResolver, setting string, config c
 	added := missing(newKeys, oldKeys)
 
 	if health := resolver.GetForwarderHealth(); health != nil {
-		health.UpdateAPIKeys(resolver.GetBaseDomain(), removed, added)
+		health.UpdateAPIKeys(resolver.GetConfigName(), removed, added)
 	}
 
 	removed = scrubKeys(removed)


### PR DESCRIPTION
Backport 8829ef34be03a0c78422992f65b2da249067a37e from (#47351)

---

### What does this PR do?
Addresses: https://datadoghq.atlassian.net/browse/AGENT-15723 - Forwarder health check fails after successful API key rotation in Kubernetes

This was caused by the health 'cache' not recieving the new api key during rotation due to a trailing dot from FQDN.

### Motivation

### Describe how you validated your changes

#### QA

**reproduce the issue first:**

1. setup
```
minikube start --memory=4096 --cpus=2
helm repo add datadog https://helm.datadoghq.com
helm repo update
```

2. create k8s namespace and secret
```
kubectl create namespace datadog-qa
kubectl create secret generic dd-secret \
  --namespace datadog-qa \
  --from-literal=api_key=<FULL_KEY_A_VALUE>
```

3. create yaml for helm <details>
<summary>yaml</summary>

```yaml
cat > /tmp/qa-values-stock.yaml <<'EOF'
datadog:
  apiKey: "fakekey00000000000000000000000001" # will get replaced by actual key, yaml needs placeholder
  site: datadoghq.com

  secretBackend:
    command: "/readsecret_multiple_providers.sh"
    enableGlobalPermissions: true
    refreshInterval: 30

  logs:
    enabled: false
  apm:
    portEnabled: false
  processAgent:
    enabled: false

agents:
  image:
    repository: "gcr.io/datadoghq/agent"
    tag: "7.76.1"
    doNotCheckTag: true

  containers:
    agent:
      env:
        - name: DD_API_KEY
          value: "ENC[k8s_secret@datadog-qa/dd-secret/api_key]"
        - name: DD_SECRET_REFRESH_INTERVAL
          value: "30"
        - name: DD_FORWARDER_APIKEY_VALIDATION_INTERVAL
          value: "2"
        - name: DD_CONVERT_DD_SITE_FQDN_ENABLED
          value: "true"

clusterAgent:
  enabled: false
EOF
```
</details>

5. install agent via helm
```
helm install dd-qa datadog/datadog \
  --namespace datadog-qa \
  -f /tmp/qa-values-stock.yaml
```

6. wait for agent to spin up
```
kubectl -n datadog-qa get pods -w
kubectl -n datadog-qa get pods
AGENT_POD=<agent-pod-name>
```
7. do baseline check
```
### should be 200
kubectl -n datadog-qa exec $AGENT_POD -c agent -- \
  curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:5555/ready

### api key valid
kubectl -n datadog-qa exec $AGENT_POD -c agent -- \
  agent status forwarder 2>/dev/null | grep -A 10 "API Keys"
```

8. rotate the api key
```
  kubectl create secret generic dd-secret \
    --namespace datadog-qa \
    --from-literal=api_key=<FULL_KEY_B_VALUE> \
    --dry-run=client -o yaml | kubectl apply -f -
```

9. wait 60-120s and verify rotation
```
kubectl -n datadog-qa logs $AGENT_POD -c agent | grep "rotating API key"

kubectl -n datadog-qa exec $AGENT_POD -c agent -- \
  agent status forwarder 2>/dev/null | grep -A 10 "API Keys"

### you should see two api keys here without the fix (this branch) I believe this is the bug itself manifesting as a stale cache entry.
```

10. delete the first key
11. wait around 3-5 mins and confirm there is an issue
```
### expected 500
kubectl -n datadog-qa exec $AGENT_POD -c agent -- \
  curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:5555/ready

### should say healthcheck failed
kubectl -n datadog-qa logs $AGENT_POD -c agent | \
  grep -E "No valid api key|Healthcheck failed"
```

---

**now do the same with the fix from this branch:** follow the same exact steps as above, however this time using the CI's output of the datadog docker image
```
      repository: "registry.ddbuild.io/ci/datadog-agent/agent"
      tag: "v100426000-bbdcda07-7-arm64"
```
follow all the steps, this time at the end you should see
```
kubectl -n datadog-qa exec $AGENT_POD -c agent -- \
  curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:5555/ready
# EXPECTED: 200

kubectl -n datadog-qa exec $AGENT_POD -c agent -- \
  agent status forwarder 2>/dev/null | grep -A 15 "API Keys"
# EXPECTED:
#   API key ending with <KEY_B>: API Key valid
#   (no KEY_A entry)

kubectl -n datadog-qa logs $AGENT_POD -c agent | \
  grep -E "No valid api key|Healthcheck failed"
# EXPECTED: no output
```

### Additional Notes


(cherry picked from commit 8829ef34be03a0c78422992f65b2da249067a37e)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
