### PR TITLE
ci: use local bazel-cache action to set XDG_CACHE_HOME

### DIFF
--- a/.github/workflows/buildimages-update.yml
+++ b/.github/workflows/buildimages-update.yml
@@ -42,6 +42,9 @@ jobs:
           # credentials are needed to create the PR at the end of the workflow
           persist-credentials: true
 
+      - name: Bazel cache
+        uses: ./.github/actions/bazel-cache
+
       - name: Fetch branch
         env:
           TARGET_BRANCH: ${{ inputs.branch }}


### PR DESCRIPTION
### What does this PR do?

Modify the update-buildimages workflow to use the bazel cache.

### Motivation

The workflow was broken due to the missing bazel cache.

### Describe how you validated your changes

YOLO