### PR TITLE
adding documentation link to SNMP error message and updating test accordingly

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -59,6 +59,16 @@ const (
 	profileRefreshDelay     = 600 // Number of seconds after which a profile needs to be refreshed
 )
 
+// SNMPTroubleshootingDocURL is the public doc for troubleshooting unreachable or misconfigured devices (exported for tests).
+const SNMPTroubleshootingDocURL = "https://docs.datadoghq.com/network_monitoring/devices/troubleshooting/?tab=linux#unreachable-or-misconfigured-device"
+
+const snmpCheckErrorDocSuffix = ", see this documentation for troubleshooting: "
+
+// formatCheckErrorMessage appends the troubleshooting doc link to the error message shown in service checks and CLI.
+func formatCheckErrorMessage(err error) string {
+	return err.Error() + snmpCheckErrorDocSuffix + SNMPTroubleshootingDocURL
+}
+
 type profileCache struct {
 	sysObjectID string
 	timestamp   time.Time
@@ -272,7 +282,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	tags := utils.CopyStrings(staticTags)
 	if checkErr != nil {
 		tags = append(tags, d.savedDynamicTags...)
-		d.sender.ServiceCheck(serviceCheckName, servicecheck.ServiceCheckCritical, tags, checkErr.Error())
+		d.sender.ServiceCheck(serviceCheckName, servicecheck.ServiceCheckCritical, tags, formatCheckErrorMessage(checkErr))
 	} else {
 		d.profileCache.RemoveMissingOIDs(values)
 
@@ -348,7 +358,10 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	d.setDeviceHostExternalTags()
 	d.interfaceBandwidthState.RemoveExpiredBandwidthUsageRates(startTime.UnixNano())
 
-	return checkErr
+	if checkErr != nil {
+		return errors.New(formatCheckErrorMessage(checkErr))
+	}
+	return nil
 }
 
 func (d *DeviceCheck) setDeviceHostExternalTags() {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -629,8 +629,9 @@ profiles:
 	sess.ConnectErr = errors.New("some error")
 	err = deviceCk.Run(time.Now())
 
-	assert.Error(t, err, "some error")
-	sender.Mock.AssertCalled(t, "ServiceCheck", "snmp.can_check", servicecheck.ServiceCheckCritical, "", mocksender.MatchTagsContains(snmpTags), "snmp connection error: some error")
+	expectedMsg := "snmp connection error: some error" + ", see this documentation for troubleshooting: " + SNMPTroubleshootingDocURL
+	assert.EqualError(t, err, expectedMsg)
+	sender.Mock.AssertCalled(t, "ServiceCheck", "snmp.can_check", servicecheck.ServiceCheckCritical, "", mocksender.MatchTagsContains(snmpTags), expectedMsg)
 	sender.AssertMetric(t, "Gauge", deviceUnreachableMetric, 1., "", snmpTags)
 	sender.AssertMetric(t, "Gauge", deviceReachableMetric, 0., "", snmpTags)
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -1023,14 +1023,15 @@ community_string: public
 	sender.On("Commit").Return()
 
 	err = chk.Run()
-	assert.Error(t, err, "snmp connection error: can't connect")
+	connErrMsg := "snmp connection error: can't connect" + ", see this documentation for troubleshooting: " + devicecheck.SNMPTroubleshootingDocURL
+	assert.EqualError(t, err, connErrMsg)
 
 	snmpTags := []string{"snmp_device:1.2.3.4", "device_ip:1.2.3.4", "device_id:default:1.2.3.4"}
 
 	sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 0.0, "", snmpTags)
 	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpTags)
 	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpTags)
-	sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckCritical, "", snmpTags, "snmp connection error: can't connect")
+	sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckCritical, "", snmpTags, connErrMsg)
 }
 
 func TestCheckID(t *testing.T) {
@@ -1283,7 +1284,8 @@ namespace: '%s'
 			sender.On("Commit").Return()
 
 			err = chk.Run()
-			assert.EqualError(t, err, tt.expectedErr)
+			expectedMsg := tt.expectedErr + ", see this documentation for troubleshooting: " + devicecheck.SNMPTroubleshootingDocURL
+			assert.EqualError(t, err, expectedMsg)
 
 			snmpTags := []string{"snmp_device:1.2.3.4", "device_ip:1.2.3.4"}
 
@@ -1291,7 +1293,7 @@ namespace: '%s'
 			sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpTags)
 			sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpTags)
 
-			sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckCritical, "", snmpTags, tt.expectedErr)
+			sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckCritical, "", snmpTags, expectedMsg)
 		})
 		break
 	}
@@ -1678,7 +1680,8 @@ tags:
 
 	sender.AssertEventPlatformEvent(t, compactEvent.Bytes(), "network-devices-metadata")
 
-	sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckCritical, "", snmpTags, "failed to autodetect profile: failed to fetch sysobjectid: cannot get sysobjectid: no value")
+	expectedMsg := "failed to autodetect profile: failed to fetch sysobjectid: cannot get sysobjectid: no value" + ", see this documentation for troubleshooting: " + devicecheck.SNMPTroubleshootingDocURL
+	sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckCritical, "", snmpTags, expectedMsg)
 }
 
 func TestReportDeviceMetadataWithFetchError(t *testing.T) {
@@ -1736,9 +1739,10 @@ tags:
 	sess.On("Get", []string{"1.3.6.1.2.1.1.1.0"}).Return(nilPacket, errors.New("device failure"))
 
 	expectedErrMsg := "check device reachable: failed: no value for GetNext; failed to autodetect profile: failed to fetch sysobjectid: cannot get sysobjectid: no value; failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: failed getting oids `[1.3.6.1.2.1.1.1.0]` using Get: device failure"
+	expectedMsg := expectedErrMsg + ", see this documentation for troubleshooting: " + devicecheck.SNMPTroubleshootingDocURL
 
 	err = chk.Run()
-	assert.EqualError(t, err, expectedErrMsg)
+	assert.EqualError(t, err, expectedMsg)
 
 	snmpTags := []string{"device_namespace:default", "snmp_device:1.2.3.5", "device_ip:1.2.3.5", "device_id:default:1.2.3.5"}
 
@@ -1801,7 +1805,7 @@ tags:
 
 	sender.AssertEventPlatformEvent(t, compactEvent.Bytes(), "network-devices-metadata")
 
-	sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckCritical, "", snmpTags, expectedErrMsg)
+	sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckCritical, "", snmpTags, expectedMsg)
 }
 
 func TestDiscovery(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
For this particular error message we already have public docs with troubleshooting steps, so now the error message will link customers to that doc
https://docs.datadoghq.com/network_monitoring/devices/troubleshooting/?tab=linux#unreachable-or-misconfigured-device

### Motivation
https://datadoghq.atlassian.net/browse/DEN-13
https://datadoghq.atlassian.net/browse/BAEM-12

### Describe how you validated your changes
built agent locally with dda and saw error message with my change

### Additional Notes
