### PR TITLE
ci: fix `bazel-cache` order in `buildimages-update`

### DIFF
--- a/.github/workflows/buildimages-update.yml
+++ b/.github/workflows/buildimages-update.yml
@@ -42,9 +42,6 @@ jobs:
           # credentials are needed to create the PR at the end of the workflow
           persist-credentials: true
 
-      - name: Bazel cache
-        uses: ./.github/actions/bazel-cache
-
       - name: Fetch branch
         env:
           TARGET_BRANCH: ${{ inputs.branch }}
@@ -63,6 +60,9 @@ jobs:
         with:
           ref: ${{ inputs.branch }}
           persist-credentials: false
+
+      - name: Bazel cache
+        uses: ./.github/actions/bazel-cache
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:


### PR DESCRIPTION
### What does this PR do?
Move the `bazel-cache` step to after the last `actions/checkout` step.

### Motivation
Address https://github.com/DataDog/datadog-agent/pull/47611#discussion_r2906954848.

`actions/checkout` defaults to `clean: true`, which removes untracked files including the `.cache/` directory just restored by the preceding cache step.
As a result, all subsequent steps (esp. `update_build_images`) ran with a cold cache, defeating the fix from #47611.