### PR TITLE
dyninst: rewrite yaml golden files for updated yaml lib

### DIFF
--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,12 +1,12 @@
 - offset: "0x000c96a0"
   size: 8
   kind: ptr
-  nameEntry: "*lib_v2.V2Type (exported)"
-  name: "*lib_v2.V2Type"
+  nameEntry: '*lib_v2.V2Type (exported)'
+  name: '*lib_v2.V2Type'
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
   methods:
-  - name: MyMethod (exported)
-    type: func()
+    - name: MyMethod (exported)
+      type: func()
   pointer:
     elem: lib_v2.V2Type
 - offset: "0x000e7480"
@@ -21,56 +21,56 @@
 - offset: "0x000c9340"
   size: 8
   kind: ptr
-  nameEntry: "*main.firstBehavior"
-  name: "*main.firstBehavior"
+  nameEntry: '*main.firstBehavior'
+  name: '*main.firstBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.firstBehavior
 - offset: "0x000c93a0"
   size: 8
   kind: ptr
-  nameEntry: "*main.secondBehavior"
-  name: "*main.secondBehavior"
+  nameEntry: '*main.secondBehavior'
+  name: '*main.secondBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.secondBehavior
 - offset: "0x000c9400"
   size: 8
   kind: ptr
-  nameEntry: "*main.somethingImpl"
-  name: "*main.somethingImpl"
+  nameEntry: '*main.somethingImpl'
+  name: '*main.somethingImpl'
   pkg: main
   methods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
   pointer:
     elem: main.somethingImpl
 - offset: "0x000d6720"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[int]"
-  name: "*main.typeWithGenerics[int]"
+  nameEntry: '*main.typeWithGenerics[int]'
+  name: '*main.typeWithGenerics[int]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
 - offset: "0x000d6780"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[string]"
-  name: "*main.typeWithGenerics[string]"
+  nameEntry: '*main.typeWithGenerics[string]'
+  name: '*main.typeWithGenerics[string]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
 - offset: "0x000ef3c0"
@@ -81,8 +81,8 @@
   pkg: main
   ptrToThis: "0x00056ce0"
   interfaceMethods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
 - offset: "0x0010cae0"
   size: 8
   kind: struct
@@ -92,9 +92,9 @@
   ptrToThis: "0x000570a0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap2
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap2
+          offset: 0
 - offset: "0x0010ca60"
   size: 8
   kind: struct
@@ -104,9 +104,9 @@
   ptrToThis: "0x00057060"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap3
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap3
+          offset: 0
 - offset: "0x0010c9e0"
   size: 8
   kind: struct
@@ -116,9 +116,9 @@
   ptrToThis: "0x00057020"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap4
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap4
+          offset: 0
 - offset: "0x0010c960"
   size: 8
   kind: struct
@@ -128,9 +128,9 @@
   ptrToThis: "0x00056fe0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap5
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap5
+          offset: 0
 - offset: "0x0010c8e0"
   size: 8
   kind: struct
@@ -140,9 +140,9 @@
   ptrToThis: "0x00056fa0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap6
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap6
+          offset: 0
 - offset: "0x0010c860"
   size: 8
   kind: struct
@@ -152,9 +152,9 @@
   ptrToThis: "0x00056f60"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap7
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap7
+          offset: 0
 - offset: "0x0010c7e0"
   size: 8
   kind: struct
@@ -164,9 +164,9 @@
   ptrToThis: "0x00056f20"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap8
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap8
+          offset: 0
 - offset: "0x0010c760"
   size: 8
   kind: struct
@@ -176,9 +176,9 @@
   ptrToThis: "0x00056ee0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap9
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap9
+          offset: 0
 - offset: "0x0010c6e0"
   size: 8
   kind: struct
@@ -188,9 +188,9 @@
   ptrToThis: "0x00056ea0"
   struct:
     fields:
-    - name: a
-      type: map[int]interface {}
-      offset: 0
+        - name: a
+          type: map[int]interface {}
+          offset: 0
 - offset: "0x0010cf60"
   size: 8
   kind: struct
@@ -200,9 +200,9 @@
   ptrToThis: "0x000572e0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr2"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr2'
+          offset: 0
 - offset: "0x0010cee0"
   size: 8
   kind: struct
@@ -212,9 +212,9 @@
   ptrToThis: "0x000572a0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr3"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr3'
+          offset: 0
 - offset: "0x0010ce60"
   size: 8
   kind: struct
@@ -224,9 +224,9 @@
   ptrToThis: "0x00057260"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr4"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr4'
+          offset: 0
 - offset: "0x0010cde0"
   size: 8
   kind: struct
@@ -236,9 +236,9 @@
   ptrToThis: "0x00057220"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr5"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr5'
+          offset: 0
 - offset: "0x0010cd60"
   size: 8
   kind: struct
@@ -248,9 +248,9 @@
   ptrToThis: "0x000571e0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr6"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr6'
+          offset: 0
 - offset: "0x0010cce0"
   size: 8
   kind: struct
@@ -260,9 +260,9 @@
   ptrToThis: "0x000571a0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr7"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr7'
+          offset: 0
 - offset: "0x0010cc60"
   size: 8
   kind: struct
@@ -272,9 +272,9 @@
   ptrToThis: "0x00057160"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr8"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr8'
+          offset: 0
 - offset: "0x0010cbe0"
   size: 8
   kind: struct
@@ -284,9 +284,9 @@
   ptrToThis: "0x00057120"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr9"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr9'
+          offset: 0
 - offset: "0x0010cb60"
   size: 16
   kind: struct
@@ -296,9 +296,9 @@
   ptrToThis: "0x000570e0"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x0010d3e0"
   size: 24
   kind: struct
@@ -308,9 +308,9 @@
   ptrToThis: "0x00057520"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice2"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice2'
+          offset: 0
 - offset: "0x0010d360"
   size: 24
   kind: struct
@@ -320,9 +320,9 @@
   ptrToThis: "0x000574e0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice3"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice3'
+          offset: 0
 - offset: "0x0010d2e0"
   size: 24
   kind: struct
@@ -332,9 +332,9 @@
   ptrToThis: "0x000574a0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice4"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice4'
+          offset: 0
 - offset: "0x0010d260"
   size: 24
   kind: struct
@@ -344,9 +344,9 @@
   ptrToThis: "0x00057460"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice5"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice5'
+          offset: 0
 - offset: "0x0010d1e0"
   size: 24
   kind: struct
@@ -356,9 +356,9 @@
   ptrToThis: "0x00057420"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice6"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice6'
+          offset: 0
 - offset: "0x0010d160"
   size: 24
   kind: struct
@@ -368,9 +368,9 @@
   ptrToThis: "0x000573e0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice7"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice7'
+          offset: 0
 - offset: "0x0010d0e0"
   size: 24
   kind: struct
@@ -380,9 +380,9 @@
   ptrToThis: "0x000573a0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice8"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice8'
+          offset: 0
 - offset: "0x0010d060"
   size: 24
   kind: struct
@@ -392,9 +392,9 @@
   ptrToThis: "0x00057360"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice9"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice9'
+          offset: 0
 - offset: "0x0010cfe0"
   size: 24
   kind: struct
@@ -404,9 +404,9 @@
   ptrToThis: "0x00057320"
   struct:
     fields:
-    - name: a
-      type: "[]interface {}"
-      offset: 0
+        - name: a
+          type: '[]interface {}'
+          offset: 0
 - offset: "0x001a0480"
   size: 112
   kind: struct
@@ -416,21 +416,21 @@
   ptrToThis: "0x00057560"
   struct:
     fields:
-    - name: esotericStack (embedded)
-      type: main.esotericStack
-      offset: 0
-    - name: mu
-      type: sync.Mutex
-      offset: 64
-    - name: once
-      type: sync.Once
-      offset: 72
-    - name: wg
-      type: sync.WaitGroup
-      offset: 88
-    - name: a
-      type: atomic.Int32
-      offset: 104
+        - name: esotericStack (embedded)
+          type: main.esotericStack
+          offset: 0
+        - name: mu
+          type: sync.Mutex
+          offset: 64
+        - name: once
+          type: sync.Once
+          offset: 72
+        - name: wg
+          type: sync.WaitGroup
+          offset: 88
+        - name: a
+          type: atomic.Int32
+          offset: 104
 - offset: "0x001bf280"
   size: 64
   kind: struct
@@ -440,27 +440,27 @@
   ptrToThis: "0x00056d60"
   struct:
     fields:
-    - name: _
-      type: int32
-      offset: 0
-    - name: _valid
-      type: int32
-      offset: 4
-    - name: c
-      type: chan struct {}
-      offset: 8
-    - name: val
-      type: interface {}
-      offset: 16
-    - name: _
-      type: uint64
-      offset: 32
-    - name: work
-      type: main.something
-      offset: 40
-    - name: foo
-      type: func()
-      offset: 56
+        - name: _
+          type: int32
+          offset: 0
+        - name: _valid
+          type: int32
+          offset: 4
+        - name: c
+          type: chan struct {}
+          offset: 8
+        - name: val
+          type: interface {}
+          offset: 16
+        - name: _
+          type: uint64
+          offset: 32
+        - name: work
+          type: main.something
+          offset: 40
+        - name: foo
+          type: func()
+          offset: 56
 - offset: "0x0012cc40"
   size: 16
   kind: struct
@@ -469,13 +469,13 @@
   pkg: main
   ptrToThis: "0x000c9340"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00138980"
   size: 24
   kind: struct
@@ -485,12 +485,12 @@
   ptrToThis: "0x000575e0"
   struct:
     fields:
-    - name: anotherInt
-      type: int
-      offset: 0
-    - name: anotherString
-      type: string
-      offset: 8
+        - name: anotherInt
+          type: int
+          offset: 0
+        - name: anotherString
+          type: string
+          offset: 8
 - offset: "0x001388e0"
   size: 16
   kind: struct
@@ -500,12 +500,12 @@
   ptrToThis: "0x000575a0"
   struct:
     fields:
-    - name: val
-      type: int
-      offset: 0
-    - name: b
-      type: "*main.node"
-      offset: 8
+        - name: val
+          type: int
+          offset: 0
+        - name: b
+          type: '*main.node'
+          offset: 8
 - offset: "0x0010c4e0"
   size: 16
   kind: struct
@@ -515,9 +515,9 @@
   ptrToThis: "0x00056da0"
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x0010c560"
   size: 8
   kind: struct
@@ -527,9 +527,9 @@
   ptrToThis: "0x00056de0"
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x0012cce0"
   size: 8
   kind: struct
@@ -538,13 +538,13 @@
   pkg: main
   ptrToThis: "0x000c93a0"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x000ef440"
   size: 16
   kind: interface
@@ -553,8 +553,8 @@
   pkg: main
   ptrToThis: "0x00056d20"
   interfaceMethods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
 - offset: "0x000e7300"
   size: 0
   kind: struct
@@ -573,9 +573,9 @@
   ptrToThis: "0x00056e20"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x0010c660"
   size: 8
   kind: struct
@@ -585,9 +585,9 @@
   ptrToThis: "0x00056e60"
   struct:
     fields:
-    - name: m
-      type: map[int]int
-      offset: 0
+        - name: m
+          type: map[int]int
+          offset: 0
 - offset: "0x00135c00"
   size: 8
   kind: struct
@@ -596,13 +596,13 @@
   pkg: main
   ptrToThis: "0x000d6720"
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: int
-      offset: 0
+        - name: Value (exported)
+          type: int
+          offset: 0
 - offset: "0x00135ca0"
   size: 16
   kind: struct
@@ -611,10 +611,10 @@
   pkg: main
   ptrToThis: "0x000d6780"
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: string
-      offset: 0
+        - name: Value (exported)
+          type: string
+          offset: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,12 +1,12 @@
 - offset: "0x000da380"
   size: 8
   kind: ptr
-  nameEntry: "*lib_v2.V2Type (exported)"
-  name: "*lib_v2.V2Type"
+  nameEntry: '*lib_v2.V2Type (exported)'
+  name: '*lib_v2.V2Type'
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
   methods:
-  - name: MyMethod (exported)
-    type: func()
+    - name: MyMethod (exported)
+      type: func()
   pointer:
     elem: lib_v2.V2Type
 - offset: "0x000f08a0"
@@ -21,56 +21,56 @@
 - offset: "0x000da020"
   size: 8
   kind: ptr
-  nameEntry: "*main.firstBehavior"
-  name: "*main.firstBehavior"
+  nameEntry: '*main.firstBehavior'
+  name: '*main.firstBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.firstBehavior
 - offset: "0x000da080"
   size: 8
   kind: ptr
-  nameEntry: "*main.secondBehavior"
-  name: "*main.secondBehavior"
+  nameEntry: '*main.secondBehavior'
+  name: '*main.secondBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.secondBehavior
 - offset: "0x000da0e0"
   size: 8
   kind: ptr
-  nameEntry: "*main.somethingImpl"
-  name: "*main.somethingImpl"
+  nameEntry: '*main.somethingImpl'
+  name: '*main.somethingImpl'
   pkg: main
   methods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
   pointer:
     elem: main.somethingImpl
 - offset: "0x000e7820"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[int]"
-  name: "*main.typeWithGenerics[int]"
+  nameEntry: '*main.typeWithGenerics[int]'
+  name: '*main.typeWithGenerics[int]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
 - offset: "0x000e7880"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[string]"
-  name: "*main.typeWithGenerics[string]"
+  nameEntry: '*main.typeWithGenerics[string]'
+  name: '*main.typeWithGenerics[string]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
 - offset: "0x000f8da0"
@@ -81,8 +81,8 @@
   pkg: main
   ptrToThis: "0x0005d780"
   interfaceMethods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
 - offset: "0x00121040"
   size: 8
   kind: struct
@@ -92,9 +92,9 @@
   ptrToThis: "0x0005db40"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap2
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap2
+          offset: 0
 - offset: "0x00120fc0"
   size: 8
   kind: struct
@@ -104,9 +104,9 @@
   ptrToThis: "0x0005db00"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap3
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap3
+          offset: 0
 - offset: "0x00120f40"
   size: 8
   kind: struct
@@ -116,9 +116,9 @@
   ptrToThis: "0x0005dac0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap4
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap4
+          offset: 0
 - offset: "0x00120ec0"
   size: 8
   kind: struct
@@ -128,9 +128,9 @@
   ptrToThis: "0x0005da80"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap5
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap5
+          offset: 0
 - offset: "0x00120e40"
   size: 8
   kind: struct
@@ -140,9 +140,9 @@
   ptrToThis: "0x0005da40"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap6
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap6
+          offset: 0
 - offset: "0x00120dc0"
   size: 8
   kind: struct
@@ -152,9 +152,9 @@
   ptrToThis: "0x0005da00"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap7
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap7
+          offset: 0
 - offset: "0x00120d40"
   size: 8
   kind: struct
@@ -164,9 +164,9 @@
   ptrToThis: "0x0005d9c0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap8
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap8
+          offset: 0
 - offset: "0x00120cc0"
   size: 8
   kind: struct
@@ -176,9 +176,9 @@
   ptrToThis: "0x0005d980"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap9
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap9
+          offset: 0
 - offset: "0x00120c40"
   size: 8
   kind: struct
@@ -188,9 +188,9 @@
   ptrToThis: "0x0005d940"
   struct:
     fields:
-    - name: a
-      type: map[int]interface {}
-      offset: 0
+        - name: a
+          type: map[int]interface {}
+          offset: 0
 - offset: "0x001214c0"
   size: 8
   kind: struct
@@ -200,9 +200,9 @@
   ptrToThis: "0x0005dd80"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr2"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr2'
+          offset: 0
 - offset: "0x00121440"
   size: 8
   kind: struct
@@ -212,9 +212,9 @@
   ptrToThis: "0x0005dd40"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr3"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr3'
+          offset: 0
 - offset: "0x001213c0"
   size: 8
   kind: struct
@@ -224,9 +224,9 @@
   ptrToThis: "0x0005dd00"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr4"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr4'
+          offset: 0
 - offset: "0x00121340"
   size: 8
   kind: struct
@@ -236,9 +236,9 @@
   ptrToThis: "0x0005dcc0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr5"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr5'
+          offset: 0
 - offset: "0x001212c0"
   size: 8
   kind: struct
@@ -248,9 +248,9 @@
   ptrToThis: "0x0005dc80"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr6"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr6'
+          offset: 0
 - offset: "0x00121240"
   size: 8
   kind: struct
@@ -260,9 +260,9 @@
   ptrToThis: "0x0005dc40"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr7"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr7'
+          offset: 0
 - offset: "0x001211c0"
   size: 8
   kind: struct
@@ -272,9 +272,9 @@
   ptrToThis: "0x0005dc00"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr8"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr8'
+          offset: 0
 - offset: "0x00121140"
   size: 8
   kind: struct
@@ -284,9 +284,9 @@
   ptrToThis: "0x0005dbc0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr9"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr9'
+          offset: 0
 - offset: "0x001210c0"
   size: 16
   kind: struct
@@ -296,9 +296,9 @@
   ptrToThis: "0x0005db80"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00121940"
   size: 24
   kind: struct
@@ -308,9 +308,9 @@
   ptrToThis: "0x0005dfc0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice2"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice2'
+          offset: 0
 - offset: "0x001218c0"
   size: 24
   kind: struct
@@ -320,9 +320,9 @@
   ptrToThis: "0x0005df80"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice3"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice3'
+          offset: 0
 - offset: "0x00121840"
   size: 24
   kind: struct
@@ -332,9 +332,9 @@
   ptrToThis: "0x0005df40"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice4"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice4'
+          offset: 0
 - offset: "0x001217c0"
   size: 24
   kind: struct
@@ -344,9 +344,9 @@
   ptrToThis: "0x0005df00"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice5"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice5'
+          offset: 0
 - offset: "0x00121740"
   size: 24
   kind: struct
@@ -356,9 +356,9 @@
   ptrToThis: "0x0005dec0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice6"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice6'
+          offset: 0
 - offset: "0x001216c0"
   size: 24
   kind: struct
@@ -368,9 +368,9 @@
   ptrToThis: "0x0005de80"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice7"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice7'
+          offset: 0
 - offset: "0x00121640"
   size: 24
   kind: struct
@@ -380,9 +380,9 @@
   ptrToThis: "0x0005de40"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice8"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice8'
+          offset: 0
 - offset: "0x001215c0"
   size: 24
   kind: struct
@@ -392,9 +392,9 @@
   ptrToThis: "0x0005de00"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice9"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice9'
+          offset: 0
 - offset: "0x00121540"
   size: 24
   kind: struct
@@ -404,9 +404,9 @@
   ptrToThis: "0x0005ddc0"
   struct:
     fields:
-    - name: a
-      type: "[]interface {}"
-      offset: 0
+        - name: a
+          type: '[]interface {}'
+          offset: 0
 - offset: "0x001be220"
   size: 112
   kind: struct
@@ -416,21 +416,21 @@
   ptrToThis: "0x0005e000"
   struct:
     fields:
-    - name: esotericStack (embedded)
-      type: main.esotericStack
-      offset: 0
-    - name: mu
-      type: sync.Mutex
-      offset: 64
-    - name: once
-      type: sync.Once
-      offset: 72
-    - name: wg
-      type: sync.WaitGroup
-      offset: 88
-    - name: a
-      type: atomic.Int32
-      offset: 104
+        - name: esotericStack (embedded)
+          type: main.esotericStack
+          offset: 0
+        - name: mu
+          type: sync.Mutex
+          offset: 64
+        - name: once
+          type: sync.Once
+          offset: 72
+        - name: wg
+          type: sync.WaitGroup
+          offset: 88
+        - name: a
+          type: atomic.Int32
+          offset: 104
 - offset: "0x001dece0"
   size: 64
   kind: struct
@@ -440,27 +440,27 @@
   ptrToThis: "0x0005d800"
   struct:
     fields:
-    - name: _
-      type: int32
-      offset: 0
-    - name: _valid
-      type: int32
-      offset: 4
-    - name: c
-      type: chan struct {}
-      offset: 8
-    - name: val
-      type: interface {}
-      offset: 16
-    - name: _
-      type: uint64
-      offset: 32
-    - name: work
-      type: main.something
-      offset: 40
-    - name: foo
-      type: func()
-      offset: 56
+        - name: _
+          type: int32
+          offset: 0
+        - name: _valid
+          type: int32
+          offset: 4
+        - name: c
+          type: chan struct {}
+          offset: 8
+        - name: val
+          type: interface {}
+          offset: 16
+        - name: _
+          type: uint64
+          offset: 32
+        - name: work
+          type: main.something
+          offset: 40
+        - name: foo
+          type: func()
+          offset: 56
 - offset: "0x001585a0"
   size: 16
   kind: struct
@@ -469,13 +469,13 @@
   pkg: main
   ptrToThis: "0x000da020"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00164620"
   size: 24
   kind: struct
@@ -485,12 +485,12 @@
   ptrToThis: "0x0005e080"
   struct:
     fields:
-    - name: anotherInt
-      type: int
-      offset: 0
-    - name: anotherString
-      type: string
-      offset: 8
+        - name: anotherInt
+          type: int
+          offset: 0
+        - name: anotherString
+          type: string
+          offset: 8
 - offset: "0x00164580"
   size: 16
   kind: struct
@@ -500,12 +500,12 @@
   ptrToThis: "0x0005e040"
   struct:
     fields:
-    - name: val
-      type: int
-      offset: 0
-    - name: b
-      type: "*main.node"
-      offset: 8
+        - name: val
+          type: int
+          offset: 0
+        - name: b
+          type: '*main.node'
+          offset: 8
 - offset: "0x00120a40"
   size: 16
   kind: struct
@@ -515,9 +515,9 @@
   ptrToThis: "0x0005d840"
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00120ac0"
   size: 8
   kind: struct
@@ -527,9 +527,9 @@
   ptrToThis: "0x0005d880"
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x00158640"
   size: 8
   kind: struct
@@ -538,13 +538,13 @@
   pkg: main
   ptrToThis: "0x000da080"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x000f8e20"
   size: 16
   kind: interface
@@ -553,8 +553,8 @@
   pkg: main
   ptrToThis: "0x0005d7c0"
   interfaceMethods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
 - offset: "0x000f0720"
   size: 0
   kind: struct
@@ -573,9 +573,9 @@
   ptrToThis: "0x0005d8c0"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00120bc0"
   size: 8
   kind: struct
@@ -585,9 +585,9 @@
   ptrToThis: "0x0005d900"
   struct:
     fields:
-    - name: m
-      type: map[int]int
-      offset: 0
+        - name: m
+          type: map[int]int
+          offset: 0
 - offset: "0x00161920"
   size: 8
   kind: struct
@@ -596,13 +596,13 @@
   pkg: main
   ptrToThis: "0x000e7820"
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: int
-      offset: 0
+        - name: Value (exported)
+          type: int
+          offset: 0
 - offset: "0x001619c0"
   size: 16
   kind: struct
@@ -611,10 +611,10 @@
   pkg: main
   ptrToThis: "0x000e7880"
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: string
-      offset: 0
+        - name: Value (exported)
+          type: string
+          offset: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,12 +1,12 @@
 - offset: "0x000db4a0"
   size: 8
   kind: ptr
-  nameEntry: "*lib_v2.V2Type (exported)"
-  name: "*lib_v2.V2Type"
+  nameEntry: '*lib_v2.V2Type (exported)'
+  name: '*lib_v2.V2Type'
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
   methods:
-  - name: MyMethod (exported)
-    type: func()
+    - name: MyMethod (exported)
+      type: func()
   pointer:
     elem: lib_v2.V2Type
 - offset: "0x000f19e0"
@@ -21,56 +21,56 @@
 - offset: "0x000db140"
   size: 8
   kind: ptr
-  nameEntry: "*main.firstBehavior"
-  name: "*main.firstBehavior"
+  nameEntry: '*main.firstBehavior'
+  name: '*main.firstBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.firstBehavior
 - offset: "0x000db1a0"
   size: 8
   kind: ptr
-  nameEntry: "*main.secondBehavior"
-  name: "*main.secondBehavior"
+  nameEntry: '*main.secondBehavior'
+  name: '*main.secondBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.secondBehavior
 - offset: "0x000db200"
   size: 8
   kind: ptr
-  nameEntry: "*main.somethingImpl"
-  name: "*main.somethingImpl"
+  nameEntry: '*main.somethingImpl'
+  name: '*main.somethingImpl'
   pkg: main
   methods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
   pointer:
     elem: main.somethingImpl
 - offset: "0x000e8ac0"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[int]"
-  name: "*main.typeWithGenerics[int]"
+  nameEntry: '*main.typeWithGenerics[int]'
+  name: '*main.typeWithGenerics[int]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
 - offset: "0x000e8b20"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[string]"
-  name: "*main.typeWithGenerics[string]"
+  nameEntry: '*main.typeWithGenerics[string]'
+  name: '*main.typeWithGenerics[string]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
 - offset: "0x000f9e60"
@@ -81,8 +81,8 @@
   pkg: main
   ptrToThis: "0x0005e280"
   interfaceMethods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
 - offset: "0x00121fe0"
   size: 8
   kind: struct
@@ -92,9 +92,9 @@
   ptrToThis: "0x0005e640"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap2
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap2
+          offset: 0
 - offset: "0x00121f60"
   size: 8
   kind: struct
@@ -104,9 +104,9 @@
   ptrToThis: "0x0005e600"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap3
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap3
+          offset: 0
 - offset: "0x00121ee0"
   size: 8
   kind: struct
@@ -116,9 +116,9 @@
   ptrToThis: "0x0005e5c0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap4
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap4
+          offset: 0
 - offset: "0x00121e60"
   size: 8
   kind: struct
@@ -128,9 +128,9 @@
   ptrToThis: "0x0005e580"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap5
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap5
+          offset: 0
 - offset: "0x00121de0"
   size: 8
   kind: struct
@@ -140,9 +140,9 @@
   ptrToThis: "0x0005e540"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap6
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap6
+          offset: 0
 - offset: "0x00121d60"
   size: 8
   kind: struct
@@ -152,9 +152,9 @@
   ptrToThis: "0x0005e500"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap7
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap7
+          offset: 0
 - offset: "0x00121ce0"
   size: 8
   kind: struct
@@ -164,9 +164,9 @@
   ptrToThis: "0x0005e4c0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap8
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap8
+          offset: 0
 - offset: "0x00121c60"
   size: 8
   kind: struct
@@ -176,9 +176,9 @@
   ptrToThis: "0x0005e480"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap9
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap9
+          offset: 0
 - offset: "0x00121be0"
   size: 8
   kind: struct
@@ -188,9 +188,9 @@
   ptrToThis: "0x0005e440"
   struct:
     fields:
-    - name: a
-      type: map[int]interface {}
-      offset: 0
+        - name: a
+          type: map[int]interface {}
+          offset: 0
 - offset: "0x00122460"
   size: 8
   kind: struct
@@ -200,9 +200,9 @@
   ptrToThis: "0x0005e880"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr2"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr2'
+          offset: 0
 - offset: "0x001223e0"
   size: 8
   kind: struct
@@ -212,9 +212,9 @@
   ptrToThis: "0x0005e840"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr3"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr3'
+          offset: 0
 - offset: "0x00122360"
   size: 8
   kind: struct
@@ -224,9 +224,9 @@
   ptrToThis: "0x0005e800"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr4"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr4'
+          offset: 0
 - offset: "0x001222e0"
   size: 8
   kind: struct
@@ -236,9 +236,9 @@
   ptrToThis: "0x0005e7c0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr5"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr5'
+          offset: 0
 - offset: "0x00122260"
   size: 8
   kind: struct
@@ -248,9 +248,9 @@
   ptrToThis: "0x0005e780"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr6"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr6'
+          offset: 0
 - offset: "0x001221e0"
   size: 8
   kind: struct
@@ -260,9 +260,9 @@
   ptrToThis: "0x0005e740"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr7"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr7'
+          offset: 0
 - offset: "0x00122160"
   size: 8
   kind: struct
@@ -272,9 +272,9 @@
   ptrToThis: "0x0005e700"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr8"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr8'
+          offset: 0
 - offset: "0x001220e0"
   size: 8
   kind: struct
@@ -284,9 +284,9 @@
   ptrToThis: "0x0005e6c0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr9"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr9'
+          offset: 0
 - offset: "0x00122060"
   size: 16
   kind: struct
@@ -296,9 +296,9 @@
   ptrToThis: "0x0005e680"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x001228e0"
   size: 24
   kind: struct
@@ -308,9 +308,9 @@
   ptrToThis: "0x0005eac0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice2"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice2'
+          offset: 0
 - offset: "0x00122860"
   size: 24
   kind: struct
@@ -320,9 +320,9 @@
   ptrToThis: "0x0005ea80"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice3"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice3'
+          offset: 0
 - offset: "0x001227e0"
   size: 24
   kind: struct
@@ -332,9 +332,9 @@
   ptrToThis: "0x0005ea40"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice4"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice4'
+          offset: 0
 - offset: "0x00122760"
   size: 24
   kind: struct
@@ -344,9 +344,9 @@
   ptrToThis: "0x0005ea00"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice5"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice5'
+          offset: 0
 - offset: "0x001226e0"
   size: 24
   kind: struct
@@ -356,9 +356,9 @@
   ptrToThis: "0x0005e9c0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice6"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice6'
+          offset: 0
 - offset: "0x00122660"
   size: 24
   kind: struct
@@ -368,9 +368,9 @@
   ptrToThis: "0x0005e980"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice7"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice7'
+          offset: 0
 - offset: "0x001225e0"
   size: 24
   kind: struct
@@ -380,9 +380,9 @@
   ptrToThis: "0x0005e940"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice8"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice8'
+          offset: 0
 - offset: "0x00122560"
   size: 24
   kind: struct
@@ -392,9 +392,9 @@
   ptrToThis: "0x0005e900"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice9"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice9'
+          offset: 0
 - offset: "0x001224e0"
   size: 24
   kind: struct
@@ -404,9 +404,9 @@
   ptrToThis: "0x0005e8c0"
   struct:
     fields:
-    - name: a
-      type: "[]interface {}"
-      offset: 0
+        - name: a
+          type: '[]interface {}'
+          offset: 0
 - offset: "0x001c0660"
   size: 112
   kind: struct
@@ -416,21 +416,21 @@
   ptrToThis: "0x0005eb00"
   struct:
     fields:
-    - name: esotericStack (embedded)
-      type: main.esotericStack
-      offset: 0
-    - name: mu
-      type: sync.Mutex
-      offset: 64
-    - name: once
-      type: sync.Once
-      offset: 72
-    - name: wg
-      type: sync.WaitGroup
-      offset: 88
-    - name: a
-      type: atomic.Int32
-      offset: 104
+        - name: esotericStack (embedded)
+          type: main.esotericStack
+          offset: 0
+        - name: mu
+          type: sync.Mutex
+          offset: 64
+        - name: once
+          type: sync.Once
+          offset: 72
+        - name: wg
+          type: sync.WaitGroup
+          offset: 88
+        - name: a
+          type: atomic.Int32
+          offset: 104
 - offset: "0x001e0f20"
   size: 64
   kind: struct
@@ -440,27 +440,27 @@
   ptrToThis: "0x0005e300"
   struct:
     fields:
-    - name: _
-      type: int32
-      offset: 0
-    - name: _valid
-      type: int32
-      offset: 4
-    - name: c
-      type: chan struct {}
-      offset: 8
-    - name: val
-      type: interface {}
-      offset: 16
-    - name: _
-      type: uint64
-      offset: 32
-    - name: work
-      type: main.something
-      offset: 40
-    - name: foo
-      type: func()
-      offset: 56
+        - name: _
+          type: int32
+          offset: 0
+        - name: _valid
+          type: int32
+          offset: 4
+        - name: c
+          type: chan struct {}
+          offset: 8
+        - name: val
+          type: interface {}
+          offset: 16
+        - name: _
+          type: uint64
+          offset: 32
+        - name: work
+          type: main.something
+          offset: 40
+        - name: foo
+          type: func()
+          offset: 56
 - offset: "0x001594c0"
   size: 16
   kind: struct
@@ -469,13 +469,13 @@
   pkg: main
   ptrToThis: "0x000db140"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00165800"
   size: 24
   kind: struct
@@ -485,12 +485,12 @@
   ptrToThis: "0x0005eb80"
   struct:
     fields:
-    - name: anotherInt
-      type: int
-      offset: 0
-    - name: anotherString
-      type: string
-      offset: 8
+        - name: anotherInt
+          type: int
+          offset: 0
+        - name: anotherString
+          type: string
+          offset: 8
 - offset: "0x00165760"
   size: 16
   kind: struct
@@ -500,12 +500,12 @@
   ptrToThis: "0x0005eb40"
   struct:
     fields:
-    - name: val
-      type: int
-      offset: 0
-    - name: b
-      type: "*main.node"
-      offset: 8
+        - name: val
+          type: int
+          offset: 0
+        - name: b
+          type: '*main.node'
+          offset: 8
 - offset: "0x001219e0"
   size: 16
   kind: struct
@@ -515,9 +515,9 @@
   ptrToThis: "0x0005e340"
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00121a60"
   size: 8
   kind: struct
@@ -527,9 +527,9 @@
   ptrToThis: "0x0005e380"
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x00159560"
   size: 8
   kind: struct
@@ -538,13 +538,13 @@
   pkg: main
   ptrToThis: "0x000db1a0"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x000f9ee0"
   size: 16
   kind: interface
@@ -553,8 +553,8 @@
   pkg: main
   ptrToThis: "0x0005e2c0"
   interfaceMethods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
 - offset: "0x000f1860"
   size: 0
   kind: struct
@@ -573,9 +573,9 @@
   ptrToThis: "0x0005e3c0"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00121b60"
   size: 8
   kind: struct
@@ -585,9 +585,9 @@
   ptrToThis: "0x0005e400"
   struct:
     fields:
-    - name: m
-      type: map[int]int
-      offset: 0
+        - name: m
+          type: map[int]int
+          offset: 0
 - offset: "0x00162a20"
   size: 8
   kind: struct
@@ -596,13 +596,13 @@
   pkg: main
   ptrToThis: "0x000e8ac0"
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: int
-      offset: 0
+        - name: Value (exported)
+          type: int
+          offset: 0
 - offset: "0x00162ac0"
   size: 16
   kind: struct
@@ -611,10 +611,10 @@
   pkg: main
   ptrToThis: "0x000e8b20"
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: string
-      offset: 0
+        - name: Value (exported)
+          type: string
+          offset: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -1,12 +1,12 @@
 - offset: "0x000dd500"
   size: 8
   kind: ptr
-  nameEntry: "*lib_v2.V2Type (exported)"
-  name: "*lib_v2.V2Type"
+  nameEntry: '*lib_v2.V2Type (exported)'
+  name: '*lib_v2.V2Type'
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
   methods:
-  - name: MyMethod (exported)
-    type: func()
+    - name: MyMethod (exported)
+      type: func()
   pointer:
     elem: lib_v2.V2Type
 - offset: "0x000f3d40"
@@ -21,56 +21,56 @@
 - offset: "0x000dd1a0"
   size: 8
   kind: ptr
-  nameEntry: "*main.firstBehavior"
-  name: "*main.firstBehavior"
+  nameEntry: '*main.firstBehavior'
+  name: '*main.firstBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.firstBehavior
 - offset: "0x000dd200"
   size: 8
   kind: ptr
-  nameEntry: "*main.secondBehavior"
-  name: "*main.secondBehavior"
+  nameEntry: '*main.secondBehavior'
+  name: '*main.secondBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.secondBehavior
 - offset: "0x000dd260"
   size: 8
   kind: ptr
-  nameEntry: "*main.somethingImpl"
-  name: "*main.somethingImpl"
+  nameEntry: '*main.somethingImpl'
+  name: '*main.somethingImpl'
   pkg: main
   methods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
   pointer:
     elem: main.somethingImpl
 - offset: "0x000eaee0"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[int]"
-  name: "*main.typeWithGenerics[int]"
+  nameEntry: '*main.typeWithGenerics[int]'
+  name: '*main.typeWithGenerics[int]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
 - offset: "0x000eaf40"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[string]"
-  name: "*main.typeWithGenerics[string]"
+  nameEntry: '*main.typeWithGenerics[string]'
+  name: '*main.typeWithGenerics[string]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
 - offset: "0x000fc100"
@@ -81,8 +81,8 @@
   pkg: main
   ptrToThis: "0x0005f620"
   interfaceMethods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
 - offset: "0x00123e80"
   size: 8
   kind: struct
@@ -92,9 +92,9 @@
   ptrToThis: "0x0005f9e0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap2
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap2
+          offset: 0
 - offset: "0x00123e00"
   size: 8
   kind: struct
@@ -104,9 +104,9 @@
   ptrToThis: "0x0005f9a0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap3
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap3
+          offset: 0
 - offset: "0x00123d80"
   size: 8
   kind: struct
@@ -116,9 +116,9 @@
   ptrToThis: "0x0005f960"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap4
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap4
+          offset: 0
 - offset: "0x00123d00"
   size: 8
   kind: struct
@@ -128,9 +128,9 @@
   ptrToThis: "0x0005f920"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap5
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap5
+          offset: 0
 - offset: "0x00123c80"
   size: 8
   kind: struct
@@ -140,9 +140,9 @@
   ptrToThis: "0x0005f8e0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap6
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap6
+          offset: 0
 - offset: "0x00123c00"
   size: 8
   kind: struct
@@ -152,9 +152,9 @@
   ptrToThis: "0x0005f8a0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap7
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap7
+          offset: 0
 - offset: "0x00123b80"
   size: 8
   kind: struct
@@ -164,9 +164,9 @@
   ptrToThis: "0x0005f860"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap8
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap8
+          offset: 0
 - offset: "0x00123b00"
   size: 8
   kind: struct
@@ -176,9 +176,9 @@
   ptrToThis: "0x0005f820"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap9
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap9
+          offset: 0
 - offset: "0x00123a80"
   size: 8
   kind: struct
@@ -188,9 +188,9 @@
   ptrToThis: "0x0005f7e0"
   struct:
     fields:
-    - name: a
-      type: map[int]interface {}
-      offset: 0
+        - name: a
+          type: map[int]interface {}
+          offset: 0
 - offset: "0x00124300"
   size: 8
   kind: struct
@@ -200,9 +200,9 @@
   ptrToThis: "0x0005fc20"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr2"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr2'
+          offset: 0
 - offset: "0x00124280"
   size: 8
   kind: struct
@@ -212,9 +212,9 @@
   ptrToThis: "0x0005fbe0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr3"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr3'
+          offset: 0
 - offset: "0x00124200"
   size: 8
   kind: struct
@@ -224,9 +224,9 @@
   ptrToThis: "0x0005fba0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr4"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr4'
+          offset: 0
 - offset: "0x00124180"
   size: 8
   kind: struct
@@ -236,9 +236,9 @@
   ptrToThis: "0x0005fb60"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr5"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr5'
+          offset: 0
 - offset: "0x00124100"
   size: 8
   kind: struct
@@ -248,9 +248,9 @@
   ptrToThis: "0x0005fb20"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr6"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr6'
+          offset: 0
 - offset: "0x00124080"
   size: 8
   kind: struct
@@ -260,9 +260,9 @@
   ptrToThis: "0x0005fae0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr7"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr7'
+          offset: 0
 - offset: "0x00124000"
   size: 8
   kind: struct
@@ -272,9 +272,9 @@
   ptrToThis: "0x0005faa0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr8"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr8'
+          offset: 0
 - offset: "0x00123f80"
   size: 8
   kind: struct
@@ -284,9 +284,9 @@
   ptrToThis: "0x0005fa60"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr9"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr9'
+          offset: 0
 - offset: "0x00123f00"
   size: 16
   kind: struct
@@ -296,9 +296,9 @@
   ptrToThis: "0x0005fa20"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00124780"
   size: 24
   kind: struct
@@ -308,9 +308,9 @@
   ptrToThis: "0x0005fe60"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice2"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice2'
+          offset: 0
 - offset: "0x00124700"
   size: 24
   kind: struct
@@ -320,9 +320,9 @@
   ptrToThis: "0x0005fe20"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice3"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice3'
+          offset: 0
 - offset: "0x00124680"
   size: 24
   kind: struct
@@ -332,9 +332,9 @@
   ptrToThis: "0x0005fde0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice4"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice4'
+          offset: 0
 - offset: "0x00124600"
   size: 24
   kind: struct
@@ -344,9 +344,9 @@
   ptrToThis: "0x0005fda0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice5"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice5'
+          offset: 0
 - offset: "0x00124580"
   size: 24
   kind: struct
@@ -356,9 +356,9 @@
   ptrToThis: "0x0005fd60"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice6"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice6'
+          offset: 0
 - offset: "0x00124500"
   size: 24
   kind: struct
@@ -368,9 +368,9 @@
   ptrToThis: "0x0005fd20"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice7"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice7'
+          offset: 0
 - offset: "0x00124480"
   size: 24
   kind: struct
@@ -380,9 +380,9 @@
   ptrToThis: "0x0005fce0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice8"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice8'
+          offset: 0
 - offset: "0x00124400"
   size: 24
   kind: struct
@@ -392,9 +392,9 @@
   ptrToThis: "0x0005fca0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice9"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice9'
+          offset: 0
 - offset: "0x00124380"
   size: 24
   kind: struct
@@ -404,9 +404,9 @@
   ptrToThis: "0x0005fc60"
   struct:
     fields:
-    - name: a
-      type: "[]interface {}"
-      offset: 0
+        - name: a
+          type: '[]interface {}'
+          offset: 0
 - offset: "0x001c4ce0"
   size: 112
   kind: struct
@@ -416,21 +416,21 @@
   ptrToThis: "0x0005fea0"
   struct:
     fields:
-    - name: esotericStack (embedded)
-      type: main.esotericStack
-      offset: 0
-    - name: mu
-      type: sync.Mutex
-      offset: 64
-    - name: once
-      type: sync.Once
-      offset: 72
-    - name: wg
-      type: sync.WaitGroup
-      offset: 88
-    - name: a
-      type: atomic.Int32
-      offset: 104
+        - name: esotericStack (embedded)
+          type: main.esotericStack
+          offset: 0
+        - name: mu
+          type: sync.Mutex
+          offset: 64
+        - name: once
+          type: sync.Once
+          offset: 72
+        - name: wg
+          type: sync.WaitGroup
+          offset: 88
+        - name: a
+          type: atomic.Int32
+          offset: 104
 - offset: "0x001e5ee0"
   size: 64
   kind: struct
@@ -440,27 +440,27 @@
   ptrToThis: "0x0005f6a0"
   struct:
     fields:
-    - name: _
-      type: int32
-      offset: 0
-    - name: _valid
-      type: int32
-      offset: 4
-    - name: c
-      type: chan struct {}
-      offset: 8
-    - name: val
-      type: interface {}
-      offset: 16
-    - name: _
-      type: uint64
-      offset: 32
-    - name: work
-      type: main.something
-      offset: 40
-    - name: foo
-      type: func()
-      offset: 56
+        - name: _
+          type: int32
+          offset: 0
+        - name: _valid
+          type: int32
+          offset: 4
+        - name: c
+          type: chan struct {}
+          offset: 8
+        - name: val
+          type: interface {}
+          offset: 16
+        - name: _
+          type: uint64
+          offset: 32
+        - name: work
+          type: main.something
+          offset: 40
+        - name: foo
+          type: func()
+          offset: 56
 - offset: "0x0015be60"
   size: 16
   kind: struct
@@ -469,13 +469,13 @@
   pkg: main
   ptrToThis: "0x000dd1a0"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00168400"
   size: 24
   kind: struct
@@ -485,12 +485,12 @@
   ptrToThis: "0x0005ff20"
   struct:
     fields:
-    - name: anotherInt
-      type: int
-      offset: 0
-    - name: anotherString
-      type: string
-      offset: 8
+        - name: anotherInt
+          type: int
+          offset: 0
+        - name: anotherString
+          type: string
+          offset: 8
 - offset: "0x00168360"
   size: 16
   kind: struct
@@ -500,12 +500,12 @@
   ptrToThis: "0x0005fee0"
   struct:
     fields:
-    - name: val
-      type: int
-      offset: 0
-    - name: b
-      type: "*main.node"
-      offset: 8
+        - name: val
+          type: int
+          offset: 0
+        - name: b
+          type: '*main.node'
+          offset: 8
 - offset: "0x00123880"
   size: 16
   kind: struct
@@ -515,9 +515,9 @@
   ptrToThis: "0x0005f6e0"
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00123900"
   size: 8
   kind: struct
@@ -527,9 +527,9 @@
   ptrToThis: "0x0005f720"
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x0015bf00"
   size: 8
   kind: struct
@@ -538,13 +538,13 @@
   pkg: main
   ptrToThis: "0x000dd200"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x000fc180"
   size: 16
   kind: interface
@@ -553,8 +553,8 @@
   pkg: main
   ptrToThis: "0x0005f660"
   interfaceMethods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
 - offset: "0x000f3bc0"
   size: 0
   kind: struct
@@ -573,9 +573,9 @@
   ptrToThis: "0x0005f760"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00123a00"
   size: 8
   kind: struct
@@ -585,9 +585,9 @@
   ptrToThis: "0x0005f7a0"
   struct:
     fields:
-    - name: m
-      type: map[int]int
-      offset: 0
+        - name: m
+          type: map[int]int
+          offset: 0
 - offset: "0x001655a0"
   size: 8
   kind: struct
@@ -596,13 +596,13 @@
   pkg: main
   ptrToThis: "0x000eaee0"
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: int
-      offset: 0
+        - name: Value (exported)
+          type: int
+          offset: 0
 - offset: "0x00165640"
   size: 16
   kind: struct
@@ -611,10 +611,10 @@
   pkg: main
   ptrToThis: "0x000eaf40"
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: string
-      offset: 0
+        - name: Value (exported)
+          type: string
+          offset: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,12 +1,12 @@
 - offset: "0x000c9700"
   size: 8
   kind: ptr
-  nameEntry: "*lib_v2.V2Type (exported)"
-  name: "*lib_v2.V2Type"
+  nameEntry: '*lib_v2.V2Type (exported)'
+  name: '*lib_v2.V2Type'
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
   methods:
-  - name: MyMethod (exported)
-    type: func()
+    - name: MyMethod (exported)
+      type: func()
   pointer:
     elem: lib_v2.V2Type
 - offset: "0x000e7540"
@@ -21,56 +21,56 @@
 - offset: "0x000c93a0"
   size: 8
   kind: ptr
-  nameEntry: "*main.firstBehavior"
-  name: "*main.firstBehavior"
+  nameEntry: '*main.firstBehavior'
+  name: '*main.firstBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.firstBehavior
 - offset: "0x000c9400"
   size: 8
   kind: ptr
-  nameEntry: "*main.secondBehavior"
-  name: "*main.secondBehavior"
+  nameEntry: '*main.secondBehavior'
+  name: '*main.secondBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.secondBehavior
 - offset: "0x000c9460"
   size: 8
   kind: ptr
-  nameEntry: "*main.somethingImpl"
-  name: "*main.somethingImpl"
+  nameEntry: '*main.somethingImpl'
+  name: '*main.somethingImpl'
   pkg: main
   methods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
   pointer:
     elem: main.somethingImpl
 - offset: "0x000d6780"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[int]"
-  name: "*main.typeWithGenerics[int]"
+  nameEntry: '*main.typeWithGenerics[int]'
+  name: '*main.typeWithGenerics[int]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
 - offset: "0x000d67e0"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[string]"
-  name: "*main.typeWithGenerics[string]"
+  nameEntry: '*main.typeWithGenerics[string]'
+  name: '*main.typeWithGenerics[string]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
 - offset: "0x000ef480"
@@ -81,8 +81,8 @@
   pkg: main
   ptrToThis: "0x00056d20"
   interfaceMethods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
 - offset: "0x0010cba0"
   size: 8
   kind: struct
@@ -92,9 +92,9 @@
   ptrToThis: "0x000570e0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap2
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap2
+          offset: 0
 - offset: "0x0010cb20"
   size: 8
   kind: struct
@@ -104,9 +104,9 @@
   ptrToThis: "0x000570a0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap3
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap3
+          offset: 0
 - offset: "0x0010caa0"
   size: 8
   kind: struct
@@ -116,9 +116,9 @@
   ptrToThis: "0x00057060"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap4
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap4
+          offset: 0
 - offset: "0x0010ca20"
   size: 8
   kind: struct
@@ -128,9 +128,9 @@
   ptrToThis: "0x00057020"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap5
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap5
+          offset: 0
 - offset: "0x0010c9a0"
   size: 8
   kind: struct
@@ -140,9 +140,9 @@
   ptrToThis: "0x00056fe0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap6
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap6
+          offset: 0
 - offset: "0x0010c920"
   size: 8
   kind: struct
@@ -152,9 +152,9 @@
   ptrToThis: "0x00056fa0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap7
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap7
+          offset: 0
 - offset: "0x0010c8a0"
   size: 8
   kind: struct
@@ -164,9 +164,9 @@
   ptrToThis: "0x00056f60"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap8
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap8
+          offset: 0
 - offset: "0x0010c820"
   size: 8
   kind: struct
@@ -176,9 +176,9 @@
   ptrToThis: "0x00056f20"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap9
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap9
+          offset: 0
 - offset: "0x0010c7a0"
   size: 8
   kind: struct
@@ -188,9 +188,9 @@
   ptrToThis: "0x00056ee0"
   struct:
     fields:
-    - name: a
-      type: map[int]interface {}
-      offset: 0
+        - name: a
+          type: map[int]interface {}
+          offset: 0
 - offset: "0x0010d020"
   size: 8
   kind: struct
@@ -200,9 +200,9 @@
   ptrToThis: "0x00057320"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr2"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr2'
+          offset: 0
 - offset: "0x0010cfa0"
   size: 8
   kind: struct
@@ -212,9 +212,9 @@
   ptrToThis: "0x000572e0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr3"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr3'
+          offset: 0
 - offset: "0x0010cf20"
   size: 8
   kind: struct
@@ -224,9 +224,9 @@
   ptrToThis: "0x000572a0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr4"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr4'
+          offset: 0
 - offset: "0x0010cea0"
   size: 8
   kind: struct
@@ -236,9 +236,9 @@
   ptrToThis: "0x00057260"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr5"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr5'
+          offset: 0
 - offset: "0x0010ce20"
   size: 8
   kind: struct
@@ -248,9 +248,9 @@
   ptrToThis: "0x00057220"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr6"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr6'
+          offset: 0
 - offset: "0x0010cda0"
   size: 8
   kind: struct
@@ -260,9 +260,9 @@
   ptrToThis: "0x000571e0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr7"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr7'
+          offset: 0
 - offset: "0x0010cd20"
   size: 8
   kind: struct
@@ -272,9 +272,9 @@
   ptrToThis: "0x000571a0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr8"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr8'
+          offset: 0
 - offset: "0x0010cca0"
   size: 8
   kind: struct
@@ -284,9 +284,9 @@
   ptrToThis: "0x00057160"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr9"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr9'
+          offset: 0
 - offset: "0x0010cc20"
   size: 16
   kind: struct
@@ -296,9 +296,9 @@
   ptrToThis: "0x00057120"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x0010d4a0"
   size: 24
   kind: struct
@@ -308,9 +308,9 @@
   ptrToThis: "0x00057560"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice2"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice2'
+          offset: 0
 - offset: "0x0010d420"
   size: 24
   kind: struct
@@ -320,9 +320,9 @@
   ptrToThis: "0x00057520"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice3"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice3'
+          offset: 0
 - offset: "0x0010d3a0"
   size: 24
   kind: struct
@@ -332,9 +332,9 @@
   ptrToThis: "0x000574e0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice4"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice4'
+          offset: 0
 - offset: "0x0010d320"
   size: 24
   kind: struct
@@ -344,9 +344,9 @@
   ptrToThis: "0x000574a0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice5"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice5'
+          offset: 0
 - offset: "0x0010d2a0"
   size: 24
   kind: struct
@@ -356,9 +356,9 @@
   ptrToThis: "0x00057460"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice6"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice6'
+          offset: 0
 - offset: "0x0010d220"
   size: 24
   kind: struct
@@ -368,9 +368,9 @@
   ptrToThis: "0x00057420"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice7"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice7'
+          offset: 0
 - offset: "0x0010d1a0"
   size: 24
   kind: struct
@@ -380,9 +380,9 @@
   ptrToThis: "0x000573e0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice8"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice8'
+          offset: 0
 - offset: "0x0010d120"
   size: 24
   kind: struct
@@ -392,9 +392,9 @@
   ptrToThis: "0x000573a0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice9"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice9'
+          offset: 0
 - offset: "0x0010d0a0"
   size: 24
   kind: struct
@@ -404,9 +404,9 @@
   ptrToThis: "0x00057360"
   struct:
     fields:
-    - name: a
-      type: "[]interface {}"
-      offset: 0
+        - name: a
+          type: '[]interface {}'
+          offset: 0
 - offset: "0x001a06a0"
   size: 112
   kind: struct
@@ -416,21 +416,21 @@
   ptrToThis: "0x000575a0"
   struct:
     fields:
-    - name: esotericStack (embedded)
-      type: main.esotericStack
-      offset: 0
-    - name: mu
-      type: sync.Mutex
-      offset: 64
-    - name: once
-      type: sync.Once
-      offset: 72
-    - name: wg
-      type: sync.WaitGroup
-      offset: 88
-    - name: a
-      type: atomic.Int32
-      offset: 104
+        - name: esotericStack (embedded)
+          type: main.esotericStack
+          offset: 0
+        - name: mu
+          type: sync.Mutex
+          offset: 64
+        - name: once
+          type: sync.Once
+          offset: 72
+        - name: wg
+          type: sync.WaitGroup
+          offset: 88
+        - name: a
+          type: atomic.Int32
+          offset: 104
 - offset: "0x001bf4a0"
   size: 64
   kind: struct
@@ -440,27 +440,27 @@
   ptrToThis: "0x00056da0"
   struct:
     fields:
-    - name: _
-      type: int32
-      offset: 0
-    - name: _valid
-      type: int32
-      offset: 4
-    - name: c
-      type: chan struct {}
-      offset: 8
-    - name: val
-      type: interface {}
-      offset: 16
-    - name: _
-      type: uint64
-      offset: 32
-    - name: work
-      type: main.something
-      offset: 40
-    - name: foo
-      type: func()
-      offset: 56
+        - name: _
+          type: int32
+          offset: 0
+        - name: _valid
+          type: int32
+          offset: 4
+        - name: c
+          type: chan struct {}
+          offset: 8
+        - name: val
+          type: interface {}
+          offset: 16
+        - name: _
+          type: uint64
+          offset: 32
+        - name: work
+          type: main.something
+          offset: 40
+        - name: foo
+          type: func()
+          offset: 56
 - offset: "0x0012cd00"
   size: 16
   kind: struct
@@ -469,13 +469,13 @@
   pkg: main
   ptrToThis: "0x000c93a0"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00138a40"
   size: 24
   kind: struct
@@ -485,12 +485,12 @@
   ptrToThis: "0x00057620"
   struct:
     fields:
-    - name: anotherInt
-      type: int
-      offset: 0
-    - name: anotherString
-      type: string
-      offset: 8
+        - name: anotherInt
+          type: int
+          offset: 0
+        - name: anotherString
+          type: string
+          offset: 8
 - offset: "0x001389a0"
   size: 16
   kind: struct
@@ -500,12 +500,12 @@
   ptrToThis: "0x000575e0"
   struct:
     fields:
-    - name: val
-      type: int
-      offset: 0
-    - name: b
-      type: "*main.node"
-      offset: 8
+        - name: val
+          type: int
+          offset: 0
+        - name: b
+          type: '*main.node'
+          offset: 8
 - offset: "0x0010c5a0"
   size: 16
   kind: struct
@@ -515,9 +515,9 @@
   ptrToThis: "0x00056de0"
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x0010c620"
   size: 8
   kind: struct
@@ -527,9 +527,9 @@
   ptrToThis: "0x00056e20"
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x0012cda0"
   size: 8
   kind: struct
@@ -538,13 +538,13 @@
   pkg: main
   ptrToThis: "0x000c9400"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x000ef500"
   size: 16
   kind: interface
@@ -553,8 +553,8 @@
   pkg: main
   ptrToThis: "0x00056d60"
   interfaceMethods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
 - offset: "0x000e73c0"
   size: 0
   kind: struct
@@ -573,9 +573,9 @@
   ptrToThis: "0x00056e60"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x0010c720"
   size: 8
   kind: struct
@@ -585,9 +585,9 @@
   ptrToThis: "0x00056ea0"
   struct:
     fields:
-    - name: m
-      type: map[int]int
-      offset: 0
+        - name: m
+          type: map[int]int
+          offset: 0
 - offset: "0x00135cc0"
   size: 8
   kind: struct
@@ -596,13 +596,13 @@
   pkg: main
   ptrToThis: "0x000d6780"
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: int
-      offset: 0
+        - name: Value (exported)
+          type: int
+          offset: 0
 - offset: "0x00135d60"
   size: 16
   kind: struct
@@ -611,10 +611,10 @@
   pkg: main
   ptrToThis: "0x000d67e0"
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: string
-      offset: 0
+        - name: Value (exported)
+          type: string
+          offset: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,12 +1,12 @@
 - offset: "0x000da140"
   size: 8
   kind: ptr
-  nameEntry: "*lib_v2.V2Type (exported)"
-  name: "*lib_v2.V2Type"
+  nameEntry: '*lib_v2.V2Type (exported)'
+  name: '*lib_v2.V2Type'
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
   methods:
-  - name: MyMethod (exported)
-    type: func()
+    - name: MyMethod (exported)
+      type: func()
   pointer:
     elem: lib_v2.V2Type
 - offset: "0x000f0600"
@@ -21,56 +21,56 @@
 - offset: "0x000d9de0"
   size: 8
   kind: ptr
-  nameEntry: "*main.firstBehavior"
-  name: "*main.firstBehavior"
+  nameEntry: '*main.firstBehavior'
+  name: '*main.firstBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.firstBehavior
 - offset: "0x000d9e40"
   size: 8
   kind: ptr
-  nameEntry: "*main.secondBehavior"
-  name: "*main.secondBehavior"
+  nameEntry: '*main.secondBehavior'
+  name: '*main.secondBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.secondBehavior
 - offset: "0x000d9ea0"
   size: 8
   kind: ptr
-  nameEntry: "*main.somethingImpl"
-  name: "*main.somethingImpl"
+  nameEntry: '*main.somethingImpl'
+  name: '*main.somethingImpl'
   pkg: main
   methods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
   pointer:
     elem: main.somethingImpl
 - offset: "0x000e7580"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[int]"
-  name: "*main.typeWithGenerics[int]"
+  nameEntry: '*main.typeWithGenerics[int]'
+  name: '*main.typeWithGenerics[int]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
 - offset: "0x000e75e0"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[string]"
-  name: "*main.typeWithGenerics[string]"
+  nameEntry: '*main.typeWithGenerics[string]'
+  name: '*main.typeWithGenerics[string]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
 - offset: "0x000f8b00"
@@ -81,8 +81,8 @@
   pkg: main
   ptrToThis: "0x0005d740"
   interfaceMethods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
 - offset: "0x00120da0"
   size: 8
   kind: struct
@@ -92,9 +92,9 @@
   ptrToThis: "0x0005db00"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap2
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap2
+          offset: 0
 - offset: "0x00120d20"
   size: 8
   kind: struct
@@ -104,9 +104,9 @@
   ptrToThis: "0x0005dac0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap3
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap3
+          offset: 0
 - offset: "0x00120ca0"
   size: 8
   kind: struct
@@ -116,9 +116,9 @@
   ptrToThis: "0x0005da80"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap4
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap4
+          offset: 0
 - offset: "0x00120c20"
   size: 8
   kind: struct
@@ -128,9 +128,9 @@
   ptrToThis: "0x0005da40"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap5
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap5
+          offset: 0
 - offset: "0x00120ba0"
   size: 8
   kind: struct
@@ -140,9 +140,9 @@
   ptrToThis: "0x0005da00"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap6
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap6
+          offset: 0
 - offset: "0x00120b20"
   size: 8
   kind: struct
@@ -152,9 +152,9 @@
   ptrToThis: "0x0005d9c0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap7
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap7
+          offset: 0
 - offset: "0x00120aa0"
   size: 8
   kind: struct
@@ -164,9 +164,9 @@
   ptrToThis: "0x0005d980"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap8
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap8
+          offset: 0
 - offset: "0x00120a20"
   size: 8
   kind: struct
@@ -176,9 +176,9 @@
   ptrToThis: "0x0005d940"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap9
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap9
+          offset: 0
 - offset: "0x001209a0"
   size: 8
   kind: struct
@@ -188,9 +188,9 @@
   ptrToThis: "0x0005d900"
   struct:
     fields:
-    - name: a
-      type: map[int]interface {}
-      offset: 0
+        - name: a
+          type: map[int]interface {}
+          offset: 0
 - offset: "0x00121220"
   size: 8
   kind: struct
@@ -200,9 +200,9 @@
   ptrToThis: "0x0005dd40"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr2"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr2'
+          offset: 0
 - offset: "0x001211a0"
   size: 8
   kind: struct
@@ -212,9 +212,9 @@
   ptrToThis: "0x0005dd00"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr3"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr3'
+          offset: 0
 - offset: "0x00121120"
   size: 8
   kind: struct
@@ -224,9 +224,9 @@
   ptrToThis: "0x0005dcc0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr4"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr4'
+          offset: 0
 - offset: "0x001210a0"
   size: 8
   kind: struct
@@ -236,9 +236,9 @@
   ptrToThis: "0x0005dc80"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr5"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr5'
+          offset: 0
 - offset: "0x00121020"
   size: 8
   kind: struct
@@ -248,9 +248,9 @@
   ptrToThis: "0x0005dc40"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr6"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr6'
+          offset: 0
 - offset: "0x00120fa0"
   size: 8
   kind: struct
@@ -260,9 +260,9 @@
   ptrToThis: "0x0005dc00"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr7"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr7'
+          offset: 0
 - offset: "0x00120f20"
   size: 8
   kind: struct
@@ -272,9 +272,9 @@
   ptrToThis: "0x0005dbc0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr8"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr8'
+          offset: 0
 - offset: "0x00120ea0"
   size: 8
   kind: struct
@@ -284,9 +284,9 @@
   ptrToThis: "0x0005db80"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr9"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr9'
+          offset: 0
 - offset: "0x00120e20"
   size: 16
   kind: struct
@@ -296,9 +296,9 @@
   ptrToThis: "0x0005db40"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x001216a0"
   size: 24
   kind: struct
@@ -308,9 +308,9 @@
   ptrToThis: "0x0005df80"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice2"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice2'
+          offset: 0
 - offset: "0x00121620"
   size: 24
   kind: struct
@@ -320,9 +320,9 @@
   ptrToThis: "0x0005df40"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice3"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice3'
+          offset: 0
 - offset: "0x001215a0"
   size: 24
   kind: struct
@@ -332,9 +332,9 @@
   ptrToThis: "0x0005df00"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice4"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice4'
+          offset: 0
 - offset: "0x00121520"
   size: 24
   kind: struct
@@ -344,9 +344,9 @@
   ptrToThis: "0x0005dec0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice5"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice5'
+          offset: 0
 - offset: "0x001214a0"
   size: 24
   kind: struct
@@ -356,9 +356,9 @@
   ptrToThis: "0x0005de80"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice6"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice6'
+          offset: 0
 - offset: "0x00121420"
   size: 24
   kind: struct
@@ -368,9 +368,9 @@
   ptrToThis: "0x0005de40"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice7"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice7'
+          offset: 0
 - offset: "0x001213a0"
   size: 24
   kind: struct
@@ -380,9 +380,9 @@
   ptrToThis: "0x0005de00"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice8"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice8'
+          offset: 0
 - offset: "0x00121320"
   size: 24
   kind: struct
@@ -392,9 +392,9 @@
   ptrToThis: "0x0005ddc0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice9"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice9'
+          offset: 0
 - offset: "0x001212a0"
   size: 24
   kind: struct
@@ -404,9 +404,9 @@
   ptrToThis: "0x0005dd80"
   struct:
     fields:
-    - name: a
-      type: "[]interface {}"
-      offset: 0
+        - name: a
+          type: '[]interface {}'
+          offset: 0
 - offset: "0x001be020"
   size: 112
   kind: struct
@@ -416,21 +416,21 @@
   ptrToThis: "0x0005dfc0"
   struct:
     fields:
-    - name: esotericStack (embedded)
-      type: main.esotericStack
-      offset: 0
-    - name: mu
-      type: sync.Mutex
-      offset: 64
-    - name: once
-      type: sync.Once
-      offset: 72
-    - name: wg
-      type: sync.WaitGroup
-      offset: 88
-    - name: a
-      type: atomic.Int32
-      offset: 104
+        - name: esotericStack (embedded)
+          type: main.esotericStack
+          offset: 0
+        - name: mu
+          type: sync.Mutex
+          offset: 64
+        - name: once
+          type: sync.Once
+          offset: 72
+        - name: wg
+          type: sync.WaitGroup
+          offset: 88
+        - name: a
+          type: atomic.Int32
+          offset: 104
 - offset: "0x001dea00"
   size: 64
   kind: struct
@@ -440,27 +440,27 @@
   ptrToThis: "0x0005d7c0"
   struct:
     fields:
-    - name: _
-      type: int32
-      offset: 0
-    - name: _valid
-      type: int32
-      offset: 4
-    - name: c
-      type: chan struct {}
-      offset: 8
-    - name: val
-      type: interface {}
-      offset: 16
-    - name: _
-      type: uint64
-      offset: 32
-    - name: work
-      type: main.something
-      offset: 40
-    - name: foo
-      type: func()
-      offset: 56
+        - name: _
+          type: int32
+          offset: 0
+        - name: _valid
+          type: int32
+          offset: 4
+        - name: c
+          type: chan struct {}
+          offset: 8
+        - name: val
+          type: interface {}
+          offset: 16
+        - name: _
+          type: uint64
+          offset: 32
+        - name: work
+          type: main.something
+          offset: 40
+        - name: foo
+          type: func()
+          offset: 56
 - offset: "0x00158300"
   size: 16
   kind: struct
@@ -469,13 +469,13 @@
   pkg: main
   ptrToThis: "0x000d9de0"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00164380"
   size: 24
   kind: struct
@@ -485,12 +485,12 @@
   ptrToThis: "0x0005e040"
   struct:
     fields:
-    - name: anotherInt
-      type: int
-      offset: 0
-    - name: anotherString
-      type: string
-      offset: 8
+        - name: anotherInt
+          type: int
+          offset: 0
+        - name: anotherString
+          type: string
+          offset: 8
 - offset: "0x001642e0"
   size: 16
   kind: struct
@@ -500,12 +500,12 @@
   ptrToThis: "0x0005e000"
   struct:
     fields:
-    - name: val
-      type: int
-      offset: 0
-    - name: b
-      type: "*main.node"
-      offset: 8
+        - name: val
+          type: int
+          offset: 0
+        - name: b
+          type: '*main.node'
+          offset: 8
 - offset: "0x001207a0"
   size: 16
   kind: struct
@@ -515,9 +515,9 @@
   ptrToThis: "0x0005d800"
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00120820"
   size: 8
   kind: struct
@@ -527,9 +527,9 @@
   ptrToThis: "0x0005d840"
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x001583a0"
   size: 8
   kind: struct
@@ -538,13 +538,13 @@
   pkg: main
   ptrToThis: "0x000d9e40"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x000f8b80"
   size: 16
   kind: interface
@@ -553,8 +553,8 @@
   pkg: main
   ptrToThis: "0x0005d780"
   interfaceMethods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
 - offset: "0x000f0480"
   size: 0
   kind: struct
@@ -573,9 +573,9 @@
   ptrToThis: "0x0005d880"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00120920"
   size: 8
   kind: struct
@@ -585,9 +585,9 @@
   ptrToThis: "0x0005d8c0"
   struct:
     fields:
-    - name: m
-      type: map[int]int
-      offset: 0
+        - name: m
+          type: map[int]int
+          offset: 0
 - offset: "0x00161680"
   size: 8
   kind: struct
@@ -596,13 +596,13 @@
   pkg: main
   ptrToThis: "0x000e7580"
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: int
-      offset: 0
+        - name: Value (exported)
+          type: int
+          offset: 0
 - offset: "0x00161720"
   size: 16
   kind: struct
@@ -611,10 +611,10 @@
   pkg: main
   ptrToThis: "0x000e75e0"
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: string
-      offset: 0
+        - name: Value (exported)
+          type: string
+          offset: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,12 +1,12 @@
 - offset: "0x000db240"
   size: 8
   kind: ptr
-  nameEntry: "*lib_v2.V2Type (exported)"
-  name: "*lib_v2.V2Type"
+  nameEntry: '*lib_v2.V2Type (exported)'
+  name: '*lib_v2.V2Type'
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
   methods:
-  - name: MyMethod (exported)
-    type: func()
+    - name: MyMethod (exported)
+      type: func()
   pointer:
     elem: lib_v2.V2Type
 - offset: "0x000f1720"
@@ -21,56 +21,56 @@
 - offset: "0x000daee0"
   size: 8
   kind: ptr
-  nameEntry: "*main.firstBehavior"
-  name: "*main.firstBehavior"
+  nameEntry: '*main.firstBehavior'
+  name: '*main.firstBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.firstBehavior
 - offset: "0x000daf40"
   size: 8
   kind: ptr
-  nameEntry: "*main.secondBehavior"
-  name: "*main.secondBehavior"
+  nameEntry: '*main.secondBehavior'
+  name: '*main.secondBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.secondBehavior
 - offset: "0x000dafa0"
   size: 8
   kind: ptr
-  nameEntry: "*main.somethingImpl"
-  name: "*main.somethingImpl"
+  nameEntry: '*main.somethingImpl'
+  name: '*main.somethingImpl'
   pkg: main
   methods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
   pointer:
     elem: main.somethingImpl
 - offset: "0x000e8800"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[int]"
-  name: "*main.typeWithGenerics[int]"
+  nameEntry: '*main.typeWithGenerics[int]'
+  name: '*main.typeWithGenerics[int]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
 - offset: "0x000e8860"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[string]"
-  name: "*main.typeWithGenerics[string]"
+  nameEntry: '*main.typeWithGenerics[string]'
+  name: '*main.typeWithGenerics[string]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
 - offset: "0x000f9ba0"
@@ -81,8 +81,8 @@
   pkg: main
   ptrToThis: "0x0005e220"
   interfaceMethods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
 - offset: "0x00121d20"
   size: 8
   kind: struct
@@ -92,9 +92,9 @@
   ptrToThis: "0x0005e5e0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap2
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap2
+          offset: 0
 - offset: "0x00121ca0"
   size: 8
   kind: struct
@@ -104,9 +104,9 @@
   ptrToThis: "0x0005e5a0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap3
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap3
+          offset: 0
 - offset: "0x00121c20"
   size: 8
   kind: struct
@@ -116,9 +116,9 @@
   ptrToThis: "0x0005e560"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap4
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap4
+          offset: 0
 - offset: "0x00121ba0"
   size: 8
   kind: struct
@@ -128,9 +128,9 @@
   ptrToThis: "0x0005e520"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap5
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap5
+          offset: 0
 - offset: "0x00121b20"
   size: 8
   kind: struct
@@ -140,9 +140,9 @@
   ptrToThis: "0x0005e4e0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap6
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap6
+          offset: 0
 - offset: "0x00121aa0"
   size: 8
   kind: struct
@@ -152,9 +152,9 @@
   ptrToThis: "0x0005e4a0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap7
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap7
+          offset: 0
 - offset: "0x00121a20"
   size: 8
   kind: struct
@@ -164,9 +164,9 @@
   ptrToThis: "0x0005e460"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap8
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap8
+          offset: 0
 - offset: "0x001219a0"
   size: 8
   kind: struct
@@ -176,9 +176,9 @@
   ptrToThis: "0x0005e420"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap9
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap9
+          offset: 0
 - offset: "0x00121920"
   size: 8
   kind: struct
@@ -188,9 +188,9 @@
   ptrToThis: "0x0005e3e0"
   struct:
     fields:
-    - name: a
-      type: map[int]interface {}
-      offset: 0
+        - name: a
+          type: map[int]interface {}
+          offset: 0
 - offset: "0x001221a0"
   size: 8
   kind: struct
@@ -200,9 +200,9 @@
   ptrToThis: "0x0005e820"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr2"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr2'
+          offset: 0
 - offset: "0x00122120"
   size: 8
   kind: struct
@@ -212,9 +212,9 @@
   ptrToThis: "0x0005e7e0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr3"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr3'
+          offset: 0
 - offset: "0x001220a0"
   size: 8
   kind: struct
@@ -224,9 +224,9 @@
   ptrToThis: "0x0005e7a0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr4"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr4'
+          offset: 0
 - offset: "0x00122020"
   size: 8
   kind: struct
@@ -236,9 +236,9 @@
   ptrToThis: "0x0005e760"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr5"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr5'
+          offset: 0
 - offset: "0x00121fa0"
   size: 8
   kind: struct
@@ -248,9 +248,9 @@
   ptrToThis: "0x0005e720"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr6"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr6'
+          offset: 0
 - offset: "0x00121f20"
   size: 8
   kind: struct
@@ -260,9 +260,9 @@
   ptrToThis: "0x0005e6e0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr7"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr7'
+          offset: 0
 - offset: "0x00121ea0"
   size: 8
   kind: struct
@@ -272,9 +272,9 @@
   ptrToThis: "0x0005e6a0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr8"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr8'
+          offset: 0
 - offset: "0x00121e20"
   size: 8
   kind: struct
@@ -284,9 +284,9 @@
   ptrToThis: "0x0005e660"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr9"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr9'
+          offset: 0
 - offset: "0x00121da0"
   size: 16
   kind: struct
@@ -296,9 +296,9 @@
   ptrToThis: "0x0005e620"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00122620"
   size: 24
   kind: struct
@@ -308,9 +308,9 @@
   ptrToThis: "0x0005ea60"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice2"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice2'
+          offset: 0
 - offset: "0x001225a0"
   size: 24
   kind: struct
@@ -320,9 +320,9 @@
   ptrToThis: "0x0005ea20"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice3"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice3'
+          offset: 0
 - offset: "0x00122520"
   size: 24
   kind: struct
@@ -332,9 +332,9 @@
   ptrToThis: "0x0005e9e0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice4"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice4'
+          offset: 0
 - offset: "0x001224a0"
   size: 24
   kind: struct
@@ -344,9 +344,9 @@
   ptrToThis: "0x0005e9a0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice5"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice5'
+          offset: 0
 - offset: "0x00122420"
   size: 24
   kind: struct
@@ -356,9 +356,9 @@
   ptrToThis: "0x0005e960"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice6"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice6'
+          offset: 0
 - offset: "0x001223a0"
   size: 24
   kind: struct
@@ -368,9 +368,9 @@
   ptrToThis: "0x0005e920"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice7"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice7'
+          offset: 0
 - offset: "0x00122320"
   size: 24
   kind: struct
@@ -380,9 +380,9 @@
   ptrToThis: "0x0005e8e0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice8"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice8'
+          offset: 0
 - offset: "0x001222a0"
   size: 24
   kind: struct
@@ -392,9 +392,9 @@
   ptrToThis: "0x0005e8a0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice9"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice9'
+          offset: 0
 - offset: "0x00122220"
   size: 24
   kind: struct
@@ -404,9 +404,9 @@
   ptrToThis: "0x0005e860"
   struct:
     fields:
-    - name: a
-      type: "[]interface {}"
-      offset: 0
+        - name: a
+          type: '[]interface {}'
+          offset: 0
 - offset: "0x001c0440"
   size: 112
   kind: struct
@@ -416,21 +416,21 @@
   ptrToThis: "0x0005eaa0"
   struct:
     fields:
-    - name: esotericStack (embedded)
-      type: main.esotericStack
-      offset: 0
-    - name: mu
-      type: sync.Mutex
-      offset: 64
-    - name: once
-      type: sync.Once
-      offset: 72
-    - name: wg
-      type: sync.WaitGroup
-      offset: 88
-    - name: a
-      type: atomic.Int32
-      offset: 104
+        - name: esotericStack (embedded)
+          type: main.esotericStack
+          offset: 0
+        - name: mu
+          type: sync.Mutex
+          offset: 64
+        - name: once
+          type: sync.Once
+          offset: 72
+        - name: wg
+          type: sync.WaitGroup
+          offset: 88
+        - name: a
+          type: atomic.Int32
+          offset: 104
 - offset: "0x001e0c20"
   size: 64
   kind: struct
@@ -440,27 +440,27 @@
   ptrToThis: "0x0005e2a0"
   struct:
     fields:
-    - name: _
-      type: int32
-      offset: 0
-    - name: _valid
-      type: int32
-      offset: 4
-    - name: c
-      type: chan struct {}
-      offset: 8
-    - name: val
-      type: interface {}
-      offset: 16
-    - name: _
-      type: uint64
-      offset: 32
-    - name: work
-      type: main.something
-      offset: 40
-    - name: foo
-      type: func()
-      offset: 56
+        - name: _
+          type: int32
+          offset: 0
+        - name: _valid
+          type: int32
+          offset: 4
+        - name: c
+          type: chan struct {}
+          offset: 8
+        - name: val
+          type: interface {}
+          offset: 16
+        - name: _
+          type: uint64
+          offset: 32
+        - name: work
+          type: main.something
+          offset: 40
+        - name: foo
+          type: func()
+          offset: 56
 - offset: "0x00159200"
   size: 16
   kind: struct
@@ -469,13 +469,13 @@
   pkg: main
   ptrToThis: "0x000daee0"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00165540"
   size: 24
   kind: struct
@@ -485,12 +485,12 @@
   ptrToThis: "0x0005eb20"
   struct:
     fields:
-    - name: anotherInt
-      type: int
-      offset: 0
-    - name: anotherString
-      type: string
-      offset: 8
+        - name: anotherInt
+          type: int
+          offset: 0
+        - name: anotherString
+          type: string
+          offset: 8
 - offset: "0x001654a0"
   size: 16
   kind: struct
@@ -500,12 +500,12 @@
   ptrToThis: "0x0005eae0"
   struct:
     fields:
-    - name: val
-      type: int
-      offset: 0
-    - name: b
-      type: "*main.node"
-      offset: 8
+        - name: val
+          type: int
+          offset: 0
+        - name: b
+          type: '*main.node'
+          offset: 8
 - offset: "0x00121720"
   size: 16
   kind: struct
@@ -515,9 +515,9 @@
   ptrToThis: "0x0005e2e0"
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x001217a0"
   size: 8
   kind: struct
@@ -527,9 +527,9 @@
   ptrToThis: "0x0005e320"
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x001592a0"
   size: 8
   kind: struct
@@ -538,13 +538,13 @@
   pkg: main
   ptrToThis: "0x000daf40"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x000f9c20"
   size: 16
   kind: interface
@@ -553,8 +553,8 @@
   pkg: main
   ptrToThis: "0x0005e260"
   interfaceMethods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
 - offset: "0x000f15a0"
   size: 0
   kind: struct
@@ -573,9 +573,9 @@
   ptrToThis: "0x0005e360"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x001218a0"
   size: 8
   kind: struct
@@ -585,9 +585,9 @@
   ptrToThis: "0x0005e3a0"
   struct:
     fields:
-    - name: m
-      type: map[int]int
-      offset: 0
+        - name: m
+          type: map[int]int
+          offset: 0
 - offset: "0x00162760"
   size: 8
   kind: struct
@@ -596,13 +596,13 @@
   pkg: main
   ptrToThis: "0x000e8800"
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: int
-      offset: 0
+        - name: Value (exported)
+          type: int
+          offset: 0
 - offset: "0x00162800"
   size: 16
   kind: struct
@@ -611,10 +611,10 @@
   pkg: main
   ptrToThis: "0x000e8860"
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: string
-      offset: 0
+        - name: Value (exported)
+          type: string
+          offset: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -1,12 +1,12 @@
 - offset: "0x000dd260"
   size: 8
   kind: ptr
-  nameEntry: "*lib_v2.V2Type (exported)"
-  name: "*lib_v2.V2Type"
+  nameEntry: '*lib_v2.V2Type (exported)'
+  name: '*lib_v2.V2Type'
   pkg: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/sample/lib.v2
   methods:
-  - name: MyMethod (exported)
-    type: func()
+    - name: MyMethod (exported)
+      type: func()
   pointer:
     elem: lib_v2.V2Type
 - offset: "0x000f3a40"
@@ -21,56 +21,56 @@
 - offset: "0x000dcf00"
   size: 8
   kind: ptr
-  nameEntry: "*main.firstBehavior"
-  name: "*main.firstBehavior"
+  nameEntry: '*main.firstBehavior'
+  name: '*main.firstBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.firstBehavior
 - offset: "0x000dcf60"
   size: 8
   kind: ptr
-  nameEntry: "*main.secondBehavior"
-  name: "*main.secondBehavior"
+  nameEntry: '*main.secondBehavior'
+  name: '*main.secondBehavior'
   pkg: main
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   pointer:
     elem: main.secondBehavior
 - offset: "0x000dcfc0"
   size: 8
   kind: ptr
-  nameEntry: "*main.somethingImpl"
-  name: "*main.somethingImpl"
+  nameEntry: '*main.somethingImpl'
+  name: '*main.somethingImpl'
   pkg: main
   methods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
   pointer:
     elem: main.somethingImpl
 - offset: "0x000eabe0"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[int]"
-  name: "*main.typeWithGenerics[int]"
+  nameEntry: '*main.typeWithGenerics[int]'
+  name: '*main.typeWithGenerics[int]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   pointer:
     elem: main.typeWithGenerics[int]
 - offset: "0x000eac40"
   size: 8
   kind: ptr
-  nameEntry: "*main.typeWithGenerics[string]"
-  name: "*main.typeWithGenerics[string]"
+  nameEntry: '*main.typeWithGenerics[string]'
+  name: '*main.typeWithGenerics[string]'
   pkg: main
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   pointer:
     elem: main.typeWithGenerics[string]
 - offset: "0x000fbe00"
@@ -81,8 +81,8 @@
   pkg: main
   ptrToThis: "0x0005f580"
   interfaceMethods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
 - offset: "0x00123b80"
   size: 8
   kind: struct
@@ -92,9 +92,9 @@
   ptrToThis: "0x0005f940"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap2
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap2
+          offset: 0
 - offset: "0x00123b00"
   size: 8
   kind: struct
@@ -104,9 +104,9 @@
   ptrToThis: "0x0005f900"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap3
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap3
+          offset: 0
 - offset: "0x00123a80"
   size: 8
   kind: struct
@@ -116,9 +116,9 @@
   ptrToThis: "0x0005f8c0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap4
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap4
+          offset: 0
 - offset: "0x00123a00"
   size: 8
   kind: struct
@@ -128,9 +128,9 @@
   ptrToThis: "0x0005f880"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap5
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap5
+          offset: 0
 - offset: "0x00123980"
   size: 8
   kind: struct
@@ -140,9 +140,9 @@
   ptrToThis: "0x0005f840"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap6
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap6
+          offset: 0
 - offset: "0x00123900"
   size: 8
   kind: struct
@@ -152,9 +152,9 @@
   ptrToThis: "0x0005f800"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap7
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap7
+          offset: 0
 - offset: "0x00123880"
   size: 8
   kind: struct
@@ -164,9 +164,9 @@
   ptrToThis: "0x0005f7c0"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap8
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap8
+          offset: 0
 - offset: "0x00123800"
   size: 8
   kind: struct
@@ -176,9 +176,9 @@
   ptrToThis: "0x0005f780"
   struct:
     fields:
-    - name: a
-      type: map[int]*main.deepMap9
-      offset: 0
+        - name: a
+          type: map[int]*main.deepMap9
+          offset: 0
 - offset: "0x00123780"
   size: 8
   kind: struct
@@ -188,9 +188,9 @@
   ptrToThis: "0x0005f740"
   struct:
     fields:
-    - name: a
-      type: map[int]interface {}
-      offset: 0
+        - name: a
+          type: map[int]interface {}
+          offset: 0
 - offset: "0x00124000"
   size: 8
   kind: struct
@@ -200,9 +200,9 @@
   ptrToThis: "0x0005fb80"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr2"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr2'
+          offset: 0
 - offset: "0x00123f80"
   size: 8
   kind: struct
@@ -212,9 +212,9 @@
   ptrToThis: "0x0005fb40"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr3"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr3'
+          offset: 0
 - offset: "0x00123f00"
   size: 8
   kind: struct
@@ -224,9 +224,9 @@
   ptrToThis: "0x0005fb00"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr4"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr4'
+          offset: 0
 - offset: "0x00123e80"
   size: 8
   kind: struct
@@ -236,9 +236,9 @@
   ptrToThis: "0x0005fac0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr5"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr5'
+          offset: 0
 - offset: "0x00123e00"
   size: 8
   kind: struct
@@ -248,9 +248,9 @@
   ptrToThis: "0x0005fa80"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr6"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr6'
+          offset: 0
 - offset: "0x00123d80"
   size: 8
   kind: struct
@@ -260,9 +260,9 @@
   ptrToThis: "0x0005fa40"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr7"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr7'
+          offset: 0
 - offset: "0x00123d00"
   size: 8
   kind: struct
@@ -272,9 +272,9 @@
   ptrToThis: "0x0005fa00"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr8"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr8'
+          offset: 0
 - offset: "0x00123c80"
   size: 8
   kind: struct
@@ -284,9 +284,9 @@
   ptrToThis: "0x0005f9c0"
   struct:
     fields:
-    - name: a
-      type: "*main.deepPtr9"
-      offset: 0
+        - name: a
+          type: '*main.deepPtr9'
+          offset: 0
 - offset: "0x00123c00"
   size: 16
   kind: struct
@@ -296,9 +296,9 @@
   ptrToThis: "0x0005f980"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00124480"
   size: 24
   kind: struct
@@ -308,9 +308,9 @@
   ptrToThis: "0x0005fdc0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice2"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice2'
+          offset: 0
 - offset: "0x00124400"
   size: 24
   kind: struct
@@ -320,9 +320,9 @@
   ptrToThis: "0x0005fd80"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice3"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice3'
+          offset: 0
 - offset: "0x00124380"
   size: 24
   kind: struct
@@ -332,9 +332,9 @@
   ptrToThis: "0x0005fd40"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice4"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice4'
+          offset: 0
 - offset: "0x00124300"
   size: 24
   kind: struct
@@ -344,9 +344,9 @@
   ptrToThis: "0x0005fd00"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice5"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice5'
+          offset: 0
 - offset: "0x00124280"
   size: 24
   kind: struct
@@ -356,9 +356,9 @@
   ptrToThis: "0x0005fcc0"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice6"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice6'
+          offset: 0
 - offset: "0x00124200"
   size: 24
   kind: struct
@@ -368,9 +368,9 @@
   ptrToThis: "0x0005fc80"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice7"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice7'
+          offset: 0
 - offset: "0x00124180"
   size: 24
   kind: struct
@@ -380,9 +380,9 @@
   ptrToThis: "0x0005fc40"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice8"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice8'
+          offset: 0
 - offset: "0x00124100"
   size: 24
   kind: struct
@@ -392,9 +392,9 @@
   ptrToThis: "0x0005fc00"
   struct:
     fields:
-    - name: a
-      type: "[]*main.deepSlice9"
-      offset: 0
+        - name: a
+          type: '[]*main.deepSlice9'
+          offset: 0
 - offset: "0x00124080"
   size: 24
   kind: struct
@@ -404,9 +404,9 @@
   ptrToThis: "0x0005fbc0"
   struct:
     fields:
-    - name: a
-      type: "[]interface {}"
-      offset: 0
+        - name: a
+          type: '[]interface {}'
+          offset: 0
 - offset: "0x001c4a80"
   size: 112
   kind: struct
@@ -416,21 +416,21 @@
   ptrToThis: "0x0005fe00"
   struct:
     fields:
-    - name: esotericStack (embedded)
-      type: main.esotericStack
-      offset: 0
-    - name: mu
-      type: sync.Mutex
-      offset: 64
-    - name: once
-      type: sync.Once
-      offset: 72
-    - name: wg
-      type: sync.WaitGroup
-      offset: 88
-    - name: a
-      type: atomic.Int32
-      offset: 104
+        - name: esotericStack (embedded)
+          type: main.esotericStack
+          offset: 0
+        - name: mu
+          type: sync.Mutex
+          offset: 64
+        - name: once
+          type: sync.Once
+          offset: 72
+        - name: wg
+          type: sync.WaitGroup
+          offset: 88
+        - name: a
+          type: atomic.Int32
+          offset: 104
 - offset: "0x001e5ba0"
   size: 64
   kind: struct
@@ -440,27 +440,27 @@
   ptrToThis: "0x0005f600"
   struct:
     fields:
-    - name: _
-      type: int32
-      offset: 0
-    - name: _valid
-      type: int32
-      offset: 4
-    - name: c
-      type: chan struct {}
-      offset: 8
-    - name: val
-      type: interface {}
-      offset: 16
-    - name: _
-      type: uint64
-      offset: 32
-    - name: work
-      type: main.something
-      offset: 40
-    - name: foo
-      type: func()
-      offset: 56
+        - name: _
+          type: int32
+          offset: 0
+        - name: _valid
+          type: int32
+          offset: 4
+        - name: c
+          type: chan struct {}
+          offset: 8
+        - name: val
+          type: interface {}
+          offset: 16
+        - name: _
+          type: uint64
+          offset: 32
+        - name: work
+          type: main.something
+          offset: 40
+        - name: foo
+          type: func()
+          offset: 56
 - offset: "0x0015bb60"
   size: 16
   kind: struct
@@ -469,13 +469,13 @@
   pkg: main
   ptrToThis: "0x000dcf00"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00168100"
   size: 24
   kind: struct
@@ -485,12 +485,12 @@
   ptrToThis: "0x0005fe80"
   struct:
     fields:
-    - name: anotherInt
-      type: int
-      offset: 0
-    - name: anotherString
-      type: string
-      offset: 8
+        - name: anotherInt
+          type: int
+          offset: 0
+        - name: anotherString
+          type: string
+          offset: 8
 - offset: "0x00168060"
   size: 16
   kind: struct
@@ -500,12 +500,12 @@
   ptrToThis: "0x0005fe40"
   struct:
     fields:
-    - name: val
-      type: int
-      offset: 0
-    - name: b
-      type: "*main.node"
-      offset: 8
+        - name: val
+          type: int
+          offset: 0
+        - name: b
+          type: '*main.node'
+          offset: 8
 - offset: "0x00123580"
   size: 16
   kind: struct
@@ -515,9 +515,9 @@
   ptrToThis: "0x0005f640"
   struct:
     fields:
-    - name: s
-      type: string
-      offset: 0
+        - name: s
+          type: string
+          offset: 0
 - offset: "0x00123600"
   size: 8
   kind: struct
@@ -527,9 +527,9 @@
   ptrToThis: "0x0005f680"
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x0015bc00"
   size: 8
   kind: struct
@@ -538,13 +538,13 @@
   pkg: main
   ptrToThis: "0x000dcf60"
   methods:
-  - name: DoSomething (exported)
-    type: func() string
+    - name: DoSomething (exported)
+      type: func() string
   struct:
     fields:
-    - name: i
-      type: int
-      offset: 0
+        - name: i
+          type: int
+          offset: 0
 - offset: "0x000fbe80"
   size: 16
   kind: interface
@@ -553,8 +553,8 @@
   pkg: main
   ptrToThis: "0x0005f5c0"
   interfaceMethods:
-  - name: Do (exported)
-    type: func()
+    - name: Do (exported)
+      type: func()
 - offset: "0x000f38c0"
   size: 0
   kind: struct
@@ -573,9 +573,9 @@
   ptrToThis: "0x0005f6c0"
   struct:
     fields:
-    - name: a
-      type: interface {}
-      offset: 0
+        - name: a
+          type: interface {}
+          offset: 0
 - offset: "0x00123700"
   size: 8
   kind: struct
@@ -585,9 +585,9 @@
   ptrToThis: "0x0005f700"
   struct:
     fields:
-    - name: m
-      type: map[int]int
-      offset: 0
+        - name: m
+          type: map[int]int
+          offset: 0
 - offset: "0x001652a0"
   size: 8
   kind: struct
@@ -596,13 +596,13 @@
   pkg: main
   ptrToThis: "0x000eabe0"
   methods:
-  - name: Guess (exported)
-    type: func(int) bool
+    - name: Guess (exported)
+      type: func(int) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: int
-      offset: 0
+        - name: Value (exported)
+          type: int
+          offset: 0
 - offset: "0x00165340"
   size: 16
   kind: struct
@@ -611,10 +611,10 @@
   pkg: main
   ptrToThis: "0x000eac40"
   methods:
-  - name: Guess (exported)
-    type: func(string) bool
+    - name: Guess (exported)
+      type: func(string) bool
   struct:
     fields:
-    - name: Value (exported)
-      type: string
-      offset: 0
+        - name: Value (exported)
+          type: string
+          offset: 0

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -7,9 +7,9 @@
   ptrToThis: "0x00006060"
   struct:
     fields:
-    - name: a
-      type: int
-      offset: 0
+        - name: a
+          type: int
+          offset: 0
 - offset: "0x0001b7a0"
   size: 184
   kind: struct
@@ -19,27 +19,27 @@
   ptrToThis: "0x000060a0"
   struct:
     fields:
-    - name: Field1 (exported)
-      type: int
-      offset: 0
-    - name: Field2 (exported)
-      type: int
-      offset: 8
-    - name: Field3 (exported)
-      type: int
-      offset: 16
-    - name: Field4 (exported)
-      type: int
-      offset: 24
-    - name: Field5 (exported)
-      type: int
-      offset: 32
-    - name: Field6 (exported)
-      type: int
-      offset: 40
-    - name: Field7 (exported)
-      type: int
-      offset: 48
-    - name: data
-      type: "[128]uint8"
-      offset: 56
+        - name: Field1 (exported)
+          type: int
+          offset: 0
+        - name: Field2 (exported)
+          type: int
+          offset: 8
+        - name: Field3 (exported)
+          type: int
+          offset: 16
+        - name: Field4 (exported)
+          type: int
+          offset: 24
+        - name: Field5 (exported)
+          type: int
+          offset: 32
+        - name: Field6 (exported)
+          type: int
+          offset: 40
+        - name: Field7 (exported)
+          type: int
+          offset: 48
+        - name: data
+          type: '[128]uint8'
+          offset: 56

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -7,9 +7,9 @@
   ptrToThis: "0x00006a20"
   struct:
     fields:
-    - name: a
-      type: int
-      offset: 0
+        - name: a
+          type: int
+          offset: 0
 - offset: "0x0001dea0"
   size: 184
   kind: struct
@@ -19,27 +19,27 @@
   ptrToThis: "0x00006a60"
   struct:
     fields:
-    - name: Field1 (exported)
-      type: int
-      offset: 0
-    - name: Field2 (exported)
-      type: int
-      offset: 8
-    - name: Field3 (exported)
-      type: int
-      offset: 16
-    - name: Field4 (exported)
-      type: int
-      offset: 24
-    - name: Field5 (exported)
-      type: int
-      offset: 32
-    - name: Field6 (exported)
-      type: int
-      offset: 40
-    - name: Field7 (exported)
-      type: int
-      offset: 48
-    - name: data
-      type: "[128]uint8"
-      offset: 56
+        - name: Field1 (exported)
+          type: int
+          offset: 0
+        - name: Field2 (exported)
+          type: int
+          offset: 8
+        - name: Field3 (exported)
+          type: int
+          offset: 16
+        - name: Field4 (exported)
+          type: int
+          offset: 24
+        - name: Field5 (exported)
+          type: int
+          offset: 32
+        - name: Field6 (exported)
+          type: int
+          offset: 40
+        - name: Field7 (exported)
+          type: int
+          offset: 48
+        - name: data
+          type: '[128]uint8'
+          offset: 56

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -7,9 +7,9 @@
   ptrToThis: "0x00006da0"
   struct:
     fields:
-    - name: a
-      type: int
-      offset: 0
+        - name: a
+          type: int
+          offset: 0
 - offset: "0x0001f240"
   size: 184
   kind: struct
@@ -19,27 +19,27 @@
   ptrToThis: "0x00006de0"
   struct:
     fields:
-    - name: Field1 (exported)
-      type: int
-      offset: 0
-    - name: Field2 (exported)
-      type: int
-      offset: 8
-    - name: Field3 (exported)
-      type: int
-      offset: 16
-    - name: Field4 (exported)
-      type: int
-      offset: 24
-    - name: Field5 (exported)
-      type: int
-      offset: 32
-    - name: Field6 (exported)
-      type: int
-      offset: 40
-    - name: Field7 (exported)
-      type: int
-      offset: 48
-    - name: data
-      type: "[128]uint8"
-      offset: 56
+        - name: Field1 (exported)
+          type: int
+          offset: 0
+        - name: Field2 (exported)
+          type: int
+          offset: 8
+        - name: Field3 (exported)
+          type: int
+          offset: 16
+        - name: Field4 (exported)
+          type: int
+          offset: 24
+        - name: Field5 (exported)
+          type: int
+          offset: 32
+        - name: Field6 (exported)
+          type: int
+          offset: 40
+        - name: Field7 (exported)
+          type: int
+          offset: 48
+        - name: data
+          type: '[128]uint8'
+          offset: 56

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -7,9 +7,9 @@
   ptrToThis: "0x00007480"
   struct:
     fields:
-    - name: a
-      type: int
-      offset: 0
+        - name: a
+          type: int
+          offset: 0
 - offset: "0x00020f20"
   size: 184
   kind: struct
@@ -19,27 +19,27 @@
   ptrToThis: "0x000074c0"
   struct:
     fields:
-    - name: Field1 (exported)
-      type: int
-      offset: 0
-    - name: Field2 (exported)
-      type: int
-      offset: 8
-    - name: Field3 (exported)
-      type: int
-      offset: 16
-    - name: Field4 (exported)
-      type: int
-      offset: 24
-    - name: Field5 (exported)
-      type: int
-      offset: 32
-    - name: Field6 (exported)
-      type: int
-      offset: 40
-    - name: Field7 (exported)
-      type: int
-      offset: 48
-    - name: data
-      type: "[128]uint8"
-      offset: 56
+        - name: Field1 (exported)
+          type: int
+          offset: 0
+        - name: Field2 (exported)
+          type: int
+          offset: 8
+        - name: Field3 (exported)
+          type: int
+          offset: 16
+        - name: Field4 (exported)
+          type: int
+          offset: 24
+        - name: Field5 (exported)
+          type: int
+          offset: 32
+        - name: Field6 (exported)
+          type: int
+          offset: 40
+        - name: Field7 (exported)
+          type: int
+          offset: 48
+        - name: data
+          type: '[128]uint8'
+          offset: 56

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -7,9 +7,9 @@
   ptrToThis: "0x00006040"
   struct:
     fields:
-    - name: a
-      type: int
-      offset: 0
+        - name: a
+          type: int
+          offset: 0
 - offset: "0x0001b720"
   size: 184
   kind: struct
@@ -19,27 +19,27 @@
   ptrToThis: "0x00006080"
   struct:
     fields:
-    - name: Field1 (exported)
-      type: int
-      offset: 0
-    - name: Field2 (exported)
-      type: int
-      offset: 8
-    - name: Field3 (exported)
-      type: int
-      offset: 16
-    - name: Field4 (exported)
-      type: int
-      offset: 24
-    - name: Field5 (exported)
-      type: int
-      offset: 32
-    - name: Field6 (exported)
-      type: int
-      offset: 40
-    - name: Field7 (exported)
-      type: int
-      offset: 48
-    - name: data
-      type: "[128]uint8"
-      offset: 56
+        - name: Field1 (exported)
+          type: int
+          offset: 0
+        - name: Field2 (exported)
+          type: int
+          offset: 8
+        - name: Field3 (exported)
+          type: int
+          offset: 16
+        - name: Field4 (exported)
+          type: int
+          offset: 24
+        - name: Field5 (exported)
+          type: int
+          offset: 32
+        - name: Field6 (exported)
+          type: int
+          offset: 40
+        - name: Field7 (exported)
+          type: int
+          offset: 48
+        - name: data
+          type: '[128]uint8'
+          offset: 56

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -7,9 +7,9 @@
   ptrToThis: "0x00006a00"
   struct:
     fields:
-    - name: a
-      type: int
-      offset: 0
+        - name: a
+          type: int
+          offset: 0
 - offset: "0x0001de20"
   size: 184
   kind: struct
@@ -19,27 +19,27 @@
   ptrToThis: "0x00006a40"
   struct:
     fields:
-    - name: Field1 (exported)
-      type: int
-      offset: 0
-    - name: Field2 (exported)
-      type: int
-      offset: 8
-    - name: Field3 (exported)
-      type: int
-      offset: 16
-    - name: Field4 (exported)
-      type: int
-      offset: 24
-    - name: Field5 (exported)
-      type: int
-      offset: 32
-    - name: Field6 (exported)
-      type: int
-      offset: 40
-    - name: Field7 (exported)
-      type: int
-      offset: 48
-    - name: data
-      type: "[128]uint8"
-      offset: 56
+        - name: Field1 (exported)
+          type: int
+          offset: 0
+        - name: Field2 (exported)
+          type: int
+          offset: 8
+        - name: Field3 (exported)
+          type: int
+          offset: 16
+        - name: Field4 (exported)
+          type: int
+          offset: 24
+        - name: Field5 (exported)
+          type: int
+          offset: 32
+        - name: Field6 (exported)
+          type: int
+          offset: 40
+        - name: Field7 (exported)
+          type: int
+          offset: 48
+        - name: data
+          type: '[128]uint8'
+          offset: 56

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -7,9 +7,9 @@
   ptrToThis: "0x00006d80"
   struct:
     fields:
-    - name: a
-      type: int
-      offset: 0
+        - name: a
+          type: int
+          offset: 0
 - offset: "0x0001f1c0"
   size: 184
   kind: struct
@@ -19,27 +19,27 @@
   ptrToThis: "0x00006dc0"
   struct:
     fields:
-    - name: Field1 (exported)
-      type: int
-      offset: 0
-    - name: Field2 (exported)
-      type: int
-      offset: 8
-    - name: Field3 (exported)
-      type: int
-      offset: 16
-    - name: Field4 (exported)
-      type: int
-      offset: 24
-    - name: Field5 (exported)
-      type: int
-      offset: 32
-    - name: Field6 (exported)
-      type: int
-      offset: 40
-    - name: Field7 (exported)
-      type: int
-      offset: 48
-    - name: data
-      type: "[128]uint8"
-      offset: 56
+        - name: Field1 (exported)
+          type: int
+          offset: 0
+        - name: Field2 (exported)
+          type: int
+          offset: 8
+        - name: Field3 (exported)
+          type: int
+          offset: 16
+        - name: Field4 (exported)
+          type: int
+          offset: 24
+        - name: Field5 (exported)
+          type: int
+          offset: 32
+        - name: Field6 (exported)
+          type: int
+          offset: 40
+        - name: Field7 (exported)
+          type: int
+          offset: 48
+        - name: data
+          type: '[128]uint8'
+          offset: 56

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -7,9 +7,9 @@
   ptrToThis: "0x00007420"
   struct:
     fields:
-    - name: a
-      type: int
-      offset: 0
+        - name: a
+          type: int
+          offset: 0
 - offset: "0x00020e60"
   size: 184
   kind: struct
@@ -19,27 +19,27 @@
   ptrToThis: "0x00007460"
   struct:
     fields:
-    - name: Field1 (exported)
-      type: int
-      offset: 0
-    - name: Field2 (exported)
-      type: int
-      offset: 8
-    - name: Field3 (exported)
-      type: int
-      offset: 16
-    - name: Field4 (exported)
-      type: int
-      offset: 24
-    - name: Field5 (exported)
-      type: int
-      offset: 32
-    - name: Field6 (exported)
-      type: int
-      offset: 40
-    - name: Field7 (exported)
-      type: int
-      offset: 48
-    - name: data
-      type: "[128]uint8"
-      offset: 56
+        - name: Field1 (exported)
+          type: int
+          offset: 0
+        - name: Field2 (exported)
+          type: int
+          offset: 8
+        - name: Field3 (exported)
+          type: int
+          offset: 16
+        - name: Field4 (exported)
+          type: int
+          offset: 24
+        - name: Field5 (exported)
+          type: int
+          offset: 32
+        - name: Field6 (exported)
+          type: int
+          offset: 40
+        - name: Field7 (exported)
+          type: int
+          offset: 48
+        - name: data
+          type: '[128]uint8'
+          offset: 56


### PR DESCRIPTION
It would appear that the yaml library, which was updated recently,
changed some options for marshaling. Some indentation for lists and
quoting for strings changed. This patch rewrites the files in the new
style.  I looked into taking control over these options; we can do it
only for the list intentation; I couldn't see a way to do it for the
strings, so I didn't bother doing it for either.