### PR TITLE
[CWS] capture panics on Windows

### DIFF
--- a/pkg/security/probe/probe_windows.go
+++ b/pkg/security/probe/probe_windows.go
@@ -10,7 +10,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -917,6 +919,17 @@ func (p *WindowsProbe) Start() error {
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				buf := make([]byte, 1<<20)
+				n := runtime.Stack(buf, true)
+				log.Criticalf("panic in event processing goroutine: %v\n%s", r, buf[:n])
+
+				time.Sleep(20 * time.Second)
+
+				os.Exit(2)
+			}
+		}()
 
 		for {
 			ev := p.zeroEvent()

--- a/pkg/security/rules/engine.go
+++ b/pkg/security/rules/engine.go
@@ -184,6 +184,17 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}) erro
 	e.wg.Add(1)
 	go func() {
 		defer e.wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				buf := make([]byte, 1<<20)
+				n := runtime.Stack(buf, true)
+				seclog.Errorf("panic in reloadChan ReloadPolicies goroutine: %v\n%s", r, buf[:n])
+
+				time.Sleep(20 * time.Second)
+
+				os.Exit(2)
+			}
+		}()
 
 		for range reloadChan {
 			if err := e.ReloadPolicies(); err != nil {
@@ -195,6 +206,17 @@ func (e *RuleEngine) Start(ctx context.Context, reloadChan <-chan struct{}) erro
 	e.wg.Add(1)
 	go func() {
 		defer e.wg.Done()
+		defer func() {
+			if r := recover(); r != nil {
+				buf := make([]byte, 1<<20)
+				n := runtime.Stack(buf, true)
+				seclog.Errorf("panic in NewPolicyReady ReloadPolicies goroutine: %v\n%s", r, buf[:n])
+
+				time.Sleep(20 * time.Second)
+
+				os.Exit(2)
+			}
+		}()
 
 		for range e.policyLoader.NewPolicyReady() {
 			if err := e.ReloadPolicies(); err != nil {


### PR DESCRIPTION
### What does this PR do?

On Windows, panic stack traces were not reported in the logs. This change captures and forwards the stack trace when a panic occurs.


### Motivation

### Describe how you validated your changes

### Additional Notes
