### PR TITLE
ci(renovate): Enable 7 day cooldown for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended"],
+    "extends": ["config:recommended", ":enablePreCommit"],
     "minimumReleaseAge": "7 days",
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
@@ -10,11 +10,13 @@
       {
         "matchDepNames": ["integrations-core"],
         "changelogUrl": "https://github.com/DataDog/integrations-core/compare/{{currentDigest}}..{{newDigest}}",
-        "schedule": ["* 2-6 * * 1,3"]
+        "schedule": ["* 2-6 * * 1,3"],
+        "minimumReleaseAge: null
       },
       {
         "matchDepNames": ["omnibus-ruby"],
         "changelogUrl": "https://github.com/DataDog/omnibus-ruby/compare/{{currentDigest}}..{{newDigest}}",
+        "minimumReleaseAge: null,
         "matchUpdateTypes": ["major", "minor", "patch"],
         "enabled": false
       },

--- a/renovate.json
+++ b/renovate.json
@@ -11,12 +11,12 @@
         "matchDepNames": ["integrations-core"],
         "changelogUrl": "https://github.com/DataDog/integrations-core/compare/{{currentDigest}}..{{newDigest}}",
         "schedule": ["* 2-6 * * 1,3"],
-        "minimumReleaseAge: null
+        "minimumReleaseAge": null
       },
       {
         "matchDepNames": ["omnibus-ruby"],
         "changelogUrl": "https://github.com/DataDog/omnibus-ruby/compare/{{currentDigest}}..{{newDigest}}",
-        "minimumReleaseAge: null,
+        "minimumReleaseAge": null,
         "matchUpdateTypes": ["major", "minor", "patch"],
         "enabled": false
       },

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "enabledManagers": ["custom.regex", "pre-commit", "github-actions", "dockerfile", "docker-compose", "cargo", "bazel-module"],
-    "minimumReleaseAge": "7 days",
+    "extends": ["config:recommended"],
+    "minimumReleaseAge": "2 days",
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
     "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
@@ -38,17 +38,6 @@
       {
         "matchManagers": ["github-actions"],
         "labels": ["dependencies", "dependencies-github-actions", "changelog/no-changelog", "qa/no-code-change"],
-        "schedule": ["on saturday"]
-      },
-      {
-        "matchManagers": ["dockerfile"],
-        "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
-        "schedule": ["on saturday"]
-      },
-      {
-        "matchManagers": ["docker-compose"],
-        "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
-        "schedule": ["on saturday"]
       },
       {
         "matchManagers": ["docker-compose"],
@@ -58,13 +47,26 @@
       {
         "matchManagers": ["cargo"],
         "labels": ["dependencies", "dependencies-cargo", "changelog/no-changelog", "qa/no-code-change"],
-        "schedule": ["on saturday"]
+      },
+      {
+        "matchManagers": ["npm"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["gomod"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["maven"],
+        "matchUpdateTypes": ["major", "minor"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["bazelisk"],
+        "matchUpdateTypes": ["major"],
+        "enabled": false
       }
     ],
-    "pre-commit": {
-      "enabled": true,
-      "managerFilePatterns": [".pre-commit-config.yaml"]
-    },
     "customManagers" : [
       {
         "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "enabledManagers": ["custom.regex", "pre-commit", "github-actions", "dockerfile", "docker-compose", "cargo", "bazel-module"],
+    "minimumReleaseAge": "7 days",
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
     "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended"],
-    "minimumReleaseAge": "2 days",
+    "minimumReleaseAge": "7 days",
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
     "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],


### PR DESCRIPTION
### What does this PR do?

- Add a 7d cooldown before any dependency update. This is a recommendation from security as a follow-up of #incident-51602
- Enable the recommended configuration, to not name all managers
- Remove the schedules on saturday, only the go deps will have this
- Disable gomod for now, will do a specific PR for this

### Motivation

Wait at least one week before update of dependencies. This cooldown prevents updating on a dependency whose latest version could be compromised

### Describe how you validated your changes

Configuration-only change. Validated against the [Renovate docs](https://docs.renovatebot.com/configuration-options/#separatemajorminor).

### Additional Notes

Renovate migration