### PR TITLE
Add UTOF models and report formatter

### DIFF
--- a/tasks/libs/testing/utof/__init__.py
+++ b/tasks/libs/testing/utof/__init__.py
@@ -1,0 +1,31 @@
+"""Unified Test Output Format (UTOF) — public API re-exports."""
+
+from tasks.libs.testing.utof.models import (
+    UTOFAttempt,
+    UTOFCIMetadata,
+    UTOFDocument,
+    UTOFEnvironmentMetadata,
+    UTOFFlaky,
+    UTOFGitMetadata,
+    UTOFLink,
+    UTOFMetadata,
+    UTOFSummary,
+    UTOFTestResult,
+)
+from tasks.libs.testing.utof.report import format_report
+
+__all__ = [
+    # models
+    "UTOFAttempt",
+    "UTOFCIMetadata",
+    "UTOFDocument",
+    "UTOFEnvironmentMetadata",
+    "UTOFFlaky",
+    "UTOFGitMetadata",
+    "UTOFLink",
+    "UTOFMetadata",
+    "UTOFSummary",
+    "UTOFTestResult",
+    # report
+    "format_report",
+]

--- a/tasks/libs/testing/utof/metadata.py
+++ b/tasks/libs/testing/utof/metadata.py
@@ -6,6 +6,8 @@ import os
 import platform
 from datetime import datetime, timezone
 
+from invoke import Context
+
 from tasks.libs.testing.utof.models import (
     UTOFCIMetadata,
     UTOFEnvironmentMetadata,
@@ -14,17 +16,26 @@ from tasks.libs.testing.utof.models import (
 )
 
 
-def generate_metadata(test_system: str, flavor: str = "") -> UTOFMetadata:
+def _git_value(ctx: Context, cmd: str) -> str:
+    """Run a git command via invoke and return its stripped stdout, or "" on failure."""
+    result = ctx.run(cmd, hide=True, warn=True)
+    if result and result.ok:
+        return result.stdout.strip()
+    return ""
+
+
+def generate_metadata(ctx: Context, test_system: str, flavor: str = "") -> UTOFMetadata:
     """Generate UTOF metadata from the current environment.
 
     Args:
+        ctx: Invoke context for running git commands locally.
         test_system: Identifies the test system (e.g. "unit", "e2e", "kmt", "smp").
         flavor: Optional agent flavor string.
     """
     git = UTOFGitMetadata(
-        branch=os.environ.get("CI_COMMIT_REF_NAME", ""),
-        commit_sha=os.environ.get("CI_COMMIT_SHA", ""),
-        commit_author=os.environ.get("CI_COMMIT_AUTHOR", ""),
+        branch=os.environ.get("CI_COMMIT_REF_NAME") or _git_value(ctx, "git rev-parse --abbrev-ref HEAD"),
+        commit_sha=os.environ.get("CI_COMMIT_SHA") or _git_value(ctx, "git rev-parse HEAD"),
+        commit_author=os.environ.get("CI_COMMIT_AUTHOR") or _git_value(ctx, "git log -1 --format='%aN <%aE>'"),
     )
     ci = UTOFCIMetadata(
         pipeline_id=os.environ.get("CI_PIPELINE_ID", ""),

--- a/tasks/libs/testing/utof/metadata.py
+++ b/tasks/libs/testing/utof/metadata.py
@@ -49,6 +49,8 @@ def generate_metadata(ctx: Context, test_system: str, flavor: str = "") -> UTOFM
         arch=platform.machine(),
         kernel=platform.version() if platform.system() == "Linux" else "",
         agent_flavor=flavor,
+        runner_cpu_request=os.environ.get("KUBERNETES_CPU_REQUEST", ""),
+        runner_memory_request=os.environ.get("KUBERNETES_MEMORY_REQUEST", ""),
     )
 
     return UTOFMetadata(

--- a/tasks/libs/testing/utof/metadata.py
+++ b/tasks/libs/testing/utof/metadata.py
@@ -1,0 +1,49 @@
+"""Shared UTOF metadata generation from the current CI/environment context."""
+
+from __future__ import annotations
+
+import os
+import platform
+from datetime import datetime, timezone
+
+from tasks.libs.testing.utof.models import (
+    UTOFCIMetadata,
+    UTOFEnvironmentMetadata,
+    UTOFGitMetadata,
+    UTOFMetadata,
+)
+
+
+def generate_metadata(test_system: str, flavor: str = "") -> UTOFMetadata:
+    """Generate UTOF metadata from the current environment.
+
+    Args:
+        test_system: Identifies the test system (e.g. "unit", "e2e", "kmt", "smp").
+        flavor: Optional agent flavor string.
+    """
+    git = UTOFGitMetadata(
+        branch=os.environ.get("CI_COMMIT_REF_NAME", ""),
+        commit_sha=os.environ.get("CI_COMMIT_SHA", ""),
+        commit_author=os.environ.get("CI_COMMIT_AUTHOR", ""),
+    )
+    ci = UTOFCIMetadata(
+        pipeline_id=os.environ.get("CI_PIPELINE_ID", ""),
+        job_id=os.environ.get("CI_JOB_ID", ""),
+        job_name=os.environ.get("CI_JOB_NAME", ""),
+        job_url=os.environ.get("CI_JOB_URL", ""),
+    )
+    env = UTOFEnvironmentMetadata(
+        os=platform.system(),
+        os_version=platform.release(),
+        arch=platform.machine(),
+        kernel=platform.version() if platform.system() == "Linux" else "",
+        agent_flavor=flavor,
+    )
+
+    return UTOFMetadata(
+        test_system=test_system,
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        git=git,
+        ci=ci,
+        environment=env,
+    )

--- a/tasks/libs/testing/utof/models.py
+++ b/tasks/libs/testing/utof/models.py
@@ -96,7 +96,6 @@ class UTOFTestResult:
     status: str = "pass"  # pass, fail, skip, flaky_pass, flaky_fail
     duration_seconds: float = 0.0
     retry_count: int = 0
-    failure: UTOFFailure | None = None
     flaky: UTOFFlaky | None = None
     attempts: list[UTOFAttempt] = field(default_factory=list)
     subtests: list[UTOFTestResult] | None = None

--- a/tasks/libs/testing/utof/models.py
+++ b/tasks/libs/testing/utof/models.py
@@ -29,7 +29,7 @@ class UTOFEnvironmentMetadata:
     os_version: str = ""
     arch: str = ""
     kernel: str = ""
-    runtime_version: str = ""
+    runtime_version: str = ""  # noqa: F841
     agent_flavor: str = ""
 
 

--- a/tasks/libs/testing/utof/models.py
+++ b/tasks/libs/testing/utof/models.py
@@ -31,6 +31,8 @@ class UTOFEnvironmentMetadata:
     kernel: str = ""
     runtime_version: str = ""  # noqa: F841
     agent_flavor: str = ""
+    runner_cpu_request: str = ""  # noqa: F841
+    runner_memory_request: str = ""  # noqa: F841
 
 
 @dataclass

--- a/tasks/libs/testing/utof/models.py
+++ b/tasks/libs/testing/utof/models.py
@@ -1,0 +1,131 @@
+"""UTOF dataclasses — pure data, no logic beyond serialization."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass
+class UTOFGitMetadata:
+    branch: str = ""
+    commit_sha: str = ""
+    commit_author: str = ""  # noqa: F841
+    base_branch: str = ""
+    base_sha: str = ""  # noqa: F841
+
+
+@dataclass
+class UTOFCIMetadata:
+    pipeline_id: str = ""
+    job_id: str = ""
+    job_name: str = ""
+    job_url: str = ""
+
+
+@dataclass
+class UTOFEnvironmentMetadata:
+    os: str = ""
+    os_version: str = ""
+    arch: str = ""
+    kernel: str = ""
+    go_version: str = ""
+    agent_flavor: str = ""
+
+
+@dataclass
+class UTOFMetadata:
+    test_system: str = "unit"
+    timestamp: str = ""
+    duration_seconds: float = 0.0
+    git: UTOFGitMetadata = field(default_factory=UTOFGitMetadata)
+    ci: UTOFCIMetadata = field(default_factory=UTOFCIMetadata)
+    environment: UTOFEnvironmentMetadata = field(default_factory=UTOFEnvironmentMetadata)
+    build_tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class UTOFSummary:
+    total: int = 0
+    passed: int = 0
+    failed: int = 0
+    skipped: int = 0
+    flaky: int = 0
+    retried: int = 0  # noqa: F841
+    status: str = "pass"
+
+
+@dataclass
+class UTOFFailure:
+    message: str = ""
+    type: str = ""  # assertion, panic, timeout, build
+    stacktrace: str = ""
+    raw_output: str = ""  # noqa: F841
+
+
+@dataclass
+class UTOFFlaky:
+    is_known_flaky: bool = False
+    source: str = ""  # "marker", "washer", "log_pattern"
+    pattern: str = ""
+
+
+@dataclass
+class UTOFAttempt:
+    """A single execution attempt of a test."""
+
+    attempt: int = 1
+    status: str = "pass"  # pass, fail
+    duration_seconds: float = 0.0
+    failure: UTOFFailure | None = None
+
+
+@dataclass
+class UTOFTestResult:
+    id: str = ""
+    name: str = ""
+    full_name: str = ""  # original test2json name, e.g. "TestSketch/useStore=true/empty_flush"
+    package: str = ""
+    suite: str = ""
+    type: str = "unit"
+    status: str = "pass"  # pass, fail, skip, flaky_pass, flaky_fail
+    duration_seconds: float = 0.0
+    retry_count: int = 0
+    failure: UTOFFailure | None = None
+    flaky: UTOFFlaky | None = None
+    attempts: list[UTOFAttempt] = field(default_factory=list)
+    subtests: list[UTOFTestResult] | None = None
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class UTOFLink:
+    label: str = ""
+    url: str = ""
+
+
+@dataclass
+class UTOFDocument:
+    version: str = "1.0.0"
+    metadata: UTOFMetadata = field(default_factory=UTOFMetadata)
+    summary: UTOFSummary = field(default_factory=UTOFSummary)
+    tests: list[UTOFTestResult] = field(default_factory=list)
+    links: list[UTOFLink] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        """Convert the document to a dictionary, stripping None values."""
+        return _strip_none(asdict(self))
+
+    def write_json(self, path: str) -> None:
+        """Write the document as formatted JSON to the given path."""
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+
+def _strip_none(obj):
+    """Recursively remove keys with None or empty-list values from dicts."""
+    if isinstance(obj, dict):
+        return {k: _strip_none(v) for k, v in obj.items() if v is not None and v != []}
+    if isinstance(obj, list):
+        return [_strip_none(item) for item in obj]
+    return obj

--- a/tasks/libs/testing/utof/models.py
+++ b/tasks/libs/testing/utof/models.py
@@ -29,7 +29,7 @@ class UTOFEnvironmentMetadata:
     os_version: str = ""
     arch: str = ""
     kernel: str = ""
-    go_version: str = ""
+    runtime_version: str = ""
     agent_flavor: str = ""
 
 
@@ -58,9 +58,14 @@ class UTOFSummary:
 @dataclass
 class UTOFFailure:
     message: str = ""
-    type: str = ""  # assertion, panic, timeout, build
+    type: str = ""  # assertion, panic, timeout, build, infrastructure
     stacktrace: str = ""
     raw_output: str = ""  # noqa: F841
+    # True when the failure originates from a direct assertion on this test.
+    # False when it is inferred/propagated from child test failures.
+    # Consumers can use this to avoid rendering redundant failure details on
+    # parent nodes that are already explained by their children.
+    direct: bool = False
 
 
 @dataclass
@@ -84,7 +89,7 @@ class UTOFAttempt:
 class UTOFTestResult:
     id: str = ""
     name: str = ""
-    full_name: str = ""  # original test2json name, e.g. "TestSketch/useStore=true/empty_flush"
+    full_name: str = ""  # original fully-qualified test name, e.g. "TestSketch/useStore=true/empty_flush"
     package: str = ""
     suite: str = ""
     type: str = "unit"

--- a/tasks/libs/testing/utof/report.py
+++ b/tasks/libs/testing/utof/report.py
@@ -1,0 +1,264 @@
+"""Human-readable colored report formatter for UTOF documents."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from tasks.libs.common.color import color_message
+from tasks.libs.testing.utof.models import UTOFDocument, UTOFFailure, UTOFTestResult
+
+
+def _short_package(package: str) -> str:
+    """Strip the common github.com/DataDog/datadog-agent/ prefix."""
+    prefix = "github.com/DataDog/datadog-agent/"
+    return package[len(prefix) :] if package.startswith(prefix) else package
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds < 1:
+        return f"{seconds * 1000:.0f}ms"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = int(seconds) // 60
+    secs = seconds - minutes * 60
+    return f"{minutes}m{secs:.0f}s"
+
+
+def _indent(text: str, prefix: str = "    ") -> str:
+    return "\n".join(f"{prefix}{line}" for line in text.splitlines())
+
+
+def _status_badge(status: str) -> str:
+    """Return a colored status badge for display."""
+    badges = {
+        "pass": color_message(" PASS ", "green"),
+        "fail": color_message(" FAIL ", "red"),
+        "skip": color_message(" SKIP ", "grey"),
+        "flaky_pass": color_message(" FLAKY PASS ", "orange"),
+        "flaky_fail": color_message(" FLAKY FAIL ", "orange"),
+    }
+    return badges.get(status, status.upper())
+
+
+def _render_failure(failure: UTOFFailure, prefix: str) -> list[str]:
+    """Render a failure block as indented lines.
+
+    For assertion failures the file locations are already embedded in the
+    message (e.g. "[1] value_test.go:62: ..."), so we only show the
+    stacktrace for panics where it contains a goroutine trace.
+
+    When a failure has no message and isn't a panic, it's just Go
+    propagating a subtest failure to the parent — skip it entirely.
+    """
+    if not failure.message and failure.type != "panic":
+        return []
+    out: list[str] = []
+    if failure.type:
+        out.append(color_message(f"{prefix}type: {failure.type}", "grey"))
+    if failure.message:
+        for msg_line in failure.message.splitlines():
+            out.append(f"{prefix}{msg_line}")
+    # Only show stacktrace for panics — assertion locations are in the message
+    if failure.type == "panic" and failure.stacktrace:
+        out.append(color_message(_indent(failure.stacktrace, prefix), "grey"))
+    return out
+
+
+def _has_matching_descendant(t: UTOFTestResult, predicate: Callable[[UTOFTestResult], bool]) -> bool:
+    """Check if test or any of its subtests (recursively) match the predicate."""
+    if predicate(t):
+        return True
+    if t.subtests:
+        return any(_has_matching_descendant(sub, predicate) for sub in t.subtests)
+    return False
+
+
+def _collect_all_tests(tests: list[UTOFTestResult]) -> list[UTOFTestResult]:
+    """Flatten a tree of tests into a single list (for backward-compat counting)."""
+    result: list[UTOFTestResult] = []
+
+    def _walk(t: UTOFTestResult):
+        result.append(t)
+        if t.subtests:
+            for sub in t.subtests:
+                _walk(sub)
+
+    for t in tests:
+        _walk(t)
+    return result
+
+
+def _render_subtests(
+    subtests: list[UTOFTestResult],
+    predicate: Callable[[UTOFTestResult], bool],
+    depth: int,
+    render_fn: Callable[[UTOFTestResult, int], list[str]],
+) -> list[str]:
+    """Render matching subtests recursively with tree indentation."""
+    out: list[str] = []
+    matching = [s for s in subtests if _has_matching_descendant(s, predicate)]
+    for sub in matching:
+        out.extend(render_fn(sub, depth))
+    return out
+
+
+def format_report(doc: UTOFDocument) -> str:
+    """Produce a human-friendly, color-coded text report from a UTOF document.
+
+    Designed to be printed in CI logs. Sections are ordered by
+    severity: failures first, then retried tests, then flaky, then
+    a compact summary. Uses ANSI colors to make failures immediately
+    visible in terminal / CI output.
+    """
+    lines: list[str] = []
+    s = doc.summary
+
+    # -- Header --
+    separator = "=" * 60
+    if s.status == "pass":
+        title = f"  Test Report ({doc.metadata.test_system}) — PASSED  "
+        lines.append(color_message(separator, "green"))
+        lines.append(color_message(title, "green"))
+        lines.append(color_message(separator, "green"))
+    else:
+        title = f"  Test Report ({doc.metadata.test_system}) — FAILED  "
+        lines.append(color_message(separator, "red"))
+        lines.append(color_message(title, "red"))
+        lines.append(color_message(separator, "red"))
+    lines.append("")
+
+    # -- Summary bar --
+    parts = [color_message(f"{s.total} total", "bold")]
+    if s.passed:
+        parts.append(color_message(f"{s.passed} passed", "green"))
+    if s.failed:
+        parts.append(color_message(f"{s.failed} failed", "red"))
+    if s.skipped:
+        parts.append(color_message(f"{s.skipped} skipped", "grey"))
+    if s.flaky:
+        parts.append(color_message(f"{s.flaky} flaky", "orange"))
+    if s.retried:
+        parts.append(color_message(f"{s.retried} retried", "orange"))
+    if doc.metadata.duration_seconds:
+        parts.append(f"in {_format_duration(doc.metadata.duration_seconds)}")
+    lines.append("  ".join(parts))
+    lines.append("")
+
+    # -- Helper to render a test entry with subtests --
+    def _tree_prefix(depth: int) -> str:
+        return "    " * depth + "└─ " if depth > 0 else "  "
+
+    def _failure_prefix(depth: int) -> str:
+        return "    " * depth + "         "
+
+    # -- Failed tests --
+    def fail_pred(t: UTOFTestResult) -> bool:
+        return t.status == "fail"
+
+    all_tests = _collect_all_tests(doc.tests)
+    fail_count = sum(1 for t in all_tests if fail_pred(t) and not t.subtests)
+    failed_roots = [t for t in doc.tests if _has_matching_descendant(t, fail_pred)]
+    if failed_roots:
+
+        def _render_failed(t: UTOFTestResult, depth: int = 0) -> list[str]:
+            out: list[str] = []
+            prefix = _tree_prefix(depth)
+            fp = _failure_prefix(depth)
+            badge = _status_badge(t.status)
+            if depth == 0:
+                name = color_message(f"{_short_package(t.package)} :: {t.name}", "bold")
+            else:
+                name = color_message(t.name, "bold")
+            out.append(f"{prefix}{badge}  {name}")
+            if t.failure:
+                out.extend(_render_failure(t.failure, fp))
+            if t.subtests:
+                out.extend(_render_subtests(t.subtests, fail_pred, depth + 1, _render_failed))
+            return out
+
+        lines.append(color_message(f"--- Failures ({fail_count}) ---", "red"))
+        lines.append("")
+        for t in failed_roots:
+            lines.extend(_render_failed(t))
+        lines.append("")
+
+    # -- Retried tests --
+    def retry_pred(t: UTOFTestResult) -> bool:
+        return t.retry_count > 0
+
+    retry_count = sum(1 for t in all_tests if retry_pred(t) and not t.subtests)
+    retried_roots = [t for t in doc.tests if _has_matching_descendant(t, retry_pred)]
+    if retried_roots:
+
+        def _render_retried(t: UTOFTestResult, depth: int = 0) -> list[str]:
+            out: list[str] = []
+            prefix = _tree_prefix(depth)
+            fp = _failure_prefix(depth)
+            badge = _status_badge(t.status)
+            if depth == 0:
+                name = color_message(f"{_short_package(t.package)} :: {t.name}", "bold")
+            else:
+                name = color_message(t.name, "bold")
+            if t.retry_count > 0:
+                retry_info = color_message(f"({t.retry_count} retry, final: {t.status})", "grey")
+                out.append(f"{prefix}{badge}  {name}  {retry_info}")
+                # Skip per-attempt detail on parent tests — subtests show their own
+                if not t.subtests:
+                    if t.attempts:
+                        for a in t.attempts:
+                            if a.status == "fail":
+                                marker = color_message("[x]", "red")
+                                attempt_status = color_message(f"attempt {a.attempt}: fail", "red")
+                            else:
+                                marker = color_message("[v]", "green")
+                                attempt_status = color_message(f"attempt {a.attempt}: pass", "green")
+                            dur = color_message(f"({_format_duration(a.duration_seconds)})", "grey")
+                            out.append(f"{fp}{marker} {attempt_status} {dur}")
+                            if a.failure:
+                                out.extend(_render_failure(a.failure, fp + "     "))
+                    elif t.failure and t.failure.message:
+                        out.append(f"{fp}initial failure: {t.failure.message}")
+            else:
+                out.append(f"{prefix}{badge}  {name}")
+            if t.subtests:
+                out.extend(_render_subtests(t.subtests, retry_pred, depth + 1, _render_retried))
+            return out
+
+        lines.append(color_message(f"--- Retried ({retry_count}) ---", "orange"))
+        lines.append("")
+        for t in retried_roots:
+            lines.extend(_render_retried(t))
+        lines.append("")
+
+    # -- Flaky tests (not already shown above) --
+    def flaky_pred(t: UTOFTestResult) -> bool:
+        return t.status in ("flaky_pass", "flaky_fail") and t.retry_count == 0
+
+    flaky_count = sum(1 for t in all_tests if flaky_pred(t) and not t.subtests)
+    flaky_roots = [t for t in doc.tests if _has_matching_descendant(t, flaky_pred)]
+    if flaky_roots:
+
+        def _render_flaky(t: UTOFTestResult, depth: int = 0) -> list[str]:
+            out: list[str] = []
+            prefix = _tree_prefix(depth)
+            fp = _failure_prefix(depth)
+            badge = _status_badge(t.status)
+            if depth == 0:
+                name = color_message(f"{_short_package(t.package)} :: {t.name}", "bold")
+            else:
+                name = color_message(t.name, "bold")
+            source = color_message(f"(source: {t.flaky.source})", "grey") if t.flaky else ""
+            out.append(f"{prefix}{badge}  {name}  {source}")
+            if t.failure:
+                out.extend(_render_failure(t.failure, fp))
+            if t.subtests:
+                out.extend(_render_subtests(t.subtests, flaky_pred, depth + 1, _render_flaky))
+            return out
+
+        lines.append(color_message(f"--- Flaky ({flaky_count}) ---", "orange"))
+        lines.append("")
+        for t in flaky_roots:
+            lines.extend(_render_flaky(t))
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tasks/libs/testing/utof/report.py
+++ b/tasks/libs/testing/utof/report.py
@@ -40,6 +40,23 @@ def _status_badge(status: str) -> str:
     return badges.get(status, status.upper())
 
 
+def _get_test_failure(t: UTOFTestResult) -> UTOFFailure | None:
+    """Resolve the most relevant failure for a test from its attempts list.
+
+    For a final fail: the last failed attempt's failure (most recent signal).
+    For a pass/flaky after retries: the first failed attempt's failure (initial cause).
+    """
+    if t.status == "fail":
+        for attempt in reversed(t.attempts):
+            if attempt.status == "fail" and attempt.failure:
+                return attempt.failure
+    else:
+        for attempt in t.attempts:
+            if attempt.status == "fail" and attempt.failure:
+                return attempt.failure
+    return None
+
+
 def _render_failure(failure: UTOFFailure, prefix: str) -> list[str]:
     """Render a failure block as indented lines.
 
@@ -175,8 +192,9 @@ def format_report(doc: UTOFDocument) -> str:
             # A direct assertion (testify blocks, panic, infrastructure) on the
             # parent must always be shown even when subtests also failed.
             has_failing_subtests = t.subtests and any(_has_matching_descendant(s, fail_pred) for s in t.subtests)
-            if t.failure and (not has_failing_subtests or t.failure.direct):
-                out.extend(_render_failure(t.failure, fp))
+            failure = _get_test_failure(t)
+            if failure and (not has_failing_subtests or failure.direct):
+                out.extend(_render_failure(failure, fp))
             if t.subtests:
                 out.extend(_render_subtests(t.subtests, fail_pred, depth + 1, _render_failed))
             return out
@@ -209,20 +227,17 @@ def format_report(doc: UTOFDocument) -> str:
                 out.append(f"{prefix}{badge}  {name}  {retry_info}")
                 # Skip per-attempt detail on parent tests — subtests show their own
                 if not t.subtests:
-                    if t.attempts:
-                        for a in t.attempts:
-                            if a.status == "fail":
-                                marker = color_message("[x]", "red")
-                                attempt_status = color_message(f"attempt {a.attempt}: fail", "red")
-                            else:
-                                marker = color_message("[v]", "green")
-                                attempt_status = color_message(f"attempt {a.attempt}: pass", "green")
-                            dur = color_message(f"({_format_duration(a.duration_seconds)})", "grey")
-                            out.append(f"{fp}{marker} {attempt_status} {dur}")
-                            if a.failure:
-                                out.extend(_render_failure(a.failure, fp + "     "))
-                    elif t.failure and t.failure.message:
-                        out.append(f"{fp}initial failure: {t.failure.message}")
+                    for a in t.attempts:
+                        if a.status == "fail":
+                            marker = color_message("[x]", "red")
+                            attempt_status = color_message(f"attempt {a.attempt}: fail", "red")
+                        else:
+                            marker = color_message("[v]", "green")
+                            attempt_status = color_message(f"attempt {a.attempt}: pass", "green")
+                        dur = color_message(f"({_format_duration(a.duration_seconds)})", "grey")
+                        out.append(f"{fp}{marker} {attempt_status} {dur}")
+                        if a.failure:
+                            out.extend(_render_failure(a.failure, fp + "     "))
             else:
                 out.append(f"{prefix}{badge}  {name}")
             if t.subtests:
@@ -255,8 +270,9 @@ def format_report(doc: UTOFDocument) -> str:
             source = color_message(f"(source: {t.flaky.source})", "grey") if t.flaky else ""
             out.append(f"{prefix}{badge}  {name}  {source}")
             has_flaky_subtests = t.subtests and any(_has_matching_descendant(s, flaky_pred) for s in t.subtests)
-            if t.failure and (not has_flaky_subtests or t.failure.direct):
-                out.extend(_render_failure(t.failure, fp))
+            failure = _get_test_failure(t)
+            if failure and (not has_flaky_subtests or failure.direct):
+                out.extend(_render_failure(failure, fp))
             if t.subtests:
                 out.extend(_render_subtests(t.subtests, flaky_pred, depth + 1, _render_flaky))
             return out

--- a/tasks/libs/testing/utof/report.py
+++ b/tasks/libs/testing/utof/report.py
@@ -35,7 +35,7 @@ def _status_badge(status: str) -> str:
         "fail": color_message(" FAIL ", "red"),
         "skip": color_message(" SKIP ", "grey"),
         "flaky_pass": color_message(" FLAKY PASS ", "orange"),
-        "flaky_fail": color_message(" FLAKY FAIL ", "orange"),
+        "flaky_fail": color_message(" FLAKY FAIL ", "magenta"),
     }
     return badges.get(status, status.upper())
 

--- a/tasks/libs/testing/utof/report.py
+++ b/tasks/libs/testing/utof/report.py
@@ -90,21 +90,6 @@ def _has_matching_descendant(t: UTOFTestResult, predicate: Callable[[UTOFTestRes
     return False
 
 
-def _collect_all_tests(tests: list[UTOFTestResult]) -> list[UTOFTestResult]:
-    """Flatten a tree of tests into a single list (for backward-compat counting)."""
-    result: list[UTOFTestResult] = []
-
-    def _walk(t: UTOFTestResult):
-        result.append(t)
-        if t.subtests:
-            for sub in t.subtests:
-                _walk(sub)
-
-    for t in tests:
-        _walk(t)
-    return result
-
-
 def _render_subtests(
     subtests: list[UTOFTestResult],
     predicate: Callable[[UTOFTestResult], bool],
@@ -116,6 +101,94 @@ def _render_subtests(
     matching = [s for s in subtests if _has_matching_descendant(s, predicate)]
     for sub in matching:
         out.extend(render_fn(sub, depth))
+    return out
+
+
+def _tree_prefix(depth: int) -> str:
+    return "    " * depth + "└─ " if depth > 0 else "  "
+
+
+def _failure_prefix(depth: int) -> str:
+    return "    " * depth + "         "
+
+
+def _test_name(t: UTOFTestResult, depth: int) -> str:
+    if depth == 0:
+        return color_message(f"{_short_package(t.package)} :: {t.name}", "bold")
+    return color_message(t.name, "bold")
+
+
+def _fail_pred(t: UTOFTestResult) -> bool:
+    return t.status == "fail"
+
+
+def _retry_pred(t: UTOFTestResult) -> bool:
+    return t.retry_count > 0
+
+
+def _flaky_pred(t: UTOFTestResult) -> bool:
+    return t.status in ("flaky_pass", "flaky_fail") and t.retry_count == 0
+
+
+def _render_failed(t: UTOFTestResult, depth: int = 0) -> list[str]:
+    out: list[str] = []
+    prefix = _tree_prefix(depth)
+    fp = _failure_prefix(depth)
+    out.append(f"{prefix}{_status_badge(t.status)}  {_test_name(t, depth)}")
+    # Suppress parent failure when subtests already explain the cause,
+    # but only if the failure is inferred (not a direct assertion).
+    # A direct assertion (testify blocks, panic, infrastructure) on the
+    # parent must always be shown even when subtests also failed.
+    has_failing_subtests = t.subtests and any(_has_matching_descendant(s, _fail_pred) for s in t.subtests)
+    failure = _get_test_failure(t)
+    if failure and (not has_failing_subtests or failure.direct):
+        out.extend(_render_failure(failure, fp))
+    if t.subtests:
+        out.extend(_render_subtests(t.subtests, _fail_pred, depth + 1, _render_failed))
+    return out
+
+
+def _render_retried(t: UTOFTestResult, depth: int = 0) -> list[str]:
+    out: list[str] = []
+    prefix = _tree_prefix(depth)
+    fp = _failure_prefix(depth)
+    name = _test_name(t, depth)
+    badge = _status_badge(t.status)
+    if t.retry_count > 0:
+        retry_info = color_message(f"({t.retry_count} retry, final: {t.status})", "grey")
+        out.append(f"{prefix}{badge}  {name}  {retry_info}")
+        if not t.subtests:
+            for a in t.attempts:
+                if a.status == "fail":
+                    marker = color_message("[x]", "red")
+                    attempt_status = color_message(f"attempt {a.attempt}: fail", "red")
+                else:
+                    marker = color_message("[v]", "green")
+                    attempt_status = color_message(f"attempt {a.attempt}: pass", "green")
+                dur = color_message(f"({_format_duration(a.duration_seconds)})", "grey")
+                out.append(f"{fp}{marker} {attempt_status} {dur}")
+                if a.failure:
+                    out.extend(_render_failure(a.failure, fp + "     "))
+    else:
+        out.append(f"{prefix}{badge}  {name}")
+    if t.subtests:
+        out.extend(_render_subtests(t.subtests, _retry_pred, depth + 1, _render_retried))
+    return out
+
+
+def _render_flaky(t: UTOFTestResult, depth: int = 0) -> list[str]:
+    out: list[str] = []
+    prefix = _tree_prefix(depth)
+    fp = _failure_prefix(depth)
+    name = _test_name(t, depth)
+    source = color_message(f"(source: {t.flaky.source})", "grey") if t.flaky else ""
+    out.append(f"{prefix}{_status_badge(t.status)}  {name}  {source}")
+    has_flaky_subtests = t.subtests and any(_has_matching_descendant(s, _flaky_pred) for s in t.subtests)
+    failure = _get_test_failure(t)
+    if failure and (not has_flaky_subtests or failure.direct):
+        out.extend(_render_failure(failure, fp))
+    if t.subtests:
+        out.extend(_render_subtests(t.subtests, _flaky_pred, depth + 1, _render_flaky))
     return out
 
 
@@ -161,123 +234,28 @@ def format_report(doc: UTOFDocument) -> str:
     lines.append("  ".join(parts))
     lines.append("")
 
-    # -- Helper to render a test entry with subtests --
-    def _tree_prefix(depth: int) -> str:
-        return "    " * depth + "└─ " if depth > 0 else "  "
-
-    def _failure_prefix(depth: int) -> str:
-        return "    " * depth + "         "
-
     # -- Failed tests --
-    def fail_pred(t: UTOFTestResult) -> bool:
-        return t.status == "fail"
-
-    all_tests = _collect_all_tests(doc.tests)
-    fail_count = sum(1 for t in all_tests if fail_pred(t) and not t.subtests)
-    failed_roots = [t for t in doc.tests if _has_matching_descendant(t, fail_pred)]
+    failed_roots = [t for t in doc.tests if _has_matching_descendant(t, _fail_pred)]
     if failed_roots:
-
-        def _render_failed(t: UTOFTestResult, depth: int = 0) -> list[str]:
-            out: list[str] = []
-            prefix = _tree_prefix(depth)
-            fp = _failure_prefix(depth)
-            badge = _status_badge(t.status)
-            if depth == 0:
-                name = color_message(f"{_short_package(t.package)} :: {t.name}", "bold")
-            else:
-                name = color_message(t.name, "bold")
-            out.append(f"{prefix}{badge}  {name}")
-            # Suppress parent failure when subtests already explain the cause,
-            # but only if the failure is inferred (not a direct assertion).
-            # A direct assertion (testify blocks, panic, infrastructure) on the
-            # parent must always be shown even when subtests also failed.
-            has_failing_subtests = t.subtests and any(_has_matching_descendant(s, fail_pred) for s in t.subtests)
-            failure = _get_test_failure(t)
-            if failure and (not has_failing_subtests or failure.direct):
-                out.extend(_render_failure(failure, fp))
-            if t.subtests:
-                out.extend(_render_subtests(t.subtests, fail_pred, depth + 1, _render_failed))
-            return out
-
-        lines.append(color_message(f"--- Failures ({fail_count}) ---", "red"))
+        lines.append(color_message(f"--- Failures ({s.failed}) ---", "red"))
         lines.append("")
         for t in failed_roots:
             lines.extend(_render_failed(t))
         lines.append("")
 
     # -- Retried tests --
-    def retry_pred(t: UTOFTestResult) -> bool:
-        return t.retry_count > 0
-
-    retry_count = sum(1 for t in all_tests if retry_pred(t) and not t.subtests)
-    retried_roots = [t for t in doc.tests if _has_matching_descendant(t, retry_pred)]
+    retried_roots = [t for t in doc.tests if _has_matching_descendant(t, _retry_pred)]
     if retried_roots:
-
-        def _render_retried(t: UTOFTestResult, depth: int = 0) -> list[str]:
-            out: list[str] = []
-            prefix = _tree_prefix(depth)
-            fp = _failure_prefix(depth)
-            badge = _status_badge(t.status)
-            if depth == 0:
-                name = color_message(f"{_short_package(t.package)} :: {t.name}", "bold")
-            else:
-                name = color_message(t.name, "bold")
-            if t.retry_count > 0:
-                retry_info = color_message(f"({t.retry_count} retry, final: {t.status})", "grey")
-                out.append(f"{prefix}{badge}  {name}  {retry_info}")
-                # Skip per-attempt detail on parent tests — subtests show their own
-                if not t.subtests:
-                    for a in t.attempts:
-                        if a.status == "fail":
-                            marker = color_message("[x]", "red")
-                            attempt_status = color_message(f"attempt {a.attempt}: fail", "red")
-                        else:
-                            marker = color_message("[v]", "green")
-                            attempt_status = color_message(f"attempt {a.attempt}: pass", "green")
-                        dur = color_message(f"({_format_duration(a.duration_seconds)})", "grey")
-                        out.append(f"{fp}{marker} {attempt_status} {dur}")
-                        if a.failure:
-                            out.extend(_render_failure(a.failure, fp + "     "))
-            else:
-                out.append(f"{prefix}{badge}  {name}")
-            if t.subtests:
-                out.extend(_render_subtests(t.subtests, retry_pred, depth + 1, _render_retried))
-            return out
-
-        lines.append(color_message(f"--- Retried ({retry_count}) ---", "orange"))
+        lines.append(color_message(f"--- Retried ({s.retried}) ---", "orange"))
         lines.append("")
         for t in retried_roots:
             lines.extend(_render_retried(t))
         lines.append("")
 
     # -- Flaky tests (not already shown above) --
-    def flaky_pred(t: UTOFTestResult) -> bool:
-        return t.status in ("flaky_pass", "flaky_fail") and t.retry_count == 0
-
-    flaky_count = sum(1 for t in all_tests if flaky_pred(t) and not t.subtests)
-    flaky_roots = [t for t in doc.tests if _has_matching_descendant(t, flaky_pred)]
+    flaky_roots = [t for t in doc.tests if _has_matching_descendant(t, _flaky_pred)]
     if flaky_roots:
-
-        def _render_flaky(t: UTOFTestResult, depth: int = 0) -> list[str]:
-            out: list[str] = []
-            prefix = _tree_prefix(depth)
-            fp = _failure_prefix(depth)
-            badge = _status_badge(t.status)
-            if depth == 0:
-                name = color_message(f"{_short_package(t.package)} :: {t.name}", "bold")
-            else:
-                name = color_message(t.name, "bold")
-            source = color_message(f"(source: {t.flaky.source})", "grey") if t.flaky else ""
-            out.append(f"{prefix}{badge}  {name}  {source}")
-            has_flaky_subtests = t.subtests and any(_has_matching_descendant(s, flaky_pred) for s in t.subtests)
-            failure = _get_test_failure(t)
-            if failure and (not has_flaky_subtests or failure.direct):
-                out.extend(_render_failure(failure, fp))
-            if t.subtests:
-                out.extend(_render_subtests(t.subtests, flaky_pred, depth + 1, _render_flaky))
-            return out
-
-        lines.append(color_message(f"--- Flaky ({flaky_count}) ---", "orange"))
+        lines.append(color_message(f"--- Flaky ({s.flaky}) ---", "orange"))
         lines.append("")
         for t in flaky_roots:
             lines.extend(_render_flaky(t))

--- a/tasks/libs/testing/utof/report.py
+++ b/tasks/libs/testing/utof/report.py
@@ -156,7 +156,7 @@ def format_report(doc: UTOFDocument) -> str:
         return t.status == "fail"
 
     all_tests = _collect_all_tests(doc.tests)
-    fail_count = sum(1 for t in all_tests if fail_pred(t) and (not t.subtests or t.failure is not None))
+    fail_count = sum(1 for t in all_tests if fail_pred(t) and not t.subtests)
     failed_roots = [t for t in doc.tests if _has_matching_descendant(t, fail_pred)]
     if failed_roots:
 
@@ -170,7 +170,12 @@ def format_report(doc: UTOFDocument) -> str:
             else:
                 name = color_message(t.name, "bold")
             out.append(f"{prefix}{badge}  {name}")
-            if t.failure:
+            # Suppress parent failure when subtests already explain the cause,
+            # but only if the failure is inferred (not a direct assertion).
+            # A direct assertion (testify blocks, panic, infrastructure) on the
+            # parent must always be shown even when subtests also failed.
+            has_failing_subtests = t.subtests and any(_has_matching_descendant(s, fail_pred) for s in t.subtests)
+            if t.failure and (not has_failing_subtests or t.failure.direct):
                 out.extend(_render_failure(t.failure, fp))
             if t.subtests:
                 out.extend(_render_subtests(t.subtests, fail_pred, depth + 1, _render_failed))
@@ -186,7 +191,7 @@ def format_report(doc: UTOFDocument) -> str:
     def retry_pred(t: UTOFTestResult) -> bool:
         return t.retry_count > 0
 
-    retry_count = sum(1 for t in all_tests if retry_pred(t) and (not t.subtests or t.failure is not None))
+    retry_count = sum(1 for t in all_tests if retry_pred(t) and not t.subtests)
     retried_roots = [t for t in doc.tests if _has_matching_descendant(t, retry_pred)]
     if retried_roots:
 
@@ -234,7 +239,7 @@ def format_report(doc: UTOFDocument) -> str:
     def flaky_pred(t: UTOFTestResult) -> bool:
         return t.status in ("flaky_pass", "flaky_fail") and t.retry_count == 0
 
-    flaky_count = sum(1 for t in all_tests if flaky_pred(t) and (not t.subtests or t.failure is not None))
+    flaky_count = sum(1 for t in all_tests if flaky_pred(t) and not t.subtests)
     flaky_roots = [t for t in doc.tests if _has_matching_descendant(t, flaky_pred)]
     if flaky_roots:
 
@@ -249,7 +254,8 @@ def format_report(doc: UTOFDocument) -> str:
                 name = color_message(t.name, "bold")
             source = color_message(f"(source: {t.flaky.source})", "grey") if t.flaky else ""
             out.append(f"{prefix}{badge}  {name}  {source}")
-            if t.failure:
+            has_flaky_subtests = t.subtests and any(_has_matching_descendant(s, flaky_pred) for s in t.subtests)
+            if t.failure and (not has_flaky_subtests or t.failure.direct):
                 out.extend(_render_failure(t.failure, fp))
             if t.subtests:
                 out.extend(_render_subtests(t.subtests, flaky_pred, depth + 1, _render_flaky))

--- a/tasks/libs/testing/utof/report.py
+++ b/tasks/libs/testing/utof/report.py
@@ -44,13 +44,13 @@ def _render_failure(failure: UTOFFailure, prefix: str) -> list[str]:
     """Render a failure block as indented lines.
 
     For assertion failures the file locations are already embedded in the
-    message (e.g. "[1] value_test.go:62: ..."), so we only show the
-    stacktrace for panics where it contains a goroutine trace.
+    message, so we only show the stacktrace for panics where it contains
+    a runtime crash trace.
 
-    When a failure has no message and isn't a panic, it's just Go
-    propagating a subtest failure to the parent — skip it entirely.
+    When a failure has no message and no type, the failure carries no
+    useful diagnostic information — skip it entirely.
     """
-    if not failure.message and failure.type != "panic":
+    if not failure.message and not failure.type:
         return []
     out: list[str] = []
     if failure.type:

--- a/tasks/libs/testing/utof/report.py
+++ b/tasks/libs/testing/utof/report.py
@@ -156,7 +156,7 @@ def format_report(doc: UTOFDocument) -> str:
         return t.status == "fail"
 
     all_tests = _collect_all_tests(doc.tests)
-    fail_count = sum(1 for t in all_tests if fail_pred(t) and not t.subtests)
+    fail_count = sum(1 for t in all_tests if fail_pred(t) and (not t.subtests or t.failure is not None))
     failed_roots = [t for t in doc.tests if _has_matching_descendant(t, fail_pred)]
     if failed_roots:
 
@@ -186,7 +186,7 @@ def format_report(doc: UTOFDocument) -> str:
     def retry_pred(t: UTOFTestResult) -> bool:
         return t.retry_count > 0
 
-    retry_count = sum(1 for t in all_tests if retry_pred(t) and not t.subtests)
+    retry_count = sum(1 for t in all_tests if retry_pred(t) and (not t.subtests or t.failure is not None))
     retried_roots = [t for t in doc.tests if _has_matching_descendant(t, retry_pred)]
     if retried_roots:
 
@@ -234,7 +234,7 @@ def format_report(doc: UTOFDocument) -> str:
     def flaky_pred(t: UTOFTestResult) -> bool:
         return t.status in ("flaky_pass", "flaky_fail") and t.retry_count == 0
 
-    flaky_count = sum(1 for t in all_tests if flaky_pred(t) and not t.subtests)
+    flaky_count = sum(1 for t in all_tests if flaky_pred(t) and (not t.subtests or t.failure is not None))
     flaky_roots = [t for t in doc.tests if _has_matching_descendant(t, flaky_pred)]
     if flaky_roots:
 

--- a/tasks/unit_tests/unified_output_tests.py
+++ b/tasks/unit_tests/unified_output_tests.py
@@ -1,0 +1,225 @@
+"""Tests for UTOF models, metadata, and report formatter."""
+
+import json
+import tempfile
+import unittest
+
+from tasks.libs.testing.utof import UTOFMetadata, format_report
+from tasks.libs.testing.utof.metadata import generate_metadata
+from tasks.libs.testing.utof.models import (
+    UTOFAttempt,
+    UTOFDocument,
+    UTOFEnvironmentMetadata,
+    UTOFFailure,
+    UTOFSummary,
+    UTOFTestResult,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_pass_doc() -> UTOFDocument:
+    """Build a minimal all-passing UTOFDocument without a converter."""
+    return UTOFDocument(
+        metadata=UTOFMetadata(test_system="unit"),
+        summary=UTOFSummary(total=2, passed=2, failed=0, status="pass"),
+        tests=[
+            UTOFTestResult(id="a1", name="TestFoo", full_name="TestFoo", package="pkg/foo", type="unit", status="pass"),
+            UTOFTestResult(id="b2", name="TestBar", full_name="TestBar", package="pkg/foo", type="unit", status="pass"),
+        ],
+    )
+
+
+def _make_fail_doc() -> UTOFDocument:
+    """Build a minimal failing UTOFDocument without a converter."""
+    return UTOFDocument(
+        metadata=UTOFMetadata(test_system="unit"),
+        summary=UTOFSummary(total=3, passed=1, failed=1, skipped=1, status="fail"),
+        tests=[
+            UTOFTestResult(
+                id="a1", name="TestFoo", full_name="TestFoo", package="testpackage1", type="unit", status="pass"
+            ),
+            UTOFTestResult(
+                id="b2",
+                name="TestBar",
+                full_name="TestBar",
+                package="testpackage1",
+                type="unit",
+                status="fail",
+                failure=UTOFFailure(message="expected 1, got 2", type="assertion"),
+            ),
+            UTOFTestResult(
+                id="c3", name="TestBaz", full_name="TestBaz", package="testpackage1", type="unit", status="skip"
+            ),
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestUTOFModels(unittest.TestCase):
+    """Test UTOFDocument construction, serialization, and None stripping."""
+
+    def test_to_dict_contains_required_fields(self):
+        d = _make_pass_doc().to_dict()
+        self.assertIn("version", d)
+        self.assertIn("metadata", d)
+        self.assertIn("summary", d)
+        self.assertIn("tests", d)
+
+    def test_version(self):
+        self.assertEqual(_make_pass_doc().to_dict()["version"], "1.0.0")
+
+    def test_none_values_stripped_on_passing_tests(self):
+        d = _make_pass_doc().to_dict()
+        for test in d["tests"]:
+            self.assertNotIn("failure", test)
+            self.assertNotIn("flaky", test)
+
+    def test_failure_field_present_when_set(self):
+        d = _make_fail_doc().to_dict()
+        failing = next(t for t in d["tests"] if t["status"] == "fail")
+        self.assertIn("failure", failing)
+        self.assertEqual(failing["failure"]["message"], "expected 1, got 2")
+        self.assertEqual(failing["failure"]["type"], "assertion")
+
+    def test_write_json(self):
+        doc = _make_pass_doc()
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False, mode="w") as f:
+            path = f.name
+        try:
+            doc.write_json(path)
+            with open(path) as f:
+                parsed = json.load(f)
+            self.assertEqual(parsed["version"], "1.0.0")
+            self.assertEqual(len(parsed["tests"]), 2)
+        finally:
+            import os
+
+            os.unlink(path)
+
+    def test_valid_json_roundtrip(self):
+        doc = _make_fail_doc()
+        parsed = json.loads(json.dumps(doc.to_dict()))
+        self.assertEqual(parsed["summary"]["total"], 3)
+        self.assertEqual(parsed["summary"]["failed"], 1)
+        self.assertEqual(parsed["summary"]["status"], "fail")
+
+    def test_attempts_stripped_when_empty(self):
+        # An attempt list that is empty should be stripped from the dict
+        doc = UTOFDocument(
+            metadata=UTOFMetadata(test_system="unit"),
+            summary=UTOFSummary(total=1, passed=1, status="pass"),
+            tests=[
+                UTOFTestResult(
+                    id="x", name="TestX", full_name="TestX", package="pkg", type="unit", status="pass", attempts=[]
+                ),
+            ],
+        )
+        d = doc.to_dict()
+        self.assertNotIn("attempts", d["tests"][0])
+
+    def test_attempts_present_when_non_empty(self):
+        doc = UTOFDocument(
+            metadata=UTOFMetadata(test_system="unit"),
+            summary=UTOFSummary(total=1, passed=1, status="pass"),
+            tests=[
+                UTOFTestResult(
+                    id="x",
+                    name="TestX",
+                    full_name="TestX",
+                    package="pkg",
+                    type="unit",
+                    status="pass",
+                    attempts=[UTOFAttempt(attempt=1, status="pass", duration_seconds=0.1)],
+                ),
+            ],
+        )
+        d = doc.to_dict()
+        self.assertIn("attempts", d["tests"][0])
+        self.assertEqual(len(d["tests"][0]["attempts"]), 1)
+
+
+# ---------------------------------------------------------------------------
+# Metadata tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateMetadata(unittest.TestCase):
+    """Test metadata generation from environment context."""
+
+    def test_test_system_unit(self):
+        self.assertEqual(generate_metadata("unit").test_system, "unit")
+
+    def test_test_system_e2e(self):
+        self.assertEqual(generate_metadata("e2e").test_system, "e2e")
+
+    def test_test_system_kmt(self):
+        self.assertEqual(generate_metadata("kmt").test_system, "kmt")
+
+    def test_test_system_smp(self):
+        self.assertEqual(generate_metadata("smp").test_system, "smp")
+
+    def test_environment_populated(self):
+        meta = generate_metadata("unit")
+        self.assertIsInstance(meta.environment, UTOFEnvironmentMetadata)
+        self.assertGreater(len(meta.environment.os), 0)
+
+    def test_timestamp_set(self):
+        self.assertGreater(len(generate_metadata("unit").timestamp), 0)
+
+    def test_flavor_stored(self):
+        meta = generate_metadata("unit", flavor="heroku")
+        self.assertEqual(meta.environment.agent_flavor, "heroku")
+
+
+# ---------------------------------------------------------------------------
+# Report formatter tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReport(unittest.TestCase):
+    """Test the human-readable report formatter with manually-constructed docs."""
+
+    def test_report_header_pass(self):
+        report = format_report(_make_pass_doc())
+        self.assertIn("PASSED", report)
+        self.assertIn("Test Report (unit)", report)
+
+    def test_report_header_fail(self):
+        self.assertIn("FAILED", format_report(_make_fail_doc()))
+
+    def test_report_summary_counts(self):
+        report = format_report(_make_fail_doc())
+        self.assertIn("3 total", report)
+        self.assertIn("passed", report)
+        self.assertIn("failed", report)
+        self.assertIn("skipped", report)
+
+    def test_report_failures_section(self):
+        report = format_report(_make_fail_doc())
+        self.assertIn("Failures", report)
+        self.assertIn("TestBar", report)
+        self.assertIn("testpackage1", report)
+
+    def test_report_no_failures_section_when_all_pass(self):
+        report = format_report(_make_pass_doc())
+        self.assertNotIn("Failures", report)
+        self.assertNotIn("Retried", report)
+
+    def test_report_e2e_system_label(self):
+        doc = UTOFDocument(
+            metadata=UTOFMetadata(test_system="e2e"),
+            summary=UTOFSummary(total=1, passed=1, status="pass"),
+            tests=[
+                UTOFTestResult(
+                    id="x1", name="TestSuite", full_name="TestSuite", package="test/new-e2e", type="e2e", status="pass"
+                )
+            ],
+        )
+        self.assertIn("Test Report (e2e)", format_report(doc))

--- a/tasks/unit_tests/unified_output_tests.py
+++ b/tasks/unit_tests/unified_output_tests.py
@@ -224,13 +224,8 @@ class TestFormatReport(unittest.TestCase):
         )
         self.assertIn("Test Report (e2e)", format_report(doc))
 
-    def test_report_fail_count_matches_when_parent_has_own_failure(self):
-        """Failures (N) header must match the number of failure blocks printed.
-
-        A parent with both subtests and its own UTOFFailure (e.g. a setup panic)
-        must be counted in the section header so it doesn't read "Failures (0)"
-        while still printing a failure block.
-        """
+    def test_report_direct_failure_shown_even_when_subtests_also_fail(self):
+        """A direct failure (e.g. panic) on a parent is rendered even when subtests also fail."""
         parent = UTOFTestResult(
             id="p1",
             name="TestSuite",
@@ -238,7 +233,7 @@ class TestFormatReport(unittest.TestCase):
             package="pkg/example",
             type="unit",
             status="fail",
-            failure=UTOFFailure(message="panic: nil pointer dereference", type="panic"),
+            failure=UTOFFailure(message="panic: nil pointer dereference", type="panic", direct=True),
             subtests=[
                 UTOFTestResult(
                     id="s1",
@@ -246,15 +241,15 @@ class TestFormatReport(unittest.TestCase):
                     full_name="TestSuite/Sub",
                     package="pkg/example",
                     type="unit",
-                    status="pass",
+                    status="fail",
+                    failure=UTOFFailure(message="expected 1 got 2", type="assertion", direct=True),
                 ),
             ],
         )
         doc = UTOFDocument(
             metadata=UTOFMetadata(test_system="unit"),
-            summary=UTOFSummary(total=2, passed=1, failed=1, status="fail"),
+            summary=UTOFSummary(total=1, passed=0, failed=1, status="fail"),
             tests=[parent],
         )
         report = format_report(doc)
-        self.assertIn("Failures (1)", report)
-        self.assertNotIn("Failures (0)", report)
+        self.assertIn("panic: nil pointer dereference", report)

--- a/tasks/unit_tests/unified_output_tests.py
+++ b/tasks/unit_tests/unified_output_tests.py
@@ -223,3 +223,38 @@ class TestFormatReport(unittest.TestCase):
             ],
         )
         self.assertIn("Test Report (e2e)", format_report(doc))
+
+    def test_report_fail_count_matches_when_parent_has_own_failure(self):
+        """Failures (N) header must match the number of failure blocks printed.
+
+        A parent with both subtests and its own UTOFFailure (e.g. a setup panic)
+        must be counted in the section header so it doesn't read "Failures (0)"
+        while still printing a failure block.
+        """
+        parent = UTOFTestResult(
+            id="p1",
+            name="TestSuite",
+            full_name="TestSuite",
+            package="pkg/example",
+            type="unit",
+            status="fail",
+            failure=UTOFFailure(message="panic: nil pointer dereference", type="panic"),
+            subtests=[
+                UTOFTestResult(
+                    id="s1",
+                    name="TestSuite/Sub",
+                    full_name="TestSuite/Sub",
+                    package="pkg/example",
+                    type="unit",
+                    status="pass",
+                ),
+            ],
+        )
+        doc = UTOFDocument(
+            metadata=UTOFMetadata(test_system="unit"),
+            summary=UTOFSummary(total=2, passed=1, failed=1, status="fail"),
+            tests=[parent],
+        )
+        report = format_report(doc)
+        self.assertIn("Failures (1)", report)
+        self.assertNotIn("Failures (0)", report)

--- a/tasks/unit_tests/unified_output_tests.py
+++ b/tasks/unit_tests/unified_output_tests.py
@@ -48,7 +48,11 @@ def _make_fail_doc() -> UTOFDocument:
                 package="testpackage1",
                 type="unit",
                 status="fail",
-                attempts=[UTOFAttempt(attempt=1, status="fail", failure=UTOFFailure(message="expected 1, got 2", type="assertion"))],
+                attempts=[
+                    UTOFAttempt(
+                        attempt=1, status="fail", failure=UTOFFailure(message="expected 1, got 2", type="assertion")
+                    )
+                ],
             ),
             UTOFTestResult(
                 id="c3", name="TestBaz", full_name="TestBaz", package="testpackage1", type="unit", status="skip"
@@ -235,7 +239,13 @@ class TestFormatReport(unittest.TestCase):
             package="pkg/example",
             type="unit",
             status="fail",
-            attempts=[UTOFAttempt(attempt=1, status="fail", failure=UTOFFailure(message="panic: nil pointer dereference", type="panic", direct=True))],
+            attempts=[
+                UTOFAttempt(
+                    attempt=1,
+                    status="fail",
+                    failure=UTOFFailure(message="panic: nil pointer dereference", type="panic", direct=True),
+                )
+            ],
             subtests=[
                 UTOFTestResult(
                     id="s1",
@@ -244,7 +254,13 @@ class TestFormatReport(unittest.TestCase):
                     package="pkg/example",
                     type="unit",
                     status="fail",
-                    attempts=[UTOFAttempt(attempt=1, status="fail", failure=UTOFFailure(message="expected 1 got 2", type="assertion", direct=True))],
+                    attempts=[
+                        UTOFAttempt(
+                            attempt=1,
+                            status="fail",
+                            failure=UTOFFailure(message="expected 1 got 2", type="assertion", direct=True),
+                        )
+                    ],
                 ),
             ],
         )

--- a/tasks/unit_tests/unified_output_tests.py
+++ b/tasks/unit_tests/unified_output_tests.py
@@ -48,7 +48,7 @@ def _make_fail_doc() -> UTOFDocument:
                 package="testpackage1",
                 type="unit",
                 status="fail",
-                failure=UTOFFailure(message="expected 1, got 2", type="assertion"),
+                attempts=[UTOFAttempt(attempt=1, status="fail", failure=UTOFFailure(message="expected 1, got 2", type="assertion"))],
             ),
             UTOFTestResult(
                 id="c3", name="TestBaz", full_name="TestBaz", package="testpackage1", type="unit", status="skip"
@@ -81,12 +81,14 @@ class TestUTOFModels(unittest.TestCase):
             self.assertNotIn("failure", test)
             self.assertNotIn("flaky", test)
 
-    def test_failure_field_present_when_set(self):
+    def test_failure_in_attempt_when_set(self):
         d = _make_fail_doc().to_dict()
         failing = next(t for t in d["tests"] if t["status"] == "fail")
-        self.assertIn("failure", failing)
-        self.assertEqual(failing["failure"]["message"], "expected 1, got 2")
-        self.assertEqual(failing["failure"]["type"], "assertion")
+        self.assertIn("attempts", failing)
+        failed_attempt = next(a for a in failing["attempts"] if a["status"] == "fail")
+        self.assertIn("failure", failed_attempt)
+        self.assertEqual(failed_attempt["failure"]["message"], "expected 1, got 2")
+        self.assertEqual(failed_attempt["failure"]["type"], "assertion")
 
     def test_write_json(self):
         doc = _make_pass_doc()
@@ -233,7 +235,7 @@ class TestFormatReport(unittest.TestCase):
             package="pkg/example",
             type="unit",
             status="fail",
-            failure=UTOFFailure(message="panic: nil pointer dereference", type="panic", direct=True),
+            attempts=[UTOFAttempt(attempt=1, status="fail", failure=UTOFFailure(message="panic: nil pointer dereference", type="panic", direct=True))],
             subtests=[
                 UTOFTestResult(
                     id="s1",
@@ -242,7 +244,7 @@ class TestFormatReport(unittest.TestCase):
                     package="pkg/example",
                     type="unit",
                     status="fail",
-                    failure=UTOFFailure(message="expected 1 got 2", type="assertion", direct=True),
+                    attempts=[UTOFAttempt(attempt=1, status="fail", failure=UTOFFailure(message="expected 1 got 2", type="assertion", direct=True))],
                 ),
             ],
         )

--- a/tasks/unit_tests/unified_output_tests.py
+++ b/tasks/unit_tests/unified_output_tests.py
@@ -3,6 +3,7 @@
 import json
 import tempfile
 import unittest
+from unittest.mock import MagicMock
 
 from tasks.libs.testing.utof import UTOFMetadata, format_report
 from tasks.libs.testing.utof.metadata import generate_metadata
@@ -159,28 +160,35 @@ class TestUTOFModels(unittest.TestCase):
 class TestGenerateMetadata(unittest.TestCase):
     """Test metadata generation from environment context."""
 
+    def setUp(self):
+        self.ctx = MagicMock()
+        result = MagicMock()
+        result.ok = True
+        result.stdout = ""
+        self.ctx.run.return_value = result
+
     def test_test_system_unit(self):
-        self.assertEqual(generate_metadata("unit").test_system, "unit")
+        self.assertEqual(generate_metadata(self.ctx, "unit").test_system, "unit")
 
     def test_test_system_e2e(self):
-        self.assertEqual(generate_metadata("e2e").test_system, "e2e")
+        self.assertEqual(generate_metadata(self.ctx, "e2e").test_system, "e2e")
 
     def test_test_system_kmt(self):
-        self.assertEqual(generate_metadata("kmt").test_system, "kmt")
+        self.assertEqual(generate_metadata(self.ctx, "kmt").test_system, "kmt")
 
     def test_test_system_smp(self):
-        self.assertEqual(generate_metadata("smp").test_system, "smp")
+        self.assertEqual(generate_metadata(self.ctx, "smp").test_system, "smp")
 
     def test_environment_populated(self):
-        meta = generate_metadata("unit")
+        meta = generate_metadata(self.ctx, "unit")
         self.assertIsInstance(meta.environment, UTOFEnvironmentMetadata)
         self.assertGreater(len(meta.environment.os), 0)
 
     def test_timestamp_set(self):
-        self.assertGreater(len(generate_metadata("unit").timestamp), 0)
+        self.assertGreater(len(generate_metadata(self.ctx, "unit").timestamp), 0)
 
     def test_flavor_stored(self):
-        meta = generate_metadata("unit", flavor="heroku")
+        meta = generate_metadata(self.ctx, "unit", flavor="heroku")
         self.assertEqual(meta.environment.agent_flavor, "heroku")
 
 


### PR DESCRIPTION
### What does this PR do?

Create a format to have the same output report for all the tests we run in the CI.
The goal is to create an output format for all our test that will be easily printable, with all the meaningful information visible directly, without needing to scroll tons of logs.

That PR only introduce the class for the format, and a method to print that report. Next PRs will introduce converter for go test output to the Unified test output format

Here is an example of the output in job logs: 
<img width="1536" height="980" alt="image" src="https://github.com/user-attachments/assets/71b059fa-1891-4fb6-b22a-4d72f3f5d1b4" />


### Motivation

Improve test report readability for both humans and AI agent that need to interact with the CI

### Describe how you validated your changes

### Additional Notes
