### PR TITLE
Use direct references instead of dynamic loading for cgo_free tests

### DIFF
--- a/rtloader/test/CMakeLists.txt
+++ b/rtloader/test/CMakeLists.txt
@@ -22,14 +22,13 @@ endif()
 set (CGO_CFLAGS \"-I${CMAKE_SOURCE_DIR}/include -I${CMAKE_SOURCE_DIR}/common -Wno-deprecated-declarations\")
 
 if (WIN32)
-    set (CGO_LDFLAGS -L${PROJECT_BINARY_DIR}/rtloader -ldatadog-agent-rtloader -lstdc++ -static)
+    set (CGO_LDFLAGS \"-L${PROJECT_BINARY_DIR}/rtloader -ldatadog-agent-rtloader -lstdc++ -static\")
 elseif(APPLE)
-    set (CGO_LDFLAGS -L${PROJECT_BINARY_DIR}/rtloader -ldatadog-agent-rtloader -ldl -rpath ${PROJECT_BINARY_DIR}/../../dev/lib)
+    set (CGO_LDFLAGS \"-L${PROJECT_BINARY_DIR}/rtloader -ldatadog-agent-rtloader -ldl -rpath ${PROJECT_BINARY_DIR}/../../dev/lib\")
 else()
-    set (CGO_LDFLAGS -L${PROJECT_BINARY_DIR}/rtloader -ldatadog-agent-rtloader -ldl)
+    set (CGO_LDFLAGS \"-L${PROJECT_BINARY_DIR}/rtloader -ldatadog-agent-rtloader -ldl\")
 endif()
 
-set (CGO_LDFLAGS \"-L${PROJECT_BINARY_DIR}/three/ ${CGO_LDFLAGS}\")
 add_custom_command(
     OUTPUT testPy3
     COMMAND ${CMAKE_COMMAND} -E env CGO_CFLAGS=${CGO_CFLAGS} CGO_LDFLAGS=${CGO_LDFLAGS} DYLD_LIBRARY_PATH=${LIBS_PATH} LD_LIBRARY_PATH=${LIBS_PATH} go test -mod=readonly -count=1 -p=1 ${PKGS}

--- a/rtloader/test/common/cgo_free_three.go
+++ b/rtloader/test/common/cgo_free_three.go
@@ -6,15 +6,45 @@
 package testcommon
 
 /*
-#cgo CFLAGS: -I../../common
-#cgo !windows LDFLAGS: -L../../three/ -ldatadog-agent-three
-#cgo windows LDFLAGS: -L../../three/ -ldatadog-agent-three.dll
-#include "cgo_free.h"
+#cgo !windows LDFLAGS: -ldl
 
-extern void cgo_free(void *ptr);
+// c_callCgoFree calls the cgo_free from the dynamically loaded `three` library.
+
+#ifdef _WIN32
+#include <windows.h>
 
 void c_callCgoFree(void *ptr) {
-	cgo_free(ptr);
+    HMODULE handle = GetModuleHandleA("libdatadog-agent-three.dll");
+    if (handle != NULL) {
+        typedef void (*cgo_free_t)(void *);
+        cgo_free_t fn = (cgo_free_t)GetProcAddress(handle, "cgo_free");
+        if (fn != NULL) {
+            fn(ptr);
+        }
+    }
 }
+
+#else
+#include <dlfcn.h>
+
+#if defined(__linux__)
+#  define THREE_LIB "libdatadog-agent-three.so"
+#elif defined(__APPLE__)
+#  define THREE_LIB "libdatadog-agent-three.dylib"
+#endif
+
+void c_callCgoFree(void *ptr) {
+    void *handle = dlopen(THREE_LIB, RTLD_NOLOAD | RTLD_LAZY);
+    if (handle != NULL) {
+        typedef void (*cgo_free_t)(void *);
+        cgo_free_t fn = (cgo_free_t)dlsym(handle, "cgo_free");
+        if (fn != NULL) {
+            fn(ptr);
+        }
+        dlclose(handle);
+    }
+}
+
+#endif
 */
 import "C"

--- a/rtloader/test/common/cgo_free_three.go
+++ b/rtloader/test/common/cgo_free_three.go
@@ -27,7 +27,7 @@ void c_callCgoFree(void *ptr) {
 #else
 #include <dlfcn.h>
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 #  define THREE_LIB "libdatadog-agent-three.so"
 #elif defined(__APPLE__)
 #  define THREE_LIB "libdatadog-agent-three.dylib"

--- a/rtloader/test/common/cgo_free_three.go
+++ b/rtloader/test/common/cgo_free_three.go
@@ -12,20 +12,26 @@ package testcommon
 
 #ifdef _WIN32
 #include <windows.h>
+#include <stdio.h>
 
 void c_callCgoFree(void *ptr) {
     HMODULE handle = GetModuleHandleA("libdatadog-agent-three.dll");
-    if (handle != NULL) {
-        typedef void (*cgo_free_t)(void *);
-        cgo_free_t fn = (cgo_free_t)GetProcAddress(handle, "cgo_free");
-        if (fn != NULL) {
-            fn(ptr);
-        }
+    if (handle == NULL) {
+        fprintf(stderr, "c_callCgoFree: libdatadog-agent-three.dll is not loaded\n");
+        return;
     }
+    typedef void (*cgo_free_t)(void *);
+    cgo_free_t fn = (cgo_free_t)GetProcAddress(handle, "cgo_free");
+    if (fn == NULL) {
+        fprintf(stderr, "c_callCgoFree: cgo_free symbol not found in libdatadog-agent-three.dll\n");
+        return;
+    }
+    fn(ptr);
 }
 
 #else
 #include <dlfcn.h>
+#include <stdio.h>
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #  define THREE_LIB "libdatadog-agent-three.so"
@@ -35,14 +41,19 @@ void c_callCgoFree(void *ptr) {
 
 void c_callCgoFree(void *ptr) {
     void *handle = dlopen(THREE_LIB, RTLD_NOLOAD | RTLD_LAZY);
-    if (handle != NULL) {
-        typedef void (*cgo_free_t)(void *);
-        cgo_free_t fn = (cgo_free_t)dlsym(handle, "cgo_free");
-        if (fn != NULL) {
-            fn(ptr);
-        }
-        dlclose(handle);
+    if (handle == NULL) {
+        fprintf(stderr, "c_callCgoFree: " THREE_LIB " is not loaded\n");
+        return;
     }
+    typedef void (*cgo_free_t)(void *);
+    cgo_free_t fn = (cgo_free_t)dlsym(handle, "cgo_free");
+    if (fn == NULL) {
+        fprintf(stderr, "c_callCgoFree: cgo_free symbol not found in " THREE_LIB "\n");
+        dlclose(handle);
+        return;
+    }
+    fn(ptr);
+    dlclose(handle);
 }
 
 #endif


### PR DESCRIPTION
### What does this PR do?

It changes the instrumentation for `cgo_free` tests in rtloader so that it doesn't rely on dynamic linking to get a reference to the `cgo_free` function, but grabs a reference to it via the dynamically loaded library (via `make3`).

### Motivation

As part of migrating rtloader to Bazel ([ABLD-323](https://datadoghq.atlassian.net/browse/ABLD-323)), the existing setup, requiring dynamic linking makes things unnecessarily hard on Windows.

The existing setup also doesn't reflect a "realistic" use case, in that linking against and opening the same dynamic library is not how the library would normally be used. The proposed change is more explicit.

### Describe how you validated your changes

Passing tests.

### Additional Notes


[ABLD-323]: https://datadoghq.atlassian.net/browse/ABLD-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ