### PR TITLE
fix(discovery): Reduce info-level logging in service discovery Rust module

### DIFF
--- a/pkg/discovery/module/rust/src/language.rs
+++ b/pkg/discovery/module/rust/src/language.rs
@@ -16,7 +16,6 @@ use std::sync::{LazyLock, Mutex};
 use anyhow::Result;
 use elf::abi::{PF_W, PF_X, PT_LOAD};
 use elf::endian::AnyEndian;
-use log::info;
 use lru::LruCache;
 use memchr::memmem;
 use serde::{Deserialize, Serialize};
@@ -58,7 +57,6 @@ impl Language {
     }
 
     pub fn detect(pid: i32, exe: &Exe, cmdline: &Cmdline, open_files_info: &OpenFilesInfo) -> Self {
-        info!("detect: exe={exe:?} cmdline={cmdline:?}");
         if let Some(lang) = Self::from_basename(cmdline) {
             return lang;
         }
@@ -81,7 +79,6 @@ impl Language {
     fn from_basename(cmdline: &Cmdline) -> Option<Self> {
         let mut args = cmdline.args();
         let exe = Path::new(args.next()?).file_name()?;
-        info!("from_basename: exe from args: {exe:?}");
 
         if is_jruby(exe, cmdline) {
             return Some(Self::Ruby);
@@ -99,7 +96,6 @@ impl Language {
     }
 
     fn from_command(comm: &str) -> Option<Self> {
-        info!("from_command: {comm}");
         match comm {
             "py" | "python" => return Some(Self::Python),
             "java" => return Some(Self::Java),
@@ -111,20 +107,16 @@ impl Language {
         }
 
         if comm.starts_with("python") {
-            info!("from_command: {comm} -> python");
             return Some(Self::Python);
         }
         if comm.starts_with("java") && comm != "javac" {
-            info!("from_command: {comm} -> java");
             return Some(Self::Java);
         }
 
         if is_ruby_prefix(comm) {
-            info!("from_command: {comm} -> ruby");
             return Some(Self::Ruby);
         }
         if is_php_prefix(comm) {
-            info!("from_command: {comm} -> php");
             return Some(Self::PHP);
         }
 

--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -37,7 +37,7 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use log::{error, info, warn};
+use log::{debug, error, info, warn};
 use serde_json::json;
 use tokio::net::UnixListener;
 use tokio::signal::unix::{SignalKind, signal};
@@ -143,7 +143,7 @@ async fn handle_services(
     };
 
     let services = get_services(params);
-    info!("Found {} services", services.services.len());
+    debug!("Found {} services", services.services.len());
 
     Response::builder()
         .header("Content-Type", "application/json")
@@ -199,7 +199,7 @@ async fn handle_request(
 ) -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
     match (req.method(), req.uri().path()) {
         (&Method::POST, "/discovery/services") => {
-            info!("Handling /discovery/services request");
+            debug!("Handling /discovery/services request");
             handle_services(req).await
         }
         (&Method::GET, "/debug/stats") => handle_debug_stats().await,

--- a/pkg/discovery/module/rust/src/services.rs
+++ b/pkg/discovery/module/rust/src/services.rs
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
-use log::info;
 use serde::Serialize;
 
 use crate::apm;
@@ -77,7 +76,6 @@ pub fn get_services(params: Params) -> ServicesResponse {
             }
 
             if let Some(service) = get_service(*pid, &mut context, &open_files_info) {
-                info!("found service {service:#?}");
                 resp.services.push(service);
             }
         }
@@ -86,7 +84,6 @@ pub fn get_services(params: Params) -> ServicesResponse {
     if let Some(heartbeat_pids) = &params.heartbeat_pids {
         for pid in heartbeat_pids {
             if let Some(service) = get_heartbeat_service(*pid, &mut context) {
-                info!("handled heartbeat {service:#?}");
                 resp.services.push(service);
             }
         }


### PR DESCRIPTION
### What does this PR do?

Reduces excessive info-level logging in the service discovery Rust module by:
- Removing verbose `info!()` calls from language detection (`language.rs`) and service collection (`services.rs`) that logged per-process details on every scan
- Downgrading request-level logs in `main.rs` (`"Handling /discovery/services request"` and `"Found N services"`) from `info!` to `debug!`

### Motivation

The service discovery module runs periodic scans and logs detailed per-process information at the `info` level. This creates excessive log volume in production, making it harder to find meaningful log entries. These messages are useful for debugging but not for normal operation, so they should either be removed or moved to `debug` level.

### Describe how you validated your changes

Code review of log level changes. The removed/downgraded log statements are purely observational and do not affect functionality.

### Additional Notes

No behavioral changes — only log output is affected.