### PR TITLE
test(e2e): Test install script from speedup-install-script branch

### DIFF
--- a/test/new-e2e/tests/agent-platform/install/install.go
+++ b/test/new-e2e/tests/agent-platform/install/install.go
@@ -8,6 +8,7 @@ package install
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -65,9 +66,14 @@ func Unix(t *testing.T, client ExecutorWithRetry, options ...installparams.Optio
 	t.Run("Installing the agent", func(tt *testing.T) {
 		var downloadCmd string
 		var source string
+		// TODO: remove gist override once nschweitzer/speedup-install-script is merged and released
+		installScriptURL := "https://gist.githubusercontent.com/chouetz/86def624c8bd7a9a70121d244f8dcd52/raw/install_script_agent7.sh"
+		if customURL, ok := os.LookupEnv("E2E_INSTALL_SCRIPT_URL"); ok {
+			installScriptURL = customURL
+		}
 		if params.MajorVersion != "5" {
-			source = "S3"
-			downloadCmd = fmt.Sprintf(`curl -L  https://install.datadoghq.com/scripts/install_script_agent%v.sh > installscript.sh`, params.MajorVersion)
+			source = "custom URL"
+			downloadCmd = fmt.Sprintf(`curl -L  %s > installscript.sh`, installScriptURL)
 		} else {
 			source = "dd-agent repository"
 			downloadCmd = "curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh > installscript.sh"
@@ -102,7 +108,11 @@ func MacOS(t *testing.T, client ExecutorWithRetry, options ...installparams.Opti
 	exports = append(exports, "DD_SYSTEMDAEMON_INSTALL=true")
 	env := strings.Join(exports, " ")
 	// Retry curl few times
-	cmd := fmt.Sprintf(`for i in {1..5}; do curl -fsSL https://install.datadoghq.com/scripts/install_mac_os.sh -o install-script.sh && break || sleep $((2**$i)); done && for i in {1..3}; do DD_API_KEY=%s %s DD_INSTALL_ONLY=true bash install-script.sh && exit 0 || sleep $((2**$i)); done; exit 1`, apikey, env)
+	macOSInstallScriptURL := "https://install.datadoghq.com/scripts/install_mac_os.sh"
+	if customURL, ok := os.LookupEnv("E2E_MACOS_INSTALL_SCRIPT_URL"); ok {
+		macOSInstallScriptURL = customURL
+	}
+	cmd := fmt.Sprintf(`for i in {1..5}; do curl -fsSL %s -o install-script.sh && break || sleep $((2**$i)); done && for i in {1..3}; do DD_API_KEY=%s %s DD_INSTALL_ONLY=true bash install-script.sh && exit 0 || sleep $((2**$i)); done; exit 1`, macOSInstallScriptURL, apikey, env)
 
 	t.Run("Installing the agent", func(tt *testing.T) {
 		_, err := client.ExecuteWithRetry(cmd)

--- a/test/new-e2e/tests/fleet/agent/install.go
+++ b/test/new-e2e/tests/fleet/agent/install.go
@@ -21,9 +21,17 @@ import (
 )
 
 const (
-	linuxInstallScriptURL   = "https://install.datadoghq.com/scripts/install_script_agent7.sh"
-	windowsInstallScriptURL = "https://install.datadoghq.com/Install-Datadog.ps1"
+	defaultLinuxInstallScriptURL = "https://install.datadoghq.com/scripts/install_script_agent7.sh"
+	windowsInstallScriptURL      = "https://install.datadoghq.com/Install-Datadog.ps1"
 )
+
+func linuxInstallScriptURL() string {
+	if url, ok := os.LookupEnv("E2E_INSTALL_SCRIPT_URL"); ok {
+		return url
+	}
+	// TODO: remove once nschweitzer/speedup-install-script is merged and released
+	return "https://gist.githubusercontent.com/chouetz/86def624c8bd7a9a70121d244f8dcd52/raw/install_script_agent7.sh"
+}
 
 // InstallOption is an optional function parameter type for InstallParams options
 type InstallOption func(*installParams)
@@ -136,7 +144,7 @@ func (a *Agent) installLinuxInstallScript(params *installParams) error {
 		env["DD_AGENT_MINOR_VERSION"] = strings.TrimPrefix(params.stagingPackages, "7.")
 		env["DD_AGENT_DIST_CHANNEL"] = "beta"
 	}
-	_, err = a.host.RemoteHost.Execute(fmt.Sprintf(`bash -c "$(curl -L %s)"`, linuxInstallScriptURL), client.WithEnvVariables(env))
+	_, err = a.host.RemoteHost.Execute(fmt.Sprintf(`bash -c "$(curl -L %s)"`, linuxInstallScriptURL()), client.WithEnvVariables(env))
 	return err
 }
 


### PR DESCRIPTION
### What does this PR do?

Overrides the install script URL in E2E tests to use a custom build from the `nschweitzer/speedup-install-script` branch of `agent-linux-install-script`. This allows testing the modified install script across all E2E test suites (fleet and agent-platform).

Changes:
- `test/new-e2e/tests/fleet/agent/install.go`: Made the Linux install script URL configurable via `E2E_INSTALL_SCRIPT_URL` env var, defaulting to the gist-hosted build from the feature branch
- `test/new-e2e/tests/agent-platform/install/install.go`: Same override for the `Unix()` installer, plus `E2E_MACOS_INSTALL_SCRIPT_URL` support for macOS

### Motivation

Test the performance improvements from the `nschweitzer/speedup-install-script` branch across all E2E install tests before merging and releasing that change.

### Describe how you validated your changes

The gist URL is reachable and serves the built `install_script_agent7.sh` from the feature branch. The env var override mechanism was verified to compile correctly.

### Additional Notes

This is a **temporary** change — the gist override should be reverted once the install-script branch is merged and released. TODO comments mark the lines to revert. The `E2E_INSTALL_SCRIPT_URL` / `E2E_MACOS_INSTALL_SCRIPT_URL` env var mechanism is a useful addition to keep permanently.