### PR TITLE
[EBPF-1060] gpu: remove workloadmeta logger on fuzzing tests

### DIFF
--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -19,12 +19,14 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/DataDog/datadog-agent/comp/core"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	workloadmetamock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	logslog "github.com/DataDog/datadog-agent/pkg/util/log/slog"
 )
 
 // DefaultGpuCores is the default number of cores for a GPU device in the mock.
@@ -816,9 +818,21 @@ func fillAllMockFunctions[T any](obj T) {
 
 // GetWorkloadMetaMock returns a mock of the workloadmeta.Component.
 func GetWorkloadMetaMock(t testing.TB) workloadmetamock.Mock {
+	opts := []fx.Option{
+		core.MockBundle(),
+		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+	}
+
+	// If the test is a fuzz test, the logger provided in core.MockBundle() will be created with the wrong testing.TB
+	// and cause a panic.
+	if _, ok := t.(*testing.F); ok {
+		opts = append(opts, fx.Decorate(func(log.Component) log.Component { return logslog.Disabled() }))
+	}
+
 	return fxutil.Test[workloadmetamock.Mock](t, fx.Options(
 		core.MockBundle(),
 		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
+		fx.Decorate(func(log.Component) log.Component { return logslog.Disabled() }),
 	))
 }
 

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -829,11 +829,7 @@ func GetWorkloadMetaMock(t testing.TB) workloadmetamock.Mock {
 		opts = append(opts, fx.Decorate(func(log.Component) log.Component { return logslog.Disabled() }))
 	}
 
-	return fxutil.Test[workloadmetamock.Mock](t, fx.Options(
-		core.MockBundle(),
-		workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-		fx.Decorate(func(log.Component) log.Component { return logslog.Disabled() }),
-	))
+	return fxutil.Test[workloadmetamock.Mock](t, fx.Options(opts...))
 }
 
 // GetWorkloadMetaMockWithDefaultGPUs is the same as GetWorkloadMetaMock, but adds the GPUs of testutil.GPUUUIDs

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -826,6 +826,7 @@ func GetWorkloadMetaMock(t testing.TB) workloadmetamock.Mock {
 	// If the test is a fuzz test, the logger provided in core.MockBundle() will be created with the wrong testing.TB
 	// and cause a panic.
 	if _, ok := t.(*testing.F); ok {
+		// fx.Decorate allows transforming a given component, in this case we replace it with a disabled logger
 		opts = append(opts, fx.Decorate(func(log.Component) log.Component { return logslog.Disabled() }))
 	}
 


### PR DESCRIPTION
### What does this PR do?

Disables the logger in workloadmeta mocks when the mock is generated in a fuzz test.

### Motivation

If workloadmeta logs something using the logger from `f.Log()` when the fuzz target is running, it will cause a panic.

### Describe how you validated your changes

CI passing, also forced a log on every run to ensure the fix was correct.

### Additional Notes
