### PR TITLE
ci(gha): add bazel-cache action to update_dependencies workflow

### DIFF
--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -36,6 +36,8 @@ jobs:
         uses: ./.github/actions/install-dda
         with:
           features: legacy-tasks
+      - name: Set up Bazel cache
+        uses: ./.github/actions/bazel-cache
       - name: Update every golang.org/x/... package
         run: |
           go get -u golang.org/x/arch golang.org/x/crypto \


### PR DESCRIPTION
### What does this PR do?

Adds the `bazel-cache` composite action to the `update_dependencies.yml` GitHub Actions workflow, which sets `XDG_CACHE_HOME` and caches Bazel-related artifacts.

### Motivation

The workflow fails because `dda inv tidy` calls `_bazel_tidy` (since `bazel` is in PATH), which invokes the `tools/bazel` wrapper. That wrapper requires `XDG_CACHE_HOME` to point to a directory when running in CI, but the workflow never set it.

See: https://github.com/DataDog/datadog-agent/actions/runs/22889756698/job/66410225616

### Describe how you validated your changes

CI is considered enough to validate changes.

### Additional Notes

The existing `.github/actions/bazel-cache` composite action already handles this for other workflows — this PR reuses it.