### PR TITLE
fix(windows-dev-env): windows dev env start task

### DIFF
--- a/tasks/windows_dev_env.py
+++ b/tasks/windows_dev_env.py
@@ -84,8 +84,7 @@ def run(
 def _start_windows_dev_env(ctx, name: str = "windows-dev-env"):
     start_time = time.time()
 
-    with ctx.cd('./test/e2e-framework'):
-        ctx.run("dda inv -- setup")
+    ctx.run("dda inv -- setup")
     if shutil.which("rsync") is None:
         raise Exception(
             "rsync is not installed. Please install rsync by running `brew install rsync` on macOS and try again."


### PR DESCRIPTION
### What does this PR do?

This PR removes the change of directory before the setup, otherwise `windows-dev-env.start` can't find `.python-version` and the task fails.

### Motivation

Improve Windows dev env experience

### Describe how you validated your changes

### Additional Notes
