### PR TITLE
[CONTP-1361] Switch to using configmaps instead of pods in admission controller probe

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -276,25 +276,25 @@ func (s *Server) handle(w http.ResponseWriter, r *http.Request, webhookName stri
 	}
 }
 
-// podMeta is used for lightweight partial unmarshalling of a pod's metadata.
-type podMeta struct {
+// probeMeta is used for lightweight partial unmarshalling of an object's metadata.
+type probeMeta struct {
 	Metadata struct {
 		Labels map[string]string `json:"labels"`
 	} `json:"metadata"`
 }
 
-// isProbe checks whether the raw pod object carries the admission probe label.
+// isProbe checks whether the raw object carries the admission probe label.
 func isProbe(raw []byte) bool {
-	var meta podMeta
+	var meta probeMeta
 	if err := json.Unmarshal(raw, &meta); err != nil {
 		return false
 	}
 	return meta.Metadata.Labels[admicommon.ProbeLabelKey] == "true"
 }
 
-// probeResponse returns a short-circuit AdmissionResponse for probe pods,
+// probeResponse returns a short-circuit AdmissionResponse for probe objects,
 // adding the probe-received annotation without running any mutation logic.
-// Returns nil for non-probe pods.
+// Returns nil for non-probe objects.
 func probeResponse(raw []byte) *admiv1.AdmissionResponse {
 	if !isProbe(raw) {
 		return nil

--- a/cmd/cluster-agent/admission/server_test.go
+++ b/cmd/cluster-agent/admission/server_test.go
@@ -25,17 +25,17 @@ func TestIsProbe(t *testing.T) {
 		expected bool
 	}{
 		{
-			name:     "pod with probe label",
+			name:     "object with probe label",
 			raw:      `{"metadata":{"labels":{"` + admicommon.ProbeLabelKey + `":"true"}}}`,
 			expected: true,
 		},
 		{
-			name:     "pod without probe label",
+			name:     "object without probe label",
 			raw:      `{"metadata":{"labels":{"app":"nginx"}}}`,
 			expected: false,
 		},
 		{
-			name:     "pod with no labels",
+			name:     "object with no labels",
 			raw:      `{"metadata":{}}`,
 			expected: false,
 		},
@@ -58,13 +58,13 @@ func TestIsProbe(t *testing.T) {
 	}
 }
 
-func TestProbeResponse_NonProbePod(t *testing.T) {
+func TestProbeResponse_NonProbeObject(t *testing.T) {
 	raw := []byte(`{"metadata":{"labels":{"app":"nginx"}}}`)
 	resp := probeResponse(raw)
 	assert.Nil(t, resp)
 }
 
-func TestProbeResponse_ProbePod(t *testing.T) {
+func TestProbeResponse_ProbeObject(t *testing.T) {
 	raw := []byte(`{"metadata":{"labels":{"` + admicommon.ProbeLabelKey + `":"true"}}}`)
 	resp := probeResponse(raw)
 	require.NotNil(t, resp)

--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	timeout                  int32
 	failurePolicy            string
 	reinvocationPolicy       string
+	probeEnabled             bool
 }
 
 // NewConfig creates a webhook controller configuration
@@ -50,6 +51,7 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled, matchConditionsSupp
 		timeout:                  datadogConfig.GetInt32("admission_controller.timeout_seconds"),
 		failurePolicy:            datadogConfig.GetString("admission_controller.failure_policy"),
 		reinvocationPolicy:       datadogConfig.GetString("admission_controller.reinvocation_policy"),
+		probeEnabled:             datadogConfig.GetBool("admission_controller.probe.enabled"),
 	}
 }
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -394,6 +394,33 @@ func (c *ControllerV1) generateTemplates() {
 			),
 		)
 	}
+
+	if c.config.probeEnabled && len(mutatingWebhooks) > 0 {
+		probeEndpoint := *mutatingWebhooks[0].ClientConfig.Service.Path
+		mutatingWebhooks = append(mutatingWebhooks, c.getMutatingWebhookSkeleton(
+			"probe",
+			probeEndpoint,
+			[]admiv1.OperationType{admiv1.Create},
+			map[string][]string{"": {"configmaps"}},
+			&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      common.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{c.config.getServiceNs()},
+					},
+				},
+			},
+			&metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					common.ProbeLabelKey: "true",
+				},
+			},
+			nil,
+			0,
+		))
+	}
+
 	c.mutatingWebhookTemplates = mutatingWebhooks
 }
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -397,6 +397,33 @@ func (c *ControllerV1beta1) generateTemplates() {
 			),
 		)
 	}
+
+	if c.config.probeEnabled && len(mutatingWebhooks) > 0 {
+		probeEndpoint := *mutatingWebhooks[0].ClientConfig.Service.Path
+		mutatingWebhooks = append(mutatingWebhooks, c.getMutatingWebhookSkeleton(
+			"probe",
+			probeEndpoint,
+			[]admiv1beta1.OperationType{admiv1beta1.Create},
+			map[string][]string{"": {"configmaps"}},
+			&metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      common.NamespaceLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{c.config.getServiceNs()},
+					},
+				},
+			},
+			&metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					common.ProbeLabelKey: "true",
+				},
+			},
+			nil,
+			0,
+		))
+	}
+
 	c.mutatingWebhookTemplates = mutatingWebhooks
 }
 

--- a/pkg/clusteragent/admission/probe/probe.go
+++ b/pkg/clusteragent/admission/probe/probe.go
@@ -6,7 +6,7 @@
 //go:build kubeapiserver
 
 // Package probe periodically tests admission webhook connectivity by sending
-// dry-run pod creation requests through the Kubernetes API server.
+// dry-run ConfigMap creation requests through the Kubernetes API server.
 package probe
 
 import (
@@ -27,10 +27,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-var errProbeNotReceived = errors.New("dry-run probe pod was not annotated by the webhook")
+var errProbeNotReceived = errors.New("dry-run probe configmap was not annotated by the webhook")
 
 // Probe periodically verifies that the admission webhook is reachable by
-// creating dry-run pods and checking if they are handled by the webhook.
+// creating dry-run ConfigMaps and checking if they are handled by the webhook.
 type Probe struct {
 	k8sClient      kubernetes.Interface
 	isLeaderFunc   func() bool
@@ -71,7 +71,9 @@ type StatsSnapshot struct {
 const defaultInterval = 60 * time.Second
 
 // New creates a new admission controller connectivity probe.
-func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, datadogConfig config.Component) *Probe {
+// The namespace parameter specifies where dry-run ConfigMaps are created; this
+// should be the namespace the cluster agent is deployed in.
+func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, namespace string, datadogConfig config.Component) *Probe {
 	interval := time.Duration(datadogConfig.GetInt("admission_controller.probe.interval")) * time.Second
 	if interval <= 0 {
 		log.Warnf("admission_controller.probe.interval is invalid (%s), falling back to %s", interval, defaultInterval)
@@ -81,7 +83,7 @@ func New(k8sClient kubernetes.Interface, isLeaderFunc func() bool, datadogConfig
 	return &Probe{
 		k8sClient:    k8sClient,
 		isLeaderFunc: isLeaderFunc,
-		namespace:    datadogConfig.GetString("admission_controller.probe.namespace"),
+		namespace:    namespace,
 		interval:     interval,
 		gracePeriod:  time.Duration(datadogConfig.GetInt("admission_controller.probe.grace_period")) * time.Second,
 		logLimiter:   log.NewLogLimit(1, 10*time.Minute),
@@ -107,9 +109,7 @@ func (p *Probe) GetStatsSnapshot() StatsSnapshot {
 // GetStatsForStatus returns probe stats formatted for the agent status output.
 func (p *Probe) GetStatsForStatus() map[string]interface{} {
 	snap := p.GetStatsSnapshot()
-	result := map[string]interface{}{
-		"Namespace": p.namespace,
-	}
+	result := map[string]interface{}{}
 
 	if snap.ConfigError != "" {
 		result["ConfigError"] = snap.ConfigError
@@ -200,19 +200,8 @@ func (p *Probe) runProbe(ctx context.Context) {
 }
 
 func (p *Probe) handleError(err error) {
-	if k8serrors.IsNotFound(err) {
-		msg := fmt.Sprintf("Probe namespace %q does not exist. Create it to enable admission controller connectivity probing.", p.namespace)
-		p.stats.mu.Lock()
-		p.stats.ConfigError = msg
-		p.stats.mu.Unlock()
-		if p.logLimiter.ShouldLog() {
-			log.Errorf("Admission controller probe misconfigured: %s", msg)
-		}
-		return
-	}
-
 	if k8serrors.IsForbidden(err) {
-		msg := fmt.Sprintf("The cluster agent service account does not have permission to create pods in namespace %q. Grant pod creation RBAC to enable connectivity probing.", p.namespace)
+		msg := fmt.Sprintf("The cluster agent service account does not have permission to create configmaps in namespace %q. Grant configmap creation RBAC to enable connectivity probing.", p.namespace)
 		p.stats.mu.Lock()
 		p.stats.ConfigError = msg
 		p.stats.mu.Unlock()
@@ -225,7 +214,7 @@ func (p *Probe) handleError(err error) {
 	if errors.Is(err, errProbeNotReceived) {
 		if p.logLimiter.ShouldLog() {
 			log.Errorf(
-				"Admission controller probe failed: the webhook did not handle the probe pod. "+
+				"Admission controller probe failed: the webhook did not handle the probe configmap. "+
 					"This indicates a network connectivity issue between the Kubernetes API server "+
 					"and the cluster agent admission webhook. %s",
 				p.diagnosticHint,
@@ -240,25 +229,18 @@ func (p *Probe) handleError(err error) {
 }
 
 func (p *Probe) execute(ctx context.Context) error {
-	pod := &corev1.Pod{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "datadog-admission-probe-",
 			Namespace:    p.namespace,
 			Labels: map[string]string{
-				admcommon.EnabledLabelKey: "true",
-				admcommon.ProbeLabelKey:   "true",
+				admcommon.ProbeLabelKey: "true",
 			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "probe",
-				Image: "registry.k8s.io/pause:3.9",
-			}},
 		},
 	}
 
-	result, err := p.k8sClient.CoreV1().Pods(p.namespace).Create(
-		ctx, pod, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
+	result, err := p.k8sClient.CoreV1().ConfigMaps(p.namespace).Create(
+		ctx, cm, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}},
 	)
 	if err != nil {
 		return err

--- a/pkg/clusteragent/admission/probe/probe_test.go
+++ b/pkg/clusteragent/admission/probe/probe_test.go
@@ -39,17 +39,17 @@ func newTestProbe(client *fakeclientset.Clientset) *Probe {
 
 func webhookReachableReactor(action k8stesting.Action) (bool, runtime.Object, error) {
 	createAction := action.(k8stesting.CreateAction)
-	pod := createAction.GetObject().(*corev1.Pod)
-	if pod.Annotations == nil {
-		pod.Annotations = make(map[string]string)
+	cm := createAction.GetObject().(*corev1.ConfigMap)
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
 	}
-	pod.Annotations[admcommon.ProbeReceivedAnnotationKey] = "true"
-	return true, pod, nil
+	cm.Annotations[admcommon.ProbeReceivedAnnotationKey] = "true"
+	return true, cm, nil
 }
 
 func TestExecute_WebhookReachable(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", webhookReachableReactor)
+	client.PrependReactor("create", "configmaps", webhookReachableReactor)
 
 	p := newTestProbe(client)
 	err := p.execute(context.Background())
@@ -65,40 +65,39 @@ func TestExecute_WebhookNotReachable(t *testing.T) {
 	assert.ErrorIs(t, err, errProbeNotReceived)
 }
 
-func TestExecute_PodHasCorrectLabelsAndNamespace(t *testing.T) {
-	var createdPod *corev1.Pod
+func TestExecute_ConfigMapHasCorrectLabelsAndNamespace(t *testing.T) {
+	var createdCM *corev1.ConfigMap
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("create", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		createAction := action.(k8stesting.CreateAction)
-		createdPod = createAction.GetObject().(*corev1.Pod)
-		if createdPod.Annotations == nil {
-			createdPod.Annotations = make(map[string]string)
+		createdCM = createAction.GetObject().(*corev1.ConfigMap)
+		if createdCM.Annotations == nil {
+			createdCM.Annotations = make(map[string]string)
 		}
-		createdPod.Annotations[admcommon.ProbeReceivedAnnotationKey] = "true"
-		return true, createdPod, nil
+		createdCM.Annotations[admcommon.ProbeReceivedAnnotationKey] = "true"
+		return true, createdCM, nil
 	})
 
 	p := newTestProbe(client)
 	err := p.execute(context.Background())
 	require.NoError(t, err)
-	require.NotNil(t, createdPod)
-	assert.Equal(t, "true", createdPod.Labels[admcommon.EnabledLabelKey])
-	assert.Equal(t, "true", createdPod.Labels[admcommon.ProbeLabelKey])
-	assert.Equal(t, testNamespace, createdPod.Namespace)
-	assert.NotEmpty(t, createdPod.GenerateName)
+	require.NotNil(t, createdCM)
+	assert.Equal(t, "true", createdCM.Labels[admcommon.ProbeLabelKey])
+	assert.Equal(t, testNamespace, createdCM.Namespace)
+	assert.NotEmpty(t, createdCM.GenerateName)
 }
 
 func TestExecute_UsesDryRun(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+	client.PrependReactor("create", "configmaps", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		createAction := action.(k8stesting.CreateAction)
-		pod := createAction.GetObject().(*corev1.Pod)
-		if pod.Annotations == nil {
-			pod.Annotations = make(map[string]string)
+		cm := createAction.GetObject().(*corev1.ConfigMap)
+		if cm.Annotations == nil {
+			cm.Annotations = make(map[string]string)
 		}
-		pod.Annotations[admcommon.ProbeReceivedAnnotationKey] = "true"
+		cm.Annotations[admcommon.ProbeReceivedAnnotationKey] = "true"
 		assert.Contains(t, action.(k8stesting.CreateActionImpl).CreateOptions.DryRun, metav1.DryRunAll)
-		return true, pod, nil
+		return true, cm, nil
 	})
 
 	p := newTestProbe(client)
@@ -106,22 +105,10 @@ func TestExecute_UsesDryRun(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestExecute_NamespaceNotFound(t *testing.T) {
-	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, testNamespace)
-	})
-
-	p := newTestProbe(client)
-	err := p.execute(context.Background())
-	require.Error(t, err)
-	assert.True(t, k8serrors.IsNotFound(err))
-}
-
 func TestExecute_Forbidden(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", errors.New("forbidden"))
+	client.PrependReactor("create", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("forbidden"))
 	})
 
 	p := newTestProbe(client)
@@ -132,7 +119,7 @@ func TestExecute_Forbidden(t *testing.T) {
 
 func TestRunProbe_StatsOnSuccess(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", webhookReachableReactor)
+	client.PrependReactor("create", "configmaps", webhookReachableReactor)
 
 	p := newTestProbe(client)
 	p.runProbe(context.Background())
@@ -163,25 +150,10 @@ func TestRunProbe_StatsOnConnectivityFailure(t *testing.T) {
 	assert.Empty(t, snap.ConfigError)
 }
 
-func TestRunProbe_StatsOnNamespaceNotFound(t *testing.T) {
-	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, testNamespace)
-	})
-
-	p := newTestProbe(client)
-	p.runProbe(context.Background())
-
-	snap := p.GetStatsSnapshot()
-	assert.Equal(t, int64(1), snap.TotalExecutions)
-	assert.Equal(t, int64(1), snap.FailCount)
-	assert.Contains(t, snap.ConfigError, "does not exist")
-}
-
 func TestRunProbe_StatsOnForbidden(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", errors.New("forbidden"))
+	client.PrependReactor("create", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("forbidden"))
 	})
 
 	p := newTestProbe(client)
@@ -195,8 +167,8 @@ func TestRunProbe_StatsOnForbidden(t *testing.T) {
 
 func TestRunProbe_ConfigErrorClearedOnSuccess(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", errors.New("forbidden"))
+	client.PrependReactor("create", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("forbidden"))
 	})
 
 	p := newTestProbe(client)
@@ -204,7 +176,7 @@ func TestRunProbe_ConfigErrorClearedOnSuccess(t *testing.T) {
 	assert.NotEmpty(t, p.GetStatsSnapshot().ConfigError)
 
 	client.ReactionChain = nil
-	client.PrependReactor("create", "pods", webhookReachableReactor)
+	client.PrependReactor("create", "configmaps", webhookReachableReactor)
 
 	p.runProbe(context.Background())
 	snap := p.GetStatsSnapshot()
@@ -214,7 +186,7 @@ func TestRunProbe_ConfigErrorClearedOnSuccess(t *testing.T) {
 
 func TestGetStatsForStatus_SuccessRate(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", webhookReachableReactor)
+	client.PrependReactor("create", "configmaps", webhookReachableReactor)
 
 	p := newTestProbe(client)
 	p.runProbe(context.Background())
@@ -228,21 +200,19 @@ func TestGetStatsForStatus_SuccessRate(t *testing.T) {
 	assert.Equal(t, int64(3), status["TotalExecutions"])
 	assert.Equal(t, int64(2), status["SuccessCount"])
 	assert.Equal(t, int64(1), status["FailCount"])
-	assert.Equal(t, testNamespace, status["Namespace"])
 }
 
 func TestGetStatsForStatus_ConfigError(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	client.PrependReactor("create", "pods", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, k8serrors.NewNotFound(schema.GroupResource{Resource: "namespaces"}, testNamespace)
+	client.PrependReactor("create", "configmaps", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8serrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("forbidden"))
 	})
 
 	p := newTestProbe(client)
 	p.runProbe(context.Background())
 
 	status := p.GetStatsForStatus()
-	assert.Equal(t, testNamespace, status["Namespace"])
-	assert.Contains(t, status["ConfigError"], "does not exist")
+	assert.Contains(t, status["ConfigError"], "does not have permission")
 	_, hasTotalExecutions := status["TotalExecutions"]
 	assert.False(t, hasTotalExecutions)
 }

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -126,7 +126,7 @@ func StartControllers(ctx ControllerContext, wmeta workloadmeta.Component, pa wo
 	webhooks = append(webhooks, webhookController.EnabledWebhooks()...)
 
 	if datadogConfig.GetBool("admission_controller.probe.enabled") {
-		admissionProbe := admprobe.New(ctx.Client, isLeaderFunc, datadogConfig)
+		admissionProbe := admprobe.New(ctx.Client, isLeaderFunc, namespace.GetResourcesNamespace(), datadogConfig)
 		setProbe(admissionProbe)
 		probeCtx, probeCancel := context.WithCancel(context.Background())
 		go func() {

--- a/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
+++ b/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
@@ -53,7 +53,6 @@
 
     Connectivity Probe
     ------------------
-    Namespace: {{ .admissionWebhook.Probe.Namespace }}
     {{- if .admissionWebhook.Probe.ConfigError }}
     Configuration Error: {{ .admissionWebhook.Probe.ConfigError }}
     {{- else }}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -975,7 +975,6 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("admission_controller.reinvocation_policy", "IfNeeded")
 	config.BindEnvAndSetDefault("admission_controller.add_aks_selectors", false) // adds in the webhook some selectors that are required in AKS
 	config.BindEnvAndSetDefault("admission_controller.probe.enabled", false)
-	config.BindEnvAndSetDefault("admission_controller.probe.namespace", "datadog-admission-probe-dryrun")
 	config.BindEnvAndSetDefault("admission_controller.probe.interval", 60)     // in seconds
 	config.BindEnvAndSetDefault("admission_controller.probe.grace_period", 60) // in seconds
 	config.BindEnvAndSetDefault("admission_controller.auto_instrumentation.enabled", true)

--- a/releasenotes-dca/notes/add-admission-network-probe-6613ea5d5689b5f7.yaml
+++ b/releasenotes-dca/notes/add-admission-network-probe-6613ea5d5689b5f7.yaml
@@ -14,5 +14,5 @@ features:
     for EKS, GKE, and AKS. Probe results are visible in the ``agent status``
     output under the Admission Controller section. The probe is disabled by
     default and can be enabled by setting ``admission_controller.probe.enabled``
-    to ``true``. It requires a dedicated namespace (default:
-    ``datadog-admission-probe-dryrun``) and pod creation RBAC in that namespace.
+    to ``true``. The probe uses dry-run ConfigMap creation requests in the
+    cluster agent's namespace.


### PR DESCRIPTION
### What does this PR do?

This PR is based on [a previous PR](https://github.com/DataDog/datadog-agent/pull/47064) that added admission controller probe to detect network connectivity issues between the cluster agent and the control plane.

This PR changes 2 things:
- Creates configmaps instead of pods in dry-run mode
- Creates the configmaps in the agent's namespace instead of doing it in a dedicated namespace

### Motivation

- Using the agent's namespace and config maps makes rbacs management simpler for both the helm chart and the operator because the cluster agent already has CREATE permission for configmaps in its own namespace.

### Describe how you validated your changes

Same testing as [the previous PR.](https://github.com/DataDog/datadog-agent/pull/47064)

### Additional Notes

To intercept requests from the agent's namespace, we need to add a new lightweight webhook entry because the agent's namespace is disabled by default.