### PR TITLE
Introduce LLVM toolchain for ebpf programs

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -132,6 +132,20 @@ register_toolchains(
 visual_studio = use_repo_rule("//bazel/rules:visual_studio.bzl", "visual_studio")
 
 ######################################
+## LLVM BPF toolchain for eBPF    ##
+####################################
+
+llvm_bpf_ext = use_extension("//bazel/toolchains/llvm_bpf:llvm_bpf_configure.bzl", "llvm_bpf_extension")
+llvm_bpf_ext.configure(
+    clang_build_version = "v60409452-ee70de70",
+    clang_version = "12.0.1",
+    s3_base_url = "https://dd-agent-omnibus.s3.amazonaws.com/llvm",
+)
+use_repo(llvm_bpf_ext, "llvm_bpf")
+
+register_toolchains("@llvm_bpf//:llvm_bpf_toolchain")
+
+######################################
 ## Compilers and toolchains        ##
 ####################################
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -140,6 +140,14 @@ llvm_bpf_ext.configure(
     clang_build_version = "v60409452-ee70de70",
     clang_version = "12.0.1",
     s3_base_url = "https://dd-agent-omnibus.s3.amazonaws.com/llvm",
+    sha256s = {
+        "clang.amd64": "2a4df4c49a57efb33ec4e51f87f837bc80f3a5874a5828384f265541a018394e",
+        "clang.arm64": "5432ee1afc66453a457e756b025e4cace3aa56f687f595ac5d5bebcff00eac1b",
+        "llc.amd64": "aa6ca65c28ac09f3ba1d22ccbda6a85d1414c6ed4491d8d758a08351cb66f86e",
+        "llc.arm64": "08429823efd7d4ab6a247b195dabd0e8d8b43c50789704fd3a19947e71dd4776",
+        "llvm-strip.amd64": "70a9edc44ccad32361f1c6ae619c3b98e5505d4b67f24b5996f55bf841ee5cbd",
+        "llvm-strip.arm64": "1fd0cb6344d606d8c6fe6ea424fdfdd1cba1228f027dd3f08463c914bc47f67e",
+    },
 )
 use_repo(llvm_bpf_ext, "llvm_bpf")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -243,7 +243,7 @@
   "moduleExtensions": {
     "//bazel/toolchains/llvm_bpf:llvm_bpf_configure.bzl%llvm_bpf_extension": {
       "general": {
-        "bzlTransitiveDigest": "SZmn/14pk+7D7XznYkKH56mNIMXg+zSchvcQuYDAwdE=",
+        "bzlTransitiveDigest": "eOYXODssdQNOf4X8CCImpZYvyFCF/VqCz/43DBjJieA=",
         "usagesDigest": "lBRxCKYy9X03c4jyF/C6hWEAf+24zs/m6M/bS7BVXQU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -243,8 +243,8 @@
   "moduleExtensions": {
     "//bazel/toolchains/llvm_bpf:llvm_bpf_configure.bzl%llvm_bpf_extension": {
       "general": {
-        "bzlTransitiveDigest": "HjWvtZhQjnuJj8RR2Vepnr36gR3U7IXL0KBvvBU3Znw=",
-        "usagesDigest": "QEf0T1I6AGMgbNJSzsDLmmGkussQWTkWsCggoYbuGGQ=",
+        "bzlTransitiveDigest": "SZmn/14pk+7D7XznYkKH56mNIMXg+zSchvcQuYDAwdE=",
+        "usagesDigest": "lBRxCKYy9X03c4jyF/C6hWEAf+24zs/m6M/bS7BVXQU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -255,6 +255,14 @@
               "s3_base_url": "https://dd-agent-omnibus.s3.amazonaws.com/llvm",
               "clang_version": "12.0.1",
               "clang_build_version": "v60409452-ee70de70",
+              "sha256s": {
+                "clang.amd64": "2a4df4c49a57efb33ec4e51f87f837bc80f3a5874a5828384f265541a018394e",
+                "clang.arm64": "5432ee1afc66453a457e756b025e4cace3aa56f687f595ac5d5bebcff00eac1b",
+                "llc.amd64": "aa6ca65c28ac09f3ba1d22ccbda6a85d1414c6ed4491d8d758a08351cb66f86e",
+                "llc.arm64": "08429823efd7d4ab6a247b195dabd0e8d8b43c50789704fd3a19947e71dd4776",
+                "llvm-strip.amd64": "70a9edc44ccad32361f1c6ae619c3b98e5505d4b67f24b5996f55bf841ee5cbd",
+                "llvm-strip.arm64": "1fd0cb6344d606d8c6fe6ea424fdfdd1cba1228f027dd3f08463c914bc47f67e"
+              },
               "verbose": false
             }
           }

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -241,6 +241,27 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//bazel/toolchains/llvm_bpf:llvm_bpf_configure.bzl%llvm_bpf_extension": {
+      "general": {
+        "bzlTransitiveDigest": "HjWvtZhQjnuJj8RR2Vepnr36gR3U7IXL0KBvvBU3Znw=",
+        "usagesDigest": "QEf0T1I6AGMgbNJSzsDLmmGkussQWTkWsCggoYbuGGQ=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "llvm_bpf": {
+            "repoRuleId": "@@//bazel/toolchains/llvm_bpf:llvm_bpf_configure.bzl%download_llvm_bpf",
+            "attributes": {
+              "s3_base_url": "https://dd-agent-omnibus.s3.amazonaws.com/llvm",
+              "clang_version": "12.0.1",
+              "clang_build_version": "v60409452-ee70de70",
+              "verbose": false
+            }
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "//bazel/toolchains/otool:otool_configure.bzl%find_system_otool": {
       "general": {
         "bzlTransitiveDigest": "68iERr/kCkKOV3vSc2q4LzpEgt7vSpOMHMX9EL+4l7g=",

--- a/bazel/toolchains/llvm_bpf/BUILD.bazel
+++ b/bazel/toolchains/llvm_bpf/BUILD.bazel
@@ -1,0 +1,14 @@
+"""LLVM/Clang toolchain for eBPF compilation."""
+
+load(":llvm_bpf.bzl", "llvm_bpf_toolchain")
+
+toolchain_type(
+    name = "llvm_bpf_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+llvm_bpf_toolchain(
+    name = "no_llvm_bpf",
+    version = "unavailable",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/toolchains/llvm_bpf/llvm_bpf.bzl
+++ b/bazel/toolchains/llvm_bpf/llvm_bpf.bzl
@@ -1,0 +1,42 @@
+"""LLVM BPF toolchain rule and provider."""
+
+LlvmBpfToolchainInfo = provider(
+    doc = "LLVM/Clang toolchain for eBPF compilation.",
+    fields = {
+        "clang_bpf": "clang-bpf executable File, or None",
+        "llc_bpf": "llc-bpf executable File, or None",
+        "llvm_strip": "llvm-strip executable File, or None",
+        "version": "LLVM version string",
+        "valid": "Whether the toolchain is usable",
+    },
+)
+
+def _llvm_bpf_toolchain_impl(ctx):
+    return [platform_common.ToolchainInfo(
+        llvm_bpf = LlvmBpfToolchainInfo(
+            clang_bpf = ctx.file.clang_bpf if ctx.file.clang_bpf else None,
+            llc_bpf = ctx.file.llc_bpf if ctx.file.llc_bpf else None,
+            llvm_strip = ctx.file.llvm_strip if ctx.file.llvm_strip else None,
+            version = ctx.attr.version,
+            valid = ctx.file.clang_bpf != None,
+        ),
+    )]
+
+llvm_bpf_toolchain = rule(
+    implementation = _llvm_bpf_toolchain_impl,
+    attrs = {
+        "clang_bpf": attr.label(
+            doc = "clang-bpf executable",
+            allow_single_file = True,
+        ),
+        "llc_bpf": attr.label(
+            doc = "llc-bpf executable",
+            allow_single_file = True,
+        ),
+        "llvm_strip": attr.label(
+            doc = "llvm-strip executable",
+            allow_single_file = True,
+        ),
+        "version": attr.string(default = "unknown"),
+    },
+)

--- a/bazel/toolchains/llvm_bpf/llvm_bpf.bzl
+++ b/bazel/toolchains/llvm_bpf/llvm_bpf.bzl
@@ -28,14 +28,17 @@ llvm_bpf_toolchain = rule(
         "clang_bpf": attr.label(
             doc = "clang-bpf executable",
             allow_single_file = True,
+            executable = True,
         ),
         "llc_bpf": attr.label(
             doc = "llc-bpf executable",
             allow_single_file = True,
+            executable = True,
         ),
         "llvm_strip": attr.label(
             doc = "llvm-strip executable",
             allow_single_file = True,
+            executable = True,
         ),
         "version": attr.string(default = "unknown"),
     },

--- a/bazel/toolchains/llvm_bpf/llvm_bpf.bzl
+++ b/bazel/toolchains/llvm_bpf/llvm_bpf.bzl
@@ -12,13 +12,16 @@ LlvmBpfToolchainInfo = provider(
 )
 
 def _llvm_bpf_toolchain_impl(ctx):
+    clang = ctx.executable.clang_bpf if hasattr(ctx.executable, "clang_bpf") else None
+    llc = ctx.executable.llc_bpf if hasattr(ctx.executable, "llc_bpf") else None
+    strip = ctx.executable.llvm_strip if hasattr(ctx.executable, "llvm_strip") else None
     return [platform_common.ToolchainInfo(
         llvm_bpf = LlvmBpfToolchainInfo(
-            clang_bpf = ctx.file.clang_bpf if ctx.file.clang_bpf else None,
-            llc_bpf = ctx.file.llc_bpf if ctx.file.llc_bpf else None,
-            llvm_strip = ctx.file.llvm_strip if ctx.file.llvm_strip else None,
+            clang_bpf = clang,
+            llc_bpf = llc,
+            llvm_strip = strip,
             version = ctx.attr.version,
-            valid = ctx.file.clang_bpf != None,
+            valid = clang != None,
         ),
     )]
 
@@ -29,16 +32,19 @@ llvm_bpf_toolchain = rule(
             doc = "clang-bpf executable",
             allow_single_file = True,
             executable = True,
+            cfg = "exec",
         ),
         "llc_bpf": attr.label(
             doc = "llc-bpf executable",
             allow_single_file = True,
             executable = True,
+            cfg = "exec",
         ),
         "llvm_strip": attr.label(
             doc = "llvm-strip executable",
             allow_single_file = True,
             executable = True,
+            cfg = "exec",
         ),
         "version": attr.string(default = "unknown"),
     },

--- a/bazel/toolchains/llvm_bpf/llvm_bpf_configure.bzl
+++ b/bazel/toolchains/llvm_bpf/llvm_bpf_configure.bzl
@@ -1,0 +1,137 @@
+"""Repository rule to download LLVM/Clang for eBPF compilation from Datadog S3."""
+
+NAME = "llvm_bpf"
+
+_BINARIES = {
+    "clang-bpf": "clang",
+    "llc-bpf": "llc",
+    "llvm-strip": "llvm-strip",
+}
+
+def _get_url(s3_base, url_prefix, clang_version, arch, build_version):
+    return "{}/{}-{}.{}.{}".format(s3_base, url_prefix, clang_version, arch, build_version)
+
+def _download_llvm_bpf_impl(rctx):
+    downloaded = {}
+    clang_version = rctx.attr.clang_version
+
+    if "linux" in rctx.os.name:
+        arch = rctx.os.arch
+        if arch in ("x86_64", "amd64"):
+            arch = "amd64"
+        elif arch in ("aarch64", "arm64"):
+            arch = "arm64"
+        else:
+            fail("Unsupported architecture for LLVM BPF toolchain: " + arch)
+
+        for binary, url_prefix in _BINARIES.items():
+            url = _get_url(rctx.attr.s3_base_url, url_prefix, clang_version, arch, rctx.attr.clang_build_version)
+            output = "bin/" + binary
+
+            if rctx.attr.verbose:
+                # buildifier: disable=print
+                print("Downloading {} from {}".format(binary, url))
+
+            result = rctx.download(
+                url = url,
+                output = output,
+                executable = True,
+            )
+            if not result.success:
+                fail("Failed to download {} from {}".format(binary, url))
+            downloaded[binary] = output
+
+    binary_attrs = ""
+    if downloaded:
+        binary_attrs = """    clang_bpf = "{clang}",
+    llc_bpf = "{llc}",
+    llvm_strip = "{strip}",""".format(
+            clang = downloaded["clang-bpf"],
+            llc = downloaded["llc-bpf"],
+            strip = downloaded["llvm-strip"],
+        )
+
+    install_target = ""
+    if downloaded:
+        install_target = """
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
+
+pkg_files(
+    name = "all_files",
+    srcs = glob(["bin/*"]),
+    prefix = "embedded/bin",
+    attributes = pkg_attributes(mode = "0755"),
+)
+
+pkg_install(
+    name = "install",
+    srcs = [":all_files"],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+"""
+
+    rctx.file("BUILD.bazel", content = """\
+load("@@//bazel/toolchains/llvm_bpf:llvm_bpf.bzl", "llvm_bpf_toolchain")
+
+exports_files(glob(["bin/*"], allow_empty = True))
+
+llvm_bpf_toolchain(
+    name = "llvm_bpf_impl",
+{binary_attrs}
+    version = "{version}",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "llvm_bpf_toolchain",
+    target_compatible_with = ["@platforms//os:linux"],
+    toolchain = ":llvm_bpf_impl",
+    toolchain_type = "@@//bazel/toolchains/llvm_bpf:llvm_bpf_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+{install_target}""".format(
+        binary_attrs = binary_attrs,
+        version = clang_version,
+        install_target = install_target,
+    ))
+
+download_llvm_bpf = repository_rule(
+    implementation = _download_llvm_bpf_impl,
+    doc = "Download LLVM BPF toolchain binaries from Datadog S3.",
+    attrs = {
+        "s3_base_url": attr.string(mandatory = True),
+        "clang_version": attr.string(mandatory = True),
+        "clang_build_version": attr.string(mandatory = True),
+        "verbose": attr.bool(default = False),
+    },
+)
+
+_configure = tag_class(
+    attrs = {
+        "s3_base_url": attr.string(default = "https://dd-agent-omnibus.s3.amazonaws.com/llvm"),
+        "clang_version": attr.string(default = "12.0.1"),
+        "clang_build_version": attr.string(default = "v60409452-ee70de70"),
+        "verbose": attr.bool(default = False),
+    },
+)
+
+def _llvm_bpf_extension_impl(ctx):
+    cfg = ctx.modules[0].tags.configure[0] if ctx.modules[0].tags.configure else struct(
+        s3_base_url = "https://dd-agent-omnibus.s3.amazonaws.com/llvm",
+        clang_version = "12.0.1",
+        clang_build_version = "v60409452-ee70de70",
+        verbose = False,
+    )
+    download_llvm_bpf(
+        name = NAME,
+        s3_base_url = cfg.s3_base_url,
+        clang_version = cfg.clang_version,
+        clang_build_version = cfg.clang_build_version,
+        verbose = cfg.verbose,
+    )
+
+llvm_bpf_extension = module_extension(
+    implementation = _llvm_bpf_extension_impl,
+    tag_classes = {"configure": _configure},
+)

--- a/bazel/toolchains/llvm_bpf/llvm_bpf_configure.bzl
+++ b/bazel/toolchains/llvm_bpf/llvm_bpf_configure.bzl
@@ -2,6 +2,7 @@
 
 NAME = "llvm_bpf"
 
+# Maps installed binary name -> S3 URL prefix.
 _BINARIES = {
     "clang-bpf": "clang",
     "llc-bpf": "llc",
@@ -24,9 +25,12 @@ def _download_llvm_bpf_impl(rctx):
         else:
             fail("Unsupported architecture for LLVM BPF toolchain: " + arch)
 
+        sha256s = rctx.attr.sha256s
         for binary, url_prefix in _BINARIES.items():
             url = _get_url(rctx.attr.s3_base_url, url_prefix, clang_version, arch, rctx.attr.clang_build_version)
             output = "bin/" + binary
+            sha256_key = "{}.{}".format(url_prefix, arch)
+            sha256 = sha256s.get(sha256_key, "")
 
             if rctx.attr.verbose:
                 # buildifier: disable=print
@@ -36,6 +40,7 @@ def _download_llvm_bpf_impl(rctx):
                 url = url,
                 output = output,
                 executable = True,
+                sha256 = sha256,
             )
             if not result.success:
                 fail("Failed to download {} from {}".format(binary, url))
@@ -103,6 +108,7 @@ download_llvm_bpf = repository_rule(
         "s3_base_url": attr.string(mandatory = True),
         "clang_version": attr.string(mandatory = True),
         "clang_build_version": attr.string(mandatory = True),
+        "sha256s": attr.string_dict(doc = "SHA256 checksums keyed by '{binary_prefix}.{arch}', e.g. 'clang.amd64'."),
         "verbose": attr.bool(default = False),
     },
 )
@@ -112,6 +118,7 @@ _configure = tag_class(
         "s3_base_url": attr.string(default = "https://dd-agent-omnibus.s3.amazonaws.com/llvm"),
         "clang_version": attr.string(default = "12.0.1"),
         "clang_build_version": attr.string(default = "v60409452-ee70de70"),
+        "sha256s": attr.string_dict(doc = "SHA256 checksums keyed by '{binary_prefix}.{arch}', e.g. 'clang.amd64'."),
         "verbose": attr.bool(default = False),
     },
 )
@@ -121,6 +128,7 @@ def _llvm_bpf_extension_impl(ctx):
         s3_base_url = "https://dd-agent-omnibus.s3.amazonaws.com/llvm",
         clang_version = "12.0.1",
         clang_build_version = "v60409452-ee70de70",
+        sha256s = {},
         verbose = False,
     )
     download_llvm_bpf(
@@ -128,6 +136,7 @@ def _llvm_bpf_extension_impl(ctx):
         s3_base_url = cfg.s3_base_url,
         clang_version = cfg.clang_version,
         clang_build_version = cfg.clang_build_version,
+        sha256s = cfg.sha256s,
         verbose = cfg.verbose,
     )
 

--- a/bazel/toolchains/llvm_bpf/llvm_bpf_configure.bzl
+++ b/bazel/toolchains/llvm_bpf/llvm_bpf_configure.bzl
@@ -47,6 +47,7 @@ def _download_llvm_bpf_impl(rctx):
             downloaded[binary] = output
 
     binary_attrs = ""
+    install_target = ""
     if downloaded:
         binary_attrs = """    clang_bpf = "{clang}",
     llc_bpf = "{llc}",
@@ -55,9 +56,6 @@ def _download_llvm_bpf_impl(rctx):
             llc = downloaded["llc-bpf"],
             strip = downloaded["llvm-strip"],
         )
-
-    install_target = ""
-    if downloaded:
         install_target = """
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")


### PR DESCRIPTION
### What does this PR do?
- Adds a Bazel toolchain that downloads `clang-bpf`, `llc-bpf`, and `llvm-strip` from S3 for compiling eBPF programs
- Includes a `pkg_install` target for shipping the binaries to `/opt/datadog-agent/embedded/bin/`
- Toolchain configuration (S3 URL, clang version) is exposed via a tag class in `MODULE.bazel`
- Gracefully skipped on non-Linux platforms via `target_compatible_with`

This is a chunk of a bigger PR #47400.