### PR TITLE
perf(fleet): precompute stable/experiment targets in repository cleanup loop

### DIFF
--- a/pkg/fleet/installer/repository/repository.go
+++ b/pkg/fleet/installer/repository/repository.go
@@ -426,13 +426,17 @@ func (r *repositoryFiles) cleanup(ctx context.Context) error {
 		return fmt.Errorf("could not read root directory: %w", err)
 	}
 
+	// Precompute targets once to avoid repeated filepath.Base calls inside the loop.
+	stableTarget := r.stable.Target()
+	experimentTarget := r.experiment.Target()
+
 	// for all versions that are not stable or experiment:
 	// - if no pre-remove hook is configured, delete the package
 	// - if a pre-remove hook is configured, run the hook and delete the package only if the hook returns true
 	for _, file := range files {
 		isLink := file.Name() == stableVersionLink || file.Name() == experimentVersionLink
-		isStable := r.stable.Exists() && r.stable.Target() == file.Name()
-		isExperiment := r.experiment.Exists() && r.experiment.Target() == file.Name()
+		isStable := stableTarget != "" && stableTarget == file.Name()
+		isExperiment := experimentTarget != "" && experimentTarget == file.Name()
 		if isLink || isStable || isExperiment {
 			continue
 		}


### PR DESCRIPTION
### What does this PR do?

In `repositoryFiles.cleanup`, the `isStable` and `isExperiment` checks inside the loop each called `r.stable.Target()` / `r.experiment.Target()` on every iteration. `Target()` calls `filepath.Base` internally, so these values were recomputed O(n) times for n directory entries.

This PR hoists both calls outside the loop and stores the results in local variables. The `Exists()` guard is replaced by an equivalent non-empty check (since `Target()` already returns `""` when the link doesn't exist).

### Motivation

Minor but free performance improvement: avoid redundant `filepath.Base` syscall-adjacent work on every entry in the repository directory during cleanup, which runs on every install/remove/experiment operation.

### Describe how you validated your changes

Existing unit tests in `pkg/fleet/installer/repository/` pass unchanged.

### Additional Notes

No behaviour change — `Target()` returns `""` when `Exists()` is false, so `stableTarget != ""` is equivalent to the previous `r.stable.Exists() && r.stable.Target() == file.Name()`.