### PR TITLE
Run `bazel` tests in MQ as well

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -1,8 +1,7 @@
 .bazel:test:
-  rules:
-    - !reference [ .except_mergequeue ]
-    - when: on_success
   stage: source_test
+  rules:
+    - when: on_success
 
 bazel:test:linux-amd64:
   extends: [ .bazel:test, .bazel:runner:linux-amd64 ]
@@ -27,8 +26,8 @@ bazel:test:macos-arm64:
 bazel:test:windows-amd64:
   extends: [ .bazel:test, .bazel:runner:windows-amd64 ]
   rules:
-    - !reference [.except_skip_windows]
-    - !reference [.bazel:test, rules]
+    - !reference [ .except_skip_windows ]
+    - when: on_success
   variables:
     POWERSHELL_SCRIPT: |-
       bazel test //bazel/tests/... //rtloader/...


### PR DESCRIPTION
### What does this PR do?
Always run `bazel` tests, that is by lifting the MQ exclusion.

### Motivation
Prevent build & test regressions from entering `main` depending on the applied PR combination.