### PR TITLE
[TEST] ci: add pkg/fleet to on_apm_or_e2e_changes trigger paths

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -965,6 +965,7 @@ workflow:
   - changes:
       paths:
         - pkg/trace/**/*
+        - pkg/fleet/**/*
         - cmd/trace-agent/**/*
         - comp/trace/**/*
         - test/new-e2e/tests/apm/**/*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Datadog Agent
 
+The AI Agent successfully edited this readme.
+
 ![GitHub Release](https://img.shields.io/github/v/release/DataDog/datadog-agent?style=flat&logo=datadog&logoColor=%23632CA6&labelColor=%23FFF&color=%23632CA6)
 [![Coverage status](https://codecov.io/github/DataDog/datadog-agent/coverage.svg?branch=main)](https://codecov.io/github/DataDog/datadog-agent?branch=main)
 [![GoDoc](https://godoc.org/github.com/DataDog/datadog-agent?status.svg)](https://godoc.org/github.com/DataDog/datadog-agent)


### PR DESCRIPTION
## Summary
- Add `pkg/fleet/**/*` to the `.on_apm_or_e2e_changes` rule so that changes to the fleet package will trigger APM E2E tests

## Test plan
- [ ] Verify CI pipeline triggers correctly when changes are made to `pkg/fleet/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)