### PR TITLE
Add starting version for Agent-schema documentation

### DIFF
--- a/docs/public/agent-schema/examples.md
+++ b/docs/public/agent-schema/examples.md
@@ -1,0 +1,192 @@
+# Examples
+
+This page walks through three annotated examples taken from or inspired by the
+real schema files. Each example builds on the concepts introduced in the
+[Keyword Reference](keywords.md).
+
+---
+
+## Example 1 — Simple public setting node (`api_key`)
+
+```yaml
+api_key:
+  node_type: setting    # (1)
+  type: string          # (2)
+  default: ""           # (3)
+  description: |        # (4)
+    The Datadog API key used by your Agent to submit metrics and events
+    to Datadog.
+
+    Create a new API key here: https://app.datadoghq.com/organization-settings/api-keys
+  env_vars:             # (5)
+    - DD_API_KEY
+    - DATADOG_API_KEY
+  visibility: public    # (6)
+```
+
+1. **`node_type: setting`** — this node is an individual setting that holds a value.
+2. **`type: string`** — the setting holds a text value.
+3. **`default: ""`** — the default is an empty string. Mandatory for all setting
+   nodes unless `platform_default` is used instead.
+4. **`description`** — free-text documentation. Multi-line descriptions use the
+   YAML `|` block scalar. This text appears in `datadog.yaml.example` and any
+   public-facing configuration website.
+5. **`env_vars`** — lists the environment variables that set this value. Both
+   `DD_API_KEY` and `DATADOG_API_KEY` are accepted; they are checked in order
+   and the first match wins. Without this field, the Agent would derive a
+   default env var from the setting path (`DD_API_KEY` in this case, which
+   matches the automatically derived name in this case).
+6. **`visibility: public`** — includes this setting in `datadog.yaml.example`
+   and public documentation. Without this, the setting is considered internal.
+
+---
+
+## Example 2 — Section node with mixed children (`apm_config`)
+
+This example shows a section node taken from `pkg/config/schema/core_schema.yaml`
+with several child setting nodes, including one with a `platform_default`.
+
+```yaml
+apm_config:
+  node_type: section                        # (1)
+  title: "Trace Collection Configuration"   # (2)
+  description: |                            # (3)
+    Enter specific configurations for your trace collection.
+    Uncomment this parameter and the one below to enable them.
+    See https://docs.datadoghq.com/agent/apm/
+  visibility: public                        # (4)
+  properties:                               # (5)
+
+    enabled:
+      node_type: setting
+      type: boolean
+      default: false                        # (6)
+      description: Enable the APM agent.
+      env_vars:
+        - DD_APM_ENABLED
+      visibility: public
+
+    receiver_socket:
+      node_type: setting
+      type: string
+      platform_default:                     # (7)
+        linux: /var/run/datadog/apm.socket
+        other: ""
+      description: |
+        Accept traces through Unix Domain Sockets.
+        Set to "" to disable the UDS receiver.
+      env_vars:
+        - DD_APM_RECEIVER_SOCKET
+      visibility: public
+
+    apm_dd_url:
+      node_type: setting
+      type: string
+      default: ""
+      description: |
+        Define the endpoint and port to hit when using a proxy for APM.
+        The traces are forwarded in TCP, so the proxy must handle TCP connections.
+      env_vars:
+        - DD_APM_DD_URL
+      visibility: public
+```
+
+1. **`node_type: section`** — this node groups child settings/section rather than holding a value itself.
+2. **`title`** — generates a section banner in `datadog.yaml.example`:
+   ```
+   ####################################
+   ## Trace Collection Configuration ##
+   ####################################
+   ```
+3. **`description`** — section-level documentation that appears below the banner.
+4. **`visibility: public`** — marks the section as public. Child nodes still need their own `visibility: public` to
+   appear in the generated output.
+5. **`properties`** — the child settings. Each key is a setting name; each value is a setting or nested section node.
+6. **`default: false`** — a simple boolean default on a regular cross-platform setting node.
+7. **`platform_default`** — used instead of `default` when the correct default depends on the operating system. Here,
+   Linux uses a Unix socket path while all other platforms default to an empty string. The special key `other` acts as a
+   fallback for any platform not explicitly listed.
+
+---
+
+## Example 3 — Complex nested type (`cel_workload_exclude`)
+
+This example shows how JSON Schema's composable
+validation handles a non-trivial type. `cel_workload_exclude` corresponds to
+the following Go struct:
+
+```go
+type Product string
+type ResourceType string
+
+type RuleBundle struct {
+    Products []Product
+    Rules    map[ResourceType][]string
+}
+// cel_workload_exclude is []RuleBundle
+```
+
+`cel_workload_exclude` is a single **setting node** whose value is an array. The
+`items`, `properties`, and `additionalProperties` keywords below describe the
+*shape of the value* — they are JSON Schema validation keywords, not Agent
+schema nodes.
+
+```yaml
+cel_workload_exclude:
+  node_type: setting     # a single setting whose value is an array
+  type: array            # (1)
+  default: []
+
+  # Everything below describes the value, not new schema nodes:
+  items:                # (2)
+    type: object        # (3)
+
+    properties:         # (4)
+      products:
+        type: array     # (5)
+        items:
+          type: string  # each product is a string
+
+      rules:
+        type: object                  # (6)
+        additionalProperties:         # (7)
+          type: array
+          items:
+            type: string              # each rule expression is a string
+
+    additionalProperties: false       # (8)
+```
+
+1. **`type: array`** — the setting's value is a list.
+2. **`items`** — defines the schema that every element of the list must
+   satisfy. This is a value constraint, not a child node.
+3. **`type: object`** — each element of the list is a dict.
+4. **`properties`** — the allowed keys of each dict: `products` and `rules`.
+   These are keys in the *value*, not Agent schema nodes.
+5. **`type: array` / `items: {type: string}`** — `products` is a list of
+   strings.
+6. **`type: object`** — `rules` is itself a dict.
+7. **`additionalProperties: {type: array, items: {type: string}}`** — every
+   *value* in the `rules` dict must be a list of strings. The *keys* are
+   unconstrained (they are resource type names).
+8. **`additionalProperties: false`** on the outer object — no keys other than
+   `products` and `rules` are allowed in each element.
+
+A valid config value that matches this schema:
+
+```yaml
+cel_workload_exclude:
+  - products:
+      - metrics
+    rules:
+      kube_service:
+        - service.name == 'yaml-service'
+      pod:
+        - pod.namespace == 'yaml-ns'
+      container:
+        - container.name == 'yaml-test'
+```
+
+This demonstrates a key strength of JSON Schema: complex, deeply nested types
+are validated with the same small set of composable keywords used for simple
+scalars. No custom validation code is needed.

--- a/docs/public/agent-schema/faq.md
+++ b/docs/public/agent-schema/faq.md
@@ -1,0 +1,130 @@
+# FAQ
+
+---
+
+## How do I add a new setting?
+
+1. **Determine the node type.** If the setting holds a value (string, number,
+   boolean, list, or dict that *is* the value), it is a setting node. If it groups
+   other settings, it is a section node.
+
+2. **Choose the correct schema file.**
+   - Settings for `datadog.yaml` go in `pkg/config/schema/core_schema.yaml`.
+   - Settings for `system-probe.yaml` go in
+     `pkg/config/schema/system-probe_schema.yaml`.
+
+3. **Find the correct parent.** Locate the `properties` block of the parent
+   section node under which the new setting belongs.
+
+4. **Add the node** with the mandatory keywords:
+   - Setting nodes require `type` and either `default` or `platform_default`.
+   - Section nodes require `node_type: section` and `properties`.
+
+5. **Add optional keywords** as appropriate:
+   - `description` — strongly encouraged for all settings.
+   - `env_vars` — list explicit env var names if the default
+     (`DD_` + uppercase path) is wrong or if aliases are needed.
+   - `visibility: public` — add when the setting should appear in
+     configuration examples and public documentation (see
+     [How do I make a setting public?](#how-do-i-make-a-setting-public)).
+
+Minimal example:
+
+```yaml
+my_new_setting:
+  type: boolean
+  default: false
+  description: Enables the new feature.
+```
+
+---
+
+## How do I deprecate a setting?
+
+> **Note:** [WIP] Automated solution coming soon.
+
+---
+
+## How do I make a setting public?
+
+1. **Write a `description`** that explains what the setting does, what the default means, and any caveats. Every public
+   setting must have a description. The description is aimed at users not Agent developers.
+
+2. **Add `visibility: public`** to the setting or section node.
+
+3. **Make every parent section public too.** A setting node with
+   `visibility: public` nested inside a non-public section is invalid. Every
+   section in the path from the root to the setting must also have
+   `visibility: public` and a `description`. Without this the schema will be
+   rejected.
+
+   ```yaml
+   my_section:
+     node_type: section
+     visibility: public
+     description: Configuration for my feature.
+     properties:
+
+       my_setting:
+         node_type: setting
+         type: boolean
+         default: false
+         description: Enables my feature.
+         visibility: public
+   ```
+
+The setting will appear in the configuration examples (ex: `datadog.yaml.example`) the next time the file is
+regenerated.
+
+---
+
+## How do I document a public setting?
+
+1. **Write a clear `description`** covering:
+   - What the setting does.
+   - What the default value means in practice.
+   - Any important caveats or links to external documentation.
+
+2. **Use the YAML `|` block scalar** for multi-line descriptions:
+
+   ```yaml
+   flush_timeout:
+     type: number
+     default: 5
+     description: |
+       Maximum time in seconds the Agent waits before flushing metrics
+       to the intake. Lower values reduce latency but increase request
+       volume. The default of 5 seconds is suitable for most deployments.
+     visibility: public
+   ```
+
+3. **Set `visibility: public`** to include the setting in generated output.
+
+---
+
+## How do I generate `datadog.yaml.example`?
+
+The generation of `datadog.yaml.example` from the schema is wired into the
+Agent's build pipeline and runs automatically. Developers do not normally need
+to trigger it manually.
+
+If you want to validate the generated example you can use `dda inv schema.template-all` command.
+
+---
+
+## What is the difference between `datadog.yaml.example` and `system-probe.yaml.example`?
+
+Each configuration file has its own schema and its own generated example file:
+
+- **`datadog.yaml.example`** is generated from
+  `pkg/config/schema/core_schema.yaml` and covers the main Agent configuration —
+  metrics, logs, APM, processes, and more.
+
+- **`system-probe.yaml.example`** is generated from
+  `pkg/config/schema/system-probe_schema.yaml` and covers only the settings
+  specific to the system-probe component: eBPF probes, network performance
+  monitoring, universal service monitoring, and related features.
+
+Both files include only nodes with `visibility: public`. The separation mirrors
+the fact that system-probe runs as a separate binary (`system-probe`) with its
+own configuration file, independently of the main Agent process.

--- a/docs/public/agent-schema/index.md
+++ b/docs/public/agent-schema/index.md
@@ -1,0 +1,78 @@
+# Agent Configuration Schema
+
+The Datadog Agent configuration schema is a YAML-based
+[JSON Schema](https://json-schema.org/) that centrally describes every
+configuration setting for the Agent. It is written in YAML for readability but
+is fully compatible with JSON Schema tooling.
+
+## Why it exists
+
+Previously, Agent configuration was defined through a combination of imperative Go code (`BindEnv` and
+`BindEnvAndSetDefault` calls in `pkg/config/setup`), YAML example files maintained by-hand, and scattered validation
+logic. This made it hard to understand what a setting does, what values it accepts, or what its default is — without
+reading source code.
+
+The schema replaces this with a **single source of truth**. All information
+about a setting — its type, default value, documentation, environment variables,
+validation rules, and visibility — lives in one place.
+
+## What it enables
+
+- **Config validation without running the Agent** — any JSON Schema library can
+  validate a customer's `datadog.yaml` against the schema.
+- **IDE autocompletion** — the schema can be published to
+  [SchemaStore](https://www.schemastore.org/) so editors like VS Code
+  automatically validate and complete configuration files.
+- **Automatic generation of `datadog.yaml.example` and `system-probe.yaml.example** — the example file shipped with the
+  Agent is generated directly from the schema, ensuring it stays in sync.
+- **Type-safe code generation** — Go configuration code can be generated from
+  the schema, removing the imperative setup code entirely.
+- **Runtime validation**  — The user configuration can be validate at runtime by the Agent allowing automatic fallback
+  to default upon an invalid value.
+
+## Terminology
+
+- **Path** — a string of terms separated by dots (`"."`) that represents a series of nodes in the config tree.
+- **Setting** — a configurable value that can be located using a path (example `apm_config.enabled`)
+- **Section** — a groupping of settings under a common name (example `apm_config`)
+- **Object** — a data type of key-value pairs. Also called a map (in Go) or dict (in Python), but called an object in JSON Schema since it comes from JavaScript.
+- **Default** — the value that will be retrieved for a given setting if none is specified by the user's file-based configuration or environment variable (or other source).
+
+## Node types
+
+The schema tree is composed of two types of nodes:
+
+- **Setting nodes** represent individual settings. They have a type and a value.
+  For example, `apm_config.enabled` is a setting node of type `boolean`.
+- **Section nodes** represent a group of settings. Sections do not have values
+  themselves; instead they group related setting nodes together. For example, `apm_config`
+  is a section node containing `enabled` and many other setting nodes. Section
+  nodes are identified by the `node_type: section` keyword.
+
+The distinction matters when a setting's value is an object. For example, `docker_labels_as_tags` is a `type: object`
+setting node — its value is a dict of strings, but that dict is the setting's *value*, not a group of child settings. It
+is a setting node, and **not** a section node.
+
+## One schema per configuration file
+
+The Agent ships with multiple configuration files, each with its own schema:
+
+| Config file | Schema file |
+| --- | --- |
+| `datadog.yaml` | `pkg/config/schema/core-agent-schema.yaml` |
+| `system-probe.yaml` | `pkg/config/schema/system-probe-schema.yaml` |
+
+All schemas share the same keyword set described in this documentation.
+
+## JSON Schema foundation
+
+The Agent schema builds on [JSON Schema draft 2020-12](https://json-schema.org/).
+This documentation focuses on how keywords are used in the Agent schema
+specifically. For a general introduction to JSON Schema, see
+[Understanding JSON Schema](https://json-schema.org/understanding-json-schema).
+
+## Next steps
+
+- [Keyword Reference](keywords.md) — complete reference for all supported keywords.
+- [Examples](examples.md) — annotated, real-world examples from the schema.
+- [FAQ](faq.md) — common tasks such as adding a setting or making one public.

--- a/docs/public/agent-schema/keywords.md
+++ b/docs/public/agent-schema/keywords.md
@@ -1,0 +1,533 @@
+# Keyword Reference
+
+This page documents keywords supported by the Agent configuration schema.
+Keywords are grouped into two sections: standard JSON Schema keywords and
+Datadog Agent extensions.
+
+---
+
+## Standard JSON Schema keywords
+
+The following keywords come from the [JSON Schema standard](https://json-schema.org/understanding-json-schema/keywords)
+and are understood by all JSON Schema tooling. This section describes how each
+keyword is used **specifically in the Agent schema**.
+
+> **Note:** not all keywords define in the JSON Schema standard are explain here, only the most commonly used.
+
+### `type`
+
+The data type of a setting node's value.
+
+- **Mandatory:** yes, for all setting nodes. Not valid on section nodes.
+
+Supported types:
+
+| Type | Description |
+| --- | --- |
+| `boolean` | `true` or `false` |
+| `number` | integer or floating-point number |
+| `string` | text value |
+| `array` | ordered list of values |
+| `object` | key/value pairs |
+
+Complex types are composed by combining these primitives — for example, an
+`array` whose `items` are `object`s.
+
+```yaml
+network_devices:
+  node_type: setting
+  type: array
+  default: []
+  items:       # describes types of the array elements, here all elements must be an object
+    type: object
+```
+
+---
+
+### `default`
+
+The default value for a setting node.
+
+- **Mandatory:** yes, for all setting nodes. Mutually exclusive with `platform_default` (one or the other must be
+  specified).
+
+The value must match the `type` of the setting.
+
+```yaml
+check_runners:
+  node_type: setting
+  type: number
+  default: 4
+```
+
+#### Relative defaults
+
+Some default value are resolved at runtime base on the agent install parameter. Default value are often relative to the
+"install path", "log directory" ...
+
+Those concept can be express using the `${}` notation with one of the following variables. The value below show the
+default but could be change by the users. For example, the default configuration directory for Windows is `c:/programdata/datadog` but can be changed at install time. The correct value will be use at startup by the Agent.
+
+Path are all express using `/` and will be translated to the correct OS version.
+
+Existing variagbles:
+- Configuration directory:
+  - `windows`: `c:/programdata/datadog`
+  - `linux`; `/etc/datadog-agent`
+  - `darwin`: `/opt/datadog-agent/etc`
+- Installation directory:
+  - `windows`: `c:/program files/datadog/datadog agent`
+  - `linux`; `/opt/datadog-agent`
+  - `darwin`: `/opt/datadog-agent`
+- Log directory:
+  - `windows`: `c:/programdata/datadog/logs`
+  - `linux`; `/var/log/datadog`
+  - `darwin`: `/opt/datadog-agent/logs`
+- Run directory (where the Agent starts from):
+  - `windows`: `/opt/datadog-agent/run`
+  - `linux`; `c:/programdata/datadog/run`
+  - `darwin`: `/opt/datadog-agent/run`
+
+
+The above variables are available for `default` and `platform_default` keywords.
+
+Example:
+```
+confd_path:
+  node_type: setting
+  type: string
+  default: "${conf_path}/conf.d"
+```
+
+---
+
+### `description`
+
+Human-readable documentation for a node.
+
+- **Mandatory:** yes, for any node with `visibility: public`. Optional otherwise, but every setting should eventually have one — a developer should not need to read source code to understand what a setting does.
+- **Available on:** setting and section nodes.
+
+Used to generate the `datadog.yaml.example` file shipped with the Agent.
+
+Use the YAML `|` block scalar for multi-line descriptions:
+
+```yaml
+api_key:
+  node_type: setting
+  type: string
+  default: ""
+  description: |
+    The Datadog API key used by your Agent to submit metrics and events
+    to Datadog.
+
+    Create a new API key here: https://app.datadoghq.com/organization-settings/api-keys
+```
+
+---
+
+### `title`
+
+A short heading used to generate section banners in `datadog.yaml.example`.
+
+- **Available on:** section nodes only.
+
+> **Note:** The Agent schema's use of `title` differs from the JSON Schema standard, where `title` is a
+> concise human-readable summary of a schema. Here, `title` is specifically a banner label applied only
+> to section nodes that begin a new conceptual group in the generated config file.
+
+When a section has a `title`, the config example generator produces a banner like this:
+
+```
+####################################
+## Trace Collection Configuration ##
+####################################
+
+## @param apm_config - custom object - optional
+## Enter specific configurations for your trace collection.
+## Uncomment this parameter and the one below to enable them.
+## See https://docs.datadoghq.com/agent/apm/
+#
+# apm_config:
+
+#   # @param enabled - boolean - optional - default: true
+#   # @env DD_APM_ENABLED - boolean - optional - default: true
+#   # Set to true to enable the APM Agent.
+#
+#   enabled: true
+```
+
+Full section node example:
+
+```yaml
+apm_config:
+  node_type: section
+  title: "Trace Collection Configuration"
+  description: |
+    Enter specific configurations for your trace collection.
+    Uncomment this parameter and the one below to enable them.
+    See https://docs.datadoghq.com/agent/apm/
+  visibility: public
+  properties:
+
+    enabled:
+      node_type: setting
+      type: boolean
+      default: true
+      description: Enable the APM agent.
+```
+
+---
+
+### `comment`
+
+Internal comments about the field. Not rendered into any user-facing artifacts.
+
+- **Available on:** setting and section nodes.
+- **Mandatory:** no, optional.
+
+Use this for developer-oriented notes that are not meant to be user-facing — for example, explaining
+why an unusual default was chosen, referencing a bug or design decision, or noting a deprecation plan.
+
+```yaml
+hostname_fqdn:
+  node_type: setting
+  type: boolean
+  default: false
+  comment: "Maintain backward compatibility with Agent5 behavior"
+```
+
+---
+
+### `items` and `properties`
+
+These keywords describe the structure of complex types and are required by code generation tooling.
+They are listed here separately from the validation keywords below because they define the *shape* of
+a setting's value, not merely constraints on it.
+
+#### `items`
+
+Specify the type for that every element of an `array` must satisfy. Mandatory for all `array` setting nodes.
+
+```yaml
+tags:
+  node_type: setting
+  type: array
+  default: []
+  items:
+    type: string    # every element must be a string
+```
+
+---
+
+#### `properties`
+
+Define the sub-schema for a `object`. Each keys in `properties` is an entry in that map and contains its own sub-schema.
+
+```yaml
+cel_workload_exclude:
+  node_type: setting
+  type: array
+  default: []
+  items:
+    type: object
+    properties:
+      products:
+        type: array
+        items:
+          type: string
+```
+
+> **Note:** `properties` on a **section** node defines its child settings (Agent schema nodes), not
+> value sub-schemas. The two uses look identical in YAML but have different meanings depending on
+> `node_type`.
+
+---
+
+### Validation keywords
+
+Each JSON Schema type comes with built-in validation keywords. The most useful
+ones in the Agent schema are listed below. Validation rules can be arbitrarily
+nested — see [Examples](examples.md#example-3-complex-nested-type-cel_workload_exclude)
+for a real-world demonstration.
+
+| Keyword | Applies to | Description |
+| --- | --- | --- |
+| `minimum` / `maximum` | `number` | Numeric lower and upper bounds |
+| `enum` | `string`, `number`, array items | Restricts the value to a fixed set |
+| `pattern` | `string` | Regular expression the value must match |
+| `minLength` / `maxLength` | `string` | String length bounds |
+| `additionalProperties` | `object` | Control if keys not listed in `properties` are accepted or not. The JSON Schema default is `true` (unknown keys are allowed), so set to `false` explicitly to reject them. |
+| `required` | `object` | List of keys that must be present |
+| `minItems` / `maxItems` | `array` | Array length bounds |
+| `uniqueItems` | `array` | Requires all elements to be distinct |
+
+For the complete specification of these keywords, see
+[Understanding JSON Schema](https://json-schema.org/understanding-json-schema).
+
+---
+
+## Datadog Agent extensions
+
+The following keywords extend JSON Schema to meet the Agent's specific needs.
+They are **not** used for config validation — any standard JSON Schema library
+can validate a customer config without them. They are used by the Agent itself
+and by Datadog internal tooling.
+
+---
+
+### `node_type`
+
+Declares whether a node is a *section* (group of settings) or a *setting*
+(individual setting).
+
+- **Available on:** all nodes.
+- **Mandatory:** yes.
+- **Accepted values:** `section`, `setting`.
+
+This keyword marks the boundary between the schema structure and a setting's
+value. For example, `docker_labels_as_tags` has `type: object` — its value is an
+object of strings to strings. That object is the setting's *value*, so the node is a setting, not
+a section. A node is a section only when its `properties` represent *child
+settings*, not a setting with an object typed value.
+
+```yaml
+apm_config:
+  node_type: section     # Within the JSON Schema`apm_config` is a 'object' type but for the Agent it's a section
+  type: object
+  title: "Trace Collection Configuration"
+  properties:
+
+    enabled:
+      node_type: setting
+      type: boolean
+      default: false
+
+docker_labels_as_tags:
+  node_type: setting     # Within the JSON Schema`docker_labels_as_tags` is a 'object' type but for the Agent it's a setting
+  type: object
+  default: {}
+```
+
+---
+
+### `platform_default`
+
+Sets per-platform default value overrides. Mutually exclusive with `default` (One of them must be specify).
+
+- **Available on:** setting nodes only.
+- **Mandatory:** yes, unless `default` is specified. `platform_default` must cover every platform — either by listing
+  `linux`, `windows`, and `darwin` explicitly, or by including an `other` catch-all.
+- **Validation:** values must match the `type` of the setting.
+
+Supported platform keys: `linux`, `windows`, `darwin`, `container`, `other`.
+
+**Container fallback logic:** because container environments currently share many
+defaults with Linux, `container` is optional. When resolving the default for a
+container, the Agent applies the following fallback chain:
+
+1. Use `container` if present.
+2. Fall back to `linux` if present.
+3. Fall back to `other` if present.
+
+```yaml
+# Explicit entry for every platform:
+confd_path:
+  node_type: setting
+  type: string
+  platform_default:
+    windows: "C:\\ProgramData\\Datadog\\conf.d"
+    linux: "/etc/datadog-agent/conf.d"
+    darwin: "/opt/datadog-agent/etc/conf.d"
+    container: "/conf.d"
+
+# Using 'other' as a catch-all:
+gui_port:
+  node_type: setting
+  type: number
+  platform_default:
+    linux: -1
+    other: 5002             # covers windows and darwin
+```
+
+> **Note**: [Relative Path](keywords.md#relative-defaults) is also available for `platform_default`.
+
+---
+
+### `sensitive`
+
+Marks a setting as containing sensitive data.
+
+- **Available on:** setting nodes only.
+- **Mandatory:** no.
+- **Default:** `false`.
+- **Accepted values:** `true`, `false`.
+
+When `true`, the Agent scrubs the value from logs and diagnostic output. Fleet
+Automation treats the setting as a secret — it will not expose the raw value in
+its UI or API responses. Other services that consume the schema may use this flag
+in the future to apply additional protection.
+
+```yaml
+api_key:
+  node_type: setting
+  type: string
+  default: ""
+  sensitive: true
+  description: "Your Datadog API key."
+  visibility: public
+```
+
+---
+
+### `visibility`
+
+Controls whether a setting is publicly documented and included in
+`datadog.yaml.example`.
+
+- **Available on:** all nodes (setting and section).
+- **Mandatory:** no.
+- **Default:** `undocumented`.
+- **Accepted values:** `public`, `undocumented`.
+
+Any node with `visibility: public` is included in the generated config examples
+and any public-facing configuration website. Nodes without this keyword (or with
+`visibility: undocumented`) are internal and will not be surfaced.
+
+> **Note:** It's not because a setting is undocumented that it's not known or used by customers.
+
+```yaml
+api_key:
+  node_type: setting
+  type: string
+  default: ""
+  description: "Your Datadog API key."
+  visibility: public
+```
+
+> **Note:** the configuration examples are generated following the schema order. Where you add you setting in the schema
+> will determine where is will appear in the examples.
+
+---
+
+### `env_vars`
+
+The list of environment variables that can override this setting node's value.
+
+- **Available on:** setting nodes only.
+- **Mandatory:** no.
+
+**If omitted**, the Agent uses a default env var derived from the setting's full
+dotted path: `DD_` + the path in upper case with dots replaced by underscores.
+For example, `logs_config.enabled` defaults to `DD_LOGS_CONFIG_ENABLED`.
+
+When multiple env vars are listed, they are checked in order and the first match
+wins.
+
+```yaml
+api_key:
+  node_type: setting
+  type: string
+  default: ""
+  env_vars:
+    - DD_API_KEY
+    - DATADOG_API_KEY
+```
+
+---
+
+### `env_parser`
+
+Defines how the env var value is parsed into the setting's type. This is only require when loading complex types from
+the environment (JSON, maps, ...).
+
+- **Available on:** setting nodes only.
+- **Mandatory:** no. Most scalar types (`boolean`, `number`, `string`) are parsed automatically.
+
+| Value | Behaviour |
+| --- | --- |
+| `comma_separated` | Splits on commas |
+| `space_separated` | Splits on spaces |
+| `json` | Parses the entire env var value as a JSON payload matching the setting's type |
+| `comma_or_space_separated` | Splits on commas if the value contains a comma, otherwise on spaces. Used by APM for `apm_config.ignore_resources`. **Should not be used for new settings**. |
+| `comma_and_space_separated` | Both commas and spaces act as separators. Used by OTEL for `otelcollector.converter.features`. **Should not be used for new settings**. |
+| `space_or_json` | Splits on spaces, or parses as JSON if the value starts with `[`. **Should not be used for new settings**. |
+
+```yaml
+tags:
+  node_type: setting
+  type: array
+  items:        # describes the value — each element must be a string
+    type: string
+  default: []
+  env_vars:
+    - DD_TAGS
+  env_parser: space_or_json
+```
+
+---
+
+### `renamed_from`
+
+> **Note:** [WIP] Not yet implemented. The migration behaviour described below is planned.
+
+Lists previous names this setting was known by.
+
+- **Available on:** setting nodes only.
+- **Mandatory:** no.
+- **Validation:** must be a list of strings.
+
+When a setting has `renamed_from`, the config system looks for any of the
+previous names and migrates the value automatically. Previous names take
+priority over the canonical name when both are present. A deprecation warning
+is emitted at runtime whenever a previous name is used.
+
+This provides a single, consistent mechanism for setting renames across all
+teams, replacing ad-hoc solutions that previously produced inconsistent
+behaviour.
+
+```yaml
+target_traces_per_second:
+  node_type: setting
+  type: number
+  default: 10
+  renamed_from:
+    - max_traces_per_second
+```
+
+---
+
+### `tags`
+
+An arbitrary list of strings for metadata. Used by internal tooling to slice
+and filter settings — for example, to produce different variants of
+`datadog.yaml.example`.
+
+- **Available on:** all nodes (setting and section).
+- **Mandatory:** no.
+- **Validation:** must be a list of strings.
+
+```yaml
+internal_profiling:
+  node_type: section
+  tags:
+    - internal_template_section:profiling
+```
+
+Existing tags:
+
+- `template_section`: controls the different flavor of the configuration example we generate. This is directly inherited
+  from the way we used to generate example from Go templates.
+- `TODO:fix-no-default`: flag that this legacy setting has no default.
+- `TODO:fix-missing-type`: flag that this legacy setting has no type.
+- `golang_type`: flag that this setting should use a different type when generating go code. Usage of `golang_type` tag
+  is often a sign of an issue. The agent code should be easily configurable from YAML types.
+  - `golang_type:duration`: will use a `time.duration`.
+  - `golang_type:float64`: will use a `float64`.
+  - `golang_type:map[string]float64`: will used a `map[string]float64{}`.
+  - `golang_type:map[string]interface{}`: will used a `golang_type:map[string]interface{}{}`.
+  - `golang_type:nil`: will use `nil` from Go (should not be used for any new setting).
+- `no-env`: mark the settings as not configurable through en vars (should not be used by new settings).
+
+> **Note**: except from `template_section`, all the other tags exists to support legacy behavior and should not be used
+> for new settings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,6 +107,11 @@ nav:
   # - Fx overview: components/fx.md
   # - JMXFetch overview: components/jmxfetch.md
   # - FAQ: components/faq.md
+- Agent Schema:
+  - Introduction: agent-schema/index.md
+  - Keyword Reference: agent-schema/keywords.md
+  - Examples: agent-schema/examples.md
+  - FAQ: agent-schema/faq.md
 - Architecture:
   - DogStatsD:
     - Internals: architecture/dogstatsd/internals.md


### PR DESCRIPTION
### What does this PR do?

Add starting version for Agent-schema documentation. This was automatically generated from the different RFCs and development documents. It act as a starting point for a proper documentation.
