### PR TITLE
Prevent panic on missing connection context in gRPC timeout handler

### DIFF
--- a/comp/api/grpcserver/helpers/grpc.go
+++ b/comp/api/grpcserver/helpers/grpc.go
@@ -57,8 +57,9 @@ func TimeoutHandlerFunc(httpHandler http.Handler, timeout time.Duration) http.Ha
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		deadline := time.Now().Add(timeout)
 
-		conn := r.Context().Value(grpccontext.ConnContextKey).(net.Conn)
-		_ = conn.SetWriteDeadline(deadline)
+		if conn, ok := r.Context().Value(grpccontext.ConnContextKey).(net.Conn); ok {
+			_ = conn.SetWriteDeadline(deadline)
+		}
 
 		httpHandler.ServeHTTP(w, r)
 	})


### PR DESCRIPTION
### What does this PR do?

`TimeoutHandlerFunc` performs a bare type assertion `r.Context().Value(grpccontext.ConnContextKey).(net.Conn)`. If the context key is absent (e.g., the function is called outside the muxed gRPC server, or through plain HTTP without the `ConnContext` callback), the assertion panics and crashes the serving goroutine.

This PR replaces the bare assertion with the two-value form and skips setting the deadline if no connection is found in the context.

### Motivation

Prevent a potential panic that would crash the HTTP handler goroutine on any request whose context does not carry the expected connection value.

### Describe how you validated your changes

CI.

### Additional Notes

Found by Claude.