### PR TITLE
Skip malformed OTel tags without colon to prevent out-of-bounds panic

### DIFF
--- a/comp/otelcol/otlp/components/metricsclient/metrics_client.go
+++ b/comp/otelcol/otlp/components/metricsclient/metrics_client.go
@@ -73,6 +73,9 @@ func (m *metricsClient) attributeFromTags(tags []string) attribute.Set {
 	})
 	for _, t := range tags {
 		kv := strings.Split(t, ":")
+		if len(kv) < 2 {
+			continue
+		}
 		attr = append(attr, attribute.KeyValue{
 			Key:   attribute.Key(kv[0]),
 			Value: attribute.StringValue(kv[1]),

--- a/comp/otelcol/otlp/components/metricsclient/metrics_client_test.go
+++ b/comp/otelcol/otlp/components/metricsclient/metrics_client_test.go
@@ -234,7 +234,7 @@ func TestTiming(t *testing.T) {
 
 func TestGaugeMalformedTag(t *testing.T) {
 	// A tag without a colon is valid in Datadog statsd format (standalone tag).
-	// Without the fix, attributeFromTags would panic with an out-of-bounds index.
+	// Such tags should be silently skipped rather than panicking.
 	reader, metricClient, _ := setupMetricClient(t)
 
 	err := metricClient.Gauge("test_gauge", 1, []string{"malformed", "service:otelcol"}, 1)

--- a/comp/otelcol/otlp/components/metricsclient/metrics_client_test.go
+++ b/comp/otelcol/otlp/components/metricsclient/metrics_client_test.go
@@ -232,6 +232,30 @@ func TestTiming(t *testing.T) {
 	metricdatatest.AssertEqual(t, want, got, metricdatatest.IgnoreTimestamp())
 }
 
+func TestGaugeMalformedTag(t *testing.T) {
+	// A tag without a colon is valid in Datadog statsd format (standalone tag).
+	// Without the fix, attributeFromTags would panic with an out-of-bounds index.
+	reader, metricClient, _ := setupMetricClient(t)
+
+	err := metricClient.Gauge("test_gauge", 1, []string{"malformed", "service:otelcol"}, 1)
+	assert.NoError(t, err)
+	rm := metricdata.ResourceMetrics{}
+	assert.NoError(t, reader.Collect(context.Background(), &rm))
+	require.Len(t, rm.ScopeMetrics, 1)
+	sm := rm.ScopeMetrics[0]
+	require.Len(t, sm.Metrics, 1)
+	got := sm.Metrics[0]
+	want := metricdata.Metrics{
+		Name: "test_gauge",
+		Data: metricdata.Gauge[float64]{
+			DataPoints: []metricdata.DataPoint[float64]{
+				{Value: 1, Attributes: attribute.NewSet(attribute.String("service", "otelcol"), attribute.String("source", ExporterSourceTag))},
+			},
+		},
+	}
+	metricdatatest.AssertEqual(t, want, got, metricdatatest.IgnoreTimestamp())
+}
+
 // nilMeterProvider implements the MeterProvider interface and always returns nil Meters
 type nilMeterProvider struct {
 	embedded.MeterProvider


### PR DESCRIPTION
### What does this PR do?

In \`attributeFromTags\`, \`strings.Split(t, ":")\` on a tag without a colon (e.g. \`"production"\`) returns a single-element slice. The code then unconditionally accesses \`kv[1]\`, causing an out-of-bounds panic that crashes the exporter goroutine.

This PR adds a \`len(kv) < 2\` guard to skip malformed tags, consistent with the \`splitTag()\` helper already used in \`comp/otelcol/otlp/components/processor/infraattributesprocessor/common.go\`, which applies the same pattern for the same reason.

Standalone tags without a colon are valid in Datadog statsd format, so callers of \`statsd.ClientInterface\` can legitimately pass them.

A regression test is included that passes a colon-less tag alongside a well-formed one and asserts the metric is recorded without panicking, with the malformed tag silently skipped.

### Motivation

Any tag without a colon passed to the OTel metrics client panics the exporter goroutine. Standalone tags are valid in Datadog statsd format and can come from user configuration.

### Describe how you validated your changes

CI. Added a unit test that reproduces the panic before the fix.

### Additional Notes

Found by Claude.