### PR TITLE
Move defer Unlock to after Lock in JSON payload builder

### DIFF
--- a/pkg/serializer/internal/stream/json_payload_builder.go
+++ b/pkg/serializer/internal/stream/json_payload_builder.go
@@ -119,12 +119,11 @@ func (b *JSONPayloadBuilder) BuildWithOnErrItemTooBigPolicy(
 	maxUncompressedSize := b.config.GetInt("serializer_max_uncompressed_payload_size")
 
 	if b.shareAndLockBuffers {
-		defer b.mu.Unlock()
-
 		tlmCompressorLocks.Inc()
 		expvarsCompressorLocks.Add(1)
 		start := time.Now()
 		b.mu.Lock()
+		defer b.mu.Unlock()
 		elapsed := time.Since(start)
 		expvarsTotalLockTime.Add(int64(elapsed))
 		tlmTotalLockTime.Add(float64(elapsed))


### PR DESCRIPTION
### What does this PR do?

In `BuildWithOnErrItemTooBigPolicy`, `defer b.mu.Unlock()` was registered before `b.mu.Lock()` was called. If any code between the two lines panics (telemetry counter operations), the deferred `Unlock` fires on a mutex that was never locked, causing a second panic: "sync: unlock of unlocked mutex".

This PR moves `defer b.mu.Unlock()` to immediately after `b.mu.Lock()`, which is the standard safe pattern.

Note that I don't expect this to happen in practice, but it's still a change worth doing to avoid issues in the future.

### Motivation

Prevent a double-panic scenario where a panic between the deferred Unlock registration and the actual Lock would trigger "sync: unlock of unlocked mutex".

### Describe how you validated your changes

CI.

### Additional Notes

Found by Claude.