### PR TITLE
Use safe type assertion for runtime.Object in HPA autoscaler controller

### DIFF
--- a/pkg/util/kubernetes/apiserver/controllers/hpa_controller.go
+++ b/pkg/util/kubernetes/apiserver/controllers/hpa_controller.go
@@ -186,7 +186,12 @@ func (h *autoscalersController) addAutoscaler(obj interface{}) {
 		return
 	}
 	log.Debugf("Adding autoscaler %s/%s", newAutoscaler.GetNamespace(), newAutoscaler.GetName())
-	h.eventRecorder.Event(obj.(runtime.Object), corev1.EventTypeNormal, autoscalerNowHandleMsgEvent, "")
+	runtimeObj, ok := obj.(runtime.Object)
+	if !ok {
+		log.Errorf("Expected a runtime.Object type, got: %v", obj)
+		return
+	}
+	h.eventRecorder.Event(runtimeObj, corev1.EventTypeNormal, autoscalerNowHandleMsgEvent, "")
 	h.enqueue(newAutoscaler)
 }
 


### PR DESCRIPTION
### What does this PR do?

In `addAutoscaler`, after guarding the `metav1.Object` assertion, `obj.(runtime.Object)` is performed without checking the `ok` flag. `metav1.Object` and `runtime.Object` are distinct interfaces; any object that satisfies only the former causes a panic.

This PR converts the assertion to the two-value form and returns early with an error log if the assertion fails.

### Motivation

Prevent a panic in the HPA controller goroutine when an object satisfies `metav1.Object` but not `runtime.Object`.

### Describe how you validated your changes

CI.

### Additional Notes

Found by Claude.