### PR TITLE
Capture binariesExcluded under lock in ProcessKiller to prevent data race

### DIFF
--- a/pkg/security/probe/process_killer.go
+++ b/pkg/security/probe/process_killer.go
@@ -255,6 +255,7 @@ func (p *ProcessKiller) isKillAllowed(kcs []killContext) (bool, error) {
 		p.Unlock()
 		return false, errors.New("the enforcement capability is disabled")
 	}
+	binariesExcluded := p.binariesExcluded
 	p.Unlock()
 
 	for _, pc := range kcs {
@@ -262,7 +263,7 @@ func (p *ProcessKiller) isKillAllowed(kcs []killContext) (bool, error) {
 			return false, fmt.Errorf("process with pid %d cannot be killed", pc.pid)
 		}
 
-		if slices.ContainsFunc(p.binariesExcluded, func(glob *eval.Glob) bool {
+		if slices.ContainsFunc(binariesExcluded, func(glob *eval.Glob) bool {
 			return glob.Matches(pc.path)
 		}) {
 			return false, fmt.Errorf("process `%s`(%d) is protected", pc.path, pc.pid)


### PR DESCRIPTION
### What does this PR do?

In `isKillAllowed`, the mutex is released after checking `p.enabled`, and then `p.binariesExcluded` is accessed in the loop below without holding any lock. Another goroutine reloading configuration could concurrently write `p.binariesExcluded`, producing a data race.

This PR captures `p.binariesExcluded` into a local variable while the lock is still held, and uses the snapshot for the rest of the function.

### Motivation

Eliminate a data race between `isKillAllowed` and configuration reloads that write `binariesExcluded`.

### Describe how you validated your changes

CI.

### Additional Notes

Found by Claude.