### PR TITLE
Always increment tryCount in Backoff retry strategy

### DIFF
--- a/pkg/util/retry/retrier.go
+++ b/pkg/util/retry/retrier.go
@@ -133,10 +133,9 @@ func (r *Retrier) doTry() *Error {
 			}
 		case Backoff:
 			sleep := r.cfg.InitialRetryDelay * 1 << r.tryCount
-			if sleep > r.cfg.MaxRetryDelay {
+			r.tryCount++
+			if sleep > r.cfg.MaxRetryDelay || sleep <= 0 {
 				sleep = r.cfg.MaxRetryDelay
-			} else {
-				r.tryCount++
 			}
 			r.status = FailWillRetry
 			r.nextTry = r.cfg.now().Add(sleep)


### PR DESCRIPTION
### What does this PR do?

In the `Backoff` retry strategy, `r.tryCount` was only incremented when the computed sleep was below `MaxRetryDelay`. Once the delay reached the cap, `tryCount` stopped incrementing. Any code that observes `tryCount` to decide when to give up would see it frozen, potentially causing indefinite retries at max delay.

This PR moves `r.tryCount++` outside the conditional so it always increments. An additional `|| sleep <= 0` guard handles the overflow case where a very large `tryCount` would produce a non-positive duration via bit-shift overflow.

### Motivation

Ensure `tryCount` accurately reflects the number of attempts made regardless of whether the backoff delay has reached its cap.

### Describe how you validated your changes

CI.

### Additional Notes

Found by Claude.