### PR TITLE
Do not overwrite JMX status when HTTP request decode fails

### DIFF
--- a/comp/api/api/apiimpl/internal/agent/agent_jmx.go
+++ b/comp/api/api/apiimpl/internal/agent/agent_jmx.go
@@ -61,9 +61,9 @@ func setJMXStatus(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Errorf("unable to parse jmx status: %s", err)
 		http.Error(w, err.Error(), 500)
-	} else {
-		w.WriteHeader(http.StatusOK)
+		return
 	}
 
 	jmxStatus.SetStatus(status)
+	w.WriteHeader(http.StatusOK)
 }


### PR DESCRIPTION
### What does this PR do?

In `setJMXStatus`, `jmxStatus.SetStatus(status)` was called unconditionally after `decoder.Decode(&status)`. When decoding fails, `status` holds its zero value, and `SetStatus` silently overwrites all live JMX state with an empty struct.

This PR adds an early `return` on decode error so `SetStatus` is only called on success.

### Motivation

Prevent a malformed or truncated request body from silently clearing all JMX status.

### Describe how you validated your changes

CI.

### Additional Notes

Found by Claude.