### PR TITLE
Use safe type assertions for request state context value in fleet daemon

### DIFF
--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -805,12 +805,18 @@ func newRequestContext(request remoteAPIRequest) (*telemetry.Span, context.Conte
 }
 
 func setRequestInvalid(ctx context.Context) {
-	state := ctx.Value(requestStateKey).(*requestState)
+	state, ok := ctx.Value(requestStateKey).(*requestState)
+	if !ok {
+		return
+	}
 	state.State = pbgo.TaskState_INVALID_STATE
 }
 
 func setRequestDone(ctx context.Context, err error) {
-	state := ctx.Value(requestStateKey).(*requestState)
+	state, ok := ctx.Value(requestStateKey).(*requestState)
+	if !ok {
+		return
+	}
 	state.State = pbgo.TaskState_DONE
 	if err != nil {
 		state.State = pbgo.TaskState_ERROR


### PR DESCRIPTION
### What does this PR do?

`setRequestInvalid` and `setRequestDone` perform bare `ctx.Value(requestStateKey).(*requestState)` assertions. If called from a context not set up by the expected middleware (e.g., a test or future refactoring), the key is absent and the assertion panics. The companion function `refreshState` already uses the two-value form correctly.

This PR converts both functions to the two-value form with an early return when the key is absent.

### Motivation

Prevent a panic in fleet daemon request state helpers when called from unexpected contexts.

### Describe how you validated your changes

CI.

### Additional Notes

Found by Claude.