### PR TITLE
[EBPF] gpu: fix missing GPM metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -181,7 +181,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/Microsoft/hcsshim v0.13.0
-	github.com/NVIDIA/go-nvml v0.13.0-1
+	github.com/NVIDIA/go-nvml v0.12.9-0
 	github.com/ProtonMail/go-crypto v1.3.0
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.13.0 h1:/BcXOiS6Qi7N9XqUcv27vkIuVOkBEcWstd2pMlWSeaA=
 github.com/Microsoft/hcsshim v0.13.0/go.mod h1:9KWJ/8DgU+QzYGupX4tzMhRQE8h6w90lH6HAaclpEok=
-github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
-github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
+github.com/NVIDIA/go-nvml v0.12.9-0 h1:e344UK8ZkeMeeLkdQtRhmXRxNf+u532LDZPGMtkdus0=
+github.com/NVIDIA/go-nvml v0.12.9-0/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -240,6 +240,7 @@ func TestCollectorsOnDeviceChanges(t *testing.T) {
 		testutil.WithProcessInfoCallback(func(_ string) ([]nvml.ProcessInfo, nvml.Return) {
 			return nil, nvml.SUCCESS // disable process info, we don't want to mock that part here
 		}),
+		testutil.WithCapabilities(testutil.Capabilities{GPM: true}),
 		testutil.WithMIGDisabled(),
 	)
 	ddnvml.WithMockNVML(t, nvmlMock)
@@ -328,6 +329,12 @@ func TestCollectorsOnMIGDeviceChanges(t *testing.T) {
 			}
 			return testutil.GetMIGDeviceMock(deviceIdx, index, testutil.WithMockAllDeviceFunctions()), nvml.SUCCESS
 		}
+		d.GpmMigSampleGetFunc = func(_ int, _ nvml.GpmSample) nvml.Return {
+			return nvml.SUCCESS
+		}
+		d.GpmSampleGetFunc = func(_ nvml.GpmSample) nvml.Return {
+			return nvml.SUCCESS
+		}
 	})
 
 	// Setup NVML mock with single parent device
@@ -336,6 +343,7 @@ func TestCollectorsOnMIGDeviceChanges(t *testing.T) {
 		testutil.WithProcessInfoCallback(func(_ string) ([]nvml.ProcessInfo, nvml.Return) {
 			return nil, nvml.SUCCESS
 		}),
+		testutil.WithCapabilities(testutil.Capabilities{GPM: true}),
 	)
 	nvmlMock.DeviceGetCountFunc = func() (int, nvml.Return) { return 1, nvml.SUCCESS }
 	nvmlMock.DeviceGetHandleByIndexFunc = func(index int) (nvml.Device, nvml.Return) {

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -140,7 +140,7 @@ func TestAllCollectorsWork(t *testing.T) {
 	// This test doesn't validate the results of the collectors, it only checks that they work with
 	// the basic mock, and we don't have any panics or anything.
 
-	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled(), testutil.WithMockAllFunctions())
+	nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithMIGDisabled(), testutil.WithCapabilities(testutil.Capabilities{GPM: true}), testutil.WithMockAllFunctions())
 	ddnvml.WithMockNVML(t, nvmlMock)
 	deviceCache := ddnvml.NewDeviceCache()
 	eventsGatherer := NewDeviceEventsGatherer()
@@ -220,7 +220,7 @@ func TestDisabledCollectors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup NVML mock
-			nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithDeviceCount(1), testutil.WithMIGDisabled(), testutil.WithMockAllFunctions())
+			nvmlMock := testutil.GetBasicNvmlMockWithOptions(testutil.WithDeviceCount(1), testutil.WithMIGDisabled(), testutil.WithCapabilities(testutil.Capabilities{GPM: true}), testutil.WithMockAllFunctions())
 			ddnvml.WithMockNVML(t, nvmlMock)
 			deviceCache := ddnvml.NewDeviceCache()
 			devices, err := deviceCache.AllPhysicalDevices()
@@ -494,7 +494,7 @@ func TestConfiguredMetricPriority(t *testing.T) {
 			}, nvml.SUCCESS
 		}
 		return device
-	}, testutil.WithMockAllFunctions())
+	}, testutil.WithCapabilities(testutil.Capabilities{GPM: true}), testutil.WithMockAllFunctions())
 	deviceUUID := device.GetDeviceInfo().UUID
 
 	spCache := &SystemProbeCache{

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -493,6 +493,9 @@ func TestConfiguredMetricPriority(t *testing.T) {
 				{TimeStamp: lastTimestamp + 200, SampleValue: [8]byte{0, 0, 0, 0, 0, 0, 0, 2}},
 			}, nvml.SUCCESS
 		}
+		device.GpmSampleGetFunc = func(_ nvml.GpmSample) nvml.Return {
+			return nvml.SUCCESS
+		}
 		return device
 	}, testutil.WithCapabilities(testutil.Capabilities{GPM: true}), testutil.WithMockAllFunctions())
 	deviceUUID := device.GetDeviceInfo().UUID
@@ -539,6 +542,24 @@ func TestConfiguredMetricPriority(t *testing.T) {
 		"sm_active":         {sampling, ebpf},
 		"gr_engine_active":  {gpm, sampling, ebpf},
 		"process.sm_active": {sampling, ebpf},
+	}
+
+	wantedCollectors := make(map[CollectorName]bool)
+	for _, collectors := range desiredMetricPriority {
+		for _, collector := range collectors {
+			wantedCollectors[collector] = true
+		}
+	}
+
+	for wantedCollector, isWanted := range wantedCollectors {
+		found := false
+		for _, collector := range collectors {
+			if collector.Name() == wantedCollector {
+				found = true
+				break
+			}
+		}
+		require.Equal(t, isWanted, found, "collector %s state is not as expected", wantedCollector)
 	}
 
 	metricsByCollector := make(map[string]map[CollectorName]Metric)

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -80,7 +80,7 @@ func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collecto
 		return nil, errors.New("MIG device has no parent physical device")
 	}
 
-    // We don't query for device support because the API is broken in go-nvml 0.13.0
+	// We don't query for device support because the API is broken in go-nvml 0.13.0
 
 	// Clone the global allGpmMetrics map to avoid mutating global state
 	clonedMetrics := maps.Clone(allGpmMetrics)
@@ -131,11 +131,9 @@ func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collecto
 }
 
 func (c *gpmCollector) removeUnsupportedMetrics() error {
-	// Now collect two samples and try to get the metrics, to discard any unsupported ones
-	// It's a best-effort approach, so any errors in the process are ignored. If they are not temporary,
-	// the collector will fail to collect metrics later and that will show in the logs.
+	// Now collect two samples and try to get the metrics, to discard any unsupported ones.
 	for i := 0; i < 2; i++ {
-		err := c.collectSample();
+		err := c.collectSample()
 		if err != nil {
 			return err
 		}
@@ -148,7 +146,7 @@ func (c *gpmCollector) removeUnsupportedMetrics() error {
 
 	for i := uint32(0); i < metrics.NumMetrics; i++ {
 		if metrics.Metrics[i].NvmlReturn != uint32(nvml.SUCCESS) {
-			fmt.Printf("failed to get GPM metric %d: %s\n", metrics.Metrics[i].MetricId, nvml.ErrorString(nvml.Return(metrics.Metrics[i].NvmlReturn)))
+			log.Warnf("failed to get GPM metric %d on device %s: %s\n", metrics.Metrics[i].MetricId, c.device.GetDeviceInfo().UUID, nvml.ErrorString(nvml.Return(metrics.Metrics[i].NvmlReturn)))
 			delete(c.metricsToCollect, nvml.GpmMetricId(metrics.Metrics[i].MetricId))
 		}
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -18,6 +18,7 @@ import (
 
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const sampleBufferSize = 2

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -80,17 +80,7 @@ func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collecto
 		return nil, errors.New("MIG device has no parent physical device")
 	}
 
-	var support nvml.GpmSupport
-	// The query for device support needs to be made on the physical device always
-	if isMig {
-		support, err = migDevice.Parent.GpmQueryDeviceSupport()
-	} else {
-		support, err = device.GpmQueryDeviceSupport()
-	}
-
-	if support.IsSupportedDevice == 0 {
-		return nil, errUnsupportedDevice
-	}
+    // We don't query for device support because the API is broken in go-nvml 0.13.0
 
 	// Clone the global allGpmMetrics map to avoid mutating global state
 	clonedMetrics := maps.Clone(allGpmMetrics)
@@ -125,7 +115,13 @@ func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collecto
 		collector.samples[i] = sample
 	}
 
-	collector.removeUnsupportedMetrics()
+	err = collector.removeUnsupportedMetrics()
+	if err != nil {
+		if ddnvml.IsAPIUnsupportedOnDevice(err, device) {
+			return nil, errUnsupportedDevice
+		}
+		return nil, fmt.Errorf("failed to remove unsupported metrics: %w", err)
+	}
 
 	if len(collector.metricsToCollect) == 0 {
 		return nil, errUnsupportedDevice
@@ -134,27 +130,30 @@ func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collecto
 	return collector, nil
 }
 
-func (c *gpmCollector) removeUnsupportedMetrics() {
+func (c *gpmCollector) removeUnsupportedMetrics() error {
 	// Now collect two samples and try to get the metrics, to discard any unsupported ones
 	// It's a best-effort approach, so any errors in the process are ignored. If they are not temporary,
 	// the collector will fail to collect metrics later and that will show in the logs.
 	for i := 0; i < 2; i++ {
-		err := c.collectSample()
+		err := c.collectSample();
 		if err != nil {
-			return
+			return err
 		}
 	}
 
 	metrics, err := c.calculateGpmMetrics()
 	if err != nil {
-		return
+		return err
 	}
 
 	for i := uint32(0); i < metrics.NumMetrics; i++ {
 		if metrics.Metrics[i].NvmlReturn != uint32(nvml.SUCCESS) {
+			fmt.Printf("failed to get GPM metric %d: %s\n", metrics.Metrics[i].MetricId, nvml.ErrorString(nvml.Return(metrics.Metrics[i].NvmlReturn)))
 			delete(c.metricsToCollect, nvml.GpmMetricId(metrics.Metrics[i].MetricId))
 		}
 	}
+
+	return nil
 }
 
 func (c *gpmCollector) collectSample() error {

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -136,6 +136,7 @@ func (c *gpmCollector) removeUnsupportedMetrics() error {
 	for i := 0; i < 2; i++ {
 		err := c.collectSample()
 		if err != nil {
+			fmt.Printf("failed to collect GPM sample: %s\n", err)
 			return err
 		}
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
@@ -124,6 +124,7 @@ func TestGPMCollectorCollectSample(t *testing.T) {
 	calls := 0
 	collector := &gpmCollector{
 		device: &mockGpmDevice{
+			gpmSupport: nvml.GpmSupport{IsSupportedDevice: 1},
 			GpmSampleGetFunc: func(_ nvml.GpmSample) error {
 				calls++
 				return nil

--- a/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
@@ -260,9 +260,8 @@ func (m *mockGpmNvml) GpmMetricsGet(metrics *nvml.GpmMetricsGetType) nvml.Return
 
 type gpmSample struct {
 	nvml.GpmSample
-	gpmSupport nvml.GpmSupport
-	id         int
-	getIndex   int
+	id       int
+	getIndex int
 }
 
 type mockGpmDevice struct {

--- a/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
@@ -260,8 +260,9 @@ func (m *mockGpmNvml) GpmMetricsGet(metrics *nvml.GpmMetricsGetType) nvml.Return
 
 type gpmSample struct {
 	nvml.GpmSample
-	id       int
-	getIndex int
+	gpmSupport nvml.GpmSupport
+	id         int
+	getIndex   int
 }
 
 type mockGpmDevice struct {
@@ -282,6 +283,10 @@ func (m *mockGpmDevice) GpmQueryDeviceSupport() (nvml.GpmSupport, error) {
 }
 
 func (m *mockGpmDevice) GpmSampleGet(sample nvml.GpmSample) error {
+	if m.gpmSupport.IsSupportedDevice == 0 {
+		return safenvml.NewNvmlAPIErrorOrNil("GpmSampleGet", nvml.ERROR_NOT_SUPPORTED)
+	}
+
 	if m.GpmSampleGetFunc != nil {
 		return m.GpmSampleGetFunc(sample)
 	}

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -92,6 +92,16 @@ func TestMockCapabilitiesMatchArchitectureSpec(t *testing.T) {
 				}
 				assert.Equal(t, expected, support.IsSupportedDevice, "GpmQueryDeviceSupport.IsSupportedDevice should be %d when gpm=%v", expected, archSpec.Capabilities.GPM)
 
+				// Check also that GpmSampleGet returns NOT_SUPPORTED when GPM is not supported
+				var sample testutil.MockGpmSample
+				err = dev.GpmSampleGet(sample)
+				if archSpec.Capabilities.GPM && mode != DeviceModeVGPU {
+					require.NoError(t, err, "GpmSampleGet should not return an error")
+				} else {
+					require.Error(t, err, "GpmSampleGet should return an error")
+					require.True(t, ddnvml.IsUnsupported(err), "GpmSampleGet should return an API_UNSUPPORTED_ON_DEVICE error")
+				}
+
 				unsupportedIDs := UnsupportedFieldIDsForMode(t, archSpec, mode)
 				unsupportedSet := make(map[uint32]struct{}, len(unsupportedIDs))
 				for _, id := range unsupportedIDs {

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -482,6 +482,12 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 			}
 			return nvml.GpmSupport{IsSupportedDevice: 1}, nvml.SUCCESS
 		},
+		GpmSampleGetFunc: func(sample nvml.GpmSample) nvml.Return {
+			if opts.isVGPU() || (opts.gpmSupported != nil && !*opts.gpmSupported) {
+				return nvml.ERROR_NOT_SUPPORTED
+			}
+			return nvml.SUCCESS
+		},
 		GetVirtualizationModeFunc: func() (nvml.GpuVirtualizationMode, nvml.Return) {
 			if opts.isVGPU() {
 				return nvml.GPU_VIRTUALIZATION_MODE_HOST_VGPU, nvml.SUCCESS
@@ -741,6 +747,15 @@ func GetBasicNvmlMockWithOptions(options ...NvmlMockOption) *nvmlmock.Interface 
 			return eventSet.Wait(v)
 		},
 		ExtensionsFunc: opts.extensionsFunc,
+		GpmSampleAllocFunc: func() (nvml.GpmSample, nvml.Return) {
+			return &MockGpmSample{}, nvml.SUCCESS
+		},
+		GpmSampleFreeFunc: func(_ nvml.GpmSample) nvml.Return {
+			return nvml.SUCCESS
+		},
+		GpmMetricsGetFunc: func(_ *nvml.GpmMetricsGetType) nvml.Return {
+			return nvml.SUCCESS
+		},
 	}
 
 	for _, opt := range opts.libOptions {
@@ -861,4 +876,8 @@ func GetTotalExpectedDevices() int {
 		numMIG += count
 	}
 	return numPhysical + numMIG
+}
+
+type MockGpmSample struct {
+	nvml.GpmSample
 }

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -483,7 +483,13 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 			return nvml.GpmSupport{IsSupportedDevice: 1}, nvml.SUCCESS
 		},
 		GpmSampleGetFunc: func(sample nvml.GpmSample) nvml.Return {
-			if opts.isVGPU() || (opts.gpmSupported != nil && !*opts.gpmSupported) {
+			if opts.isVGPU() || opts.gpmSupported == nil || !*opts.gpmSupported {
+				return nvml.ERROR_NOT_SUPPORTED
+			}
+			return nvml.SUCCESS
+		},
+		GpmMigSampleGetFunc: func(migInstanceID int, sample nvml.GpmSample) nvml.Return {
+			if opts.isVGPU() || opts.gpmSupported == nil || !*opts.gpmSupported {
 				return nvml.ERROR_NOT_SUPPORTED
 			}
 			return nvml.SUCCESS

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -482,13 +482,13 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 			}
 			return nvml.GpmSupport{IsSupportedDevice: 1}, nvml.SUCCESS
 		},
-		GpmSampleGetFunc: func(sample nvml.GpmSample) nvml.Return {
+		GpmSampleGetFunc: func(_ nvml.GpmSample) nvml.Return {
 			if opts.isVGPU() || opts.gpmSupported == nil || !*opts.gpmSupported {
 				return nvml.ERROR_NOT_SUPPORTED
 			}
 			return nvml.SUCCESS
 		},
-		GpmMigSampleGetFunc: func(migInstanceID int, sample nvml.GpmSample) nvml.Return {
+		GpmMigSampleGetFunc: func(_ int, _ nvml.GpmSample) nvml.Return {
 			if opts.isVGPU() || opts.gpmSupported == nil || !*opts.gpmSupported {
 				return nvml.ERROR_NOT_SUPPORTED
 			}

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -759,7 +759,11 @@ func GetBasicNvmlMockWithOptions(options ...NvmlMockOption) *nvmlmock.Interface 
 		GpmSampleFreeFunc: func(_ nvml.GpmSample) nvml.Return {
 			return nvml.SUCCESS
 		},
-		GpmMetricsGetFunc: func(_ *nvml.GpmMetricsGetType) nvml.Return {
+		GpmMetricsGetFunc: func(metricsGet *nvml.GpmMetricsGetType) nvml.Return {
+			for _, metric := range metricsGet.Metrics[:metricsGet.NumMetrics] {
+				metric.NvmlReturn = uint32(nvml.SUCCESS)
+			}
+
 			return nvml.SUCCESS
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Downgrades go-nvml to version 0.12.9 and removes the call to GpmQueryDeviceSupport, relying on the return values from other GPM related calls to check for GPM collector support.

### Motivation

Version 0.13.0 seems to have an ABI incompatibility with older driver versions, causing metrics to be incorrect. Additionally, there's a bug in all versions of go-nvml after 0.12.4 (the previous one we were using) that causes `GpmQueryDeviceSupport` to always return an error (https://github.com/NVIDIA/go-nvml/issues/168).

### Describe how you validated your changes

Ran in a host with Hopper devices and another with Turing, ensured that behavior was expected.

### Additional Notes
