### PR TITLE
Renaming configstream settings

### DIFF
--- a/comp/core/configstream/README.md
+++ b/comp/core/configstream/README.md
@@ -100,7 +100,7 @@ remote_agent:
   registry:
     enabled: true  # Required for RAR-gated authorization
   configstream:
-    enabled: true
+    enabled: true # Required to use the configstreamconsumer
     sleep_interval: 10s  # Backoff on non-terminal errors (default: 10s)
 ```
 

--- a/comp/core/configstream/README.md
+++ b/comp/core/configstream/README.md
@@ -96,12 +96,12 @@ The config stream is automatically enabled when the component is loaded. No expl
 **Optional settings:**
 ```yaml
 # datadog.yaml
-config_stream:
-  sleep_interval: 10ms  # Backoff on non-terminal errors (default: 10ms)
-
 remote_agent:
   registry:
     enabled: true  # Required for RAR-gated authorization
+  configstream:
+    enabled: true
+    sleep_interval: 10s  # Backoff on non-terminal errors (default: 10s)
 ```
 
 ## Telemetry

--- a/comp/core/configstream/server/server.go
+++ b/comp/core/configstream/server/server.go
@@ -70,7 +70,7 @@ func (s *Server) StreamConfigEvents(req *pb.ConfigStreamRequest, stream pb.Agent
 	eventsCh, unsubscribe := s.comp.Subscribe(req)
 	defer unsubscribe()
 
-	interval := s.cfg.GetDuration("config_stream.sleep_interval")
+	interval := s.cfg.GetDuration("remote_agent.configstream.sleep_interval")
 
 	for {
 		select {

--- a/comp/core/configstream/server/server_test.go
+++ b/comp/core/configstream/server/server_test.go
@@ -80,7 +80,7 @@ func (m *mockRemoteAgentRegistry) GetRegisteredAgentStatuses() []remoteagentregi
 
 func setupTest(ctx context.Context, t *testing.T, sessionID string) (*Server, *mockComp, *mockStream, chan *pb.ConfigEvent) {
 	cfg := configmock.New(t)
-	cfg.Set("config_stream.sleep_interval", 10*time.Millisecond, model.SourceAgentRuntime)
+	cfg.Set("remote_agent.configstream.sleep_interval", 10*time.Millisecond, model.SourceAgentRuntime)
 
 	comp := &mockComp{}
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1322,9 +1322,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("remote_agent.registry.idle_timeout", time.Duration(30*time.Second))
 	config.BindEnvAndSetDefault("remote_agent.registry.query_timeout", time.Duration(3*time.Second))
 	config.BindEnvAndSetDefault("remote_agent.registry.recommended_refresh_interval", time.Duration(10*time.Second))
-
-	// Config Stream
-	config.BindEnvAndSetDefault("config_stream.sleep_interval", 3*time.Second)
+	config.BindEnvAndSetDefault("remote_agent.configstream.enabled", true)
+	config.BindEnvAndSetDefault("remote_agent.configstream.sleep_interval", 10*time.Second)
 
 	// Data Plane
 	config.BindEnvAndSetDefault("data_plane.enabled", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1322,7 +1322,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("remote_agent.registry.idle_timeout", time.Duration(30*time.Second))
 	config.BindEnvAndSetDefault("remote_agent.registry.query_timeout", time.Duration(3*time.Second))
 	config.BindEnvAndSetDefault("remote_agent.registry.recommended_refresh_interval", time.Duration(10*time.Second))
-	config.BindEnvAndSetDefault("remote_agent.configstream.enabled", true)
+	config.BindEnvAndSetDefault("remote_agent.configstream.enabled", false)
 	config.BindEnvAndSetDefault("remote_agent.configstream.sleep_interval", 10*time.Second)
 
 	// Data Plane


### PR DESCRIPTION
### What does this PR do?
Changing from:
```
remote_agent:
  registry:
    enabled: false
configstream: 
  enabled: false
  sleep_interval: 10*time.Second
```
to:
```
remote_agent:
  registry:
    enabled: false
  configstream: 
    enabled: false
    sleep_interval: 10*time.Second
```

### Motivation

### Describe how you validated your changes

### Additional Notes
