### PR TITLE
fix(add-to-mq): Use graphql API to get PR status

### DIFF
--- a/.github/workflows/add_dependabot_pr_to_mq.yml
+++ b/.github/workflows/add_dependabot_pr_to_mq.yml
@@ -29,32 +29,25 @@ jobs:
           github-token: ${{ steps.octo-sts.outputs.token }}
           script: |
             const pullRequestNumber = context.payload.pull_request.number;
-            const { data: pullRequest } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequestNumber
-            });
-            const { data: reviews } = await github.rest.pulls.listReviews({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequestNumber
-            });
 
-            // Users can have several reviews, which are listed in chronological order: we use a map to keep the last review state.
-            let reviewers = new Map();
-            for (const review of reviews) {
-              reviewers.set(review.user.login, review.state);
-            }
-            let allApproved = true;
-            for (const [reviewer, state] of reviewers) {
-              if (state === 'CHANGES_REQUESTED') {
-                allApproved = false;
-                break;
+            // Use GraphQL to get reviewDecision which respects branch protection rules
+            const query = `query($owner: String!, $repo: String!, $number: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $number) {
+                  reviewDecision
+                }
               }
-            }
-            // When a required reviewer approves, the team is removed from the requested_teams list.
-            // As such, a mergeable PR has no more requested teams and no changes requested in its reviews.
-            return `${allApproved && pullRequest.requested_teams.length === 0}`;
+            }`;
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: pullRequestNumber
+            });
+            const reviewDecision = result.repository.pullRequest.reviewDecision;
+            core.info(`Review decision: ${reviewDecision}`);
+
+            // reviewDecision is APPROVED only when all required reviewers have approved
+            return `${reviewDecision === 'APPROVED'}`;
           result-encoding: string
       - name: Add Merge Comment to Pull Request
         if: ${{ steps.check-mergeable.outputs.result == 'true' }}


### PR DESCRIPTION
### What does this PR do?
Use graphql API to get PR status. This API is returning a reliable status regarding the approved status of a PR

### Motivation
on this pr https://github.com/DataDog/datadog-agent/pull/47547, the /merge command was launched at every review.
The bug is a race condition / timing issue between this workflow and how team review requests get managed.

allApproved starts true and is only set to false if a reviewer has CHANGES_REQUESTED — it does not verify that approvals actually exist
It then checks requested_teams.length === 0
What happened on the PR:

6 individual reviewers all approved (aiuto, RiantZ, iliakur, chouetz, fabbing, s-alad)
Each approval triggered a pull_request_review: submitted event → the workflow ran 6 times
Each time, since no reviewer had CHANGES_REQUESTED, allApproved was true
Each time, requested_teams was apparently empty at the moment the check ran → /merge was posted 6 times
The 2 teams still shown as requested now (container-integrations, agent-security) were likely requested after or between the individual reviews — probably by the ask_review_bot_pr workflow or manually.

Root cause: The mergeable check is too permissive:

It doesn't verify that any approval actually exists — only that no one requested changes
It doesn't guard against posting /merge multiple times (no idempotency check)
requested_teams.length === 0 can be true simply because teams haven't been requested yet, or because the team request was just satisfied by the reviewer who triggered this very workflow run

### Describe how you validated your changes
Manually tested the return value of this command on PR with different states to check the possible values and accuracy.

### Additional Notes
