### PR TITLE
[EBPF] gpu: suppress insufficient size error on GetRunningProcessDetailList

### DIFF
--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -186,6 +186,7 @@ func processDetailListSample(device ddnvml.Device) ([]Metric, uint64, error) {
 
 	detail, err := device.GetRunningProcessDetailList()
 	var usage []processMemoryUsageData
+	var nvmlErr *ddnvml.NvmlAPIError
 	if err == nil {
 		// procs.ProcArray is a pointer to an array of ProcessDetail_v1, in C-style pointer+length mode,
 		// so convert it to a slice:
@@ -196,6 +197,13 @@ func processDetailListSample(device ddnvml.Device) ([]Metric, uint64, error) {
 				usedGpuMemory: proc.UsedGpuMemory,
 			})
 		}
+	} else if errors.As(err, &nvmlErr) && nvmlErr.NvmlErrorCode == nvml.ERROR_INSUFFICIENT_SIZE {
+		// Depending on the NVML implementation, there might be an issue with the size of the array being passed.
+		// This PR seems related https://github.com/NVIDIA/go-nvml/pull/165 but for now we will suppress the error
+		// and continue with the collection.
+		// In this case, if we get no metrics, processMemoryUsage will emit a memory.limit metric with low priority
+		// so that it can be overridden by alternative APIs if available.
+		err = nil
 	}
 
 	return processMemoryUsage(device, usage, High), 0, err

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -460,6 +460,14 @@ func TestProcessMemoryMetricValues(t *testing.T) {
 			expectMemory:     float64(legacyMemory),
 			expectCollectErr: true,
 		},
+		{
+			name:             "Hopper fallback on detail list insufficient size",
+			architecture:     nvml.DEVICE_ARCH_HOPPER,
+			detailListErr:    nvml.ERROR_INSUFFICIENT_SIZE,
+			expectPid:        legacyPid,
+			expectMemory:     float64(legacyMemory),
+			expectCollectErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

Supresses the `insufficent_size` error on `GetRunningProcessDetailList`.

### Motivation

In some implementations of NVML, it seems this API returns "insufficient size" when being queried. Suppressing the error removes noise with no functional changes, as there are fallback APIs for the same metric.

### Describe how you validated your changes

Added unit test, validated in Hopper GPU.

### Additional Notes
