### PR TITLE
[observer] Add F1 score to UI

### DIFF
--- a/cmd/observer-testbench/ui/src/App.tsx
+++ b/cmd/observer-testbench/ui/src/App.tsx
@@ -113,7 +113,7 @@ function formatTime(isoString: string): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
-function EpisodeInfoPanel({ info }: { info: EpisodeInfo }) {
+function EpisodeInfoPanel({ info, score }: { info: EpisodeInfo; score?: ScoreResult | null }) {
   const [expanded, setExpanded] = useState(false);
 
   const phases: { key: string; phase: typeof info.baseline }[] = [
@@ -124,8 +124,8 @@ function EpisodeInfoPanel({ info }: { info: EpisodeInfo }) {
   ].filter(p => p.phase != null);
 
   return (
-    <div className="bg-slate-800/60 border-b border-slate-700 px-4 py-2">
-      <div className="flex items-start gap-4 flex-wrap">
+    <div className="bg-slate-800/60 border-b border-slate-700 px-4 py-2 flex items-center gap-4 flex-wrap">
+      <div className="flex items-center gap-4 flex-wrap flex-1 min-w-0">
         {/* Episode identity */}
         <div className="flex items-center gap-2 shrink-0">
           <span className="text-xs font-mono text-slate-400">Episode</span>
@@ -159,6 +159,9 @@ function EpisodeInfoPanel({ info }: { info: EpisodeInfo }) {
           </button>
         </div>
 
+        {/* Score — before phase badges */}
+        {score && <ScoreDisplay score={score} />}
+
         {/* Phase timeline */}
         {phases.length > 0 && (
           <div className="flex items-center gap-1 shrink-0">
@@ -177,6 +180,7 @@ function EpisodeInfoPanel({ info }: { info: EpisodeInfo }) {
             })}
           </div>
         )}
+
       </div>
     </div>
   );
@@ -402,10 +406,6 @@ function App() {
             </div>
           </div>
           <div className="flex items-center gap-4">
-            {/* Score display — only when ground truth is available */}
-            {state.scoreResponse?.available && state.scoreResponse.score && (
-              <ScoreDisplay score={state.scoreResponse.score} />
-            )}
             {/* History navigation arrows — always visible when there's history */}
             {(canGoBack || canGoForward) && (
               <div className="flex items-center gap-1">
@@ -531,7 +531,7 @@ function App() {
       )}
 
       {/* Episode info panel (shown when episode.json is present) */}
-      {episodeInfo && <EpisodeInfoPanel info={episodeInfo} />}
+      {episodeInfo && <EpisodeInfoPanel info={episodeInfo} score={state.scoreResponse?.available ? state.scoreResponse.score : null} />}
 
       <div className="flex-1 flex relative min-h-0">
         {/* Resize handle */}

--- a/cmd/observer-testbench/ui/src/App.tsx
+++ b/cmd/observer-testbench/ui/src/App.tsx
@@ -3,7 +3,7 @@ import { useObserver } from './hooks/useObserver';
 import { MetricsView } from './components/MetricsView';
 import { CorrelatorView } from './components/CorrelatorView';
 import { LogView } from './components/LogView';
-import type { EpisodeInfo } from './api/client';
+import type { EpisodeInfo, ScoreResult } from './api/client';
 import type { PhaseMarker } from './components/ChartWithAnomalyDetails';
 
 type TabID = 'timeseries' | 'correlators' | 'logs';
@@ -177,6 +177,31 @@ function EpisodeInfoPanel({ info }: { info: EpisodeInfo }) {
             })}
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+function f1Color(f1: number): string {
+  if (f1 >= 0.7) return 'text-green-400';
+  if (f1 >= 0.4) return 'text-yellow-400';
+  return 'text-red-400';
+}
+
+function ScoreDisplay({ score }: { score: ScoreResult }) {
+  return (
+    <div className="flex items-center gap-3 bg-slate-700/50 rounded px-3 py-1.5">
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-slate-400">F1</span>
+        <span className={`text-sm font-bold font-mono ${f1Color(score.f1)}`}>{score.f1.toFixed(3)}</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-slate-400">P</span>
+        <span className="text-sm font-mono text-slate-200">{score.precision.toFixed(3)}</span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-slate-400">R</span>
+        <span className="text-sm font-mono text-slate-200">{score.recall.toFixed(3)}</span>
       </div>
     </div>
   );
@@ -377,6 +402,10 @@ function App() {
             </div>
           </div>
           <div className="flex items-center gap-4">
+            {/* Score display — only when ground truth is available */}
+            {state.scoreResponse?.available && state.scoreResponse.score && (
+              <ScoreDisplay score={state.scoreResponse.score} />
+            )}
             {/* History navigation arrows — always visible when there's history */}
             {(canGoBack || canGoForward) && (
               <div className="flex items-center gap-1">

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -235,6 +235,27 @@ export interface CorrelatorStats {
   [key: string]: Record<string, unknown>;
 }
 
+export interface ScoreResult {
+  f1: number;
+  precision: number;
+  recall: number;
+  tp: number;
+  fp: number;
+  fn: number;
+  num_predictions: number;
+  num_ground_truths: number;
+  num_filtered_warmup: number;
+  num_filtered_cascading: number;
+  num_baseline_fps: number;
+  sigma: number;
+}
+
+export interface ScoreResponse {
+  available: boolean;
+  reason?: string;
+  score?: ScoreResult;
+}
+
 class ApiClient {
   private async fetch<T>(path: string, options?: RequestInit): Promise<T> {
     const response = await fetch(`${API_BASE}${path}`, options);
@@ -343,6 +364,10 @@ class ApiClient {
 
   async getStats(): Promise<CorrelatorStats> {
     return this.fetch('/stats');
+  }
+
+  async getScore(): Promise<ScoreResponse> {
+    return this.fetch('/score');
   }
 
 }

--- a/cmd/observer-testbench/ui/src/hooks/useObserver.ts
+++ b/cmd/observer-testbench/ui/src/hooks/useObserver.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '../api/client';
 import type {
   StatusResponse, ScenarioInfo, ComponentInfo, SeriesInfo, Anomaly, LogAnomaly, LogEntry, LogsSummary, Correlation,
-  CompressedGroup, ComponentDataResponse, CorrelatorStats, ReplayProgress
+  CompressedGroup, ComponentDataResponse, CorrelatorStats, ReplayProgress, ScoreResponse
 } from '../api/client';
 
 export type ConnectionState = 'disconnected' | 'connected' | 'loading' | 'ready';
@@ -21,6 +21,7 @@ export interface ObserverState {
   componentData: Map<string, ComponentDataResponse>;
   compressedGroups: CompressedGroup[];
   correlatorStats: CorrelatorStats | null;
+  scoreResponse: ScoreResponse | null;
   scenarioDataVersion: number;
   activeScenario: string | null;
   error: string | null;
@@ -47,6 +48,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
   const [componentData, setComponentData] = useState<Map<string, ComponentDataResponse>>(new Map());
   const [compressedGroups, setCompressedGroups] = useState<CompressedGroup[]>([]);
   const [correlatorStats, setCorrelatorStats] = useState<CorrelatorStats | null>(null);
+  const [scoreResponse, setScoreResponse] = useState<ScoreResponse | null>(null);
   const [scenarioDataVersion, setScenarioDataVersion] = useState(0);
   const [activeScenario, setActiveScenario] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -76,7 +78,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
     try {
       const [
         componentsData, anomaliesData, logsSummaryData, logAnomaliesData,
-        correlationsData, compressedGroupsData, statsData, seriesData
+        correlationsData, compressedGroupsData, statsData, seriesData, scoreData
       ] = await Promise.all([
         api.getComponents(),
         api.getAnomalies(),
@@ -86,6 +88,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
         api.getCompressedCorrelations(),
         api.getStats(),
         api.getSeries(),
+        api.getScore(),
       ]);
 
       const componentNames = componentsData.map((c: ComponentInfo) => c.name);
@@ -110,6 +113,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
       setCompressedGroups(compressedGroupsData);
       setComponentData(new Map(componentDataResults));
       setCorrelatorStats(statsData);
+      setScoreResponse(scoreData);
       setScenarioDataVersion((v) => v + 1);
       clearRetryTimer();
       setError(null);
@@ -250,6 +254,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
       componentData,
       compressedGroups,
       correlatorStats,
+      scoreResponse,
       scenarioDataVersion,
       activeScenario,
       error,

--- a/cmd/observer-testbench/ui/src/hooks/useObserver.ts
+++ b/cmd/observer-testbench/ui/src/hooks/useObserver.ts
@@ -209,6 +209,7 @@ export function useObserver(): [ObserverState, ObserverActions] {
     setConnectionState('loading');
     setActiveScenario(name);
     setSeries([]);
+    setScoreResponse(null);
     setLoadProgress(null);
     setError(null);
 

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1025,19 +1025,53 @@ func (tb *TestBench) ScoreCurrentAnalysis(sigma float64) (*ScoreResult, error) {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	meta, err := scoringMetadataFromEpisode(tb.episodeInfo)
+	if tb.episodeInfo == nil {
+		return nil, errors.New("no episode info available")
+	}
+	if tb.episodeInfo.Disruption == nil || tb.episodeInfo.Disruption.Start == "" {
+		return nil, errors.New("episode info missing disruption.start")
+	}
+
+	dt, err := time.Parse(time.RFC3339, tb.episodeInfo.Disruption.Start)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parsing disruption.start: %w", err)
+	}
+	groundTruth := []int64{dt.Unix()}
+
+	var baselineStart int64
+	if tb.episodeInfo.Baseline != nil && tb.episodeInfo.Baseline.Start != "" {
+		if bt, err := time.Parse(time.RFC3339, tb.episodeInfo.Baseline.Start); err == nil {
+			baselineStart = bt.Unix()
+		}
 	}
 
 	correlations := tb.engine.StateView().CorrelationHistory()
-	predictions := make([]int64, len(correlations))
-	for i, c := range correlations {
-		predictions[i] = c.FirstSeen
+	var predictions []int64
+	var numFilteredWarmup int
+	for _, c := range correlations {
+		if baselineStart > 0 && c.FirstSeen < baselineStart {
+			numFilteredWarmup++
+			continue
+		}
+		predictions = append(predictions, c.FirstSeen)
 	}
 
-	result := scorePredictions(predictions, meta, sigma)
-	return result, nil
+	minGT := groundTruth[0]
+	var numBaselineFPs int
+	for _, p := range predictions {
+		if p < minGT {
+			numBaselineFPs++
+		}
+	}
+
+	result := ComputeGaussianF1(ScoreInput{
+		PredictionTimestamps:  predictions,
+		GroundTruthTimestamps: groundTruth,
+		Sigma:                 sigma,
+	})
+	result.NumFilteredWarmup = numFilteredWarmup
+	result.NumBaselineFPs = numBaselineFPs
+	return &result, nil
 }
 
 // RunHeadless runs a scenario synchronously without the HTTP server and writes output.

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1019,6 +1019,27 @@ func (tb *TestBench) IsCorrelatorsProcessing() bool {
 	return false
 }
 
+// ScoreCurrentAnalysis scores the loaded scenario's correlations against episode.json ground truth.
+// Returns an error if ground truth is unavailable (missing episode.json or disruption.start).
+func (tb *TestBench) ScoreCurrentAnalysis(sigma float64) (*ScoreResult, error) {
+	tb.mu.RLock()
+	defer tb.mu.RUnlock()
+
+	meta, err := scoringMetadataFromEpisode(tb.episodeInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	correlations := tb.engine.StateView().CorrelationHistory()
+	predictions := make([]int64, len(correlations))
+	for i, c := range correlations {
+		predictions[i] = c.FirstSeen
+	}
+
+	result := scorePredictions(predictions, meta, sigma)
+	return result, nil
+}
+
 // RunHeadless runs a scenario synchronously without the HTTP server and writes output.
 // If verbose is true, the output file includes full correlation detail (title, members, anomalies).
 // If verbose is false, correlations include only the anomalous time span.

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -21,6 +21,13 @@ import (
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
+// ScoreResponse is the JSON payload for GET /api/score.
+type ScoreResponse struct {
+	Available bool         `json:"available"`
+	Reason    string       `json:"reason,omitempty"`
+	Score     *ScoreResult `json:"score,omitempty"`
+}
+
 // TestBenchAPI handles HTTP API requests for the test bench.
 type TestBenchAPI struct {
 	tb     *TestBench
@@ -54,6 +61,7 @@ func (api *TestBenchAPI) Start(addr string) error {
 	mux.HandleFunc("/api/leadlag", api.cors(api.handleLeadLag))
 	mux.HandleFunc("/api/surprise", api.cors(api.handleSurprise))
 	mux.HandleFunc("/api/stats", api.cors(api.handleStats))
+	mux.HandleFunc("/api/score", api.cors(api.handleScore))
 	mux.HandleFunc("/api/components/", api.cors(api.handleComponentAction))
 	mux.HandleFunc("/api/correlations/compressed", api.cors(api.handleCompressedCorrelations))
 
@@ -1114,6 +1122,16 @@ func (api *TestBenchAPI) handleCompressedCorrelations(w http.ResponseWriter, r *
 		}
 	}
 	api.writeJSON(w, groups)
+}
+
+// handleScore returns the Gaussian F1 score for the current analysis against episode.json.
+func (api *TestBenchAPI) handleScore(w http.ResponseWriter, _ *http.Request) {
+	result, err := api.tb.ScoreCurrentAnalysis(30.0)
+	if err != nil {
+		api.writeJSON(w, ScoreResponse{Available: false, Reason: err.Error()})
+		return
+	}
+	api.writeJSON(w, ScoreResponse{Available: true, Score: result})
 }
 
 // writeJSON writes a JSON response.


### PR DESCRIPTION
## Summary

Adds live scoring to the observer testbench so detection quality is visible while iterating on scenarios.

- **F1 score in the episode bar** — Gaussian F1, precision, and recall appear alongside the phase timeline (Baseline / Disruption / Cooldown) for any scenario with ground truth in `episode.json`
- **`ScoreCurrentAnalysis`** — scores the engine's live correlation history against disruption onset, filtering warmup predictions before baseline start
- **`/api/score` endpoint** — exposes the score via the testbench HTTP API
<img width="674" height="80" alt="Screenshot 2026-03-19 at 6 02 31 PM" src="https://github.com/user-attachments/assets/b3c75c0c-673c-48d7-84bb-c4ade701320e" />

