### PR TITLE
Fix compilation: add GetTimestampUnix and GetTimestampUnixMilli methods

### DIFF
--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -252,7 +252,7 @@ func (h *recordingHandle) ObserveMetric(sample observer.MetricView) {
 	h.inner.ObserveMetric(sample)
 
 	// Record to parquet if writer is available
-	timestamp := int64(sample.GetTimestamp())
+	timestamp := sample.GetTimestampUnix()
 	if timestamp == 0 {
 		timestamp = time.Now().Unix()
 	}
@@ -297,10 +297,10 @@ func (h *recordingHandle) ObserveTraceStats(stats observer.TraceStatsView) {
 			h.name,
 			agentHostname, agentEnv,
 			row.GetClientHostname(), row.GetClientEnv(), row.GetClientVersion(), row.GetClientContainerID(),
-			row.GetBucketStart(), row.GetBucketDuration(),
+			row.GetBucketStartUnixNano(), row.GetBucketDurationNano(),
 			row.GetService(), row.GetName(), row.GetResource(), row.GetType(),
 			row.GetHTTPStatusCode(), row.GetSpanKind(), row.GetIsTraceRoot(), row.GetSynthetics(),
-			row.GetHits(), row.GetErrors(), row.GetTopLevelHits(), row.GetDuration(),
+			row.GetHits(), row.GetErrors(), row.GetTopLevelHits(), row.GetDurationNano(),
 			row.GetOkSummary(), row.GetErrorSummary(),
 			row.GetPeerTags(),
 		)
@@ -323,11 +323,11 @@ func (h *recordingHandle) ObserveTrace(trace observer.TraceView) {
 			h.name,
 			traceIDHigh, traceIDLow,
 			trace.GetEnv(), traceService, trace.GetHostname(), trace.GetContainerID(),
-			trace.GetTimestamp(), trace.GetDuration(),
+			trace.GetTimestampUnixNano(), trace.GetDurationNano(),
 			trace.GetPriority(), trace.IsError(), traceTags,
 			span.GetSpanID(), span.GetParentID(),
 			span.GetService(), span.GetName(), span.GetResource(), span.GetType(),
-			span.GetStart(), span.GetDuration(), span.GetError(),
+			span.GetStartUnixNano(), span.GetDurationNano(), span.GetError(),
 			mapToTagSlice(span.GetMeta()), mapToMetricSlice(span.GetMetrics()),
 		)
 	}
@@ -342,7 +342,7 @@ func (h *recordingHandle) ObserveProfile(profile observer.ProfileView) {
 		profile.GetProfileID(), profile.GetProfileType(),
 		profile.GetService(), profile.GetEnv(), profile.GetVersion(),
 		profile.GetHostname(), profile.GetContainerID(),
-		profile.GetTimestamp(), profile.GetDuration(),
+		profile.GetTimestampUnixNano(), profile.GetDurationNano(),
 		profile.GetContentType(),
 		profile.GetRawData(),
 		mapToTagSlice(profile.GetTags()),

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -325,6 +325,11 @@ func (m *Message) GetTimestampMs() int64 {
 	return m.IngestionTimestamp / 1000000
 }
 
+// GetTimestampUnixMilli returns the message ingestion timestamp in Unix milliseconds.
+func (m *Message) GetTimestampUnixMilli() int64 {
+	return m.IngestionTimestamp / 1000000
+}
+
 // StructuredContent stores enough information from a tailer to manipulate a
 // structured log message (from journald or windowsevents) and to render it to
 // be encoded later on in the pipeline.

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -167,6 +167,11 @@ func (m *MetricSample) GetTimestamp() float64 {
 	return m.Timestamp
 }
 
+// GetTimestampUnix returns the metric sample timestamp in Unix seconds.
+func (m *MetricSample) GetTimestampUnix() int64 {
+	return int64(m.Timestamp)
+}
+
 // GetSampleRate returns the metric sample rate.
 func (m *MetricSample) GetSampleRate() float64 {
 	return m.SampleRate


### PR DESCRIPTION
## Summary
- Add `GetTimestampUnix() int64` to `MetricSample` so it satisfies the `observer.MetricView` interface
- Add `GetTimestampUnixMilli() int64` to `Message` so it satisfies the `observer.LogView` interface

These were the two missing methods causing build failures in `pkg/aggregator/sender` and `pkg/logs/processor`.

## Test plan
- [ ] `dda inv agent.build --build-exclude=systemd` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)