### PR TITLE
fix(config): add systemd to integration.basic.allowed checks

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1489,6 +1489,7 @@ func agent(config pkgconfigmodel.Setup) {
 		"versa",
 		"cisco_aci",
 		"system",
+		"systemd",
 		"system_core",
 		"system_swap",
 		"telemetry",


### PR DESCRIPTION
### What does this PR do?
Adds `systemd` to the `integration.basic.allowed` list in the agent configuration.

### Motivation
The `systemd` core check (`pkg/collector/corechecks/systemd`) was missing from the default allowed checks for `infrastructure_mode: basic`, preventing it from running in that mode.

### Describe how you validated your changes
The check name matches `CheckName = "systemd"` defined in `pkg/collector/corechecks/systemd/systemd.go`.

### Additional Notes
N/A