### PR TITLE
ECS Managed Instances - Parse ECS /tasks metadata endpoint

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/ecs/daemon_parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/daemon_parser.go
@@ -32,6 +32,10 @@ import (
 //
 //   - V4 parsing: Lists tasks via V1, then fetches detailed info from V4 for each task
 //     See: v4parser.go - parseTasksFromV4Endpoint()
+//
+//   - V4 /tasks parsing: Fetches all host tasks in a single call from the daemon container's v4 endpoint.
+//     Used on ECS Managed Instances where the /tasks endpoint is available.
+//     See: daemon_parser.go - parseTasksFromV4TasksEndpoint()
 func (c *collector) initializeDaemonMode(ctx context.Context) error {
 	var err error
 
@@ -48,6 +52,14 @@ func (c *collector) initializeDaemonMode(ctx context.Context) error {
 			c.metadataRetryMaxElapsedTime,
 			func(d time.Duration) time.Duration { return time.Duration(c.metadataRetryTimeoutFactor) * d }),
 		)
+	}
+
+	// Attempt to initialize a v4 client for the daemon agent's own container.
+	// This enables the /tasks endpoint on ECS Managed Instances.
+	if v4Client, err := ecsmeta.V4FromCurrentTask(); err == nil {
+		c.metaV4 = v4Client
+	} else {
+		log.Debugf("ECS daemon: failed to initialize v4 client for current task (may not be available): %v", err)
 	}
 
 	c.hasResourceTags = ecsutil.HasEC2ResourceTags()
@@ -73,7 +85,11 @@ func (c *collector) initializeDaemonMode(ctx context.Context) error {
 //   - Disabled or V4 unavailable: Uses V1 metadata endpoint (basic task info)
 //     See: v1parser.go - parseTasksFromV1Endpoint()
 //
-//   - Enabled with V4: Uses V4 metadata endpoint (detailed task info with health, tags, etc.)
+//   - Enabled with V4 on Managed Instances: Uses the v4 /tasks endpoint to fetch all host tasks
+//     in a single call, including the DaemonName field for daemon-scheduled tasks.
+//     See: daemon_parser.go - parseTasksFromV4TasksEndpoint()
+//
+//   - Enabled with V4 on EC2: Uses V4 metadata endpoint per-task (detailed task info with health, tags, etc.)
 //     See: v4parser.go - parseTasksFromV4Endpoint()
 func (c *collector) setTaskCollectionParserForDaemon(version string) {
 	if !c.taskCollectionEnabled {
@@ -88,6 +104,11 @@ func (c *collector) setTaskCollectionParserForDaemon(version string) {
 		// endpoint, causing the version check to fail. Fall back to checking for the
 		// ECS_CONTAINER_METADATA_URI_V4 env var as a signal that v4 is supported
 		if _, hasV4Env := os.LookupEnv(v3or4.DefaultMetadataURIv4EnvVariable); hasV4Env {
+			if c.metaV4 != nil && c.actualLaunchType == workloadmeta.ECSLaunchTypeManagedInstances {
+				log.Infof("detailed task collection enabled, using metadata v4 /tasks endpoint for managed instances")
+				c.taskCollectionParser = c.parseTasksFromV4TasksEndpoint
+				return
+			}
 			log.Infof("detailed task collection enabled, v4 metadata endpoint available via env var (version check unavailable): using metadata v4 endpoint")
 			c.taskCollectionParser = c.parseTasksFromV4Endpoint
 			return
@@ -100,6 +121,12 @@ func (c *collector) setTaskCollectionParserForDaemon(version string) {
 	if !ok {
 		log.Infof("detailed task collection enabled but v4 metadata endpoint is not available, using metadata v1 endpoint")
 		c.taskCollectionParser = c.parseTasksFromV1Endpoint
+		return
+	}
+
+	if c.metaV4 != nil && c.actualLaunchType == workloadmeta.ECSLaunchTypeManagedInstances {
+		log.Infof("detailed task collection enabled, using metadata v4 /tasks endpoint for managed instances")
+		c.taskCollectionParser = c.parseTasksFromV4TasksEndpoint
 		return
 	}
 

--- a/comp/core/workloadmeta/collectors/internal/ecs/daemon_parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/daemon_parser_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 )
 
@@ -42,68 +43,92 @@ func taskParserName(fn interface{}) string {
 func TestSetTaskCollectionParserForDaemon(t *testing.T) {
 	v1ParserSuffix := "parseTasksFromV1Endpoint"
 	v4ParserSuffix := "parseTasksFromV4Endpoint"
+	v4TasksParserSuffix := "parseTasksFromV4TasksEndpoint"
 
 	tests := []struct {
 		name                  string
 		taskCollectionEnabled bool
 		version               string
 		setV4Env              bool
-		expectV4Parser        bool
-		expectParserSet       bool
+		actualLaunchType      workloadmeta.ECSLaunchType
+		hasMetaV4             bool
+		expectParserSuffix    string
 	}{
 		{
 			name:                  "task collection disabled uses V1",
 			taskCollectionEnabled: false,
 			version:               "Amazon ECS Agent - v1.39.0 (abc1234)",
-			expectV4Parser:        false,
-			expectParserSet:       true,
+			expectParserSuffix:    v1ParserSuffix,
 		},
 		{
 			// Use 1.54.0+ so the test passes on both Linux (min 1.39.0) and Windows (min 1.54.0)
 			name:                  "task collection enabled with V4-capable version uses V4",
 			taskCollectionEnabled: true,
 			version:               "Amazon ECS Agent - v1.54.0 (abc1234)",
-			expectV4Parser:        true,
-			expectParserSet:       true,
+			actualLaunchType:      workloadmeta.ECSLaunchTypeEC2,
+			expectParserSuffix:    v4ParserSuffix,
 		},
 		{
 			name:                  "task collection enabled with version below V4 minimum uses V1",
 			taskCollectionEnabled: true,
 			version:               "Amazon ECS Agent - v1.30.0 (abc1234)",
-			expectV4Parser:        false,
-			expectParserSet:       true,
+			expectParserSuffix:    v1ParserSuffix,
 		},
 		{
 			name:                  "task collection enabled with empty version and V4 env uses V4",
 			taskCollectionEnabled: true,
 			version:               "",
 			setV4Env:              true,
-			expectV4Parser:        true,
-			expectParserSet:       true,
+			actualLaunchType:      workloadmeta.ECSLaunchTypeEC2,
+			expectParserSuffix:    v4ParserSuffix,
 		},
 		{
 			name:                  "task collection enabled with empty version and no V4 env uses V1",
 			taskCollectionEnabled: true,
 			version:               "",
 			setV4Env:              false,
-			expectV4Parser:        false,
-			expectParserSet:       true,
+			expectParserSuffix:    v1ParserSuffix,
 		},
 		{
 			name:                  "task collection enabled with invalid version and V4 env uses V4",
 			taskCollectionEnabled: true,
 			version:               "not-a-version",
 			setV4Env:              true,
-			expectV4Parser:        true,
-			expectParserSet:       true,
+			actualLaunchType:      workloadmeta.ECSLaunchTypeEC2,
+			expectParserSuffix:    v4ParserSuffix,
 		},
 		{
 			name:                  "task collection enabled with invalid version and no V4 env uses V1",
 			taskCollectionEnabled: true,
 			version:               "not-a-version",
 			setV4Env:              false,
-			expectV4Parser:        false,
-			expectParserSet:       true,
+			expectParserSuffix:    v1ParserSuffix,
+		},
+		{
+			name:                  "managed instances with V4 env and metaV4 uses /tasks endpoint",
+			taskCollectionEnabled: true,
+			version:               "",
+			setV4Env:              true,
+			actualLaunchType:      workloadmeta.ECSLaunchTypeManagedInstances,
+			hasMetaV4:             true,
+			expectParserSuffix:    v4TasksParserSuffix,
+		},
+		{
+			name:                  "managed instances with V4 env but no metaV4 falls back to per-task V4",
+			taskCollectionEnabled: true,
+			version:               "",
+			setV4Env:              true,
+			actualLaunchType:      workloadmeta.ECSLaunchTypeManagedInstances,
+			hasMetaV4:             false,
+			expectParserSuffix:    v4ParserSuffix,
+		},
+		{
+			name:                  "managed instances with V4-capable version and metaV4 uses /tasks endpoint",
+			taskCollectionEnabled: true,
+			version:               "Amazon ECS Agent - v1.54.0 (abc1234)",
+			actualLaunchType:      workloadmeta.ECSLaunchTypeManagedInstances,
+			hasMetaV4:             true,
+			expectParserSuffix:    v4TasksParserSuffix,
 		},
 	}
 
@@ -126,24 +151,18 @@ func TestSetTaskCollectionParserForDaemon(t *testing.T) {
 
 			c := &collector{
 				taskCollectionEnabled: tt.taskCollectionEnabled,
+				actualLaunchType:      tt.actualLaunchType,
+			}
+			if tt.hasMetaV4 {
+				c.metaV4 = &fakev3or4EcsClient{}
 			}
 
 			c.setTaskCollectionParserForDaemon(tt.version)
 
-			if !tt.expectParserSet {
-				assert.Nil(t, c.taskCollectionParser)
-				return
-			}
 			require.NotNil(t, c.taskCollectionParser, "taskCollectionParser should be set")
-
 			name := taskParserName(c.taskCollectionParser)
 			require.NotEmpty(t, name, "parser function name should be resolvable")
-
-			if tt.expectV4Parser {
-				assert.Contains(t, name, v4ParserSuffix, "expected V4 parser to be set")
-			} else {
-				assert.Contains(t, name, v1ParserSuffix, "expected V1 parser to be set")
-			}
+			assert.Contains(t, name, tt.expectParserSuffix, "unexpected parser selected")
 		})
 	}
 }

--- a/comp/core/workloadmeta/collectors/internal/ecs/ecs_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/ecs_test.go
@@ -76,6 +76,10 @@ func (*fakev3or4EcsClient) GetContainerStats(_ context.Context, _ string) (*v3or
 	return nil, errors.New("unimplemented")
 }
 
+func (*fakev3or4EcsClient) GetTasks(_ context.Context) ([]v3or4.Task, error) {
+	return nil, errors.New("unimplemented")
+}
+
 // TestPull tests the Pull method
 func TestPull(t *testing.T) {
 	store := &fakeWorkloadmetaStore{}

--- a/comp/core/workloadmeta/collectors/internal/ecs/testdata/tasks_v4.json
+++ b/comp/core/workloadmeta/collectors/internal/ecs/testdata/tasks_v4.json
@@ -1,0 +1,46 @@
+[
+  {
+    "Cluster": "arn:aws:ecs:us-east-1:123457279990:cluster/ecs-cluster",
+    "TaskARN": "arn:aws:ecs:us-east-1:123457279990:task/ecs-cluster/aaa111bbb222ccc333ddd444eee55500",
+    "Family": "my-service",
+    "Revision": "2",
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "LaunchType": "MANAGED_INSTANCES",
+    "ServiceName": "my-service",
+    "Containers": [
+      {
+        "DockerId": "aaa111bbb222ccc333ddd444eee55500-1234567890",
+        "Name": "my-service",
+        "DockerName": "my-service",
+        "Image": "my-service:latest",
+        "ImageID": "sha256:aabbcc",
+        "DesiredStatus": "RUNNING",
+        "KnownStatus": "RUNNING",
+        "Type": "NORMAL"
+      }
+    ]
+  },
+  {
+    "Cluster": "arn:aws:ecs:us-east-1:123457279990:cluster/ecs-cluster",
+    "TaskARN": "arn:aws:ecs:us-east-1:123457279990:task/ecs-cluster/fff666eee555ddd444ccc333bbb22200",
+    "Family": "my-daemon",
+    "Revision": "1",
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "LaunchType": "MANAGED_INSTANCES",
+    "DaemonName": "my-daemon",
+    "Containers": [
+      {
+        "DockerId": "fff666eee555ddd444ccc333bbb22200-0987654321",
+        "Name": "my-daemon",
+        "DockerName": "my-daemon",
+        "Image": "my-daemon:latest",
+        "ImageID": "sha256:ddeeff",
+        "DesiredStatus": "RUNNING",
+        "KnownStatus": "RUNNING",
+        "Type": "NORMAL"
+      }
+    ]
+  }
+]

--- a/comp/core/workloadmeta/collectors/internal/ecs/v4parser.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v4parser.go
@@ -57,6 +57,26 @@ func (c *collector) parseTasksFromV4Endpoint(ctx context.Context) ([]workloadmet
 	return c.setLastSeenEntitiesAndUnsetEvents(events, seen), nil
 }
 
+// parseTasksFromV4TasksEndpoint fetches all host tasks from the v4 /tasks endpoint in a single call
+// and parses them. This is the preferred parser for daemon mode on ECS Managed Instances, where the
+// daemon agent's ECS_CONTAINER_METADATA_URI_V4 exposes a /tasks endpoint that returns all tasks on
+// the host.
+func (c *collector) parseTasksFromV4TasksEndpoint(ctx context.Context) ([]workloadmeta.CollectorEvent, error) {
+	tasks, err := c.metaV4.GetTasks(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	events := []workloadmeta.CollectorEvent{}
+	seen := make(map[workloadmeta.EntityID]struct{})
+
+	for _, task := range tasks {
+		events = append(events, util.ParseV4Task(task, seen)...)
+	}
+
+	return c.setLastSeenEntitiesAndUnsetEvents(events, seen), nil
+}
+
 // getTaskWithTagsFromV4Endpoint fetches task and tags from the metadata v4 API
 func (c *collector) getTaskWithTagsFromV4Endpoint(ctx context.Context, task v1.Task) (v3or4.Task, error) {
 	// Get tags from the cache

--- a/comp/core/workloadmeta/collectors/internal/ecs/v4parser_test.go
+++ b/comp/core/workloadmeta/collectors/internal/ecs/v4parser_test.go
@@ -191,6 +191,82 @@ func TestPullWithTaskCollectionEnabledWithV4ParserCacheClearing(t *testing.T) {
 	require.Equal(t, "tag_value", rt.containerInstanceTags["tag_key"])
 }
 
+// TestParseTasksFromV4TasksEndpoint tests that parseTasksFromV4TasksEndpoint correctly parses
+// all tasks returned by the v4 /tasks endpoint, including DaemonName for daemon-scheduled tasks.
+func TestParseTasksFromV4TasksEndpoint(t *testing.T) {
+	// Serve the /tasks endpoint from the daemon agent's own v4 URI
+	dummyECS, err := testutil.NewDummyECS(
+		testutil.FileHandlerOption("/v4/daemon/tasks", "./testdata/tasks_v4.json"),
+	)
+	require.NoError(t, err)
+	ts := dummyECS.Start()
+	defer ts.Close()
+
+	c := &collector{
+		metaV4:       v3or4.NewClient(ts.URL+"/v4/daemon", "v4"),
+		resourceTags: make(map[string]resourceTags),
+		seen:         make(map[workloadmeta.EntityID]struct{}),
+	}
+	c.taskCollectionParser = c.parseTasksFromV4TasksEndpoint
+
+	events, err := c.parseTasksFromV4TasksEndpoint(context.Background())
+	require.NoError(t, err)
+
+	// expect 2 task events + 2 container events
+	require.Len(t, events, 4)
+
+	var serviceTask, daemonTask *workloadmeta.ECSTask
+	for _, event := range events {
+		require.Equal(t, workloadmeta.EventTypeSet, event.Type)
+		if task, ok := event.Entity.(*workloadmeta.ECSTask); ok {
+			if task.Family == "my-service" {
+				serviceTask = task
+			} else if task.Family == "my-daemon" {
+				daemonTask = task
+			}
+		}
+	}
+
+	require.NotNil(t, serviceTask, "service task should be parsed")
+	require.Equal(t, "my-service", serviceTask.ServiceName)
+	require.Empty(t, serviceTask.DaemonName)
+
+	require.NotNil(t, daemonTask, "daemon task should be parsed")
+	require.Equal(t, "my-daemon", daemonTask.DaemonName)
+	require.Empty(t, daemonTask.ServiceName)
+}
+
+// TestParseTasksFromV4TasksEndpointUnsetsStaleTasks verifies that tasks present in a
+// previous pull but absent from the current /tasks response are emitted as unset events.
+func TestParseTasksFromV4TasksEndpointUnsetsStaleTasks(t *testing.T) {
+	dummyECS, err := testutil.NewDummyECS(
+		testutil.FileHandlerOption("/v4/daemon/tasks", "./testdata/tasks_v4.json"),
+	)
+	require.NoError(t, err)
+	ts := dummyECS.Start()
+	defer ts.Close()
+
+	staleID := workloadmeta.EntityID{Kind: workloadmeta.KindECSTask, ID: "arn:aws:ecs:us-east-1:123457279990:task/ecs-cluster/stale000"}
+
+	c := &collector{
+		metaV4:       v3or4.NewClient(ts.URL+"/v4/daemon", "v4"),
+		resourceTags: make(map[string]resourceTags),
+		seen:         map[workloadmeta.EntityID]struct{}{staleID: {}},
+	}
+
+	events, err := c.parseTasksFromV4TasksEndpoint(context.Background())
+	require.NoError(t, err)
+
+	var unsetEvents []workloadmeta.CollectorEvent
+	for _, e := range events {
+		if e.Type == workloadmeta.EventTypeUnset {
+			unsetEvents = append(unsetEvents, e)
+		}
+	}
+	require.Len(t, unsetEvents, 1)
+	require.Equal(t, staleID, unsetEvents[0].Entity.GetID())
+}
+
 func getDummyECS() (*httptest.Server, error) {
 	dummyECS, err := testutil.NewDummyECS(
 		testutil.FileHandlerOption("/v4/1234-1/taskWithTags", "./testdata/datadog-agent.json"),

--- a/comp/core/workloadmeta/collectors/util/ecs_util.go
+++ b/comp/core/workloadmeta/collectors/util/ecs_util.go
@@ -69,6 +69,7 @@ func ParseV4Task(task v3or4.Task, seen map[workloadmeta.EntityID]struct{}) []wor
 		KnownStatus:             task.KnownStatus,
 		VPCID:                   task.VPCID,
 		ServiceName:             task.ServiceName,
+		DaemonName:              task.DaemonName,
 		ServiceARN:              serviceARN,
 		TaskDefinitionARN:       taskDefinitionARN,
 		EphemeralStorageMetrics: task.EphemeralStorageMetrics,

--- a/comp/core/workloadmeta/def/types.go
+++ b/comp/core/workloadmeta/def/types.go
@@ -1436,6 +1436,7 @@ type ECSTask struct {
 	ExecutionStoppedAt      *time.Time
 	VPCID                   string
 	ServiceName             string
+	DaemonName              string
 	EphemeralStorageMetrics map[string]int64
 	Limits                  map[string]float64
 	LaunchType              ECSLaunchType

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/CycloneDX/cyclonedx-go v0.9.3
 	github.com/DATA-DOG/go-sqlmock v1.5.2
-	github.com/DataDog/agent-payload/v5 v5.0.182
+	github.com/DataDog/agent-payload/v5 v5.0.184-0.20260310210300-4fe30d36d73c
 	github.com/DataDog/datadog-agent/comp/api/api/def v0.76.0-rc.4
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/def v0.0.0
 	github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx v0.0.0-20251027120702-0e91eee9852f

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,8 @@ github.com/CycloneDX/cyclonedx-go v0.9.3 h1:Pyk/lwavPz7AaZNvugKFkdWOm93MzaIyWmBw
 github.com/CycloneDX/cyclonedx-go v0.9.3/go.mod h1:vcK6pKgO1WanCdd61qx4bFnSsDJQ6SbM2ZuMIgq86Jg=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
-github.com/DataDog/agent-payload/v5 v5.0.182 h1:FooubUrLkVwCduW33MJv2dlnyDZQNhUtFw7AhlKoNHk=
-github.com/DataDog/agent-payload/v5 v5.0.182/go.mod h1:MScePfb6eN9vN9GqPhCXTeqq1V0TlCpnjrN4OujCaQs=
+github.com/DataDog/agent-payload/v5 v5.0.184-0.20260310210300-4fe30d36d73c h1:fCGt3hwVUD2j0M2+dHiDBVoRNR7hX3993kgnwnj88Ys=
+github.com/DataDog/agent-payload/v5 v5.0.184-0.20260310210300-4fe30d36d73c/go.mod h1:MScePfb6eN9vN9GqPhCXTeqq1V0TlCpnjrN4OujCaQs=
 github.com/DataDog/appsec-internal-go v1.14.0 h1:MIEZ015kdpeSZSFYBQteSmg8f7zkQTWbMDHbSL9zBx8=
 github.com/DataDog/appsec-internal-go v1.14.0/go.mod h1:9YppRCpElfGX+emXOKruShFYsdPq7WEPq/Fen4tYYpk=
 github.com/DataDog/aptly v1.5.3 h1:oLsRvjuXSVM4ia0N83dU3KiQeiJ6BaszYbTZOkSfDlw=

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/ecs/task.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/ecs/task.go
@@ -50,6 +50,7 @@ func ExtractECSTask(task TaskWithContainers, tagger tagger.Component) *model.ECS
 		Limits:                  task.Task.Limits,
 		EphemeralStorageMetrics: task.Task.EphemeralStorageMetrics,
 		ServiceName:             task.Task.ServiceName,
+		DaemonName:              task.Task.DaemonName,
 		VpcId:                   task.Task.VPCID,
 		ContainerInstanceArn:    task.Task.ContainerInstanceARN,
 		PullStartedAt:           extractTimestampPtr(task.Task.PullStartedAt),

--- a/pkg/util/ecs/metadata/v3or4/client.go
+++ b/pkg/util/ecs/metadata/v3or4/client.go
@@ -36,6 +36,10 @@ const (
 	taskMetadataPath         = "/task"
 	taskMetadataWithTagsPath = "/taskWithTags"
 	containerStatsPath       = "/task/stats"
+	// tasksMetadataPath is the path for the /tasks endpoint, which returns all tasks on the host.
+	// This is available in daemon mode (e.g. ECS Managed Instances) and returns a list of tasks
+	// rather than the single task for the current container.
+	tasksMetadataPath = "/tasks"
 )
 
 // Client is an interface for ECS metadata v3 and v4 API clients.
@@ -44,6 +48,10 @@ type Client interface {
 	GetContainer(ctx context.Context) (*Container, error)
 	GetContainerStats(ctx context.Context, id string) (*ContainerStatsV4, error)
 	GetTaskWithTags(ctx context.Context) (*Task, error)
+	// GetTasks returns all tasks running on the host. This endpoint is available in daemon
+	// mode (e.g. ECS Managed Instances) and returns the full task list in a single call,
+	// including DaemonName for daemon-scheduled tasks.
+	GetTasks(ctx context.Context) ([]Task, error)
 }
 
 // Client represents a client for a metadata v3 or v4 API endpoint.
@@ -116,6 +124,17 @@ func (c *client) GetTask(ctx context.Context) (*Task, error) {
 // GetTaskWithTags returns the current task, including propagated resource tags.
 func (c *client) GetTaskWithTags(ctx context.Context) (*Task, error) {
 	return c.getTaskMetadataAtPath(ctx, taskMetadataWithTagsPath)
+}
+
+// GetTasks returns all tasks running on the host via the /tasks endpoint.
+// This is available in daemon mode (e.g. ECS Managed Instances) and provides
+// a full host-level view of tasks in a single call.
+func (c *client) GetTasks(ctx context.Context) ([]Task, error) {
+	var tasks []Task
+	if err := c.get(ctx, tasksMetadataPath, &tasks); err != nil {
+		return nil, err
+	}
+	return tasks, nil
 }
 
 func (c *client) get(ctx context.Context, path string, v interface{}) error {

--- a/pkg/util/ecs/metadata/v3or4/client_nodocker.go
+++ b/pkg/util/ecs/metadata/v3or4/client_nodocker.go
@@ -27,3 +27,8 @@ func (c *Client) GetTask(context.Context) (*Task, error) {
 func (c *Client) GetTaskWithTags(context.Context) (*Task, error) {
 	return new(Task), nil
 }
+
+// GetTasks returns all tasks running on the host.
+func (c *Client) GetTasks(context.Context) ([]Task, error) {
+	return []Task{}, nil
+}

--- a/pkg/util/ecs/metadata/v3or4/client_test.go
+++ b/pkg/util/ecs/metadata/v3or4/client_test.go
@@ -20,6 +20,32 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
+func TestGetTasks(t *testing.T) {
+	dummyECS, err := testutil.NewDummyECS(
+		testutil.FileHandlerOption("/v4/1234-1/tasks", "./testdata/tasks.json"),
+	)
+	require.NoError(t, err)
+	ts := dummyECS.Start()
+	defer ts.Close()
+
+	client := NewClient(ts.URL+"/v4/1234-1", "v4")
+	tasks, err := client.GetTasks(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tasks, 2)
+
+	// service task: has ServiceName, no DaemonName
+	serviceTask := tasks[0]
+	require.Equal(t, "arn:aws:ecs:us-east-1:123457279990:task/ecs-cluster/aaa111bbb222ccc333ddd444eee55500", serviceTask.TaskARN)
+	require.Equal(t, "my-service", serviceTask.ServiceName)
+	require.Empty(t, serviceTask.DaemonName)
+
+	// daemon task: has DaemonName, no ServiceName
+	daemonTask := tasks[1]
+	require.Equal(t, "arn:aws:ecs:us-east-1:123457279990:task/ecs-cluster/fff666eee555ddd444ccc333bbb22200", daemonTask.TaskARN)
+	require.Equal(t, "my-daemon", daemonTask.DaemonName)
+	require.Empty(t, daemonTask.ServiceName)
+}
+
 func TestGetV4TaskWithTags(t *testing.T) {
 	testDataPath := "./testdata/task_with_tags.json"
 	dummyECS, err := testutil.NewDummyECS(

--- a/pkg/util/ecs/metadata/v3or4/testdata/tasks.json
+++ b/pkg/util/ecs/metadata/v3or4/testdata/tasks.json
@@ -1,0 +1,46 @@
+[
+  {
+    "Cluster": "arn:aws:ecs:us-east-1:123457279990:cluster/ecs-cluster",
+    "TaskARN": "arn:aws:ecs:us-east-1:123457279990:task/ecs-cluster/aaa111bbb222ccc333ddd444eee55500",
+    "Family": "my-service",
+    "Revision": "2",
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "LaunchType": "MANAGED_INSTANCES",
+    "ServiceName": "my-service",
+    "Containers": [
+      {
+        "DockerId": "aaa111bbb222ccc333ddd444eee55500-1234567890",
+        "Name": "my-service",
+        "DockerName": "my-service",
+        "Image": "my-service:latest",
+        "ImageID": "sha256:aabbcc",
+        "DesiredStatus": "RUNNING",
+        "KnownStatus": "RUNNING",
+        "Type": "NORMAL"
+      }
+    ]
+  },
+  {
+    "Cluster": "arn:aws:ecs:us-east-1:123457279990:cluster/ecs-cluster",
+    "TaskARN": "arn:aws:ecs:us-east-1:123457279990:task/ecs-cluster/fff666eee555ddd444ccc333bbb22200",
+    "Family": "my-daemon",
+    "Revision": "1",
+    "DesiredStatus": "RUNNING",
+    "KnownStatus": "RUNNING",
+    "LaunchType": "MANAGED_INSTANCES",
+    "DaemonName": "my-daemon",
+    "Containers": [
+      {
+        "DockerId": "fff666eee555ddd444ccc333bbb22200-0987654321",
+        "Name": "my-daemon",
+        "DockerName": "my-daemon",
+        "Image": "my-daemon:latest",
+        "ImageID": "sha256:ddeeff",
+        "DesiredStatus": "RUNNING",
+        "KnownStatus": "RUNNING",
+        "Type": "NORMAL"
+      }
+    ]
+  }
+]

--- a/pkg/util/ecs/metadata/v3or4/types.go
+++ b/pkg/util/ecs/metadata/v3or4/types.go
@@ -20,6 +20,7 @@ type Task struct {
 	TaskTags                map[string]string  `json:"TaskTags,omitempty"`
 	EphemeralStorageMetrics map[string]int64   `json:"EphemeralStorageMetrics,omitempty"`
 	ServiceName             string             `json:"ServiceName,omitempty"`
+	DaemonName              string             `json:"DaemonName,omitempty"`
 	VPCID                   string             `json:"VPCID,omitempty"`
 	PullStartedAt           string             `json:"PullStartedAt,omitempty"`
 	PullStoppedAt           string             `json:"PullStoppedAt,omitempty"`


### PR DESCRIPTION
### What does this PR do?

Adds support for parsing the ECS `/tasks` metadata endpoint on ECS Managed Instances, and wires the new `DaemonName` field through to workloadmeta and the orchestrator transformer.

**`pkg/util/ecs/metadata/v3or4`**
- Add `DaemonName string` to the `Task` struct (populated from the new `DaemonName` field in the `/tasks` response, analogous to `ServiceName`)
- Add `tasksMetadataPath = "/tasks"` constant and `GetTasks(ctx) ([]Task, error)` to the `Client` interface and implementation — calls `${ECS_CONTAINER_METADATA_URI_V4}/tasks` to return all host tasks in a single call

**`comp/core/workloadmeta`**
- Add `DaemonName string` to the `ECSTask` entity in `def/types.go`
- Wire `DaemonName: task.DaemonName` in `ParseV4Task` (`collectors/util/ecs_util.go`)

**`comp/core/workloadmeta/collectors/internal/ecs`**
- Add `parseTasksFromV4TasksEndpoint`: fetches all host tasks via `GetTasks()` in a single call and parses them with `ParseV4Task`. This replaces the v1-enumerate + per-task-v4-fetch pattern.
- `setTaskCollectionParserForDaemon`: selects `parseTasksFromV4TasksEndpoint` when running on Managed Instances with a v4 endpoint available

**`pkg/collector/corechecks/cluster/orchestrator/transformers/ecs/task.go`**
- Wire `DaemonName: task.Task.DaemonName` in `ExtractECSTask` to populate the agent-payload proto field

**`go.mod`**
- Bump `agent-payload` to pick up `daemonName = 22` in the `ECSTask` proto ([agent-payload PR #456](https://github.com/DataDog/agent-payload/pull/456))

### Motivation

With the release of Daemon Scheduling on ECS Managed Instances, AWS has added a new host-level `/tasks` endpoint that returns all tasks on the host, including a `DaemonName` field for daemon tasks.

This is the agent-side prerequisite for correct `ecs_daemon_name`, `daemon_arn`, and `task_definition_arn` tagging in the backend.

### Describe how you validated your changes

Unit tests added for:
- `GetTasks` client method (`client_test.go`)
- `parseTasksFromV4TasksEndpoint` in the ECS workloadmeta collector (`v4parser_test.go`, `daemon_parser_test.go`)
- `ExtractECSTask` with `DaemonName` populated (`task_test.go` — existing tests still pass)

### Additional Notes

- The `/tasks` endpoint has no `WithTags` variant, so EC2 resource tags are not collected via this path. This is expected — `HasEC2ResourceTags()` returns false on Managed Instances.