### PR TITLE
map lookup before update to avoid bucket lock

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -29,15 +29,18 @@ BPF_HASH_MAP(oom_stats, u64, struct oom_stats, 10240)
 
 SEC("kprobe/oom_kill_process")
 int BPF_KPROBE(kprobe__oom_kill_process, struct oom_control *oc) {
-    struct oom_stats zero = {};
     struct oom_stats new = {};
     u64 ts = bpf_ktime_get_ns();
     u32 pid = bpf_get_current_pid_tgid() >> 32;
 
-    bpf_map_update_elem(&oom_stats, &ts, &zero, BPF_NOEXIST);
     struct oom_stats *s = bpf_map_lookup_elem(&oom_stats, &ts);
     if (!s) {
-        return 0;
+        struct oom_stats zero = {};
+        bpf_map_update_elem(&oom_stats, &ts, &zero, BPF_NOEXIST);
+        s = bpf_map_lookup_elem(&oom_stats, &ts);
+        if (!s) {
+            return 0;
+        }
     }
 
     // for kernel before 4.11 the prototype for bpf_probe_read helpers

--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
@@ -47,8 +47,9 @@ static __always_inline void check_sock(struct sock *sk) {
     if (!v) {
         bpf_map_update_elem(&tcp_queue_stats, &k, &zero, BPF_NOEXIST);
         v = bpf_map_lookup_elem(&tcp_queue_stats, &k);
-        if (!v)
+        if (!v) {
             return;
+        }
     }
 
     int rqueue_size = BPF_CORE_READ(sk, sk_rcvbuf);

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -146,39 +146,43 @@ probe_run(uint64_t start_ns, const probe_params_t* params, struct pt_regs* regs)
     header->event_pairing_expectation = EVENT_PAIRING_ENTRY_PAIRING_EXPECTED;
   } else if (params->kind == EVENT_KIND_ENTRY && params->has_associated_return) {
     header->event_pairing_expectation = EVENT_PAIRING_RETURN_PAIRING_EXPECTED;
-    // Optimistically assume this is the first call for this goid by just
-    // attempting to insert with a single entry.
-    //
-    // In order to do an update, we need a value to write. We keep a per-cpu
-    // array (in_progress_calls_buf) with a single element in the first slot
-    // that we can use to update the in_progress_calls map.
-    call_depths_t* depths = bpf_map_lookup_elem(&in_progress_calls_buf, &zero_uint32);
+
+    call_depths_t* depths = bpf_map_lookup_elem(&in_progress_calls, &header->goid);
     if (!depths) {
-      // This should never happen.
-      LOG(1, "failed to get in_progress_calls_buf for %lld", header->goid);
-      return;
+      // In order to do an update, we need a value to write. We keep a per-cpu
+      // array (in_progress_calls_buf) with a single element in the first slot
+      // that we can use to update the in_progress_calls map.
+      depths = bpf_map_lookup_elem(&in_progress_calls_buf, &zero_uint32);
+      if (!depths) {
+        // This should never happen.
+        LOG(1, "failed to get in_progress_calls_buf for %lld", header->goid);
+        return;
+      }
+      depths->depths[0].depth = header->stack_byte_depth;
+      depths->depths[0].probe_id = params->probe_id;
+      int ret = bpf_map_update_elem(&in_progress_calls, &header->goid, depths, BPF_NOEXIST);
+      if (ret != 0) {
+        if (ret == -E2BIG) {
+          // If the map is full, we can't insert any more calls so make sure we
+          // tell userspace not to expect a return event.
+          header->event_pairing_expectation = EVENT_PAIRING_EXPECTATION_CALL_MAP_FULL;
+        } else if (ret == -EEXIST) {
+          // If there are outstanding calls for this goid, we need to add this one
+          // to the set.
+          depths = bpf_map_lookup_elem(&in_progress_calls, &header->goid);
+          if (!depths) {
+            LOG(1, "failed to lookup in_progress_calls for goid %lld after failing to insert", header->goid);
+            return;
+          }
+        }
+      }
     }
-    depths->depths[0].depth = header->stack_byte_depth;
-    depths->depths[0].probe_id = params->probe_id;
-    int ret = bpf_map_update_elem(&in_progress_calls, &header->goid, depths, BPF_NOEXIST);
-    if (ret != 0) {
-      if (ret == -E2BIG) {
-        // If the map is full, we can't insert any more calls so make sure we
-        // tell userspace not to expect a return event.
-        header->event_pairing_expectation = EVENT_PAIRING_EXPECTATION_CALL_MAP_FULL;
-      } else if (ret == -EEXIST) {
-        // If there are outstanding calls for this goid, we need to add this one
-        // to the set.
-        depths = bpf_map_lookup_elem(&in_progress_calls, &header->goid);
-        if (!depths) {
-          LOG(1, "failed to lookup in_progress_calls for goid %lld after failing to insert", header->goid);
-          return;
-        }
-        // If we can't insert this call, we need to tell userspace not to expect
-        // a return event.
-        if (!call_depths_insert(depths, header->stack_byte_depth, params->probe_id)) {
-          header->event_pairing_expectation = EVENT_PAIRING_EXPECTATION_CALL_COUNT_EXCEEDED;
-        }
+
+    if (depths) {
+      // If we can't insert this call, we need to tell userspace not to expect
+      // a return event.
+      if (!call_depths_insert(depths, header->stack_byte_depth, params->probe_id)) {
+        header->event_pairing_expectation = EVENT_PAIRING_EXPECTATION_CALL_COUNT_EXCEEDED;
       }
     }
   } else {

--- a/pkg/network/ebpf/c/protocols/http/http.h
+++ b/pkg/network/ebpf/c/protocols/http/http.h
@@ -179,8 +179,12 @@ static __always_inline http_transaction_t *http_fetch_state(conn_tuple_t *tuple,
     // Since http_in_flight is shared between programs running in different contexts, it gets effected by the
     // above scenario.
     // However the EBUSY error does not carry any signal for us since this is caused by a kernel bug.
-    bpf_map_update_with_telemetry(http_in_flight, tuple, http, BPF_NOEXIST, -EEXIST, -EBUSY);
+    http_transaction_t *state = bpf_map_lookup_elem(&http_in_flight, tuple);
+    if (state) {
+        return state;
+    }
 
+    bpf_map_update_with_telemetry(http_in_flight, tuple, http, BPF_NOEXIST, -EEXIST, -EBUSY);
     return bpf_map_lookup_elem(&http_in_flight, tuple);
 }
 

--- a/pkg/network/ebpf/c/protocols/http2/decoding-common.h
+++ b/pkg/network/ebpf/c/protocols/http2/decoding-common.h
@@ -58,11 +58,14 @@ static __always_inline http2_stream_t *http2_fetch_stream(const http2_stream_key
 
 // get_dynamic_counter returns the current dynamic counter by the conn tuple.
 static __always_inline __u64 *get_dynamic_counter(conn_tuple_t *tup) {
-    dynamic_counter_t empty = {0};
-    bpf_map_update_elem(&http2_dynamic_counter_table, tup, &empty, BPF_NOEXIST);
     dynamic_counter_t *ptr = bpf_map_lookup_elem(&http2_dynamic_counter_table, tup);
-    if (ptr == NULL) {
-        return NULL;
+    if (!ptr) {
+        dynamic_counter_t empty = {0};
+        bpf_map_update_elem(&http2_dynamic_counter_table, tup, &empty, BPF_NOEXIST);
+        ptr = bpf_map_lookup_elem(&http2_dynamic_counter_table, tup);
+        if (!ptr) {
+            return NULL;
+        }
     }
     return &ptr->value;
 }

--- a/pkg/network/ebpf/c/tracer.c
+++ b/pkg/network/ebpf/c/tracer.c
@@ -1127,9 +1127,12 @@ static __always_inline int handle_net_dev_queue(struct sk_buff* skb) {
     if (!is_equal(&skb_tup, &sock_tup)) {
         normalize_tuple(&skb_tup);
         normalize_tuple(&sock_tup);
-        // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
-        // and do not provide any useful signal since the key is expected to be present sometimes.
-        bpf_map_update_with_telemetry(conn_tuple_to_socket_skb_conn_tuple, &sock_tup, &skb_tup, BPF_NOEXIST, -EEXIST);
+        conn_tuple_t *tmp_tup = bpf_map_lookup_elem(&conn_tuple_to_socket_skb_conn_tuple, &sock_tup);
+        if (!tmp_tup) {
+            // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
+            // and do not provide any useful signal since the key is expected to be present sometimes.
+            bpf_map_update_with_telemetry(conn_tuple_to_socket_skb_conn_tuple, &sock_tup, &skb_tup, BPF_NOEXIST, -EEXIST);
+        }
     }
 
     return 0;

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -248,16 +248,18 @@ static __always_inline void update_conn_stats(conn_tuple_t *t, size_t sent_bytes
 
 // update_tcp_stats update rtt, retransmission and state on of a TCP connection
 static __always_inline void update_tcp_stats(conn_tuple_t *t, tcp_stats_t stats) {
-    // initialize-if-no-exist the connection state, and load it
-    tcp_stats_t empty = {};
-
-    // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
-    // and do not provide any useful signal since the key is expected to be present sometimes.
-    bpf_map_update_with_telemetry(tcp_stats, t, &empty, BPF_NOEXIST, -EEXIST);
-
     tcp_stats_t *val = bpf_map_lookup_elem(&tcp_stats, t);
-    if (val == NULL) {
-        return;
+    if (!val) {
+        // initialize-if-no-exist the connection state, and load it
+        tcp_stats_t empty = {};
+
+        // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
+        // and do not provide any useful signal since the key is expected to be present sometimes.
+        bpf_map_update_with_telemetry(tcp_stats, t, &empty, BPF_NOEXIST, -EEXIST);
+        tcp_stats_t *val = bpf_map_lookup_elem(&tcp_stats, t);
+        if (!val) {
+            return;
+        }
     }
 
     if (stats.rtt > 0) {
@@ -290,19 +292,21 @@ static __always_inline int handle_retransmit(struct sock *sk, int count) {
         return 0;
     }
 
-    // initialize-if-no-exist the connection state, and load it
-    u32 u32_zero = 0;
-
-    // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
-    // and do not provide any useful signal since the key is expected to be present sometimes.
-    bpf_map_update_with_telemetry(tcp_retransmits, &t, &u32_zero, BPF_NOEXIST, -EEXIST);
     u32 *val = bpf_map_lookup_elem(&tcp_retransmits, &t);
-    if (val == NULL) {
-        return 0;
+    if (!val) {
+        // initialize-if-no-exist the connection state, and load it
+        u32 u32_zero = 0;
+
+        // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
+        // and do not provide any useful signal since the key is expected to be present sometimes.
+        bpf_map_update_with_telemetry(tcp_retransmits, &t, &u32_zero, BPF_NOEXIST, -EEXIST);
+        val = bpf_map_lookup_elem(&tcp_retransmits, &t);
+        if (!val) {
+            return 0;
+        }
     }
 
     __sync_fetch_and_add(val, count);
-
     return 0;
 }
 
@@ -407,13 +411,18 @@ static __always_inline bool is_tcp_failure_recognized(int err) {
 }
 
 static __always_inline void report_unrecognized_tcp_failure(int err) {
-    // initialize if no-exist
     __u64 one = 1;
-    bpf_map_update_with_telemetry(tcp_failure_telemetry, &err, &one, BPF_NOEXIST, -EEXIST);
     __u64 *count = bpf_map_lookup_elem(&tcp_failure_telemetry, &err);
-    if (count != NULL) {
-        __sync_fetch_and_add(count, one);
+    if (!count) {
+        // initialize if no-exist
+        bpf_map_update_with_telemetry(tcp_failure_telemetry, &err, &one, BPF_NOEXIST, -EEXIST);
+        count = bpf_map_lookup_elem(&tcp_failure_telemetry, &err);
+        if (!count) {
+            return;
+        }
     }
+
+    __sync_fetch_and_add(count, one);
 }
 
 // handle_tcp_failure handles TCP connection failures on the socket pointer and adds them to the connection tuple

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -256,7 +256,7 @@ static __always_inline void update_tcp_stats(conn_tuple_t *t, tcp_stats_t stats)
         // We skip EEXIST because of the use of BPF_NOEXIST flag. Emitting telemetry for EEXIST here spams metrics
         // and do not provide any useful signal since the key is expected to be present sometimes.
         bpf_map_update_with_telemetry(tcp_stats, t, &empty, BPF_NOEXIST, -EEXIST);
-        tcp_stats_t *val = bpf_map_lookup_elem(&tcp_stats, t);
+        val = bpf_map_lookup_elem(&tcp_stats, t);
         if (!val) {
             return;
         }

--- a/pkg/security/ebpf/c/include/helpers/network/stats.h
+++ b/pkg/security/ebpf/c/include/helpers/network/stats.h
@@ -127,21 +127,22 @@ __attribute__((always_inline)) void count_pkt(struct __sk_buff *skb, struct pack
         flip(&ns_flow.flow);
     }
 
-    u8 should_register_flow = 0;
-    struct network_stats_t *stats = NULL;
-    struct network_stats_t stats_zero = {};
     u64 now = bpf_ktime_get_ns();
-    int ret = bpf_map_update_elem(&ns_flow_to_network_stats, &ns_flow, &stats_zero, BPF_NOEXIST);
-    if (ret == 0) {
-        // register flow in active_flows
-        should_register_flow = 1;
-    }
-
-    // lookup the existing (or new) entry (now that it has been created)
-    stats = bpf_map_lookup_elem(&ns_flow_to_network_stats, &ns_flow);
+    u8 should_register_flow = 0;
+    struct network_stats_t *stats = bpf_map_lookup_elem(&ns_flow_to_network_stats, &ns_flow);
     if (stats == NULL) {
-        // should never happen, ignore
-        return;
+        struct network_stats_t stats_zero = {};
+        int ret = bpf_map_update_elem(&ns_flow_to_network_stats, &ns_flow, &stats_zero, BPF_NOEXIST);
+        if (ret == 0) {
+            // register flow in active_flows
+            should_register_flow = 1;
+        }
+        // lookup the existing (or new) entry (now that it has been created)
+        stats = bpf_map_lookup_elem(&ns_flow_to_network_stats, &ns_flow);
+        if (stats == NULL) {
+            // should never happen, ignore
+            return;
+        }
     }
 
 #if defined(DEBUG_NETWORK_FLOW)
@@ -165,17 +166,19 @@ __attribute__((always_inline)) void count_pkt(struct __sk_buff *skb, struct pack
     }
 
     if (should_register_flow) {
-        // make sure we hold the spin lock for the active flows entry
-        struct active_flows_spin_lock_t init_value = {};
-        struct active_flows_spin_lock_t *active_flows_lock;
-        bpf_map_update_elem(&active_flows_spin_locks, &pkt->pid, &init_value, BPF_NOEXIST);
-        active_flows_lock = bpf_map_lookup_elem(&active_flows_spin_locks, &pkt->pid);
+        struct active_flows_spin_lock_t *active_flows_lock = bpf_map_lookup_elem(&active_flows_spin_locks, &pkt->pid);
         if (active_flows_lock == NULL) {
-            // shouldn't happen, ignore
-            return;
+            // make sure we hold the spin lock for the active flows entry
+            struct active_flows_spin_lock_t init_value = {};
+            bpf_map_update_elem(&active_flows_spin_locks, &pkt->pid, &init_value, BPF_NOEXIST);
+            active_flows_lock = bpf_map_lookup_elem(&active_flows_spin_locks, &pkt->pid);
+            if (active_flows_lock == NULL) {
+                // shouldn't happen, ignore
+                return;
+            }
         }
 
-        struct active_flows_t *entry;
+
         struct active_flows_t *zero = get_empty_active_flows();
         if (zero == NULL) {
             // should never happen, ignore
@@ -185,18 +188,20 @@ __attribute__((always_inline)) void count_pkt(struct __sk_buff *skb, struct pack
         zero->ifindex = skb->ifindex;
         zero->last_sent = now;
 
-        // make sure the active_flows entry for the current pid exists
-        ret = bpf_map_update_elem(&active_flows, &pkt->pid, zero, BPF_NOEXIST);
-        if (ret < 0 && ret != -EEXIST) {
-            // no more space in the map, ignore for now
-            return;
-        }
-
         // lookup active_flows for current pid
-        entry = bpf_map_lookup_elem(&active_flows, &pkt->pid);
+        struct active_flows_t *entry = bpf_map_lookup_elem(&active_flows, &pkt->pid);
         if (entry == NULL) {
-            // should not happen, ignore
-            return;
+            // make sure the active_flows entry for the current pid exists
+            int ret = bpf_map_update_elem(&active_flows, &pkt->pid, zero, BPF_NOEXIST);
+            if (ret < 0 && ret != -EEXIST) {
+                // no more space in the map, ignore for now
+                return;
+            }
+            entry = bpf_map_lookup_elem(&active_flows, &pkt->pid);
+            if (entry == NULL) {
+                // should not happen, ignore
+                return;
+            }
         }
 
         // is the entry full ?


### PR DESCRIPTION
### What does this PR do?

Performs `bpf_map_lookup_elem` before doing `bpf_map_update_elem` with `BPF_NOEXIST`.

### Motivation

`bpf_map_update_elem` will hold a bucket lock, even if there is already an existing entry. This is bad for system-wide lock contention. Adding a lookup beforehand will prevent the lock from being held if not necessary.

### Describe how you validated your changes

Existing tests.

### Additional Notes
