### PR TITLE
add fentry version of TCPQ check

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
@@ -78,6 +78,30 @@ static __always_inline void check_sock(struct sock *sk) {
     log_debug("check_sock: name=%s read_max=%d write_max=%d", k.cgroup, v->read_buffer_max_usage, v->write_buffer_max_usage);
 }
 
+SEC("fentry/tcp_recvmsg")
+int BPF_PROG(tcp_recvmsg_entry, struct sock *sk) {
+    check_sock(sk);
+    return 0;
+}
+
+SEC("fexit/tcp_recvmsg")
+int BPF_PROG(tcp_recvmsg_exit, struct sock *sk) {
+    check_sock(sk);
+    return 0;
+}
+
+SEC("fentry/tcp_sendmsg")
+int BPF_PROG(tcp_sendmsg_entry, struct sock *sk) {
+    check_sock(sk);
+    return 0;
+}
+
+SEC("fexit/tcp_sendmsg")
+int BPF_PROG(tcp_sendmsg_exit, struct sock *sk) {
+    check_sock(sk);
+    return 0;
+}
+
 SEC("kprobe/tcp_recvmsg")
 int BPF_KPROBE(kprobe__tcp_recvmsg, struct sock *sk) {
     u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length.go
@@ -14,14 +14,14 @@ package tcpqueuelength
 import (
 	"fmt"
 
-	"golang.org/x/sys/unix"
-
 	manager "github.com/DataDog/ebpf-manager"
+	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/model"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
+	"github.com/DataDog/datadog-agent/pkg/ebpf/features"
 	ebpfmaps "github.com/DataDog/datadog-agent/pkg/ebpf/maps"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -59,26 +59,46 @@ func NewTracer(cfg *ebpf.Config) (*Tracer, error) {
 }
 
 func startTCPQueueLengthProbe(buf bytecode.AssetReader, managerOptions manager.Options) (*Tracer, error) {
-	probes := []*manager.Probe{
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__tcp_recvmsg", UID: "tcpq"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kretprobe__tcp_recvmsg", UID: "tcpq"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__tcp_sendmsg", UID: "tcpq"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kretprobe__tcp_sendmsg", UID: "tcpq"}},
-	}
-
-	maps := []*manager.Map{
-		{Name: "tcp_queue_stats"},
-		{Name: "who_recvmsg"},
-		{Name: "who_sendmsg"},
-	}
-
 	m := &manager.Manager{
-		Probes: probes,
-		Maps:   maps,
+		Probes: []*manager.Probe{
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__tcp_recvmsg", UID: "tcpq"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kretprobe__tcp_recvmsg", UID: "tcpq"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kprobe__tcp_sendmsg", UID: "tcpq"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "kretprobe__tcp_sendmsg", UID: "tcpq"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tcp_recvmsg_entry", UID: "tcpq"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tcp_recvmsg_exit", UID: "tcpq"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tcp_sendmsg_entry", UID: "tcpq"}},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFFuncName: "tcp_sendmsg_exit", UID: "tcpq"}},
+		},
+		Maps: []*manager.Map{
+			{Name: "tcp_queue_stats"},
+			{Name: "who_recvmsg"},
+			{Name: "who_sendmsg"},
+		},
 	}
 
 	managerOptions.RemoveRlimit = true
-	managerOptions.DefaultKProbeMaxActive = maxActive
+
+	if features.SupportsFentry("tcp_recvmsg") {
+		managerOptions.ExcludedFunctions = append(managerOptions.ExcludedFunctions,
+			"kprobe__tcp_recvmsg",
+			"kretprobe__tcp_recvmsg",
+			"kprobe__tcp_sendmsg",
+			"kretprobe__tcp_sendmsg",
+		)
+		managerOptions.ExcludedMaps = append(managerOptions.ExcludedMaps,
+			"who_recvmsg",
+			"who_sendmsg",
+		)
+	} else {
+		managerOptions.DefaultKProbeMaxActive = maxActive
+		managerOptions.ExcludedFunctions = append(managerOptions.ExcludedFunctions,
+			"tcp_recvmsg_entry",
+			"tcp_recvmsg_exit",
+			"tcp_sendmsg_entry",
+			"tcp_sendmsg_exit",
+		)
+	}
 
 	if err := m.InitWithOptions(buf, managerOptions); err != nil {
 		return nil, fmt.Errorf("failed to init manager: %w", err)

--- a/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcpqueuelength/tcp_queue_length_test.go
@@ -44,7 +44,7 @@ func TestTCPQueueLengthCompile(t *testing.T) {
 func TestTCPQueueLengthTracer(t *testing.T) {
 	ebpftest.TestBuildModes(t, []ebpftest.BuildMode{ebpftest.RuntimeCompiled, ebpftest.CORE}, "", func(t *testing.T) {
 		if kv < kernel.VersionCode(4, 8, 0) {
-			t.Skipf("Kernel version %v is not supported by the OOM probe", kv)
+			t.Skipf("Kernel version %v is not supported by the TCP Queue Length probe", kv)
 		}
 
 		cfg := ebpf.NewConfig()

--- a/pkg/ebpf/features/features.go
+++ b/pkg/ebpf/features/features.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package features contains feature detection for eBPF
+package features
+
+import (
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf/kernelbugs"
+)
+
+// SupportsFentry returns true if the kernel supports fentry/fexit functions and has no known related bugs.
+func SupportsFentry(funcName string) bool {
+	if features.HaveProgramType(ebpf.Tracing) != nil {
+		return false
+	}
+
+	spec := &ebpf.ProgramSpec{
+		Type:       ebpf.Tracing,
+		AttachType: ebpf.AttachTraceFEntry,
+		AttachTo:   funcName,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+	}
+	prog, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
+		LogDisabled: true,
+	})
+	if err != nil {
+		return false
+	}
+	defer prog.Close()
+
+	l, err := link.AttachTracing(link.TracingOptions{
+		Program: prog,
+	})
+	if err != nil {
+		return false
+	}
+	defer l.Close()
+
+	hasPotentialFentryDeadlock, err := kernelbugs.HasTasksRCUExitLockSymbol()
+	if hasPotentialFentryDeadlock || (err != nil) {
+		// in case of error, let's be safe and assume the bug is present
+		return false
+	}
+
+	return true
+}

--- a/pkg/ebpf/features/features.go
+++ b/pkg/ebpf/features/features.go
@@ -40,6 +40,13 @@ func SupportsFentry(funcName string) bool {
 	}
 	defer prog.Close()
 
+	// deadlock check must come before attach, since deadlock is upon detach
+	hasPotentialFentryDeadlock, err := kernelbugs.HasTasksRCUExitLockSymbol()
+	if hasPotentialFentryDeadlock || (err != nil) {
+		// in case of error, let's be safe and assume the bug is present
+		return false
+	}
+
 	l, err := link.AttachTracing(link.TracingOptions{
 		Program: prog,
 	})
@@ -47,12 +54,6 @@ func SupportsFentry(funcName string) bool {
 		return false
 	}
 	defer l.Close()
-
-	hasPotentialFentryDeadlock, err := kernelbugs.HasTasksRCUExitLockSymbol()
-	if hasPotentialFentryDeadlock || (err != nil) {
-		// in case of error, let's be safe and assume the bug is present
-		return false
-	}
 
 	return true
 }

--- a/pkg/ebpf/features/features.go
+++ b/pkg/ebpf/features/features.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2025-present Datadog, Inc.
 
+//go:build linux_bpf
+
 // Package features contains feature detection for eBPF
 package features
 


### PR DESCRIPTION
### What does this PR do?

Adds a fentry version of the TCPQ length check.

### Motivation

Better performance and fewer maps on kernels that support fentry/fexit.

### Describe how you validated your changes

Existing tests.

### Additional Notes
