### PR TITLE
fix(renovate): Allow any major update for buildimages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,11 +16,13 @@
       },
       {
         "matchDepNames": ["linux-images"],
+        "maxMajorIncrement": 0,
         "changelogUrl": "https://github.com/DataDog/datadog-agent-buildimages/commits/main",
         "schedule": ["* 2-6 * * 1-5"]
       },
       {
         "matchDepNames": ["windows-images"],
+        "maxMajorIncrement": 0,
         "changelogUrl": "https://github.com/DataDog/datadog-agent-buildimages/commits/main",
         "schedule": ["* 2-6 2 * *"]
       },


### PR DESCRIPTION
### What does this PR do?
The major version of buildimages is bound to gitlab pipeline Ids. As a consequence it can be huge, and this is a [defensive mechanism](https://docs.renovatebot.com/configuration-options/#maxmajorincrement) by default in renovate.
```
DEBUG: Skipping linux-images@v96944171-49f39179 because major increment 79548 exceeds maxMajorIncrement 500
```
We need to deactivate this to reactivate the automatic buildimage bumps in the repo

### Motivation
Reactivate buildimages bumps

### Describe how you validated your changes
Configuration only, no update

### Additional Notes
