### PR TITLE
fix(renovate): Prevent errors for omnibus-ruby manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,9 @@
       },
       {
         "matchDepNames": ["omnibus-ruby"],
-        "changelogUrl": "https://github.com/DataDog/omnibus-ruby/compare/{{currentDigest}}..{{newDigest}}"
+        "changelogUrl": "https://github.com/DataDog/omnibus-ruby/compare/{{currentDigest}}..{{newDigest}}",
+        "matchUpdateTypes": ["major", "minor", "patch"],
+        "enabled": false
       },
       {
         "matchDepNames": ["linux-images"],


### PR DESCRIPTION
### What does this PR do?
The omnibus-ruby manager face errors with minor/major branches. And we don't need these branches as we only rely on the digest update. So we can skip them.

### Motivation
Remove these errors from the renovate dashboard
<img width="537" height="176" alt="image" src="https://github.com/user-attachments/assets/83564efd-54e8-499f-9041-8fba1485b594" />


### Describe how you validated your changes
[Configuration](https://github.com/chouetz/psychic-guacamole/blob/main/renovate.json#L20-L23) validated on a test repo, the [correct PR was created](https://github.com/chouetz/psychic-guacamole/pull/304)

### Additional Notes
