### PR TITLE
[CONTINT-5128] Use nodeInfo.kubeletVersion to detect distribution

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -142,7 +142,7 @@ func getNodeAnnotations(w http.ResponseWriter, r *http.Request, wmeta workloadme
 	getNodeMetadata(w, r, wmeta, func(km *workloadmeta.KubernetesMetadata) map[string]string { return km.Annotations }, "annotations", finalFilter)
 }
 
-func getNodeInfo(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component) {
+func getNodeInfo(w http.ResponseWriter, r *http.Request, _ workloadmeta.Component) {
 	cl, err := as.GetAPIClient()
 	if err != nil {
 		log.Errorf("getNodeInfo: unable to get apiserver: %v", err)

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
@@ -29,6 +30,10 @@ func installKubernetesMetadataEndpoints(r *mux.Router, wmeta workloadmeta.Compon
 	r.HandleFunc("/annotations/node/{nodeName}", api.WithTelemetryWrapper(
 		"getNodeAnnotations",
 		func(w http.ResponseWriter, r *http.Request) { getNodeAnnotations(w, r, wmeta) },
+	)).Methods("GET")
+	r.HandleFunc("/info/node/{nodeName}", api.WithTelemetryWrapper(
+		"getNodeInfo",
+		func(w http.ResponseWriter, r *http.Request) { getNodeInfo(w, r, wmeta) },
 	)).Methods("GET")
 	r.HandleFunc("/tags/pod/{nodeName}/{ns}/{podName}", api.WithTelemetryWrapper("getPodMetadata", getPodMetadata)).Methods("GET")
 	r.HandleFunc("/tags/pod/{nodeName}", api.WithTelemetryWrapper("getPodMetadataForNode", getPodMetadataForNode)).Methods("GET")
@@ -135,6 +140,45 @@ func getNodeAnnotations(w http.ResponseWriter, r *http.Request, wmeta workloadme
 	}
 
 	getNodeMetadata(w, r, wmeta, func(km *workloadmeta.KubernetesMetadata) map[string]string { return km.Annotations }, "annotations", finalFilter)
+}
+
+func getNodeInfo(w http.ResponseWriter, r *http.Request, wmeta workloadmeta.Component) {
+	cl, err := as.GetAPIClient()
+	if err != nil {
+		log.Errorf("getNodeInfo: unable to get apiserver: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	nodeCl := cl.Cl.CoreV1().Nodes()
+
+	vars := mux.Vars(r)
+	nodeName := vars["nodeName"]
+
+	node, err := nodeCl.Get(r.Context(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("getNodeInfo: unable to get self node: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if node == nil {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, "Could not find node %s", nodeName)
+		return
+	}
+
+	// Marshal whole struct, unmarshal only takes what is needed on caller side.
+	data, err := json.Marshal(&node.Status.NodeInfo)
+	if err != nil {
+		log.Errorf("getNodeInfo: failed to marshal node %s info %+v: %s", nodeName, &node.Status.NodeInfo, err.Error()) //nolint:errcheck
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if len(data) > 0 {
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+		return
+	}
 }
 
 // getNamespaceMetadataWithTransformerFunc is used when the node agent hits the DCA for some (or all) metadata of a specific namespace

--- a/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
+++ b/comp/core/workloadmeta/collectors/internal/cloudfoundry/vm/cf_vm_test.go
@@ -29,8 +29,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-var waitFor = 10 * time.Second
-var tick = 50 * time.Millisecond
+var (
+	waitFor = 10 * time.Second
+	tick    = 50 * time.Millisecond
+)
 
 var activeContainerWithoutProperties = gardenfakes.FakeContainer{
 	HandleStub: func() string {
@@ -89,6 +91,7 @@ type FakeGardenUtil struct {
 func (f *FakeGardenUtil) ListContainers() ([]garden.Container, error) {
 	return f.containers, nil
 }
+
 func (f *FakeGardenUtil) GetContainersInfo(handles []string) (map[string]garden.ContainerInfoEntry, error) {
 	containersInfo := make(map[string]garden.ContainerInfoEntry)
 	for _, container := range f.containers {
@@ -110,8 +113,8 @@ func (f *FakeGardenUtil) GetContainersInfo(handles []string) (map[string]garden.
 
 func (f *FakeGardenUtil) GetContainersMetrics(_ []string) (map[string]garden.ContainerMetricsEntry, error) {
 	return map[string]garden.ContainerMetricsEntry{}, nil
-
 }
+
 func (f *FakeGardenUtil) GetContainer(handle string) (garden.Container, error) {
 	for _, container := range f.containers {
 		if container.Handle() == handle {
@@ -171,6 +174,10 @@ func (f *FakeDCAClient) GetNodeLabels(_ string) (map[string]string, error) {
 }
 
 func (f *FakeDCAClient) GetNodeAnnotations(_ string, _ ...string) (map[string]string, error) {
+	panic("implement me")
+}
+
+func (f *FakeDCAClient) GetNodeInfo(_ string, _ ...string) (*clusteragent.NodeSystemInfo, error) {
 	panic("implement me")
 }
 

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -86,6 +86,10 @@ func (f *FakeDCAClient) GetNodeAnnotations(_ string, _ ...string) (map[string]st
 	return f.NodeAnnotations, f.NodeLabelsErr
 }
 
+func (f *FakeDCAClient) GetNodeInfo(_ string, _ ...string) (*clusteragent.NodeSystemInfo, error) {
+	panic("implement me")
+}
+
 func (f *FakeDCAClient) GetNodeUID(_ string) (string, error) {
 	return f.NodeUID, f.NodeUIDErr
 }

--- a/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/collector/corechecks/orchestrator/kubeletconfig/kubeletconfig_test.go
@@ -43,9 +43,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-var testHostName = "test-host"
-var testNodeName = "node"
-var staticRawKubeletConfig = []byte(`{"sample-key":"sample-value"}`)
+var (
+	testHostName           = "test-host"
+	testNodeName           = "node"
+	staticRawKubeletConfig = []byte(`{"sample-key":"sample-value"}`)
+)
 
 type fakeSender struct {
 	mocksender.MockSender
@@ -60,30 +62,43 @@ func (f *fakeDCAClient) GetNodeLabels(_ string) (map[string]string, error) { pan
 func (f *fakeDCAClient) GetNodeAnnotations(_ string, _ ...string) (map[string]string, error) {
 	panic("not used")
 }
+
 func (f *fakeDCAClient) GetNodeUID(_ string) (string, error) {
 	return "uid-test-123", nil
 }
+
 func (f *fakeDCAClient) GetNamespaceLabels(_ string) (map[string]string, error) {
 	panic("not used")
 }
+
+func (f *fakeDCAClient) GetNodeInfo(_ string, _ ...string) (*clusteragent.NodeSystemInfo, error) {
+	panic("implement me")
+}
+
 func (f *fakeDCAClient) GetNamespaceMetadata(_ string) (*clusteragent.Metadata, error) {
 	panic("not used")
 }
+
 func (f *fakeDCAClient) GetPodsMetadataForNode(_ string) (apiv1.NamespacesPodsStringsSet, error) {
 	panic("not used")
 }
+
 func (f *fakeDCAClient) GetKubernetesMetadataNames(_, _, _ string) ([]string, error) {
 	panic("not used")
 }
+
 func (f *fakeDCAClient) GetCFAppsMetadataForNode(_ string) (map[string][]string, error) {
 	panic("not used")
 }
+
 func (f *fakeDCAClient) PostClusterCheckStatus(_ context.Context, _ string, _ types.NodeStatus) (types.StatusResponse, error) {
 	panic("not used")
 }
+
 func (f *fakeDCAClient) GetClusterCheckConfigs(_ context.Context, _ string) (types.ConfigResponse, error) {
 	panic("not used")
 }
+
 func (f *fakeDCAClient) GetEndpointsCheckConfigs(_ context.Context, _ string) (types.ConfigResponse, error) {
 	panic("not used")
 }
@@ -149,7 +164,6 @@ func (suite *KubeletConfigTestSuite) SetupSuite() {
 	getClusterAgentClient = func() (clusteragent.DCAClientInterface, error) {
 		return &fakeDCAClient{}, nil
 	}
-
 }
 
 func (suite *KubeletConfigTestSuite) TearDownSuite() {

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -57,6 +57,16 @@ type Metadata struct {
 	Labels      map[string]string
 }
 
+// NodeSystemInfo is the subset of NodeSystemInfo from k8s.io/api/core/v1
+type NodeSystemInfo struct {
+	KernelVersion           string
+	OSImage                 string
+	ContainerRuntimeVersion string
+	KubeletVersion          string
+	OperatingSystem         string
+	Architecture            string
+}
+
 // DCAClientInterface is required to query the API of Datadog cluster agent
 type DCAClientInterface interface {
 	Version(withRefresh bool) version.Version
@@ -64,6 +74,8 @@ type DCAClientInterface interface {
 
 	GetNodeLabels(nodeName string) (map[string]string, error)
 	GetNodeAnnotations(nodeName string, filter ...string) (map[string]string, error)
+	GetNodeInfo(nodeName string) (NodeSystemInfo, error)
+
 	GetNodeUID(nodeName string) (string, error)
 	GetNamespaceLabels(nsName string) (map[string]string, error)
 	GetNamespaceMetadata(nsName string) (*Metadata, error)
@@ -393,6 +405,19 @@ func (c *DCAClient) GetNodeAnnotations(nodeName string, filter ...string) (map[s
 
 	err = c.doJSONQuery(context.TODO(), path, "GET", nil, &result, false)
 	return result, err
+}
+
+// GetNodeInfo returns the node system info from the Cluster Agent.
+func (c *DCAClient) GetNodeInfo(nodeName string, filter ...string) (*NodeSystemInfo, error) {
+	ni := NodeSystemInfo{}
+	base := "api/v1/info/node/" + nodeName
+	path, err := buildQueryList(base, "filter", filter)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.doJSONQuery(context.TODO(), path, "GET", nil, &ni, false)
+	return &ni, err
 }
 
 // GetCFAppsMetadataForNode returns the CF application tags from the Cluster Agent.

--- a/pkg/util/clusteragent/clusteragent.go
+++ b/pkg/util/clusteragent/clusteragent.go
@@ -74,7 +74,7 @@ type DCAClientInterface interface {
 
 	GetNodeLabels(nodeName string) (map[string]string, error)
 	GetNodeAnnotations(nodeName string, filter ...string) (map[string]string, error)
-	GetNodeInfo(nodeName string) (NodeSystemInfo, error)
+	GetNodeInfo(nodeName string, filter ...string) (*NodeSystemInfo, error)
 
 	GetNodeUID(nodeName string) (string, error)
 	GetNamespaceLabels(nsName string) (map[string]string, error)

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider.go
@@ -45,16 +45,20 @@ func GetName(ctx context.Context) (string, error) {
 	}
 
 	nl, err := dcaClient.GetNodeLabels(nodeName)
-	if err != nil {
-		return "", err
+	nsi, err1 := dcaClient.GetNodeInfo(nodeName)
+	if err != nil && err1 != nil {
+		// Return second error because NodeInfo is the primary source for detection
+		return "", err1
 	}
 
-	nsi, err := dcaClient.GetNodeInfo(nodeName)
-	if err != nil {
-		return "", err
+	kubeletVersion := ""
+	kernelVersion := ""
+	if nsi != nil {
+		kubeletVersion = nsi.KubeletVersion
+		kernelVersion = nsi.KernelVersion
 	}
 
-	kubeDistro := getKubeDistributionName(nl, nsi.KubeletVersion, nsi.KernelVersion)
+	kubeDistro := getKubeDistributionName(nl, kubeletVersion, kernelVersion)
 
 	cache.Cache.Set(cacheKey, kubeDistro, cache.NoExpiration)
 	return kubeDistro, nil

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider.go
@@ -49,7 +49,12 @@ func GetName(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	kubeDistro := getKubeDistributionName(nl, "")
+	nsi, err := dcaClient.GetNodeInfo(nodeName)
+	if err != nil {
+		return "", err
+	}
+
+	kubeDistro := getKubeDistributionName(nl, nsi.KubeletVersion)
 
 	cache.Cache.Set(cacheKey, kubeDistro, cache.NoExpiration)
 	return kubeDistro, nil

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	eksRe = regexp.MustCompile(".*eks.*")
-	aksRe = regexp.MustCompile(".*aks.*")
+	aksRe = regexp.MustCompile(".*azure.*")
 	gkeRe = regexp.MustCompile(".*gke.*")
 )
 
@@ -54,7 +54,7 @@ func GetName(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	kubeDistro := getKubeDistributionName(nl, nsi.KubeletVersion)
+	kubeDistro := getKubeDistributionName(nl, nsi.KubeletVersion, nsi.KernelVersion)
 
 	cache.Cache.Set(cacheKey, kubeDistro, cache.NoExpiration)
 	return kubeDistro, nil
@@ -62,12 +62,12 @@ func GetName(ctx context.Context) (string, error) {
 
 // getKubeDistributionName checks kubeletVersion and certain node labels to determine the kube cloud provider.
 // Returns an empty string if no provider is determined.
-func getKubeDistributionName(nl map[string]string, kubeletVersion string) string {
+func getKubeDistributionName(nl map[string]string, kubeletVersion, kernelVersion string) string {
 	switch {
+	case aksRe.MatchString(kernelVersion):
+		return "aks"
 	case eksRe.MatchString(kubeletVersion):
 		return "eks"
-	case aksRe.MatchString(kubeletVersion):
-		return "aks"
 	case gkeRe.MatchString(kubeletVersion):
 		return "gke"
 	}

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider.go
@@ -7,11 +7,18 @@ package cloudprovider
 
 import (
 	"context"
+	"regexp"
 
 	"github.com/DataDog/datadog-agent/pkg/config/setup/constants"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/hostinfo"
+)
+
+var (
+	eksRe = regexp.MustCompile(".*eks.*")
+	aksRe = regexp.MustCompile(".*aks.*")
+	gkeRe = regexp.MustCompile(".*gke.*")
 )
 
 // GetName returns the name of the kube distribution for the current node.
@@ -42,15 +49,24 @@ func GetName(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	kubeDistro := getKubeDistributionNameFromNodeLabels(nl)
+	kubeDistro := getKubeDistributionName(nl, "")
 
 	cache.Cache.Set(cacheKey, kubeDistro, cache.NoExpiration)
 	return kubeDistro, nil
 }
 
-// getKubeDistributionNameFromNodeLabels checks certain node labels to determine the kube cloud provider.
+// getKubeDistributionName checks kubeletVersion and certain node labels to determine the kube cloud provider.
 // Returns an empty string if no provider is determined.
-func getKubeDistributionNameFromNodeLabels(nl map[string]string) string {
+func getKubeDistributionName(nl map[string]string, kubeletVersion string) string {
+	switch {
+	case eksRe.MatchString(kubeletVersion):
+		return "eks"
+	case aksRe.MatchString(kubeletVersion):
+		return "aks"
+	case gkeRe.MatchString(kubeletVersion):
+		return "gke"
+	}
+
 	for labelName := range nl {
 		switch labelName {
 		case "eks.amazonaws.com/nodegroup",

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -30,31 +31,31 @@ func DCAGetName(ctx context.Context) string {
 		return ""
 	}
 
-	nl := getNodeLabels(ctx, nodeName)
-	providerName := getKubeDistributionNameFromNodeLabels(nl)
+	nl, sysInfo := getNodeMeta(ctx, nodeName)
 
+	providerName := getKubeDistributionName(nl, sysInfo.KubeletVersion)
 	// It is fine to save empty tag to avoid querying API server over and over again.
 	// Empty tag are ignored.
 	cache.Cache.Set(cacheKey, providerName, cache.NoExpiration)
 	return providerName
 }
 
-// getNodeLabels retrieves node labels for provided nodeName in cluster agent.
-func getNodeLabels(ctx context.Context, nodeName string) map[string]string {
+// getNodeMeta retrieves node labels for provided nodeName in cluster agent.
+func getNodeMeta(ctx context.Context, nodeName string) (map[string]string, *corev1.NodeSystemInfo) {
 	cl, err := apiserver.GetAPIClient()
 	if err != nil {
 		log.Warnf("Unable to get apiserver: %v", err)
-		return nil
+		return nil, nil
 	}
 	nodeCl := cl.Cl.CoreV1().Nodes()
 
 	node, err := nodeCl.Get(ctx, nodeName, metav1.GetOptions{})
 	if err != nil {
 		log.Warnf("Unable to get self node: %v", err)
-		return nil
+		return nil, nil
 	}
 	if node == nil {
-		return nil
+		return nil, nil
 	}
-	return node.Labels
+	return node.Labels, &node.Status.NodeInfo
 }

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
@@ -32,15 +32,24 @@ func DCAGetName(ctx context.Context) string {
 	}
 
 	nl, sysInfo := getNodeMeta(ctx, nodeName)
+	if nl == nil && sysInfo == nil {
+		return ""
+	}
+	kubeletVersion := ""
+	kernelVersion := ""
+	if sysInfo != nil {
+		kubeletVersion = sysInfo.KubeletVersion
+		kernelVersion = sysInfo.KernelVersion
+	}
 
-	providerName := getKubeDistributionName(nl, sysInfo.KubeletVersion, sysInfo.KernelVersion)
+	providerName := getKubeDistributionName(nl, kubeletVersion, kernelVersion)
 	// It is fine to save empty tag to avoid querying API server over and over again.
 	// Empty tag are ignored.
 	cache.Cache.Set(cacheKey, providerName, cache.NoExpiration)
 	return providerName
 }
 
-// getNodeMeta retrieves node labels for provided nodeName in cluster agent.
+// getNodeMeta retrieves node labels and system info for provided nodeName in cluster agent.
 func getNodeMeta(ctx context.Context, nodeName string) (map[string]string, *corev1.NodeSystemInfo) {
 	cl, err := apiserver.GetAPIClient()
 	if err != nil {

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_dca.go
@@ -33,7 +33,7 @@ func DCAGetName(ctx context.Context) string {
 
 	nl, sysInfo := getNodeMeta(ctx, nodeName)
 
-	providerName := getKubeDistributionName(nl, sysInfo.KubeletVersion)
+	providerName := getKubeDistributionName(nl, sysInfo.KubeletVersion, sysInfo.KernelVersion)
 	// It is fine to save empty tag to avoid querying API server over and over again.
 	// Empty tag are ignored.
 	cache.Cache.Set(cacheKey, providerName, cache.NoExpiration)

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
@@ -14,19 +14,24 @@ import (
 func TestKubeDistributionName(t *testing.T) {
 	// Test cases for cloud provider name
 	testCases := []struct {
-		name     string
-		expected string
-		labels   map[string]string
+		name           string
+		expected       string
+		labels         map[string]string
+		kubeletVersion string
 	}{
-		{"AWS", "eks", map[string]string{"eks.amazonaws.com/compute-type": "large5n"}},
-		{"GCP", "gke", map[string]string{"cloud.google.com/gke-boot-disk": "/dev/ssd0n1"}},
-		{"Azure", "aks", map[string]string{"kubernetes.azure.com/mode": "managed-azure"}},
-		{"Unknown", "", map[string]string{"cloud.provider": "unknown"}},
+		{"AWS", "eks", map[string]string{"eks.amazonaws.com/compute-type": "large5n"}, ""},
+		{"GCP", "gke", map[string]string{"cloud.google.com/gke-boot-disk": "/dev/ssd0n1"}, ""},
+		{"Azure", "aks", map[string]string{"kubernetes.azure.com/mode": "managed-azure"}, ""},
+		{"Unknown", "", map[string]string{"cloud.provider": "unknown"}, ""},
+		// no labels detection by kubelet version
+		{"AWS", "eks", map[string]string{}, "v1.34.4-eks-efcacff"},
+		{"GCP", "gke", map[string]string{}, "v1.33.5-gke.2392000"},
+		{"Azure", "aks", map[string]string{}, "v1.27.7-aks-78901234"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			provider := getKubeDistributionNameFromNodeLabels(tc.labels)
+			provider := getKubeDistributionName(tc.labels, tc.kubeletVersion)
 			assert.Equal(t, tc.expected, provider)
 		})
 	}

--- a/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
+++ b/pkg/util/kubernetes/cloudprovider/cloudprovider_test.go
@@ -18,20 +18,22 @@ func TestKubeDistributionName(t *testing.T) {
 		expected       string
 		labels         map[string]string
 		kubeletVersion string
+		kernelVersion  string
 	}{
-		{"AWS", "eks", map[string]string{"eks.amazonaws.com/compute-type": "large5n"}, ""},
-		{"GCP", "gke", map[string]string{"cloud.google.com/gke-boot-disk": "/dev/ssd0n1"}, ""},
-		{"Azure", "aks", map[string]string{"kubernetes.azure.com/mode": "managed-azure"}, ""},
-		{"Unknown", "", map[string]string{"cloud.provider": "unknown"}, ""},
+		{"AWS", "eks", map[string]string{"eks.amazonaws.com/compute-type": "large5n"}, "", ""},
+		{"GCP", "gke", map[string]string{"cloud.google.com/gke-boot-disk": "/dev/ssd0n1"}, "", ""},
+		{"Azure", "aks", map[string]string{"kubernetes.azure.com/mode": "managed-azure"}, "", ""},
+		{"Unknown", "", map[string]string{"cloud.provider": "unknown"}, "", ""},
 		// no labels detection by kubelet version
-		{"AWS", "eks", map[string]string{}, "v1.34.4-eks-efcacff"},
-		{"GCP", "gke", map[string]string{}, "v1.33.5-gke.2392000"},
-		{"Azure", "aks", map[string]string{}, "v1.27.7-aks-78901234"},
+		{"AWS1", "eks", map[string]string{}, "v1.34.4-eks-efcacff", ""},
+		{"GCP1", "gke", map[string]string{}, "v1.33.5-gke.2392000", ""},
+		{"Azure1", "aks", map[string]string{}, "", "v1.27.7-azure-78901234"},
+		{"Azure2", "aks", map[string]string{}, "", "azure-78901234"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			provider := getKubeDistributionName(tc.labels, tc.kubeletVersion)
+			provider := getKubeDistributionName(tc.labels, tc.kubeletVersion, tc.kernelVersion)
 			assert.Equal(t, tc.expected, provider)
 		})
 	}

--- a/releasenotes/notes/fix-kube_distribution-3de2f704f604bf0c.yaml
+++ b/releasenotes/notes/fix-kube_distribution-3de2f704f604bf0c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix kube_distribution tag value detection logic by analyzing node system info first.


### PR DESCRIPTION
### What does this PR do?
Improve `kube_distribution` tag value detection logic by analyzing node system info first.

### Motivation

It has been noted that tag is sometimes missing from some environments so this is an attempt to mitigate that.

### Describe how you validated your changes

### Additional Notes
See: https://docs.google.com/document/d/1kuSnCHLwwyvoh7eYp-AQwYU3roRJCQSKwNFvOW__QH4/edit?tab=t.0#heading=h.e1mdm9bb3jt

[CONTINT-5128]: https://datadoghq.atlassian.net/browse/CONTINT-5128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ