### PR TITLE
fix(tasks): Handle new PR titles in add_reviewers

### DIFF
--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -117,13 +117,14 @@ def add_reviewers(ctx, pr_id, dry_run=False, owner_file=".github/CODEOWNERS"):
         return
 
     folder = ""
-    if pr.title.startswith("Bump the "):
-        match = re.match(r"^Bump the (\S+) group (.*$)", pr.title)
+    title = pr.title.removeprefix("build(deps): ")
+    if title.lower().startswith("bump the "):
+        match = re.match(r"^[Bb]ump the (\S+) group (.*$)", title)
         if match.group(2).startswith("in"):
             match_folder = re.match(r"^in (\S+).*$", match.group(2))
             folder = match_folder.group(1).removeprefix("/")
     else:
-        match = re.match(r"^Bump (\S+) from (\S+) to (\S+)( in .*)?$", pr.title)
+        match = re.match(r"^[Bb]ump (\S+) from (\S+) to (\S+)( in .*)?$", title)
         if match.group(4):
             match_folder = re.match(r"^ in (\S+).*$", match.group(4))
             folder = match_folder.group(1).removeprefix("/")

--- a/tasks/unit_tests/issue_tests.py
+++ b/tasks/unit_tests/issue_tests.py
@@ -113,6 +113,125 @@ tasks/unit_tests/testdata/add_reviewers/new-e2e/fake.go""")
 
     @patch('builtins.print')
     @patch('tasks.issue.GithubAPI')
+    def test_single_dependency_with_prefix(self, gh_mock, print_mock):
+        """Test that Renovate-style 'build(deps): Bump ...' titles are handled"""
+        pr_mock = MagicMock()
+        pr_mock.user.login = "dependabot[bot]"
+        pr_mock.title = "build(deps): Bump github.com/redis/go-redis/v9 from 9.1.0 to 9.7.0"
+        gh_instance = MagicMock()
+        gh_instance.repo.get_pull.return_value = pr_mock
+        gh_mock.return_value = gh_instance
+        c = MockContext(
+            run={
+                "git ls-files | grep -e \"^.*.go$\"": Result(
+                    """tasks/unit_tests/testdata/add_reviewers/network/fake.go"""
+                )
+            }
+        )
+        add_reviewers(c, 1234, owner_file="tasks/unit_tests/testdata/add_reviewers/CODEOWNERS")
+        print_mock.assert_not_called()
+        pr_mock.create_review_request.assert_called_once_with(team_reviewers=['universal-service-monitoring'])
+
+    @patch('builtins.print')
+    @patch('tasks.issue.GithubAPI')
+    def test_single_dependency_lowercase_bump(self, gh_mock, print_mock):
+        """Test that lowercase 'bump' in title is handled"""
+        pr_mock = MagicMock()
+        pr_mock.user.login = "dependabot[bot]"
+        pr_mock.title = "build(deps): bump github.com/redis/go-redis/v9 from 9.1.0 to 9.7.0"
+        gh_instance = MagicMock()
+        gh_instance.repo.get_pull.return_value = pr_mock
+        gh_mock.return_value = gh_instance
+        c = MockContext(
+            run={
+                "git ls-files | grep -e \"^.*.go$\"": Result(
+                    """tasks/unit_tests/testdata/add_reviewers/network/fake.go"""
+                )
+            }
+        )
+        add_reviewers(c, 1234, owner_file="tasks/unit_tests/testdata/add_reviewers/CODEOWNERS")
+        print_mock.assert_not_called()
+        pr_mock.create_review_request.assert_called_once_with(team_reviewers=['universal-service-monitoring'])
+
+    @patch('builtins.print')
+    @patch('tasks.issue.GithubAPI')
+    def test_group_dependency_with_prefix(self, gh_mock, print_mock):
+        """Test that Renovate-style 'build(deps): Bump the ...' group titles are handled"""
+        pr_mock = MagicMock()
+        pr_mock.user.login = "dependabot[bot]"
+        pr_mock.title = "build(deps): Bump the aws-sdk-go-v2 group with 5 updates"
+        gh_instance = MagicMock()
+        gh_instance.repo.get_pull.return_value = pr_mock
+        gh_mock.return_value = gh_instance
+        c = MockContext(
+            run={
+                "git ls-files | grep -e \"^.*.go$\"": Result("""tasks/unit_tests/testdata/add_reviewers/debugger/fake.go
+tasks/unit_tests/testdata/add_reviewers/windows/fake.go
+tasks/unit_tests/testdata/add_reviewers/new-e2e/fake.go""")
+            }
+        )
+        add_reviewers(c, 1234, owner_file="tasks/unit_tests/testdata/add_reviewers/CODEOWNERS")
+        print_mock.assert_not_called()
+        self.assertCountEqual(
+            pr_mock.create_review_request.call_args[1]['team_reviewers'],
+            [
+                'windows-products',
+                'debugger',
+                'agent-e2e-testing',
+            ],
+        )
+
+    @patch('builtins.print')
+    @patch('tasks.issue.GithubAPI')
+    def test_group_dependency_scoped_with_prefix(self, gh_mock, print_mock):
+        """Test that Renovate-style 'build(deps): bump the ...' scoped group titles are handled"""
+        pr_mock = MagicMock()
+        pr_mock.user.login = "dependabot[bot]"
+        pr_mock.title = "build(deps): bump the aws-sdk-go-v2 group in tasks/unit_tests/testdata/add_reviewers/new-e2e with 5 updates"
+        gh_instance = MagicMock()
+        gh_instance.repo.get_pull.return_value = pr_mock
+        gh_mock.return_value = gh_instance
+        c = MockContext(
+            run={
+                "git ls-files | grep -e \"^.*.go$\"": Result("""tasks/unit_tests/testdata/add_reviewers/debugger/fake.go
+tasks/unit_tests/testdata/add_reviewers/windows/fake.go
+tasks/unit_tests/testdata/add_reviewers/new-e2e/fake.go""")
+            }
+        )
+        add_reviewers(c, 1234, owner_file="tasks/unit_tests/testdata/add_reviewers/CODEOWNERS")
+        print_mock.assert_not_called()
+        self.assertCountEqual(
+            pr_mock.create_review_request.call_args[1]['team_reviewers'],
+            [
+                'agent-e2e-testing',
+            ],
+        )
+
+    @patch('builtins.print')
+    @patch('tasks.issue.GithubAPI')
+    def test_single_dependency_with_prefix_and_folder(self, gh_mock, print_mock):
+        """Test that Renovate-style prefix with folder scoping works"""
+        pr_mock = MagicMock()
+        pr_mock.user.login = "dependabot[bot]"
+        pr_mock.title = "build(deps): bump github.com/redis/go-redis/v9 from 9.1.0 to 9.7.0 in tasks/unit_tests/testdata/add_reviewers/fakeintake"
+        gh_instance = MagicMock()
+        gh_instance.repo.get_pull.return_value = pr_mock
+        gh_mock.return_value = gh_instance
+        c = MockContext(
+            run={
+                "git ls-files | grep -e \"^.*.go$\"": Result("""tasks/unit_tests/testdata/add_reviewers/network/fake.go
+tasks/unit_tests/testdata/add_reviewers/fakeintake/fake.go
+""")
+            }
+        )
+        add_reviewers(c, 1234, owner_file="tasks/unit_tests/testdata/add_reviewers/CODEOWNERS")
+        print_mock.assert_not_called()
+        self.assertCountEqual(
+            pr_mock.create_review_request.call_args[1]['team_reviewers'], ['agent-e2e-testing', 'agent-devx']
+        )
+
+    @patch('builtins.print')
+    @patch('tasks.issue.GithubAPI')
     def test_group_dependency_scoped(self, gh_mock, print_mock):
         pr_mock = MagicMock()
         pr_mock.user.login = "dependabot[bot]"


### PR DESCRIPTION
### What does this PR do?

Updates `add_reviewers` in `tasks/issue.py` to handle new title from dependabot on  dependency bump PR titles that use the `build(deps):` prefix and lowercase `bump`. Previously, the title parsing only matched Dependabot's exact format (`Bump ...`).

Changes:
- Strip the `build(deps): ` prefix before parsing
- Make the `Bump`/`bump` match case-insensitive

### Motivation
Since recently dependabot changes the titles of its PR eg here https://github.com/DataDog/datadog-agent/pull/47706
 `add_reviewers` fails to parse the dependency name and folder on these.

### Describe how you validated your changes

Added 5 new unit tests covering all title variants:
- `build(deps): Bump <dep>` (single dep, uppercase)
- `build(deps): bump <dep>` (single dep, lowercase)
- `build(deps): Bump the <group>` (group dep)
- `build(deps): bump the <group> in <folder>` (scoped group)
- `build(deps): bump <dep> in <folder>` (single dep with folder)

All 11 `TestAddReviewers` tests pass.

### Additional Notes
