### PR TITLE
Fix vsock support

### DIFF
--- a/comp/api/api/apiimpl/api.go
+++ b/comp/api/api/apiimpl/api.go
@@ -30,8 +30,8 @@ func Module() fxutil.Module {
 type apiServer struct {
 	cfg               config.Component
 	ipc               ipc.Component
-	cmdAddr           *net.TCPAddr
-	ipcAddr           *net.TCPAddr
+	cmdAddr           net.Addr
+	ipcAddr           net.Addr
 	cmdServer         *http.Server
 	ipcServer         *http.Server
 	telemetry         telemetry.Component
@@ -74,11 +74,11 @@ func newAPIServer(deps dependencies) api.Component {
 }
 
 // CMDServerAddress returns the CMD server address.
-func (server *apiServer) CMDServerAddress() *net.TCPAddr {
+func (server *apiServer) CMDServerAddress() net.Addr {
 	return server.cmdAddr
 }
 
 // IPCServerAddress returns the IPC server address.
-func (server *apiServer) IPCServerAddress() *net.TCPAddr {
+func (server *apiServer) IPCServerAddress() net.Addr {
 	return server.ipcAddr
 }

--- a/comp/api/api/apiimpl/api_mock.go
+++ b/comp/api/api/apiimpl/api_mock.go
@@ -42,11 +42,11 @@ func (mock *mockAPIServer) StopServer() {
 }
 
 // ServerAddress returns the server address.
-func (mock *mockAPIServer) CMDServerAddress() *net.TCPAddr {
+func (mock *mockAPIServer) CMDServerAddress() net.Addr {
 	return nil
 }
 
 // ServerAddress returns the server address.
-func (mock *mockAPIServer) IPCServerAddress() *net.TCPAddr {
+func (mock *mockAPIServer) IPCServerAddress() net.Addr {
 	return nil
 }

--- a/comp/api/api/apiimpl/server_cmd.go
+++ b/comp/api/api/apiimpl/server_cmd.go
@@ -7,7 +7,6 @@ package apiimpl
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"time"
 
@@ -33,7 +32,7 @@ func (server *apiServer) startCMDServer(
 		// no way we can recover from this error
 		return fmt.Errorf("unable to listen to address %s: %v", cmdAddr, err)
 	}
-	server.cmdAddr = cmdListener.Addr().(*net.TCPAddr)
+	server.cmdAddr = cmdListener.Addr()
 
 	// gRPC server
 	grpcServer := server.grpcComponent.BuildServer()

--- a/comp/api/api/apiimpl/server_ipc.go
+++ b/comp/api/api/apiimpl/server_ipc.go
@@ -7,7 +7,6 @@ package apiimpl
 
 import (
 	"crypto/tls"
-	"net"
 	"net/http"
 	"time"
 
@@ -25,9 +24,7 @@ func (server *apiServer) startIPCServer(ipcServerAddr string, tmf observability.
 	if err != nil {
 		return err
 	}
-	if tcpAddr, ok := ipcListener.Addr().(*net.TCPAddr); ok {
-		server.ipcAddr = tcpAddr
-	}
+	server.ipcAddr = ipcListener.Addr()
 
 	configEndpointMux := configendpoint.GetConfigEndpointMuxCore(server.cfg)
 

--- a/comp/api/api/def/component.go
+++ b/comp/api/api/def/component.go
@@ -22,8 +22,8 @@ import (
 
 // Component is the component type.
 type Component interface {
-	CMDServerAddress() *net.TCPAddr
-	IPCServerAddress() *net.TCPAddr
+	CMDServerAddress() net.Addr
+	IPCServerAddress() net.Addr
 }
 
 // EndpointProvider is an interface to register api endpoints

--- a/comp/core/remoteagent/helper/serverhelper.go
+++ b/comp/core/remoteagent/helper/serverhelper.go
@@ -9,17 +9,21 @@ package helper
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
+	"github.com/mdlayher/vsock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
 
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 
+	"github.com/DataDog/datadog-agent/comp/api/api/apiimpl/listener"
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	ipc "github.com/DataDog/datadog-agent/comp/core/ipc/def"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -27,6 +31,7 @@ import (
 
 	pbcore "github.com/DataDog/datadog-agent/pkg/proto/pbgo/core"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/system/socket"
 )
 
 // UnimplementedRemoteAgentServer is a wrapper around a gRPC server that implements the RemoteAgentServer protocol.
@@ -68,12 +73,12 @@ func NewUnimplementedRemoteAgentServer(ipcComp ipc.Component, log log.Component,
 	}
 
 	// Listen on a random port
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := listener.GetListener("127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}
 
-	agentClient, err := newAgentSecureClient(ipcComp, agentIpcAddress)
+	agentClient, err := newAgentSecureClient(ipcComp, agentIpcAddress, config, log)
 	if err != nil {
 		log.Errorf("failed to create agent client: %v", err)
 		return nil, err
@@ -231,11 +236,39 @@ func (s *UnimplementedRemoteAgentServer) stop() {
 	s.log.Debug("remoteAgentServer stopped")
 }
 
-func newAgentSecureClient(ipcComp ipc.Component, agentIpcAddress string) (pbcore.AgentSecureClient, error) {
-	conn, err := grpc.NewClient(agentIpcAddress,
+func newAgentSecureClient(ipcComp ipc.Component, agentIpcAddress string, cfg config.Component, log log.Component) (pbcore.AgentSecureClient, error) {
+	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(credentials.NewTLS(ipcComp.GetTLSClientConfig())),
 		grpc.WithPerRPCCredentials(grpcutil.NewBearerTokenAuth(ipcComp.GetAuthToken())),
-	)
+	}
+
+	if vsockAddr := cfg.GetString("vsock_addr"); vsockAddr != "" {
+		cid, err := socket.ParseVSockAddress(vsockAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		_, sPort, err := net.SplitHostPort(agentIpcAddress)
+		if err != nil {
+			return nil, err
+		}
+
+		cmdPort, parseErr := strconv.Atoi(sPort)
+		if parseErr != nil {
+			return nil, fmt.Errorf("invalid vsock socket path '%s'", agentIpcAddress)
+		}
+
+		if cmdPort <= 0 {
+			return nil, fmt.Errorf("invalid port '%d' for vsock", cmdPort)
+		}
+
+		opts = append(opts, grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			log.Debugf("dialing vsock address with CID %d and port %d", cid, cmdPort)
+			return vsock.Dial(cid, uint32(cmdPort), &vsock.Config{})
+		}))
+	}
+
+	conn, err := grpc.NewClient(agentIpcAddress, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cli/standalone/jmx.go
+++ b/pkg/cli/standalone/jmx.go
@@ -9,6 +9,8 @@ package standalone
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/comp/agent/jmxlogger"
@@ -66,19 +68,27 @@ func execJmxCommand(command string,
 
 	runner.Reporter = reporter
 	runner.Command = command
-	runner.IPCPort = agentAPI.CMDServerAddress().Port
+
+	_, ipcPortStr, err := net.SplitHostPort(agentAPI.CMDServerAddress().String())
+	if err != nil {
+		return fmt.Errorf("invalid CMD server address: %v", err)
+	}
+	ipcPort, err := strconv.ParseUint(ipcPortStr, 10, 16)
+	if err != nil {
+		return fmt.Errorf("invalid port for IPC listener: %v", err)
+	}
+	runner.IPCPort = int(ipcPort)
+
 	runner.Output = output
 	runner.LogLevel = logLevel
 
 	loadJMXConfigs(runner, selectedChecks, configs)
 
-	err := runner.Start(false)
-	if err != nil {
+	if err := runner.Start(false); err != nil {
 		return err
 	}
 
-	err = runner.Wait()
-	if err != nil {
+	if err := runner.Wait(); err != nil {
 		return err
 	}
 

--- a/pkg/security/agent/client.go
+++ b/pkg/security/agent/client.go
@@ -274,9 +274,16 @@ func NewRuntimeSecurityEventClient() (*RuntimeSecurityEventClient, error) {
 			return nil, fmt.Errorf("invalid port '%s' for vsock", socketPath)
 		}
 
+		cid := uint32(vsock.Host)
+		if vsockAddr := pkgconfigsetup.Datadog().GetString("vsock_addr"); vsockAddr != "" {
+			if cid, err = socket.ParseVSockAddress(vsockAddr); err != nil {
+				return nil, err
+			}
+		}
+
 		opts = append(opts, grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
-			log.Infof("Dialing vsock socket on CID %d and port %d", vsock.Host, cmdPort)
-			return vsock.Dial(vsock.Host, uint32(cmdPort), &vsock.Config{})
+			log.Infof("Dialing vsock socket on CID %d and port %d", cid, cmdPort)
+			return vsock.Dial(cid, uint32(cmdPort), &vsock.Config{})
 		}))
 	}
 

--- a/pkg/security/module/client.go
+++ b/pkg/security/module/client.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
 	"github.com/DataDog/datadog-agent/pkg/security/proto/api"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
@@ -165,9 +166,9 @@ func NewSecurityAgentAPIClient(cfg *config.RuntimeSecurityConfig) (*SecurityAgen
 
 	seclog.Infof("using socket family '%s' and path '%s' to connect to security agent", family, socketPath)
 	if family == "vsock" {
-		cmdPort, parseErr := strconv.Atoi(socketPath)
-		if parseErr != nil {
-			return nil, parseErr
+		cmdPort, err := strconv.Atoi(socketPath)
+		if err != nil {
+			return nil, err
 		}
 
 		if cmdPort <= 0 {
@@ -175,8 +176,17 @@ func NewSecurityAgentAPIClient(cfg *config.RuntimeSecurityConfig) (*SecurityAgen
 		}
 
 		socketPath = "passthrough:target"
+
+		cid := uint32(vsock.Host)
+		if vsockAddr := pkgconfigsetup.Datadog().GetString("vsock_addr"); vsockAddr != "" {
+			cid, err = socket.ParseVSockAddress(vsockAddr)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		opts = append(opts, grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
-			return vsock.Dial(vsock.Host, uint32(cmdPort), &vsock.Config{})
+			return vsock.Dial(cid, uint32(cmdPort), &vsock.Config{})
 		}))
 	}
 

--- a/pkg/security/utils/grpc/grpc.go
+++ b/pkg/security/utils/grpc/grpc.go
@@ -16,8 +16,10 @@ import (
 	"github.com/mdlayher/vsock"
 	"google.golang.org/grpc"
 
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	grpcutil "github.com/DataDog/datadog-agent/pkg/util/grpc"
+	"github.com/DataDog/datadog-agent/pkg/util/system/socket"
 )
 
 // Server defines a gRPC server
@@ -67,8 +69,15 @@ func (g *Server) Start() error {
 			return fmt.Errorf("invalid port '%s' for vsock", g.address)
 		}
 
+		cid := uint32(vsock.Host)
+		if vsockAddr := pkgconfigsetup.Datadog().GetString("vsock_addr"); vsockAddr != "" {
+			if cid, err = socket.ParseVSockAddress(vsockAddr); err != nil {
+				return err
+			}
+		}
+
 		seclog.Infof("starting runtime security agent gRPC server on vsock port %d with host context", port)
-		ln, err = vsock.ListenContextID(vsock.Host, uint32(port), &vsock.Config{})
+		ln, err = vsock.ListenContextID(cid, uint32(port), &vsock.Config{})
 	} else {
 		ln, err = net.Listen(g.family, g.address)
 	}

--- a/pkg/util/grpc/agent_client.go
+++ b/pkg/util/grpc/agent_client.go
@@ -55,6 +55,7 @@ func getGRPCClientConn(ctx context.Context, ipcAddress string, cmdPort string, t
 		}
 
 		opts = append(opts, grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			log.Debugf("dialing vsock address with CID %d and port %d", cid, port)
 			return vsock.Dial(cid, uint32(port), &vsock.Config{})
 		}))
 	}


### PR DESCRIPTION
### What does this PR do?

Fix terrapin support

### Motivation

https://github.com/DataDog/datadog-agent/pull/47214 broke the vsock support as, in this case,
the address is not a net.TCPAddr but a vsock.Addr

### Describe how you validated your changes

Manual testing, setting vsock_addr to "local"

### Additional Notes
