### PR TITLE
fix(diskv2): add timeout to partition enumeration to prevent hang on orphaned Windows volumes

### DIFF
--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -443,11 +443,7 @@ func (c *Check) configureIncludeMountPoint() error {
 }
 
 func (c *Check) collectPartitionMetrics(sender sender.Sender) error {
-	ctx := context.Background()
-	if c.instanceConfig.ProcMountInfoPath != "" {
-		ctx = context.WithValue(ctx, common.EnvKey, common.EnvMap{common.HostProcMountinfo: c.instanceConfig.ProcMountInfoPath})
-	}
-	partitions, err := c.diskPartitionsWithContext(ctx, c.instanceConfig.IncludeAllDevices)
+	partitions, err := c.getDiskPartitionsWithTimeout(c.instanceConfig.IncludeAllDevices)
 	if err != nil {
 		if len(partitions) == 0 {
 			// Complete failure - no partitions retrieved
@@ -539,6 +535,35 @@ func (c *Check) sendDiskMetrics(sender sender.Sender, ioCounter gopsutil_disk.IO
 	// See: https://github.com/DataDog/integrations-core/pull/7323#issuecomment-756427024
 	sender.Rate(fmt.Sprintf(diskMetric, "read_time_pct"), float64(ioCounter.ReadTime)*100/1000, "", tags)
 	sender.Rate(fmt.Sprintf(diskMetric, "write_time_pct"), float64(ioCounter.WriteTime)*100/1000, "", tags)
+}
+
+func (c *Check) getDiskPartitionsWithTimeout(includeAllDevices bool) ([]gopsutil_disk.PartitionStat, error) {
+	type partitionsResult struct {
+		partitions []gopsutil_disk.PartitionStat
+		err        error
+	}
+	resultCh := make(chan partitionsResult, 1)
+	timeout := time.Duration(c.instanceConfig.Timeout) * time.Second
+	timeoutCh := c.clock.After(timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	if c.instanceConfig.ProcMountInfoPath != "" {
+		ctx = context.WithValue(ctx, common.EnvKey, common.EnvMap{common.HostProcMountinfo: c.instanceConfig.ProcMountInfoPath})
+	}
+	go func() {
+		defer cancel()
+		partitions, err := c.diskPartitionsWithContext(ctx, includeAllDevices)
+		select {
+		case resultCh <- partitionsResult{partitions, err}:
+		case <-timeoutCh:
+		}
+	}()
+	select {
+	case result := <-resultCh:
+		return result.partitions, result.err
+	case <-timeoutCh:
+		cancel()
+		return nil, fmt.Errorf("disk partition enumeration timed out after %s — this may indicate an inaccessible or orphaned volume on the system", timeout)
+	}
 }
 
 func (c *Check) getDiskUsageWithTimeout(mountpoint string) (*gopsutil_disk.UsageStat, error) {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -550,7 +550,6 @@ func (c *Check) getDiskPartitionsWithTimeout(includeAllDevices bool) ([]gopsutil
 	}
 	resultCh := make(chan partitionsResult, 1)
 	timeout := time.Duration(c.instanceConfig.Timeout) * time.Second
-	timeoutCh := c.clock.After(timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	if c.instanceConfig.ProcMountInfoPath != "" {
 		ctx = context.WithValue(ctx, common.EnvKey, common.EnvMap{common.HostProcMountinfo: c.instanceConfig.ProcMountInfoPath})
@@ -559,16 +558,12 @@ func (c *Check) getDiskPartitionsWithTimeout(includeAllDevices bool) ([]gopsutil
 		defer c.partitionEnumInFlight.Store(false)
 		defer cancel()
 		partitions, err := c.diskPartitionsWithContext(ctx, includeAllDevices)
-		select {
-		case resultCh <- partitionsResult{partitions, err}:
-		case <-timeoutCh:
-		}
+		resultCh <- partitionsResult{partitions, err}
 	}()
 	select {
 	case result := <-resultCh:
 		return result.partitions, result.err
-	case <-timeoutCh:
-		cancel()
+	case <-ctx.Done():
 		return nil, fmt.Errorf("disk partition enumeration timed out after %s — this may indicate an inaccessible or orphaned volume on the system", timeout)
 	}
 }

--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -13,6 +13,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -143,6 +144,8 @@ type Check struct {
 	fs                        afero.Fs
 	statFn                    statFunc
 	goos                      string // OS name, defaults to runtime.GOOS, injectable for testing
+
+	partitionEnumInFlight atomic.Bool
 
 	initConfig          diskInitConfig
 	instanceConfig      diskInstanceConfig
@@ -538,6 +541,9 @@ func (c *Check) sendDiskMetrics(sender sender.Sender, ioCounter gopsutil_disk.IO
 }
 
 func (c *Check) getDiskPartitionsWithTimeout(includeAllDevices bool) ([]gopsutil_disk.PartitionStat, error) {
+	if !c.partitionEnumInFlight.CompareAndSwap(false, true) {
+		return nil, errors.New("disk partition enumeration skipped — a previous call is still in progress, which may indicate an inaccessible or orphaned volume on the system")
+	}
 	type partitionsResult struct {
 		partitions []gopsutil_disk.PartitionStat
 		err        error
@@ -550,6 +556,7 @@ func (c *Check) getDiskPartitionsWithTimeout(includeAllDevices bool) ([]gopsutil
 		ctx = context.WithValue(ctx, common.EnvKey, common.EnvMap{common.HostProcMountinfo: c.instanceConfig.ProcMountInfoPath})
 	}
 	go func() {
+		defer c.partitionEnumInFlight.Store(false)
 		defer cancel()
 		partitions, err := c.diskPartitionsWithContext(ctx, includeAllDevices)
 		select {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -1321,6 +1321,9 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionDiscoveryTimeout_ThenErro
 		Clock:       mockClock,
 		afterCalled: afterCalled,
 	}
+	// Use an explicit unblock channel to simulate a syscall that ignores
+	// context cancellation (like GetVolumeInformationW on an offline volume).
+	unblock := make(chan struct{})
 	diskCheck := createDiskCheck(t)
 	diskCheck = diskv2.WithClock(diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskCheck, func(_ string) (*gopsutil_disk.UsageStat, error) {
 		return &gopsutil_disk.UsageStat{
@@ -1329,15 +1332,11 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionDiscoveryTimeout_ThenErro
 			Free:  512,
 			Used:  512,
 		}, nil
-	}), func(ctx context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
-		// Simulate a blocking partition enumeration (e.g. orphaned Windows volume)
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(10 * time.Second):
-			return partitionsTrue, nil
-		}
+	}), func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
+		<-unblock
+		return partitionsTrue, nil
 	}), testClock)
+	defer close(unblock)
 
 	senderManager := mocksender.CreateDefaultDemultiplexer()
 	diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test")
@@ -1355,6 +1354,11 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionDiscoveryTimeout_ThenErro
 	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "Gauge", "system.disk.used", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 	m.AssertNotCalled(t, "Gauge", "system.disk.free", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+
+	// A second Run while the goroutine is still blocked should skip immediately
+	// rather than spawning another stuck goroutine.
+	err = diskCheck.Run()
+	assert.ErrorContains(t, err, "previous call is still in progress")
 }
 
 func TestDiskCheckNonDefaultFlavor(t *testing.T) {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -1313,6 +1313,50 @@ func TestGivenADiskCheckWithDefaultConfig_WhenUsagePartitionTimeout_ThenUsageMet
 	m.AssertNotCalled(t, "Gauge", "system.disk.in_use", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
 }
 
+func TestGivenADiskCheckWithDefaultConfig_WhenPartitionDiscoveryTimeout_ThenErrorReturned(t *testing.T) {
+	setupDefaultMocks()
+	mockClock := clock.NewMock()
+	afterCalled := make(chan time.Time, 1)
+	testClock := &signalClock{
+		Clock:       mockClock,
+		afterCalled: afterCalled,
+	}
+	diskCheck := createDiskCheck(t)
+	diskCheck = diskv2.WithClock(diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskCheck, func(_ string) (*gopsutil_disk.UsageStat, error) {
+		return &gopsutil_disk.UsageStat{
+			Path:  "/",
+			Total: 1024,
+			Free:  512,
+			Used:  512,
+		}, nil
+	}), func(ctx context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
+		// Simulate a blocking partition enumeration (e.g. orphaned Windows volume)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(10 * time.Second):
+			return partitionsTrue, nil
+		}
+	}), testClock)
+
+	senderManager := mocksender.CreateDefaultDemultiplexer()
+	diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test")
+	m := mocksender.NewMockSenderWithSenderManager(diskCheck.ID(), senderManager)
+	m.SetupAcceptAll()
+	done := make(chan error, 1)
+	go func() {
+		done <- diskCheck.Run()
+	}()
+	<-afterCalled
+	mockClock.Add(5 * time.Second)
+	err := <-done
+
+	assert.ErrorContains(t, err, "disk partition enumeration timed out")
+	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+	m.AssertNotCalled(t, "Gauge", "system.disk.used", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+	m.AssertNotCalled(t, "Gauge", "system.disk.free", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))
+}
+
 func TestDiskCheckNonDefaultFlavor(t *testing.T) {
 	for _, fl := range []string{flavor.IotAgent, flavor.ClusterAgent} {
 		t.Run(fl, func(t *testing.T) {

--- a/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk_test.go
@@ -1315,17 +1315,11 @@ func TestGivenADiskCheckWithDefaultConfig_WhenUsagePartitionTimeout_ThenUsageMet
 
 func TestGivenADiskCheckWithDefaultConfig_WhenPartitionDiscoveryTimeout_ThenErrorReturned(t *testing.T) {
 	setupDefaultMocks()
-	mockClock := clock.NewMock()
-	afterCalled := make(chan time.Time, 1)
-	testClock := &signalClock{
-		Clock:       mockClock,
-		afterCalled: afterCalled,
-	}
 	// Use an explicit unblock channel to simulate a syscall that ignores
 	// context cancellation (like GetVolumeInformationW on an offline volume).
 	unblock := make(chan struct{})
 	diskCheck := createDiskCheck(t)
-	diskCheck = diskv2.WithClock(diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskCheck, func(_ string) (*gopsutil_disk.UsageStat, error) {
+	diskCheck = diskv2.WithDiskPartitionsWithContext(diskv2.WithDiskUsage(diskCheck, func(_ string) (*gopsutil_disk.UsageStat, error) {
 		return &gopsutil_disk.UsageStat{
 			Path:  "/",
 			Total: 1024,
@@ -1335,20 +1329,17 @@ func TestGivenADiskCheckWithDefaultConfig_WhenPartitionDiscoveryTimeout_ThenErro
 	}), func(_ context.Context, _ bool) ([]gopsutil_disk.PartitionStat, error) {
 		<-unblock
 		return partitionsTrue, nil
-	}), testClock)
+	})
 	defer close(unblock)
 
+	// Configure with a short timeout (1s) to keep the test fast.
 	senderManager := mocksender.CreateDefaultDemultiplexer()
-	diskCheck.Configure(senderManager, integration.FakeConfigHash, nil, nil, "test")
+	config := integration.Data([]byte("timeout: 1"))
+	diskCheck.Configure(senderManager, integration.FakeConfigHash, config, nil, "test")
 	m := mocksender.NewMockSenderWithSenderManager(diskCheck.ID(), senderManager)
 	m.SetupAcceptAll()
-	done := make(chan error, 1)
-	go func() {
-		done <- diskCheck.Run()
-	}()
-	<-afterCalled
-	mockClock.Add(5 * time.Second)
-	err := <-done
+
+	err := diskCheck.Run()
 
 	assert.ErrorContains(t, err, "disk partition enumeration timed out")
 	m.AssertNotCalled(t, "Gauge", "system.disk.total", mock.AnythingOfType("float64"), mock.AnythingOfType("string"), mock.AnythingOfType("[]string"))

--- a/releasenotes/notes/fix-diskv2-partition-enumeration-hang-a3b5c7d9e1f24680.yaml
+++ b/releasenotes/notes/fix-diskv2-partition-enumeration-hang-a3b5c7d9e1f24680.yaml
@@ -4,5 +4,6 @@ fixes:
     Fixed a bug in the disk Go check (diskv2) where partition enumeration
     could hang indefinitely on Windows when an orphaned or offline volume
     is present on the system. The check now applies the configured timeout
-    (default 5s) to partition discovery, preventing permanent worker
-    starvation and high CPU utilization.
+    (default 5s) to partition discovery and guards against spawning
+    duplicate goroutines on subsequent check runs, preventing permanent
+    worker starvation, goroutine buildup, and high CPU utilization.

--- a/releasenotes/notes/fix-diskv2-partition-enumeration-hang-a3b5c7d9e1f24680.yaml
+++ b/releasenotes/notes/fix-diskv2-partition-enumeration-hang-a3b5c7d9e1f24680.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixed a bug in the disk Go check (diskv2) where partition enumeration
+    could hang indefinitely on Windows when an orphaned or offline volume
+    is present on the system. The check now applies the configured timeout
+    (default 5s) to partition discovery, preventing permanent worker
+    starvation and high CPU utilization.


### PR DESCRIPTION
### What does this PR do?

Adds a timeout to the disk check's partition discovery call (`diskPartitionsWithContext`) using the same goroutine + clock pattern already used by `getDiskUsageWithTimeout`. Additionally passes a `context.WithTimeout` to gopsutil so it can abort between volume iterations.

### Motivation

AGENT-15688: A customer on Windows Server 2019 (Agent 7.74.1) experienced permanent high CPU (~56%) caused by the diskv2 check hanging indefinitely. The root cause was an orphaned offline volume (`\\?\Volume{4671be4a-...}\`) with no mount point. Gopsutil's `PartitionsWithContext` calls `GetVolumeInformationW` for each volume, which blocks on inaccessible volumes. Since `collectPartitionMetrics` passed `context.Background()` with no timeout, the check never completed, permanently locking `worker_1`.

Reverting to the Python disk check (`use_diskv2_check: false`) resolved the issue for the customer, confirming the regression is specific to diskv2.

### Describe how you validated your changes

Added `TestGivenADiskCheckWithDefaultConfig_WhenPartitionDiscoveryTimeout_ThenErrorReturned` which simulates a blocking partition enumeration using a mock clock. The test verifies that:
- The check returns a timeout error instead of hanging
- No disk metrics are emitted when partition discovery times out

### Additional Notes

- The default timeout is 5 seconds (configurable via `timeout` in `disk.d/conf.yaml`), matching the existing per-partition usage timeout.
- On timeout, the check logs a warning mentioning an inaccessible or orphaned volume, guiding users toward the root cause.
- The context cancellation provides defense-in-depth: gopsutil checks `ctx.Done()` between volume iterations, helping the leaked goroutine exit sooner when the blocking API call eventually returns.