### PR TITLE
deps: krb5: stop providing libkrb5 .pc files

### DIFF
--- a/deps/krb5/krb5.BUILD.bazel
+++ b/deps/krb5/krb5.BUILD.bazel
@@ -65,7 +65,6 @@ configure_make(
         "kinit",
     ],
     out_shared_libs = SHARED_LIBS.keys(),
-    out_data_dirs = ["lib/pkgconfig"],
 )
 
 # Unversioned lib handling:
@@ -117,18 +116,6 @@ configure_make(
 ]
 
 filegroup(
-    name = "_pc_files",
-    srcs = [":krb5"],
-    output_group = "pkgconfig",
-)
-
-pkg_files(
-    name = "pc_files",
-    srcs = ["_pc_files"],
-    prefix = "embedded/lib/",
-)
-
-filegroup(
     name = "_headers",
     srcs = [":krb5"],
     output_group = "include",
@@ -175,6 +162,5 @@ pkg_install(
     name = "install",
     srcs = [
         ":all_files",
-        ":pc_files",
     ],
 )

--- a/deps/msodbcsql18/BUILD.bazel
+++ b/deps/msodbcsql18/BUILD.bazel
@@ -111,6 +111,5 @@ pkg_install(
     name = "install",
     srcs = [
         ":all_files",
-        "@krb5//:pc_files",
     ],
 )

--- a/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
@@ -16,18 +16,8 @@ if linux_target?
     command_on_repo_root "bazelisk run -- @freetds//:install --destdir='#{install_dir}'"
     command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libtdsodbc.so"
-  
+
     unless heroku_target?
-      pc_files = [
-          'gssrpc.pc',
-          'kadm-client.pc',
-          'kadm-server.pc',
-          'kdb.pc',
-          'krb5-gssapi.pc',
-          'krb5.pc',
-          'mit-krb5-gssapi.pc',
-          'mit-krb5.pc',
-        ]
       lib_files = [
           'krb5/plugins/tls/k5tls.so',
           'krb5/plugins/kdb/db2.so',
@@ -52,13 +42,11 @@ if linux_target?
       bin_files = [
           'kinit',
         ]
-      
+
       command_on_repo_root "bazelisk run -- //deps/msodbcsql18:install --destdir='#{install_dir}'"
       # (TODO(agent-build): Check if we still need pc files)
       command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
         + lib_files.map{ |l| "#{install_dir}/embedded/lib/#{l}" }.join(' ') \
-        + " " \
-        + pc_files.map{ |pc| "#{install_dir}/embedded/lib/pkgconfig/#{pc}" }.join(' ') \
         + " " \
         + bin_files.map{ |bin| "#{install_dir}/embedded/bin/#{bin}" }.join(' ') \
         + " '#{install_dir}/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.3.1'"


### PR DESCRIPTION
### What does this PR do?

Remove libkrb5's pkgconfig files.

### Motivation

Cleaning up since we don't need .pc files anymore with all dependencies being built with bazel

### Describe how you validated your changes

### Additional Notes
