### PR TITLE
deps: uniformize installation path

### DIFF
--- a/deps/acl/overlay/overlay.BUILD.bazel
+++ b/deps/acl/overlay/overlay.BUILD.bazel
@@ -182,14 +182,12 @@ so_symlink(
     src = ":acl",
     libname = "libacl",
     version = "1.1.2301",
-    prefix = "embedded",
 )
 
 pkg_files(
     name = "hdr_files",
     srcs = [":fixed_headers"],
     strip_prefix = strip_prefix.from_pkg("fixed"),
-    prefix = "embedded",
 )
 
 pkg_filegroup(
@@ -198,6 +196,7 @@ pkg_filegroup(
         ":hdr_files",
         ":lib_files",
     ],
+    prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
 )
 

--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -105,13 +105,12 @@ so_symlink(
     src = ":attr",
     libname = "libattr",
     version = "1.1.2501",
-    prefix = "embedded",
 )
 
 pkg_files(
     name = "hdr_files",
     srcs = _PUBLIC_HEADERS,
-    prefix = "embedded/include/attr/",
+    prefix = "include/attr/",
 )
 
 pkg_filegroup(
@@ -120,6 +119,7 @@ pkg_filegroup(
         ":hdr_files",
         ":lib_files",
     ],
+    prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
 )
 

--- a/deps/bzip2/overlay.BUILD.bazel
+++ b/deps/bzip2/overlay.BUILD.bazel
@@ -138,13 +138,12 @@ so_symlink(
     src = ":bz2",
     libname = "libbz2",
     version = VERSION,
-    prefix = "embedded",
 )
 
 pkg_files(
     name = "hdr_files",
     srcs = _PUBLIC_HEADERS,
-    prefix = "embedded/include",
+    prefix = "include",
 )
 
 pkg_filegroup(
@@ -153,6 +152,7 @@ pkg_filegroup(
         ":hdr_files",
         ":lib_files",
     ],
+    prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
 )
 

--- a/deps/curl/overlay/overlay.BUILD.bazel
+++ b/deps/curl/overlay/overlay.BUILD.bazel
@@ -237,7 +237,7 @@ pkg_files(
         ":curl_bin",
     ],
     attributes = pkg_attributes(mode = "0755"),
-    prefix = "embedded/bin",
+    prefix = "bin",
     renames = {
         "curl_bin": "curl",
     },
@@ -248,14 +248,13 @@ so_symlink(
     src = ":curl",
     attributes = pkg_attributes(mode = "0755"),
     libname = "libcurl",
-    prefix = "embedded",
     version = SO_VERSION,
 )
 
 pkg_files(
     name = "hdr_files",
     srcs = PUBLIC_HEADERS,
-    prefix = "embedded/include/curl",
+    prefix = "include/curl",
 )
 
 pkg_filegroup(
@@ -265,6 +264,7 @@ pkg_filegroup(
         ":hdr_files",
         ":lib_files",
     ],
+    prefix = "embedded",
 )
 
 pkg_install(

--- a/deps/freetds/overlay/freetds.BUILD.bazel
+++ b/deps/freetds/overlay/freetds.BUILD.bazel
@@ -230,20 +230,20 @@ cc_shared_library(
 pkg_files(
     name = "lib_file",
     srcs = [":tdsodbc_so"],
-    prefix = "embedded/lib",
+    prefix = "lib",
 )
 
 pkg_mklink(
     name = "so_link",
     attributes = pkg_attributes(mode = "755"),
-    link_name = "embedded/lib/libtdsodbc.so.%s" % SO_VERSION,
+    link_name = "lib/libtdsodbc.so.%s" % SO_VERSION,
     target = "libtdsodbc.so",
 )
 
 pkg_files(
     name = "hdr_files",
     srcs = _PUBLIC_HEADERS,
-    prefix = "embedded/include/tdsodbc/",
+    prefix = "include/tdsodbc/",
 )
 
 pkg_filegroup(
@@ -257,6 +257,7 @@ pkg_filegroup(
         ":lib_file",
         ":so_link",
     ],
+    prefix = "embedded",
     visibility = ["//visibility:public"],
 )
 

--- a/deps/krb5/krb5.BUILD.bazel
+++ b/deps/krb5/krb5.BUILD.bazel
@@ -130,7 +130,6 @@ filegroup(
 pkg_files(
     name = "hdr_files",
     srcs = [":_headers"],
-    prefix = "embedded/",
 )
 
 pkg_files(
@@ -138,14 +137,13 @@ pkg_files(
     srcs = [
         ":_bins",
     ],
-    prefix = "embedded/bin",
+    prefix = "bin",
     attributes = pkg_attributes("0755"),
 )
 
 pkg_filegroup(
     name = "all_libs",
     srcs = [":_lib_" + libname for libname in SHARED_LIBS.keys()],
-    prefix = "embedded/",
 )
 
 pkg_filegroup(
@@ -155,6 +153,7 @@ pkg_filegroup(
         ":bin_files",
         ":all_libs",
     ],
+    prefix = "embedded",
     visibility = ["@@//packages:__subpackages__"],
 )
 

--- a/deps/krb5/krb5.BUILD.bazel
+++ b/deps/krb5/krb5.BUILD.bazel
@@ -154,7 +154,7 @@ pkg_filegroup(
         ":all_libs",
     ],
     prefix = "embedded",
-    visibility = ["@@//packages:__subpackages__"],
+    visibility = ["@@//packages:__subpackages__", "@@//deps/msodbcsql18:__pkg__"],
 )
 
 pkg_install(

--- a/deps/msodbcsql18/BUILD.bazel
+++ b/deps/msodbcsql18/BUILD.bazel
@@ -100,9 +100,7 @@ pkg_filegroup(
     name = "all_files",
     srcs = [
         ":msodbcsql_files",
-        "@krb5//:all_libs",
-        "@krb5//:bin_files",
-        "@krb5//:hdr_files",
+        "@krb5//:all_files",
     ],
     visibility = ["//packages:__subpackages__"],
 )

--- a/deps/nfsiostat/BUILD.bazel
+++ b/deps/nfsiostat/BUILD.bazel
@@ -19,7 +19,7 @@ pkg_files(
     name = "bin_files",
     srcs = [":fix_shebang"],
     attributes = pkg_attributes(mode = "0755"),
-    prefix = "embedded/sbin",
+    prefix = "sbin",
 )
 
 pkg_filegroup(
@@ -27,6 +27,7 @@ pkg_filegroup(
     srcs = [
         ":bin_files",
     ],
+    prefix = "embedded",
 )
 
 pkg_install(

--- a/deps/nghttp2/nghttp2.BUILD.bazel
+++ b/deps/nghttp2/nghttp2.BUILD.bazel
@@ -118,8 +118,6 @@ so_symlink(
     name = "lib_files",
     src = ":nghttp2_shared",
     libname = "libnghttp2",
-    # Lands in embedded/lib. so_symlink FR, prefix should be able to override the automatic 'lib/'.
-    prefix = "embedded",
     version = SO_VERSION,
     attributes = pkg_attributes(mode = "0755"),
 )
@@ -127,7 +125,7 @@ so_symlink(
 pkg_files(
     name = "header_files",
     srcs = PUBLIC_HEADERS,
-    prefix = "embedded/include/nghttp2",
+    prefix = "include/nghttp2",
 )
 
 pkg_filegroup(
@@ -136,6 +134,7 @@ pkg_filegroup(
         ":header_files",
         ":lib_files",
     ],
+    prefix = "embedded",
     visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
 )
 

--- a/deps/systemd/systemd.BUILD.bazel
+++ b/deps/systemd/systemd.BUILD.bazel
@@ -44,12 +44,13 @@ cc_library(
 pkg_files(
     name = "hdr_files",
     srcs = _HEADERS,
-    prefix = "embedded/include/systemd",
+    prefix = "include/systemd",
 )
 
 pkg_filegroup(
     name = "all_files",
     srcs = [":hdr_files"],
+    prefix = "embedded",
     visibility = ["@@//packages:__subpackages__"],
 )
 

--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -130,13 +130,12 @@ so_symlink(
     src = ":z",
     libname = "libz",
     version = "1.3.1",
-    prefix = "embedded",
 )
 
 pkg_files(
     name = "hdr_files",
     srcs = _ZLIB_PUBLIC_HEADERS,
-    prefix = "embedded/include",
+    prefix = "include",
 )
 
 pkg_filegroup(
@@ -145,6 +144,7 @@ pkg_filegroup(
         ":hdr_files",
         ":lib_files",
     ],
+    prefix = "embedded",
 )
 
 pkg_install(


### PR DESCRIPTION
### What does this PR do?

Use the same pattern in all deps when it comes to specifying installation directory.

### Motivation

Some dependency were providing `embedded` through individual `pkg_*` entries, some were providing it through the `:all_files` `pkg_filegroup`.
This makes things harder to reason about when it comes to automatic dependency collection, since they will coalesce in a single `pkg_filegroup` (or similar).
The resulting `pkg_filegroup` can be provided with a prefix, or we can omit it, but not a mix of both, so let's simplify the setup by only passing `embedded` through `pkg_filegroup`s

### Describe how you validated your changes

### Additional Notes

Based on top of https://github.com/DataDog/datadog-agent/pull/47726