### PR TITLE
feat(linter): add --fix option to linter.python invoke task

### DIFF
--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -158,14 +158,14 @@ def update_go(_):
 
 # === PYTHON === #
 @task()
-def python(ctx, show_versions=False):
+def python(ctx, fix=False, show_versions=False):
     """Lints Python files.
 
     See 'setup.cfg' and 'pyproject.toml' file for configuration. If
     running locally, you probably want to use the pre-commit instead.
 
     Args:
-        files: Optional list of files to lint (space-separated). If not provided, lints all files.
+        fix: If True, automatically fix issues that can be auto-fixed.
         show_versions: Show the versions of the linters that are being used.
     """
 
@@ -179,14 +179,12 @@ def python(ctx, show_versions=False):
         print(f"vulture version: {ctx.run('vulture --version', hide=True).stdout.strip()}")
         print(f"mypy version: {ctx.run('mypy --version', hide=True).stdout.strip()}")
 
-    if running_in_ci():
-        # We want to the CI to fail if there are any issues, lint everything in CI
-        ctx.run("ruff format --check .")
-        ctx.run("ruff check --no-fix .")
-    else:
-        # Otherwise we just need to format the files
+    if fix:
         ctx.run("ruff format .")
         ctx.run("ruff check --fix .")
+    else:
+        ctx.run("ruff format --check .")
+        ctx.run("ruff check --no-fix .")
 
     # vulture and mypy don't work well with individual files, run on full codebase
     ctx.run("vulture")


### PR DESCRIPTION
## Summary
- Add a `--fix` flag to the `linter.python` invoke task to control whether to automatically fix issues
- By default (`fix=False`), the linter runs in check-only mode using `ruff format --check` and `ruff check --no-fix`
- When `--fix` is provided, it runs `ruff format` and `ruff check --fix` to automatically fix issues
- This makes the behavior explicit and consistent, replacing the previous implicit CI vs local environment detection

## Test plan
- [x] Verified the task runs correctly with default settings (check-only mode)
- [x] Verified pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)