### PR TITLE
[Backport 7.77.x] [EBPF] gpu: fix missing GPM metrics (#47669)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/Microsoft/hcsshim v0.13.0
-	github.com/NVIDIA/go-nvml v0.13.0-1
+	github.com/NVIDIA/go-nvml v0.12.9-0
 	github.com/ProtonMail/go-crypto v1.3.0
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b

--- a/go.sum
+++ b/go.sum
@@ -282,8 +282,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.13.0 h1:/BcXOiS6Qi7N9XqUcv27vkIuVOkBEcWstd2pMlWSeaA=
 github.com/Microsoft/hcsshim v0.13.0/go.mod h1:9KWJ/8DgU+QzYGupX4tzMhRQE8h6w90lH6HAaclpEok=
-github.com/NVIDIA/go-nvml v0.13.0-1 h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=
-github.com/NVIDIA/go-nvml v0.13.0-1/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
+github.com/NVIDIA/go-nvml v0.12.9-0 h1:e344UK8ZkeMeeLkdQtRhmXRxNf+u532LDZPGMtkdus0=
+github.com/NVIDIA/go-nvml v0.12.9-0/go.mod h1:+KNA7c7gIBH7SKSJ1ntlwkfN80zdx8ovl4hrK3LmPt4=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -326,6 +326,12 @@ func TestCollectorsOnMIGDeviceChanges(t *testing.T) {
 			}
 			return testutil.GetMIGDeviceMock(deviceIdx, index, testutil.WithMockAllDeviceFunctions()), nvml.SUCCESS
 		}
+		d.GpmMigSampleGetFunc = func(_ int, _ nvml.GpmSample) nvml.Return {
+			return nvml.SUCCESS
+		}
+		d.GpmSampleGetFunc = func(_ nvml.GpmSample) nvml.Return {
+			return nvml.SUCCESS
+		}
 	})
 
 	// Setup NVML mock with single parent device

--- a/pkg/collector/corechecks/gpu/nvidia/collector_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/collector_test.go
@@ -487,6 +487,9 @@ func TestConfiguredMetricPriority(t *testing.T) {
 				},
 			}, nvml.SUCCESS
 		}
+		device.GpmSampleGetFunc = func(_ nvml.GpmSample) nvml.Return {
+			return nvml.SUCCESS
+		}
 		return device
 	}, testutil.WithMockAllFunctions())
 	deviceUUID := device.GetDeviceInfo().UUID
@@ -532,6 +535,24 @@ func TestConfiguredMetricPriority(t *testing.T) {
 	desiredMetricPriority := map[string][]CollectorName{
 		"sm_active":         {sampling, ebpf},
 		"process.sm_active": {sampling, ebpf},
+	}
+
+	wantedCollectors := make(map[CollectorName]bool)
+	for _, collectors := range desiredMetricPriority {
+		for _, collector := range collectors {
+			wantedCollectors[collector] = true
+		}
+	}
+
+	for wantedCollector, isWanted := range wantedCollectors {
+		found := false
+		for _, collector := range collectors {
+			if collector.Name() == wantedCollector {
+				found = true
+				break
+			}
+		}
+		require.Equal(t, isWanted, found, "collector %s state is not as expected", wantedCollector)
 	}
 
 	metricsByCollector := make(map[string]map[CollectorName]Metric)

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -136,7 +136,6 @@ func (c *gpmCollector) removeUnsupportedMetrics() error {
 	for i := 0; i < 2; i++ {
 		err := c.collectSample()
 		if err != nil {
-			fmt.Printf("failed to collect GPM sample: %s\n", err)
 			return err
 		}
 	}

--- a/pkg/collector/corechecks/gpu/nvidia/gpm.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm.go
@@ -18,6 +18,7 @@ import (
 
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const sampleBufferSize = 2
@@ -80,17 +81,7 @@ func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collecto
 		return nil, errors.New("MIG device has no parent physical device")
 	}
 
-	var support nvml.GpmSupport
-	// The query for device support needs to be made on the physical device always
-	if isMig {
-		support, err = migDevice.Parent.GpmQueryDeviceSupport()
-	} else {
-		support, err = device.GpmQueryDeviceSupport()
-	}
-
-	if support.IsSupportedDevice == 0 {
-		return nil, errUnsupportedDevice
-	}
+	// We don't query for device support because the API is broken in go-nvml 0.13.0
 
 	// Clone the global allGpmMetrics map to avoid mutating global state
 	clonedMetrics := maps.Clone(allGpmMetrics)
@@ -125,7 +116,13 @@ func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collecto
 		collector.samples[i] = sample
 	}
 
-	collector.removeUnsupportedMetrics()
+	err = collector.removeUnsupportedMetrics()
+	if err != nil {
+		if ddnvml.IsAPIUnsupportedOnDevice(err, device) {
+			return nil, errUnsupportedDevice
+		}
+		return nil, fmt.Errorf("failed to remove unsupported metrics: %w", err)
+	}
 
 	if len(collector.metricsToCollect) == 0 {
 		return nil, errUnsupportedDevice
@@ -134,27 +131,29 @@ func newGPMCollector(device ddnvml.Device, _ *CollectorDependencies) (c Collecto
 	return collector, nil
 }
 
-func (c *gpmCollector) removeUnsupportedMetrics() {
-	// Now collect two samples and try to get the metrics, to discard any unsupported ones
-	// It's a best-effort approach, so any errors in the process are ignored. If they are not temporary,
-	// the collector will fail to collect metrics later and that will show in the logs.
+func (c *gpmCollector) removeUnsupportedMetrics() error {
+	// Now collect two samples and try to get the metrics, to discard any unsupported ones.
 	for i := 0; i < 2; i++ {
 		err := c.collectSample()
 		if err != nil {
-			return
+			fmt.Printf("failed to collect GPM sample: %s\n", err)
+			return err
 		}
 	}
 
 	metrics, err := c.calculateGpmMetrics()
 	if err != nil {
-		return
+		return err
 	}
 
 	for i := uint32(0); i < metrics.NumMetrics; i++ {
 		if metrics.Metrics[i].NvmlReturn != uint32(nvml.SUCCESS) {
+			log.Warnf("failed to get GPM metric %d on device %s: %s\n", metrics.Metrics[i].MetricId, c.device.GetDeviceInfo().UUID, nvml.ErrorString(nvml.Return(metrics.Metrics[i].NvmlReturn)))
 			delete(c.metricsToCollect, nvml.GpmMetricId(metrics.Metrics[i].MetricId))
 		}
 	}
+
+	return nil
 }
 
 func (c *gpmCollector) collectSample() error {

--- a/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/gpm_test.go
@@ -124,6 +124,7 @@ func TestGPMCollectorCollectSample(t *testing.T) {
 	calls := 0
 	collector := &gpmCollector{
 		device: &mockGpmDevice{
+			gpmSupport: nvml.GpmSupport{IsSupportedDevice: 1},
 			GpmSampleGetFunc: func(_ nvml.GpmSample) error {
 				calls++
 				return nil
@@ -282,6 +283,10 @@ func (m *mockGpmDevice) GpmQueryDeviceSupport() (nvml.GpmSupport, error) {
 }
 
 func (m *mockGpmDevice) GpmSampleGet(sample nvml.GpmSample) error {
+	if m.gpmSupport.IsSupportedDevice == 0 {
+		return safenvml.NewNvmlAPIErrorOrNil("GpmSampleGet", nvml.ERROR_NOT_SUPPORTED)
+	}
+
 	if m.GpmSampleGetFunc != nil {
 		return m.GpmSampleGetFunc(sample)
 	}

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -377,6 +377,19 @@ func GetBasicNvmlMockWithOptions(options ...NvmlMockOption) *nvmlmock.Interface 
 			return eventSet.Wait(v)
 		},
 		ExtensionsFunc: opts.extensionsFunc,
+		GpmSampleAllocFunc: func() (nvml.GpmSample, nvml.Return) {
+			return &MockGpmSample{}, nvml.SUCCESS
+		},
+		GpmSampleFreeFunc: func(_ nvml.GpmSample) nvml.Return {
+			return nvml.SUCCESS
+		},
+		GpmMetricsGetFunc: func(metricsGet *nvml.GpmMetricsGetType) nvml.Return {
+			for _, metric := range metricsGet.Metrics[:metricsGet.NumMetrics] {
+				metric.NvmlReturn = uint32(nvml.SUCCESS)
+			}
+
+			return nvml.SUCCESS
+		},
 	}
 
 	for _, opt := range opts.libOptions {
@@ -488,4 +501,8 @@ func GetTotalExpectedDevices() int {
 		numMIG += count
 	}
 	return numPhysical + numMIG
+}
+
+type MockGpmSample struct {
+	nvml.GpmSample
 }


### PR DESCRIPTION
Backport 0be6cec  from #47669

 ___

### What does this PR do?

Downgrades go-nvml to version 0.12.9 and removes the call to GpmQueryDeviceSupport, relying on the return values from other GPM related calls to check for GPM collector support.

### Motivation

Version 0.13.0 seems to have an ABI incompatibility with older driver versions, causing metrics to be incorrect. Additionally, there's a bug in all versions of go-nvml after 0.12.4 (the previous one we were using) that causes `GpmQueryDeviceSupport` to always return an error (https://github.com/NVIDIA/go-nvml/issues/168).

### Describe how you validated your changes

Ran in a host with Hopper devices and another with Turing, ensured that behavior was expected.

### Additional Notes
