### PR TITLE
[CWS] fix approved events incorrectly rate-limited by open sampler

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/approvers.h
+++ b/pkg/security/ebpf/c/include/helpers/approvers.h
@@ -363,7 +363,7 @@ enum SYSCALL_STATE __attribute__((always_inline)) open_approvers(struct syscall_
         state = approve_by_in_upper_layer(EVENT_OPEN, &syscall->open.file);
     }
 
-    if (approve_open_sample(syscall->open.dentry, &syscall->open.file) == SAMPLED) {
+    if (state == DISCARDED && approve_open_sample(syscall->open.dentry, &syscall->open.file) == SAMPLED) {
         return SAMPLED;
     }
 


### PR DESCRIPTION
In open_approvers, approve_open_sample was called unconditionally, even when a prior approver had already approved the event. This caused approved events to be silently discarded by the sampler.

Guard the sampling check with `state == DISCARDED` so that sampling only applies to events that no other approver has accepted.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
