### PR TITLE
[observer] Introduce shared engine for unified live/testbench execution

### DIFF
--- a/cmd/observer-testbench/ui/src/components/ChartWithAnomalyDetails.tsx
+++ b/cmd/observer-testbench/ui/src/components/ChartWithAnomalyDetails.tsx
@@ -131,16 +131,17 @@ export function ChartWithAnomalyDetails({
     setVisibleSeriesIds(buildSeriesIDSet(seriesVariants));
   }, [seriesVariantsSig]);
 
-  // Filter anomalies by enabled detectors and visible series variants.
+  // Filter anomalies by enabled detectors, visible series variants, and time range.
   const filteredAnomalies = useMemo(
     () =>
       anomalies.filter((a) => {
         if (!enabledDetectors.has(a.detectorComponent ?? a.detectorName)) return false;
+        if (timeRange && (a.timestamp < timeRange.start || a.timestamp > timeRange.end)) return false;
         if (!seriesVariants || seriesVariants.length === 0) return true;
         if (!a.sourceSeriesId) return true;
         return visibleSeriesIds.has(a.sourceSeriesId);
       }),
-    [anomalies, enabledDetectors, seriesVariants, visibleSeriesIds]
+    [anomalies, enabledDetectors, timeRange, seriesVariants, visibleSeriesIds]
   );
 
   const filteredAnomalyIds = useMemo(

--- a/comp/anomalydetection/recorder/impl/recorder.go
+++ b/comp/anomalydetection/recorder/impl/recorder.go
@@ -252,7 +252,7 @@ func (h *recordingHandle) ObserveMetric(sample observer.MetricView) {
 	h.inner.ObserveMetric(sample)
 
 	// Record to parquet if writer is available
-	timestamp := int64(sample.GetTimestamp())
+	timestamp := sample.GetTimestampUnix()
 	if timestamp == 0 {
 		timestamp = time.Now().Unix()
 	}
@@ -297,10 +297,10 @@ func (h *recordingHandle) ObserveTraceStats(stats observer.TraceStatsView) {
 			h.name,
 			agentHostname, agentEnv,
 			row.GetClientHostname(), row.GetClientEnv(), row.GetClientVersion(), row.GetClientContainerID(),
-			row.GetBucketStart(), row.GetBucketDuration(),
+			row.GetBucketStartUnixNano(), row.GetBucketDurationNano(),
 			row.GetService(), row.GetName(), row.GetResource(), row.GetType(),
 			row.GetHTTPStatusCode(), row.GetSpanKind(), row.GetIsTraceRoot(), row.GetSynthetics(),
-			row.GetHits(), row.GetErrors(), row.GetTopLevelHits(), row.GetDuration(),
+			row.GetHits(), row.GetErrors(), row.GetTopLevelHits(), row.GetDurationNano(),
 			row.GetOkSummary(), row.GetErrorSummary(),
 			row.GetPeerTags(),
 		)
@@ -323,11 +323,11 @@ func (h *recordingHandle) ObserveTrace(trace observer.TraceView) {
 			h.name,
 			traceIDHigh, traceIDLow,
 			trace.GetEnv(), traceService, trace.GetHostname(), trace.GetContainerID(),
-			trace.GetTimestamp(), trace.GetDuration(),
+			trace.GetTimestampUnixNano(), trace.GetDurationNano(),
 			trace.GetPriority(), trace.IsError(), traceTags,
 			span.GetSpanID(), span.GetParentID(),
 			span.GetService(), span.GetName(), span.GetResource(), span.GetType(),
-			span.GetStart(), span.GetDuration(), span.GetError(),
+			span.GetStartUnixNano(), span.GetDurationNano(), span.GetError(),
 			mapToTagSlice(span.GetMeta()), mapToMetricSlice(span.GetMetrics()),
 		)
 	}
@@ -342,7 +342,7 @@ func (h *recordingHandle) ObserveProfile(profile observer.ProfileView) {
 		profile.GetProfileID(), profile.GetProfileType(),
 		profile.GetService(), profile.GetEnv(), profile.GetVersion(),
 		profile.GetHostname(), profile.GetContainerID(),
-		profile.GetTimestamp(), profile.GetDuration(),
+		profile.GetTimestampUnixNano(), profile.GetDurationNano(),
 		profile.GetContentType(),
 		profile.GetRawData(),
 		mapToTagSlice(profile.GetTags()),

--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -104,7 +104,7 @@ Correlators are stateful. They receive individual anomalies, accumulate them ove
 ```
 Report(report ReportOutput)
 ```
-Reporters query state interfaces like `CorrelationState` and `RawAnomalyState` to access current system state, rather than relying solely on the report argument. Example: `StdoutReporter` queries the correlator's `ActiveCorrelations()` to print changes.
+Reporters query state interfaces like `Correlator` and `RawAnomalyState` to access current system state, rather than relying solely on the report argument. Example: `StdoutReporter` queries the correlator's `ActiveCorrelations()` to print changes.
 
 > **Note:** The Reporter interface hasn't seen much focus yet and may need some evolution as we learn more about what reporting needs look like in practice.
 

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -317,12 +317,15 @@ type AnomalyDebugInfo struct {
 	CUSUMValues []float64 // S[t] values (may be truncated to last N points)
 }
 
-// ReportOutput is a processed summary from correlators.
-// It represents clustered, filtered, or summarized anomaly information ready for display.
+// ReportOutput is the output model passed to reporters after each advance cycle.
+// It carries enough data for reporters to act without reaching back into engine internals.
 type ReportOutput struct {
-	Title    string
-	Body     string
-	Metadata map[string]string
+	// AdvancedToSec is the data time the engine advanced to.
+	AdvancedToSec int64
+	// NewAnomalies are anomalies detected in this advance cycle.
+	NewAnomalies []Anomaly
+	// ActiveCorrelations are the current correlation patterns across all correlators.
+	ActiveCorrelations []ActiveCorrelation
 }
 
 // Series is a time series with simple timestamp/value points.
@@ -364,15 +367,25 @@ type SeriesDetector interface {
 	Detect(series Series) DetectionResult
 }
 
-// Correlator accumulates anomaly events and produces reports.
+// Correlator accumulates anomaly events and produces correlated patterns.
 // Correlators are stateful and cluster/filter/summarize anomaly streams.
+//
+// The lifecycle is: ProcessAnomaly to feed anomalies, Advance to trigger
+// time-based maintenance (eviction, window finalization), and
+// ActiveCorrelations to read current state.
 type Correlator interface {
 	// Name returns the correlator name for debugging.
 	Name() string
-	// Process receives an anomaly event for accumulation.
-	Process(anomaly Anomaly)
-	// Flush processes accumulated anomalies and returns reports.
-	Flush() []ReportOutput
+	// ProcessAnomaly receives an anomaly event for accumulation.
+	ProcessAnomaly(a Anomaly)
+	// Advance performs time-based maintenance (eviction, window finalization)
+	// up to the given data time. Callers should invoke this after each
+	// detection cycle so correlators can manage their windows.
+	Advance(dataTime int64)
+	// ActiveCorrelations returns currently detected correlation patterns.
+	ActiveCorrelations() []ActiveCorrelation
+	// Reset clears all internal state for reanalysis.
+	Reset()
 }
 
 // Reporter receives reports and displays or delivers them.
@@ -381,13 +394,6 @@ type Reporter interface {
 	Name() string
 	// Report delivers a report to its destination (stdout, file, webserver, etc).
 	Report(report ReportOutput)
-}
-
-// CorrelationState provides read access to active correlations.
-// Reporters use this to display current correlation status.
-type CorrelationState interface {
-	// ActiveCorrelations returns currently detected correlation patterns.
-	ActiveCorrelations() []ActiveCorrelation
 }
 
 // ActiveCorrelation represents a detected correlation pattern.
@@ -448,6 +454,10 @@ type StorageReader interface {
 	// PointCount returns the number of raw data points for a series without
 	// loading or converting them. Returns 0 if the series is not found.
 	PointCount(key SeriesKey) int
+
+	// PointCountUpTo returns the number of raw data points with timestamp <= endTime.
+	// Uses binary search for efficiency. Returns 0 if the series is not found.
+	PointCountUpTo(key SeriesKey, endTime int64) int
 }
 
 // Detector is the flexible detection interface where detectors pull data from storage.

--- a/comp/observer/impl/agent_internal_logs_test.go
+++ b/comp/observer/impl/agent_internal_logs_test.go
@@ -55,7 +55,7 @@ func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
 	// Poll briefly since observer processes asynchronously.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if s := obs.storage.GetSeries("agent-internal-logs", metricName, tags, AggregateSum); s != nil && len(s.Points) > 0 {
+		if s := obs.engine.Storage().GetSeries("agent-internal-logs", metricName, tags, AggregateSum); s != nil && len(s.Points) > 0 {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/comp/observer/impl/anomaly_correlator_identity_keys_test.go
+++ b/comp/observer/impl/anomaly_correlator_identity_keys_test.go
@@ -25,8 +25,8 @@ func TestLeadLagCorrelator_PreservesFullSeriesIDs(t *testing.T) {
 	seriesA := observer.SeriesID("parquet|cpu.user:avg|host:A,service:web")
 	seriesB := observer.SeriesID("parquet|cpu.user:avg|host:B,service:web")
 
-	c.Process(observer.Anomaly{SourceSeriesID: seriesA, Timestamp: 100})
-	c.Process(observer.Anomaly{SourceSeriesID: seriesB, Timestamp: 108})
+	c.ProcessAnomaly(observer.Anomaly{SourceSeriesID: seriesA, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{SourceSeriesID: seriesB, Timestamp: 108})
 
 	edges := c.GetEdges()
 	require.NotEmpty(t, edges)
@@ -48,9 +48,9 @@ func TestSurpriseCorrelator_PreservesFullSeriesIDs(t *testing.T) {
 	seriesA := observer.SeriesID("parquet|net.retransmits:avg|host:A,az:1a")
 	seriesB := observer.SeriesID("parquet|net.retransmits:avg|host:B,az:1a")
 
-	c.Process(observer.Anomaly{SourceSeriesID: seriesA, Timestamp: 100})
-	c.Process(observer.Anomaly{SourceSeriesID: seriesB, Timestamp: 101})
-	c.Flush() // finalize window
+	c.ProcessAnomaly(observer.Anomaly{SourceSeriesID: seriesA, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{SourceSeriesID: seriesB, Timestamp: 101})
+	c.Advance(200) // finalize window
 
 	edges := c.GetEdges()
 	require.NotEmpty(t, edges)

--- a/comp/observer/impl/anomaly_correlator_leadlag.go
+++ b/comp/observer/impl/anomaly_correlator_leadlag.go
@@ -251,7 +251,7 @@ func (c *LeadLagCorrelator) Name() string {
 }
 
 // Process adds an anomaly and updates lag histograms for all source pairs.
-func (c *LeadLagCorrelator) Process(anomaly observer.Anomaly) {
+func (c *LeadLagCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -311,9 +311,13 @@ func (c *LeadLagCorrelator) Process(anomaly observer.Anomaly) {
 }
 
 // Flush evicts old data and returns empty (reporters pull state via ActiveCorrelations).
-func (c *LeadLagCorrelator) Flush() []observer.ReportOutput {
+func (c *LeadLagCorrelator) Advance(dataTime int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if dataTime > c.currentDataTime {
+		c.currentDataTime = dataTime
+	}
 
 	// Evict old anomalies
 	cutoff := c.currentDataTime - c.config.WindowSeconds
@@ -324,8 +328,6 @@ func (c *LeadLagCorrelator) Flush() []observer.ReportOutput {
 		}
 	}
 	c.recentAnomalies = newAnomalies
-
-	return nil
 }
 
 // Reset clears all internal state for reanalysis.
@@ -389,8 +391,7 @@ func (c *LeadLagCorrelator) GetEdges() []LeadLagEdge {
 	return edges
 }
 
-// ActiveCorrelations returns lead-lag patterns as correlations for reporting.
-// Implements CorrelationState interface.
+// ActiveCorrelations returns lead-lag patterns as correlation patterns.
 func (c *LeadLagCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	edges := c.GetEdges()
 

--- a/comp/observer/impl/anomaly_correlator_surprise.go
+++ b/comp/observer/impl/anomaly_correlator_surprise.go
@@ -143,7 +143,7 @@ func (c *SurpriseCorrelator) Name() string {
 }
 
 // Process adds an anomaly and updates co-occurrence counts.
-func (c *SurpriseCorrelator) Process(anomaly observer.Anomaly) {
+func (c *SurpriseCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -204,9 +204,13 @@ func (c *SurpriseCorrelator) finalizeWindow() {
 }
 
 // Flush evicts old data and returns empty (reporters pull state via ActiveCorrelations).
-func (c *SurpriseCorrelator) Flush() []observer.ReportOutput {
+func (c *SurpriseCorrelator) Advance(dataTime int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	if dataTime > c.currentDataTime {
+		c.currentDataTime = dataTime
+	}
 
 	// Finalize current window if it has data
 	c.finalizeWindow()
@@ -220,8 +224,6 @@ func (c *SurpriseCorrelator) Flush() []observer.ReportOutput {
 		}
 	}
 	c.recentAnomalies = newAnomalies
-
-	return nil
 }
 
 // Reset clears all internal state for reanalysis.
@@ -311,8 +313,7 @@ func (c *SurpriseCorrelator) GetEdges() []SurpriseEdge {
 	return edges
 }
 
-// ActiveCorrelations returns surprise patterns as correlations for reporting.
-// Implements CorrelationState interface.
+// ActiveCorrelations returns surprise patterns as correlation patterns.
 func (c *SurpriseCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	edges := c.GetEdges()
 

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -71,7 +71,7 @@ func (c *TimeClusterCorrelator) Name() string {
 }
 
 // Process adds an anomaly, either to an existing cluster or a new one.
-func (c *TimeClusterCorrelator) Process(anomaly observer.Anomaly) {
+func (c *TimeClusterCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -165,11 +165,13 @@ func (c *TimeClusterCorrelator) mergeClusters(clusters []*timeCluster) *timeClus
 }
 
 // Flush evicts old clusters and returns empty (reporters pull state via ActiveCorrelations).
-func (c *TimeClusterCorrelator) Flush() []observer.ReportOutput {
+func (c *TimeClusterCorrelator) Advance(dataTime int64) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if dataTime > c.currentDataTime {
+		c.currentDataTime = dataTime
+	}
 	c.evictOldClustersLocked()
-	return nil
 }
 
 // Reset clears all internal state for reanalysis.
@@ -265,8 +267,7 @@ func (c *TimeClusterCorrelator) GetExtraData() interface{} {
 	return c.GetClusters()
 }
 
-// ActiveCorrelations returns clusters that meet the minimum size threshold.
-// Implements CorrelationState interface.
+// ActiveCorrelations returns clusters as active correlation patterns.
 func (c *TimeClusterCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -180,6 +180,7 @@ func (c *TimeClusterCorrelator) Reset() {
 	defer c.mu.Unlock()
 
 	c.clusters = c.clusters[:0]
+	c.nextClusterID = 0
 	c.currentDataTime = 0
 }
 

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -20,13 +20,13 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 	})
 
 	// Two anomalies with nearby timestamps should cluster together
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.b",
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
@@ -47,13 +47,13 @@ func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 	})
 
 	// Anomalies within proximity window should cluster
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.b",
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
@@ -72,13 +72,13 @@ func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 	})
 
 	// Anomalies outside proximity window should form separate clusters
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.b",
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
@@ -99,13 +99,13 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 	})
 
 	// Create two separate clusters
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.b",
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
@@ -116,7 +116,7 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 	assert.Len(t, c.clusters, 2)
 
 	// Add anomaly that bridges both clusters
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.c",
 		SourceSeriesID: "ns|metric.c|",
 		Title:          "Anomaly C",
@@ -137,14 +137,14 @@ func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 	})
 
 	// Multiple anomalies from the same series should all be kept
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A v1",
 		Description:    "first",
 		Timestamp:      100,
 	})
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A v2",
@@ -167,13 +167,13 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 
 	// Same metric name, different tags = different SourceSeriesIDs
 	// Both should be separate members in the cluster
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|host:A",
 		Title:          "Anomaly from host A",
 		Timestamp:      100,
 	})
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|host:B",
 		Title:          "Anomaly from host B",
@@ -194,7 +194,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 	})
 
 	// Add old anomaly
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.old",
 		SourceSeriesID: "ns|metric.old|",
 		Title:          "Old Anomaly",
@@ -202,7 +202,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 	})
 
 	// Add recent anomaly (advances currentDataTime)
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.new",
 		SourceSeriesID: "ns|metric.new|",
 		Title:          "New Anomaly",
@@ -210,7 +210,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 	})
 
 	// Flush should evict the old cluster
-	c.Flush()
+	c.Advance(200)
 
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
@@ -224,7 +224,7 @@ func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 	})
 
 	// A single anomaly should form a cluster of one
-	c.Process(observer.Anomaly{
+	c.ProcessAnomaly(observer.Anomaly{
 		Source:         "metric.a",
 		SourceSeriesID: "ns|metric.a|",
 		Timestamp:      100,

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -7,7 +7,6 @@ package observerimpl
 
 import (
 	"sort"
-	"strings"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
@@ -65,7 +64,7 @@ var knownPatterns = []correlationPattern{
 }
 
 // CrossSignalCorrelator clusters anomalies from different sources within a time window
-// and detects known patterns. It implements CorrelationState and Correlator.
+// and detects known patterns. It implements Correlator.
 // Reporters read the current correlation state.
 //
 // Time is derived entirely from input data timestamps (anomaly.Timestamp),
@@ -98,7 +97,7 @@ func (c *CrossSignalCorrelator) Name() string {
 
 // Process implements Correlator. It adds an anomaly to the buffer
 // using its data timestamp and evicts old entries.
-func (c *CrossSignalCorrelator) Process(anomaly observer.Anomaly) {
+func (c *CrossSignalCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	dataTime := anomaly.Timestamp
 
 	// Update current data time (monotonically advancing)
@@ -130,9 +129,13 @@ func (c *CrossSignalCorrelator) evictOldEntries() {
 	c.buffer = newBuffer
 }
 
-// Flush implements Correlator. It checks for known patterns in the anomaly buffer
-// and updates activeCorrelations state. Returns empty slice since reporters pull state via ActiveCorrelations().
-func (c *CrossSignalCorrelator) Flush() []observer.ReportOutput {
+// Advance implements Correlator. It checks for known patterns in the anomaly buffer
+// and updates activeCorrelations state.
+func (c *CrossSignalCorrelator) Advance(dataTime int64) {
+	if dataTime > c.currentDataTime {
+		c.currentDataTime = dataTime
+	}
+
 	// Evict old entries before checking patterns
 	c.evictOldEntries()
 
@@ -180,9 +183,13 @@ func (c *CrossSignalCorrelator) Flush() []observer.ReportOutput {
 			delete(c.activeCorrelations, name)
 		}
 	}
+}
 
-	// Return empty slice - reporters pull state via ActiveCorrelations()
-	return nil
+// Reset clears all internal state for reanalysis.
+func (c *CrossSignalCorrelator) Reset() {
+	c.buffer = nil
+	c.activeCorrelations = make(map[string]*observer.ActiveCorrelation)
+	c.currentDataTime = 0
 }
 
 // patternMatches checks if all required sources for a pattern are present.
@@ -223,21 +230,11 @@ func (c *CrossSignalCorrelator) collectMatchingAnomalies(pattern correlationPatt
 }
 
 // buildReport creates a ReportOutput for a matched pattern.
-func (c *CrossSignalCorrelator) buildReport(pattern correlationPattern, sources map[observer.MetricName]struct{}) observer.ReportOutput {
-	// Get sorted list of sources for consistent output
-	sourceList := make([]string, 0, len(sources))
-	for source := range sources {
-		sourceList = append(sourceList, string(source))
-	}
-	sort.Strings(sourceList)
-
+// NOTE: This method is currently unused (dead code). It exists as a reference
+// for how a correlator might construct a ReportOutput.
+func (c *CrossSignalCorrelator) buildReport(pattern correlationPattern, _ map[observer.MetricName]struct{}) observer.ReportOutput {
 	return observer.ReportOutput{
-		Title: pattern.reportTitle,
-		Body:  "Correlated signals: " + strings.Join(sourceList, ", "),
-		Metadata: map[string]string{
-			"pattern":      pattern.name,
-			"signal_count": "3",
-		},
+		ActiveCorrelations: c.ActiveCorrelations(),
 	}
 }
 
@@ -257,7 +254,6 @@ func (c *CrossSignalCorrelator) getSortedMetricNames(sources map[observer.Metric
 }
 
 // ActiveCorrelations returns a copy of the currently active correlation patterns.
-// This implements the CorrelationState interface.
 func (c *CrossSignalCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	result := make([]observer.ActiveCorrelation, 0, len(c.activeCorrelations))
 	for _, ac := range c.activeCorrelations {

--- a/comp/observer/impl/anomaly_processor_correlator_test.go
+++ b/comp/observer/impl/anomaly_processor_correlator_test.go
@@ -16,33 +16,35 @@ import (
 func TestCorrelator_SingleAnomalyNoReport(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 	})
 
-	reports := correlator.Flush()
-	assert.Empty(t, reports, "single anomaly should not produce a report")
+	correlator.Advance(0)
+	activeCorrs := correlator.ActiveCorrelations()
+	assert.Empty(t, activeCorrs, "single anomaly should not produce a correlation")
 }
 
 func TestCorrelator_TwoAnomaliesSameSignalNoReport(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Add two anomalies from the same signal
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Title:       "High retransmits 1",
 		Description: "First occurrence",
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Title:       "High retransmits 2",
 		Description: "Second occurrence",
 	})
 
-	reports := correlator.Flush()
-	assert.Empty(t, reports, "two anomalies from same signal should not produce a report")
+	correlator.Advance(0)
+	activeCorrs := correlator.ActiveCorrelations()
+	assert.Empty(t, activeCorrs, "two anomalies from same signal should not produce a correlation")
 }
 
 func TestCorrelator_ThreeRequiredSignalsProduceReport(t *testing.T) {
@@ -50,25 +52,24 @@ func TestCorrelator_ThreeRequiredSignalsProduceReport(t *testing.T) {
 
 	// Add anomalies from all three required signals for kernel bottleneck pattern
 	// Note: Source names now include aggregation suffix (avg for value, count for frequency)
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "ebpf.lock_contention_ns:avg",
 		Title:       "Lock contention",
 		Description: "High lock contention detected",
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "connection.errors:count",
 		Title:       "Connection errors",
 		Description: "Connection error rate elevated",
 	})
 
-	// Flush updates internal state
-	reports := correlator.Flush()
-	assert.Empty(t, reports, "Flush should return empty slice in stateful model")
+	// Advance updates internal state
+	correlator.Advance(0)
 
 	// Active correlations should include all matching patterns
 	// With 3 signals present, all 3 patterns match (kernel_bottleneck, network_degradation, lock_contention_cascade)
@@ -98,7 +99,7 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 	correlator := NewCorrelator(config)
 
 	// Add first anomaly at data time 1000
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
@@ -106,13 +107,13 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 	})
 
 	// Add remaining anomalies at data time 1031 (31 seconds later, beyond window)
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "ebpf.lock_contention_ns:avg",
 		Title:       "Lock contention",
 		Description: "High lock contention detected",
 		Timestamp:   1031,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "connection.errors:count",
 		Title:       "Connection errors",
 		Description: "Connection error rate elevated",
@@ -120,8 +121,7 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 	})
 
 	// First anomaly should be evicted (1000 < 1031 - 30 = 1001), so pattern should not match
-	reports := correlator.Flush()
-	assert.Empty(t, reports, "pattern should not match when first anomaly is evicted")
+	correlator.Advance(1031)
 
 	// Verify buffer only contains the two recent anomalies
 	assert.Len(t, correlator.GetBuffer(), 2)
@@ -130,11 +130,11 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.Process(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.Process(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.Process(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3, "all three patterns should match")
 
@@ -153,11 +153,11 @@ func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.Process(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.Process(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.Process(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3, "all three patterns should match")
 
@@ -167,20 +167,20 @@ func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
 	assert.NotNil(t, findCorrelation(activeCorrs, "lock_contention_cascade"))
 }
 
-func TestCorrelator_BufferNotClearedAfterFlush(t *testing.T) {
+func TestCorrelator_BufferNotClearedAfterAdvance(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.Process(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.Process(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.Process(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
 
 	// First flush should create active correlations
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs1 := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs1, 3)
 
 	// Second flush should maintain active correlations (buffer not cleared)
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs2 := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs2, 3)
 
@@ -202,10 +202,10 @@ func TestCorrelator_PartialPatternNoActiveCorrelation(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Only two of three required signals
-	correlator.Process(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.Process(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	assert.Empty(t, activeCorrs, "partial pattern should not produce active correlation")
 }
@@ -214,12 +214,12 @@ func TestCorrelator_ExtraSignalsStillMatch(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// All required signals plus an extra one
-	correlator.Process(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.Process(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.Process(observer.Anomaly{Source: "connection.errors:count"})
-	correlator.Process(observer.Anomaly{Source: "extra.signal:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: "extra.signal:avg"})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3, "all patterns should match even with extra signals")
 
@@ -230,7 +230,7 @@ func TestCorrelator_ExtraSignalsStillMatch(t *testing.T) {
 func TestCorrelator_EmptyBufferNoActiveCorrelation(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	assert.Empty(t, activeCorrs, "empty buffer should have no active correlations")
 }
@@ -239,20 +239,20 @@ func TestCorrelator_ActiveCorrelationTimestamps(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Add all required signals at data time 1000
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:    "network.retransmits:avg",
 		Timestamp: 1000,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:    "ebpf.lock_contention_ns:avg",
 		Timestamp: 1000,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:    "connection.errors:count",
 		Timestamp: 1000,
 	})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3)
 
@@ -265,12 +265,12 @@ func TestCorrelator_ActiveCorrelationTimestamps(t *testing.T) {
 	assert.Equal(t, int64(1000), found.LastUpdated)
 
 	// Add new anomalies at data time 1010
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:    "network.retransmits:avg",
 		Timestamp: 1010,
 	})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs = correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3)
 
@@ -290,30 +290,30 @@ func TestCorrelator_ActiveCorrelationCleared(t *testing.T) {
 	correlator := NewCorrelator(config)
 
 	// Add all required signals at data time 1000
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:    "network.retransmits:avg",
 		Timestamp: 1000,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:    "ebpf.lock_contention_ns:avg",
 		Timestamp: 1000,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:    "connection.errors:count",
 		Timestamp: 1000,
 	})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3, "all patterns should be active")
 
 	// Add an anomaly at data time 1035 (35 seconds later), which advances currentDataTime
 	// and causes all previous signals to expire (1000 < 1035 - 30 = 1005)
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:    "some.other.signal:avg",
 		Timestamp: 1035,
 	})
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs = correlator.ActiveCorrelations()
 	assert.Empty(t, activeCorrs, "all patterns should be cleared when signals expire")
 }
@@ -322,23 +322,23 @@ func TestCorrelator_ActiveCorrelationContainsAnomalies(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Add anomalies with descriptions for all required signals
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Title:       "High retransmits",
 		Description: "network.retransmits:avg elevated: recent avg 100 vs baseline 10 (>3 stddev)",
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "ebpf.lock_contention_ns:avg",
 		Title:       "Lock contention",
 		Description: "ebpf.lock_contention_ns:avg elevated: recent avg 500 vs baseline 50 (>3 stddev)",
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "connection.errors:count",
 		Title:       "Connection errors",
 		Description: "connection.errors:count elevated: recent avg 25 vs baseline 2 (>3 stddev)",
 	})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3)
 
@@ -360,27 +360,27 @@ func TestCorrelator_ActiveCorrelationContainsAnomalies(t *testing.T) {
 	assert.True(t, descriptions["connection.errors:count elevated: recent avg 25 vs baseline 2 (>3 stddev)"])
 }
 
-func TestCorrelator_AnomaliesUpdatedOnFlush(t *testing.T) {
+func TestCorrelator_AnomaliesUpdatedOnAdvance(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Add initial anomalies - all within 30 second window
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Description: "first retransmits anomaly",
 		Timestamp:   1010,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "ebpf.lock_contention_ns:avg",
 		Description: "first lock contention anomaly",
 		Timestamp:   1010,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "connection.errors:count",
 		Description: "first connection errors anomaly",
 		Timestamp:   1010,
 	})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3)
 
@@ -389,13 +389,13 @@ func TestCorrelator_AnomaliesUpdatedOnFlush(t *testing.T) {
 	require.Len(t, found.Anomalies, 3)
 
 	// Add another anomaly for one of the signals with later timestamp (still within 30s window)
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Description: "second retransmits anomaly",
 		Timestamp:   1020, // later but within window
 	})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs = correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3)
 
@@ -410,35 +410,35 @@ func TestCorrelator_DedupesBySourceKeepingMostRecent(t *testing.T) {
 
 	// Add multiple anomalies for the same source with different timestamps
 	// All timestamps within the 30-second window
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Description: "oldest retransmits",
 		Timestamp:   1010,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Description: "newest retransmits", // should be kept
 		Timestamp:   1025,                 // latest timestamp
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Description: "middle retransmits",
 		Timestamp:   1015,
 	})
 
 	// Add other required signals - all within window
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "ebpf.lock_contention_ns:avg",
 		Description: "lock contention",
 		Timestamp:   1010,
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "connection.errors:count",
 		Description: "connection errors",
 		Timestamp:   1010,
 	})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3)
 
@@ -462,24 +462,24 @@ func TestCorrelator_AnomaliesOnlyIncludesMatchingSignals(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Add all required signals plus an extra one
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "network.retransmits:avg",
 		Description: "retransmits anomaly",
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "ebpf.lock_contention_ns:avg",
 		Description: "lock contention anomaly",
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "connection.errors:count",
 		Description: "connection errors anomaly",
 	})
-	correlator.Process(observer.Anomaly{
+	correlator.ProcessAnomaly(observer.Anomaly{
 		Source:      "extra.signal:avg",
 		Description: "extra signal anomaly",
 	})
 
-	correlator.Flush()
+	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
 	require.Len(t, activeCorrs, 3)
 

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -1,0 +1,259 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+
+// componentKind distinguishes detectors from correlators in the catalog.
+type componentKind int
+
+const (
+	componentDetector   componentKind = iota
+	componentCorrelator
+)
+
+// componentEntry describes a registered pipeline component (detector or correlator).
+type componentEntry struct {
+	name           string
+	displayName    string
+	kind           componentKind
+	factory        func() any
+	defaultEnabled bool
+}
+
+// componentInstance tracks a component entry paired with its runtime instance and enabled state.
+type componentInstance struct {
+	entry    componentEntry
+	instance any
+	enabled  bool
+}
+
+// componentCatalog is the shared registry of all available pipeline components.
+// Both the live observer and the testbench use this to discover and instantiate
+// detectors and correlators, eliminating duplicated component assembly logic.
+type componentCatalog struct {
+	entries []componentEntry
+}
+
+// defaultCatalog returns the standard component catalog used by both live and testbench.
+// All known detectors and correlators are registered here. Consumers use enable
+// overrides to select which subset is active.
+func defaultCatalog() *componentCatalog {
+	return &componentCatalog{
+		entries: []componentEntry{
+			// ---- Detectors ----
+			{
+				name:        "cusum",
+				displayName: "CUSUM",
+				kind:        componentDetector,
+				factory: func() any {
+					return NewCUSUMDetector()
+				},
+				defaultEnabled: true,
+			},
+			{
+				name:        "bocpd",
+				displayName: "BOCPD",
+				kind:        componentDetector,
+				factory: func() any {
+					return NewBOCPDDetector()
+				},
+				defaultEnabled: true,
+			},
+			{
+				name:        "rrcf",
+				displayName: "RRCF",
+				kind:        componentDetector,
+				factory: func() any {
+					return NewRRCFDetector(DefaultRRCFConfig())
+				},
+				defaultEnabled: true,
+			},
+			// ---- Correlators ----
+			{
+				name:        "cross_signal",
+				displayName: "CrossSignal",
+				kind:        componentCorrelator,
+				factory: func() any {
+					return NewCorrelator(CorrelatorConfig{})
+				},
+				defaultEnabled: true,
+			},
+			{
+				name:        "time_cluster",
+				displayName: "TimeCluster",
+				kind:        componentCorrelator,
+				factory: func() any {
+					return NewTimeClusterCorrelator(TimeClusterConfig{
+						ProximitySeconds: 10,
+						WindowSeconds:    120,
+					})
+				},
+				defaultEnabled: false,
+			},
+			{
+				name:        "lead_lag",
+				displayName: "Lead-Lag",
+				kind:        componentCorrelator,
+				factory: func() any {
+					return NewLeadLagCorrelator(LeadLagConfig{
+						MaxLagSeconds:       30,
+						MinObservations:     3,
+						ConfidenceThreshold: 0.6,
+						WindowSeconds:       120,
+					})
+				},
+				defaultEnabled: false,
+			},
+			{
+				name:        "surprise",
+				displayName: "Surprise",
+				kind:        componentCorrelator,
+				factory: func() any {
+					return NewSurpriseCorrelator(SurpriseConfig{
+						WindowSizeSeconds: 10,
+						MinLift:           2.0,
+						MinSupport:        2,
+					})
+				},
+				defaultEnabled: false,
+			},
+		},
+	}
+}
+
+// testbenchCatalog returns a catalog customized for the testbench.
+// It differs from the default in two ways:
+//   - RRCF uses testbench-specific metrics (parquet names instead of DogStatsD names)
+//     and is disabled by default (calibration mode).
+//   - cross_signal is disabled (testbench uses time_cluster instead).
+//   - time_cluster is enabled by default.
+func testbenchCatalog() *componentCatalog {
+	cat := defaultCatalog()
+	cat = cat.WithOverride("rrcf", func() any {
+		config := DefaultRRCFConfig()
+		config.Metrics = TestBenchRRCFMetrics()
+		return NewRRCFDetector(config)
+	})
+	cat = cat.WithDefaultEnabled("rrcf", false)
+	cat = cat.WithDefaultEnabled("cross_signal", false)
+	cat = cat.WithDefaultEnabled("time_cluster", true)
+	return cat
+}
+
+// WithOverride returns a copy of the catalog with the named component's factory replaced.
+func (c *componentCatalog) WithOverride(name string, factory func() any) *componentCatalog {
+	newEntries := make([]componentEntry, len(c.entries))
+	copy(newEntries, c.entries)
+	for i, e := range newEntries {
+		if e.name == name {
+			newEntries[i].factory = factory
+			break
+		}
+	}
+	return &componentCatalog{entries: newEntries}
+}
+
+// WithDefaultEnabled returns a copy of the catalog with the named component's defaultEnabled changed.
+func (c *componentCatalog) WithDefaultEnabled(name string, enabled bool) *componentCatalog {
+	newEntries := make([]componentEntry, len(c.entries))
+	copy(newEntries, c.entries)
+	for i, e := range newEntries {
+		if e.name == name {
+			newEntries[i].defaultEnabled = enabled
+			break
+		}
+	}
+	return &componentCatalog{entries: newEntries}
+}
+
+// Instantiate creates component instances. The overrides map controls which
+// components are enabled; keys not present in overrides use the catalog default.
+// Returns the lists of enabled detectors and correlators ready for engine use,
+// plus a map of all component instances (enabled or not) for state management.
+func (c *componentCatalog) Instantiate(overrides map[string]bool) (
+	detectors []observerdef.Detector,
+	correlators []observerdef.Correlator,
+	components map[string]*componentInstance,
+) {
+	components = make(map[string]*componentInstance, len(c.entries))
+
+	for _, entry := range c.entries {
+		enabled := entry.defaultEnabled
+		if overrides != nil {
+			if override, ok := overrides[entry.name]; ok {
+				enabled = override
+			}
+		}
+
+		instance := entry.factory()
+		ci := &componentInstance{
+			entry:    entry,
+			instance: instance,
+			enabled:  enabled,
+		}
+		components[entry.name] = ci
+
+		if !enabled {
+			continue
+		}
+
+		switch entry.kind {
+		case componentDetector:
+			if d, ok := instance.(observerdef.Detector); ok {
+				detectors = append(detectors, d)
+			} else if sd, ok := instance.(observerdef.SeriesDetector); ok {
+				detectors = append(detectors, newSeriesDetectorAdapter(sd, defaultAggregations))
+			}
+		case componentCorrelator:
+			if cor, ok := instance.(observerdef.Correlator); ok {
+				correlators = append(correlators, cor)
+			}
+		}
+	}
+	return detectors, correlators, components
+}
+
+// Entries returns a copy of all catalog entries (for UI/API use).
+func (c *componentCatalog) Entries() []componentEntry {
+	result := make([]componentEntry, len(c.entries))
+	copy(result, c.entries)
+	return result
+}
+
+// enabledDetectors returns the enabled Detector instances from a components map.
+// SeriesDetector implementations are wrapped with seriesDetectorAdapter.
+func catalogEnabledDetectors(components map[string]*componentInstance, catalog *componentCatalog) []observerdef.Detector {
+	var result []observerdef.Detector
+	// Iterate in catalog order for deterministic ordering
+	for _, entry := range catalog.entries {
+		ci, ok := components[entry.name]
+		if !ok || !ci.enabled || ci.entry.kind != componentDetector {
+			continue
+		}
+		if d, ok := ci.instance.(observerdef.Detector); ok {
+			result = append(result, d)
+		} else if sd, ok := ci.instance.(observerdef.SeriesDetector); ok {
+			result = append(result, newSeriesDetectorAdapter(sd, defaultAggregations))
+		}
+	}
+	return result
+}
+
+// enabledCorrelators returns the enabled Correlator instances from a components map.
+func catalogEnabledCorrelators(components map[string]*componentInstance, catalog *componentCatalog) []observerdef.Correlator {
+	var result []observerdef.Correlator
+	for _, entry := range catalog.entries {
+		ci, ok := components[entry.name]
+		if !ok || !ci.enabled || ci.entry.kind != componentCorrelator {
+			continue
+		}
+		if cor, ok := ci.instance.(observerdef.Correlator); ok {
+			result = append(result, cor)
+		}
+	}
+	return result
+}

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -52,7 +52,7 @@ func defaultCatalog() *componentCatalog {
 				factory: func() any {
 					return NewCUSUMDetector()
 				},
-				defaultEnabled: true,
+				defaultEnabled: false,
 			},
 			{
 				name:        "bocpd",
@@ -126,9 +126,8 @@ func defaultCatalog() *componentCatalog {
 }
 
 // testbenchCatalog returns a catalog customized for the testbench.
-// It differs from the default in two ways:
-//   - RRCF uses testbench-specific metrics (parquet names instead of DogStatsD names)
-//     and is disabled by default (calibration mode).
+// It differs from the default in these ways:
+//   - RRCF uses testbench-specific metrics (parquet names instead of DogStatsD names).
 //   - cross_signal is disabled (testbench uses time_cluster instead).
 //   - time_cluster is enabled by default.
 func testbenchCatalog() *componentCatalog {
@@ -138,7 +137,6 @@ func testbenchCatalog() *componentCatalog {
 		config.Metrics = TestBenchRRCFMetrics()
 		return NewRRCFDetector(config)
 	})
-	cat = cat.WithDefaultEnabled("rrcf", false)
 	cat = cat.WithDefaultEnabled("cross_signal", false)
 	cat = cat.WithDefaultEnabled("time_cluster", true)
 	return cat

--- a/comp/observer/impl/consumer_memory.go
+++ b/comp/observer/impl/consumer_memory.go
@@ -7,7 +7,6 @@ package observerimpl
 
 import (
 	"fmt"
-	"strings"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
@@ -23,30 +22,22 @@ func (p *PassthroughCorrelator) Name() string {
 	return "passthrough_correlator"
 }
 
-// Process adds an anomaly to the pending list.
-func (p *PassthroughCorrelator) Process(anomaly observer.Anomaly) {
-	p.anomalies = append(p.anomalies, anomaly)
+// ProcessAnomaly adds an anomaly to the pending list.
+func (p *PassthroughCorrelator) ProcessAnomaly(a observer.Anomaly) {
+	p.anomalies = append(p.anomalies, a)
 }
 
-// Flush converts accumulated anomalies to reports and clears the list.
-func (p *PassthroughCorrelator) Flush() []observer.ReportOutput {
-	if len(p.anomalies) == 0 {
-		return nil
-	}
+// Advance is a no-op for the passthrough correlator (no time-based eviction).
+func (p *PassthroughCorrelator) Advance(_ int64) {}
 
-	reports := make([]observer.ReportOutput, len(p.anomalies))
-	for i, a := range p.anomalies {
-		reports[i] = observer.ReportOutput{
-			Title: a.Title,
-			Body:  a.Description,
-			Metadata: map[string]string{
-				"tags": strings.Join(a.Tags, ","),
-			},
-		}
-	}
+// ActiveCorrelations returns empty (passthrough does not produce correlations).
+func (p *PassthroughCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
+	return nil
+}
 
+// Reset clears accumulated anomalies.
+func (p *PassthroughCorrelator) Reset() {
 	p.anomalies = nil
-	return reports
 }
 
 // GetPending returns pending anomalies (for testing).
@@ -56,11 +47,12 @@ func (p *PassthroughCorrelator) GetPending() []observer.Anomaly {
 
 // StdoutReporter prints reports to stdout.
 // It tracks correlation state changes and only prints when correlations appear or disappear.
+// All data comes through Report(ReportOutput) — no backdoor access to engine internals.
 type StdoutReporter struct {
-	correlationState observer.CorrelationState
-	rawAnomalyState  observer.RawAnomalyState
 	seenCorrelations map[string]string // pattern -> title for correlations we've reported
 	seenRawAnomalies map[string]bool   // source|detector -> whether we've reported this raw anomaly
+	// lastCorrelations is cached from the most recent Report call for PrintFinalState.
+	lastCorrelations []observer.ActiveCorrelation
 }
 
 // Name returns the reporter name.
@@ -68,41 +60,26 @@ func (r *StdoutReporter) Name() string {
 	return "stdout_reporter"
 }
 
-// SetCorrelationState sets the correlation state source for the reporter.
-func (r *StdoutReporter) SetCorrelationState(state observer.CorrelationState) {
-	r.correlationState = state
-	r.seenCorrelations = make(map[string]string)
-}
-
-// SetRawAnomalyState sets the raw anomaly state source for the reporter.
-func (r *StdoutReporter) SetRawAnomalyState(state observer.RawAnomalyState) {
-	r.rawAnomalyState = state
-	r.seenRawAnomalies = make(map[string]bool)
-}
-
-// Report checks correlation state and prints changes.
-// It prints "[observer] NEW: {title}" when a correlation first appears
-// and "[observer] CLEARED: {title}" when a correlation disappears.
+// Report receives a ReportOutput with anomalies and correlations from the engine
+// and prints changes. It prints new anomalies and tracks correlation state changes,
+// printing "[observer] NEW: {title}" when a correlation first appears and
+// "[observer] CLEARED: {title}" when a correlation disappears.
 func (r *StdoutReporter) Report(report observer.ReportOutput) {
-	// Report raw anomalies first (with detector identification)
-	if r.rawAnomalyState != nil {
-		r.reportRawAnomalyChanges()
-	}
-	// If we have correlation state configured, check for changes
-	if r.correlationState != nil {
-		r.reportCorrelationChanges()
-	}
+	// Report new anomalies (with detector identification)
+	r.reportNewAnomalies(report.NewAnomalies)
+	// Check for correlation changes
+	r.reportCorrelationChanges(report.ActiveCorrelations)
+	// Cache for PrintFinalState
+	r.lastCorrelations = report.ActiveCorrelations
 }
 
-// reportRawAnomalyChanges prints new raw anomalies with their detector source.
-func (r *StdoutReporter) reportRawAnomalyChanges() {
+// reportNewAnomalies prints new anomalies from this advance cycle.
+func (r *StdoutReporter) reportNewAnomalies(anomalies []observer.Anomaly) {
 	if r.seenRawAnomalies == nil {
 		r.seenRawAnomalies = make(map[string]bool)
 	}
 
-	rawAnomalies := r.rawAnomalyState.RawAnomalies()
-
-	for _, anomaly := range rawAnomalies {
+	for _, anomaly := range anomalies {
 		key := string(anomaly.Source) + "|" + anomaly.DetectorName
 		if !r.seenRawAnomalies[key] {
 			fmt.Printf("[observer] [%s] ANOMALY: %s\n", anomaly.DetectorName, anomaly.Source)
@@ -113,13 +90,10 @@ func (r *StdoutReporter) reportRawAnomalyChanges() {
 }
 
 // reportCorrelationChanges checks for new and cleared correlations.
-func (r *StdoutReporter) reportCorrelationChanges() {
+func (r *StdoutReporter) reportCorrelationChanges(activeCorrelations []observer.ActiveCorrelation) {
 	if r.seenCorrelations == nil {
 		r.seenCorrelations = make(map[string]string)
 	}
-
-	// Get current active correlations
-	activeCorrelations := r.correlationState.ActiveCorrelations()
 
 	// Build set of currently active pattern names
 	currentlyActive := make(map[string]string) // pattern -> title
@@ -147,43 +121,16 @@ func (r *StdoutReporter) reportCorrelationChanges() {
 	}
 }
 
-// PrintFinalState prints the current state of all correlations and raw anomalies.
+// PrintFinalState prints the current state of all correlations.
 // Call this at the end of a demo to see final cluster contents.
+// Uses the last correlations received via Report.
 func (r *StdoutReporter) PrintFinalState() {
-	// Print raw anomaly summary by detector
-	if r.rawAnomalyState != nil {
-		rawAnomalies := r.rawAnomalyState.RawAnomalies()
-		if len(rawAnomalies) > 0 {
-			byDetector := make(map[string][]observer.Anomaly)
-			for _, a := range rawAnomalies {
-				byDetector[a.DetectorName] = append(byDetector[a.DetectorName], a)
-			}
-
-			fmt.Println("[observer] Raw Anomaly Summary:")
-			for detector, anomalies := range byDetector {
-				sources := make(map[observer.MetricName]bool)
-				for _, a := range anomalies {
-					sources[a.Source] = true
-				}
-				fmt.Printf("  [%s]: %d anomalies across %d metrics\n", detector, len(anomalies), len(sources))
-				for _, a := range anomalies {
-					fmt.Printf("    - %s\n", a.Description)
-				}
-			}
-		}
-	}
-
-	// Print correlation summary
-	if r.correlationState == nil {
-		return
-	}
-	activeCorrelations := r.correlationState.ActiveCorrelations()
-	if len(activeCorrelations) == 0 {
+	if len(r.lastCorrelations) == 0 {
 		fmt.Println("[observer] Final state: no active correlations")
 		return
 	}
 	fmt.Println("[observer] Correlation Summary:")
-	for _, ac := range activeCorrelations {
+	for _, ac := range r.lastCorrelations {
 		fmt.Printf("  Cluster: %d anomalies\n", len(ac.Anomalies))
 		for _, anomaly := range ac.Anomalies {
 			fmt.Printf("    - %s\n", anomaly.Description)

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -49,12 +49,12 @@ type engine struct {
 	// Raw anomaly tracking (for telemetry and testbench display).
 	rawAnomalies         []observerdef.Anomaly
 	rawAnomalyIndex      map[anomalyDedupKey]int // O(1) dedup lookup
-	rawAnomalyMu        sync.RWMutex
-	rawAnomalyWindow     int64                             // seconds to keep (0 = unlimited)
-	maxRawAnomalies      int                               // max count to keep (0 = unlimited)
-	currentDataTime      int64                             // latest anomaly timestamp seen
-	totalAnomalyCount    int                               // total count ever (no cap)
-	uniqueAnomalySources map[observerdef.MetricName]bool   // unique sources that had anomalies
+	rawAnomalyMu         sync.RWMutex
+	rawAnomalyWindow     int64                           // seconds to keep (0 = unlimited)
+	maxRawAnomalies      int                             // max count to keep (0 = unlimited)
+	currentDataTime      int64                           // latest anomaly timestamp seen
+	totalAnomalyCount    int                             // total count ever (no cap)
+	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
 
 	// Accumulated telemetry from detection runs (for StateView access).
 	accumulatedTelemetry []observerdef.ObserverTelemetry
@@ -397,6 +397,16 @@ func (e *engine) SetCorrelators(correlators []observerdef.Correlator) {
 func (e *engine) Reset() {
 	e.lastAnalyzedDataTime = 0
 	e.latestDataTime = 0
+
+	for _, detector := range e.detectors {
+		if resetter, ok := detector.(interface{ Reset() }); ok {
+			resetter.Reset()
+		}
+	}
+
+	for _, correlator := range e.correlators {
+		correlator.Reset()
+	}
 }
 
 // resetRawAnomalies clears the raw anomaly tracking state.

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -308,10 +308,8 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) {
 		detectorName: anomaly.DetectorName,
 		timestamp:    anomaly.Timestamp,
 	}
-	if idx, ok := e.rawAnomalyIndex[key]; ok {
-		if anomaly.Timestamp > e.rawAnomalies[idx].Timestamp {
-			e.rawAnomalies[idx] = anomaly
-		}
+	if _, ok := e.rawAnomalyIndex[key]; ok {
+		return // exact duplicate (same series + detector + timestamp)
 	} else {
 		if e.rawAnomalyIndex == nil {
 			e.rawAnomalyIndex = make(map[anomalyDedupKey]int)

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -56,6 +56,14 @@ type engine struct {
 	totalAnomalyCount    int                             // total count ever (no cap)
 	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
 
+	// Accumulated correlations from all advance cycles.
+	// Correlators maintain sliding windows that evict old state, but for
+	// testbench/replay we want the full history. This map accumulates
+	// every correlation ever seen, keyed by Pattern string, updating
+	// existing entries when the correlator reports a newer version.
+	accumulatedCorrelations map[string]observerdef.ActiveCorrelation
+	correlationMu          sync.RWMutex
+
 	// Accumulated telemetry from detection runs (for StateView access).
 	accumulatedTelemetry []observerdef.ObserverTelemetry
 	telemetryMu          sync.RWMutex
@@ -247,6 +255,7 @@ func (e *engine) runDetectorsAndCorrelators(upTo int64) advanceResult {
 	// Advance correlators so they can update their internal state.
 	for _, correlator := range e.correlators {
 		correlator.Advance(upTo)
+		e.accumulateCorrelations(correlator.ActiveCorrelations())
 		e.emit(engineEvent{
 			kind:      eventCorrelationUpdated,
 			timestamp: upTo,
@@ -370,6 +379,35 @@ func (e *engine) UniqueAnomalySourceCount() int {
 	return len(e.uniqueAnomalySources)
 }
 
+// accumulateCorrelations merges active correlations into the engine's historical set.
+// Existing entries are updated if the new version has more anomalies or a later timestamp.
+func (e *engine) accumulateCorrelations(active []observerdef.ActiveCorrelation) {
+	e.correlationMu.Lock()
+	defer e.correlationMu.Unlock()
+
+	if e.accumulatedCorrelations == nil {
+		e.accumulatedCorrelations = make(map[string]observerdef.ActiveCorrelation)
+	}
+	for _, ac := range active {
+		existing, ok := e.accumulatedCorrelations[ac.Pattern]
+		if !ok || len(ac.Anomalies) > len(existing.Anomalies) || ac.LastUpdated > existing.LastUpdated {
+			e.accumulatedCorrelations[ac.Pattern] = ac
+		}
+	}
+}
+
+// AccumulatedCorrelations returns all correlations ever detected across the run.
+func (e *engine) AccumulatedCorrelations() []observerdef.ActiveCorrelation {
+	e.correlationMu.RLock()
+	defer e.correlationMu.RUnlock()
+
+	result := make([]observerdef.ActiveCorrelation, 0, len(e.accumulatedCorrelations))
+	for _, ac := range e.accumulatedCorrelations {
+		result = append(result, ac)
+	}
+	return result
+}
+
 // Storage returns the engine's storage.
 func (e *engine) Storage() *timeSeriesStorage {
 	return e.storage
@@ -428,12 +466,20 @@ func (e *engine) resetTelemetry() {
 	e.accumulatedTelemetry = nil
 }
 
-// resetFull resets all engine state: analysis progress, raw anomalies, and telemetry.
+// resetCorrelations clears accumulated correlation history.
+func (e *engine) resetCorrelations() {
+	e.correlationMu.Lock()
+	defer e.correlationMu.Unlock()
+	e.accumulatedCorrelations = nil
+}
+
+// resetFull resets all engine state: analysis progress, raw anomalies, telemetry, and correlations.
 // Storage is NOT cleared — the caller manages storage lifecycle.
 func (e *engine) resetFull() {
 	e.Reset()
 	e.resetRawAnomalies()
 	e.resetTelemetry()
+	e.resetCorrelations()
 }
 
 // ReplayStoredData replays all data in storage through the scheduler policy,

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -1,0 +1,460 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"sync"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// Note: stateView is defined in stateview.go and provides read-only access
+// to engine state for consumers like the testbench UI.
+
+// anomalyDedupKey is a map key for O(1) anomaly deduplication.
+type anomalyDedupKey struct {
+	seriesID     observerdef.SeriesID
+	detectorName string
+	timestamp    int64
+}
+
+// engine is the shared orchestration core for the observer pipeline.
+// It encapsulates storage, log extraction, detection, and correlation,
+// providing a single execution path used by both the live observer and testbench.
+//
+// The engine does not own reporters or scheduling policy. It accepts explicit
+// Advance calls and returns results that callers route to their own outputs.
+type engine struct {
+	storage     *timeSeriesStorage
+	extractors  []observerdef.LogMetricsExtractor
+	detectors   []observerdef.Detector
+	correlators []observerdef.Correlator
+
+	// scheduler decides when the engine should advance analysis.
+	scheduler schedulerPolicy
+
+	// logObservers are detectors that also implement LogObserver.
+	// Cached at construction time to avoid repeated type assertions.
+	logObservers []observerdef.LogObserver
+
+	// lastAnalyzedDataTime is the data timestamp up to which detection has run.
+	lastAnalyzedDataTime int64
+
+	// latestDataTime is the latest data timestamp seen across all ingested observations.
+	latestDataTime int64
+
+	// Raw anomaly tracking (for telemetry and testbench display).
+	rawAnomalies         []observerdef.Anomaly
+	rawAnomalyIndex      map[anomalyDedupKey]int // O(1) dedup lookup
+	rawAnomalyMu        sync.RWMutex
+	rawAnomalyWindow     int64                             // seconds to keep (0 = unlimited)
+	maxRawAnomalies      int                               // max count to keep (0 = unlimited)
+	currentDataTime      int64                             // latest anomaly timestamp seen
+	totalAnomalyCount    int                               // total count ever (no cap)
+	uniqueAnomalySources map[observerdef.MetricName]bool   // unique sources that had anomalies
+
+	// Accumulated telemetry from detection runs (for StateView access).
+	accumulatedTelemetry []observerdef.ObserverTelemetry
+	telemetryMu          sync.RWMutex
+
+	// Event subscription management.
+	sinks   []eventSink
+	sinksMu sync.RWMutex
+}
+
+// engineConfig holds the parameters for constructing an engine.
+type engineConfig struct {
+	storage     *timeSeriesStorage
+	extractors  []observerdef.LogMetricsExtractor
+	detectors   []observerdef.Detector
+	correlators []observerdef.Correlator
+
+	// scheduler is the scheduling policy. If nil, defaults to currentBehaviorPolicy.
+	scheduler schedulerPolicy
+
+	rawAnomalyWindow int64
+	maxRawAnomalies  int
+}
+
+// newEngine creates an engine with the given configuration.
+func newEngine(cfg engineConfig) *engine {
+	sched := cfg.scheduler
+	if sched == nil {
+		sched = &currentBehaviorPolicy{}
+	}
+
+	e := &engine{
+		storage:     cfg.storage,
+		extractors:  cfg.extractors,
+		detectors:   cfg.detectors,
+		correlators: cfg.correlators,
+		scheduler:   sched,
+
+		rawAnomalyWindow: cfg.rawAnomalyWindow,
+		maxRawAnomalies:  cfg.maxRawAnomalies,
+	}
+
+	// Cache log observers from detectors.
+	for _, d := range e.detectors {
+		if lo, ok := d.(observerdef.LogObserver); ok {
+			e.logObservers = append(e.logObservers, lo)
+		}
+	}
+
+	return e
+}
+
+// Subscribe registers an event sink to receive engine events.
+// Returns an unsubscribe function that removes the sink.
+func (e *engine) Subscribe(sink eventSink) func() {
+	e.sinksMu.Lock()
+	e.sinks = append(e.sinks, sink)
+	// Capture the sink pointer for removal.
+	registered := sink
+	e.sinksMu.Unlock()
+
+	return func() {
+		e.sinksMu.Lock()
+		defer e.sinksMu.Unlock()
+		for i, s := range e.sinks {
+			if s == registered {
+				e.sinks = append(e.sinks[:i], e.sinks[i+1:]...)
+				return
+			}
+		}
+	}
+}
+
+// emit sends an event to all registered sinks.
+func (e *engine) emit(evt engineEvent) {
+	e.sinksMu.RLock()
+	sinks := make([]eventSink, len(e.sinks))
+	copy(sinks, e.sinks)
+	e.sinksMu.RUnlock()
+
+	for _, sink := range sinks {
+		sink.onEngineEvent(evt)
+	}
+}
+
+// IngestMetric stores a metric observation and consults the scheduler policy
+// to determine whether detectors should advance. Returns advance requests
+// that the caller should execute via Advance.
+func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
+	e.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
+	e.trackLatestDataTime(m.timestamp)
+	return e.scheduler.onObservation(m.timestamp, e.schedulerState())
+}
+
+// IngestLog processes a log observation: runs extractors to produce virtual metrics,
+// notifies log observers, and consults the scheduler policy to determine whether
+// detectors should advance. Returns advance requests that the caller should execute.
+func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
+	view := &logView{obs: l}
+	for _, extractor := range e.extractors {
+		metrics := extractor.ProcessLog(view)
+		for _, m := range metrics {
+			e.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
+		}
+	}
+	for _, lo := range e.logObservers {
+		lo.ProcessLog(view)
+	}
+	dataTimeSec := l.timestampMs / 1000
+	e.trackLatestDataTime(dataTimeSec)
+	return e.scheduler.onObservation(dataTimeSec, e.schedulerState())
+}
+
+// trackLatestDataTime updates latestDataTime if the given timestamp is newer.
+func (e *engine) trackLatestDataTime(dataTimeSec int64) {
+	if dataTimeSec > e.latestDataTime {
+		e.latestDataTime = dataTimeSec
+	}
+}
+
+// schedulerState returns the current scheduler-relevant state.
+func (e *engine) schedulerState() schedulerState {
+	return schedulerState{
+		lastAnalyzedDataTime: e.lastAnalyzedDataTime,
+		latestDataTime:       e.latestDataTime,
+	}
+}
+
+// advanceResult holds the outputs from an Advance call.
+type advanceResult struct {
+	anomalies []observerdef.Anomaly
+	telemetry []observerdef.ObserverTelemetry
+}
+
+// Advance runs detectors and correlators up to the given event time.
+// It returns all anomalies produced and updates the lastAnalyzedDataTime.
+// The caller is responsible for routing anomalies to reporters or UI.
+func (e *engine) Advance(upToSec int64) advanceResult {
+	return e.advanceWithReason(upToSec, advanceReasonManual)
+}
+
+// advanceWithReason runs detectors and correlators up to the given event time,
+// recording the reason for the advance in the emitted event.
+func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceResult {
+	if upToSec <= e.lastAnalyzedDataTime {
+		return advanceResult{}
+	}
+
+	result := e.runDetectorsAndCorrelators(upToSec)
+	e.lastAnalyzedDataTime = upToSec
+
+	e.emit(engineEvent{
+		kind:      eventAdvanceCompleted,
+		timestamp: upToSec,
+		advanceCompleted: &advanceCompletedEvent{
+			advancedToSec:  upToSec,
+			reason:         reason,
+			anomalyCount:   len(result.anomalies),
+			telemetryCount: len(result.telemetry),
+			anomalies:      result.anomalies,
+		},
+	})
+
+	return result
+}
+
+// runDetectorsAndCorrelators runs all detectors and feeds results through correlators.
+func (e *engine) runDetectorsAndCorrelators(upTo int64) advanceResult {
+	var allAnomalies []observerdef.Anomaly
+	var allTelemetry []observerdef.ObserverTelemetry
+
+	for _, detector := range e.detectors {
+		result := detector.Detect(e.storage, upTo)
+		for _, anomaly := range result.Anomalies {
+			e.captureRawAnomaly(anomaly)
+			e.processAnomaly(anomaly)
+			allAnomalies = append(allAnomalies, anomaly)
+
+			e.emit(engineEvent{
+				kind:      eventAnomalyCreated,
+				timestamp: anomaly.Timestamp,
+				anomalyCreated: &anomalyCreatedEvent{
+					anomaly: anomaly,
+				},
+			})
+		}
+		allTelemetry = append(allTelemetry, result.Telemetry...)
+	}
+
+	// Advance correlators so they can update their internal state.
+	for _, correlator := range e.correlators {
+		correlator.Advance(upTo)
+		e.emit(engineEvent{
+			kind:      eventCorrelationUpdated,
+			timestamp: upTo,
+			correlationUpdated: &correlationUpdatedEvent{
+				correlatorName: correlator.Name(),
+			},
+		})
+	}
+
+	// Accumulate telemetry so StateView can expose it.
+	if len(allTelemetry) > 0 {
+		e.telemetryMu.Lock()
+		e.accumulatedTelemetry = append(e.accumulatedTelemetry, allTelemetry...)
+		e.telemetryMu.Unlock()
+	}
+
+	return advanceResult{
+		anomalies: allAnomalies,
+		telemetry: allTelemetry,
+	}
+}
+
+// processAnomaly sends an anomaly to all registered correlators.
+func (e *engine) processAnomaly(anomaly observerdef.Anomaly) {
+	for _, correlator := range e.correlators {
+		correlator.ProcessAnomaly(anomaly)
+	}
+}
+
+// captureRawAnomaly stores a raw anomaly for telemetry and testbench display.
+// Deduplicates by SourceSeriesID+DetectorName+Timestamp.
+func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) {
+	e.rawAnomalyMu.Lock()
+	defer e.rawAnomalyMu.Unlock()
+
+	e.totalAnomalyCount++
+
+	if e.uniqueAnomalySources == nil {
+		e.uniqueAnomalySources = make(map[observerdef.MetricName]bool)
+	}
+	e.uniqueAnomalySources[anomaly.Source] = true
+
+	if anomaly.Timestamp > e.currentDataTime {
+		e.currentDataTime = anomaly.Timestamp
+	}
+
+	// Deduplicate by SourceSeriesID+DetectorName+Timestamp
+	key := anomalyDedupKey{
+		seriesID:     anomaly.SourceSeriesID,
+		detectorName: anomaly.DetectorName,
+		timestamp:    anomaly.Timestamp,
+	}
+	if idx, ok := e.rawAnomalyIndex[key]; ok {
+		if anomaly.Timestamp > e.rawAnomalies[idx].Timestamp {
+			e.rawAnomalies[idx] = anomaly
+		}
+	} else {
+		if e.rawAnomalyIndex == nil {
+			e.rawAnomalyIndex = make(map[anomalyDedupKey]int)
+		}
+		e.rawAnomalyIndex[key] = len(e.rawAnomalies)
+		e.rawAnomalies = append(e.rawAnomalies, anomaly)
+	}
+
+	// Evict old anomalies if window is set
+	needsReindex := false
+	if e.rawAnomalyWindow > 0 {
+		cutoff := e.currentDataTime - e.rawAnomalyWindow
+		newBuffer := e.rawAnomalies[:0]
+		for _, a := range e.rawAnomalies {
+			if a.Timestamp >= cutoff {
+				newBuffer = append(newBuffer, a)
+			}
+		}
+		if len(newBuffer) != len(e.rawAnomalies) {
+			needsReindex = true
+		}
+		e.rawAnomalies = newBuffer
+	}
+
+	// Cap at maxRawAnomalies if set
+	if e.maxRawAnomalies > 0 && len(e.rawAnomalies) > e.maxRawAnomalies {
+		e.rawAnomalies = e.rawAnomalies[len(e.rawAnomalies)-e.maxRawAnomalies:]
+		needsReindex = true
+	}
+
+	// Rebuild index after eviction changes indices.
+	if needsReindex {
+		e.rawAnomalyIndex = make(map[anomalyDedupKey]int, len(e.rawAnomalies))
+		for i, a := range e.rawAnomalies {
+			e.rawAnomalyIndex[anomalyDedupKey{
+				seriesID:     a.SourceSeriesID,
+				detectorName: a.DetectorName,
+				timestamp:    a.Timestamp,
+			}] = i
+		}
+	}
+}
+
+// RawAnomalies returns a copy of currently tracked raw anomalies.
+func (e *engine) RawAnomalies() []observerdef.Anomaly {
+	e.rawAnomalyMu.RLock()
+	defer e.rawAnomalyMu.RUnlock()
+
+	result := make([]observerdef.Anomaly, len(e.rawAnomalies))
+	copy(result, e.rawAnomalies)
+	return result
+}
+
+// TotalAnomalyCount returns the total number of anomalies ever detected.
+func (e *engine) TotalAnomalyCount() int {
+	e.rawAnomalyMu.RLock()
+	defer e.rawAnomalyMu.RUnlock()
+	return e.totalAnomalyCount
+}
+
+// UniqueAnomalySourceCount returns the number of unique sources that had anomalies.
+func (e *engine) UniqueAnomalySourceCount() int {
+	e.rawAnomalyMu.RLock()
+	defer e.rawAnomalyMu.RUnlock()
+	return len(e.uniqueAnomalySources)
+}
+
+// Storage returns the engine's storage.
+func (e *engine) Storage() *timeSeriesStorage {
+	return e.storage
+}
+
+// SetDetectors replaces the engine's detectors. Used when testbench components
+// are toggled. Also refreshes the cached log observers list.
+func (e *engine) SetDetectors(detectors []observerdef.Detector) {
+	e.detectors = detectors
+	e.logObservers = nil
+	for _, d := range e.detectors {
+		if lo, ok := d.(observerdef.LogObserver); ok {
+			e.logObservers = append(e.logObservers, lo)
+		}
+	}
+}
+
+// SetCorrelators replaces the engine's correlators.
+func (e *engine) SetCorrelators(correlators []observerdef.Correlator) {
+	e.correlators = correlators
+}
+
+// Reset clears analysis state so detectors will re-analyze from scratch.
+// This does NOT clear storage or raw anomalies — use resetFull for that.
+func (e *engine) Reset() {
+	e.lastAnalyzedDataTime = 0
+	e.latestDataTime = 0
+}
+
+// resetRawAnomalies clears the raw anomaly tracking state.
+func (e *engine) resetRawAnomalies() {
+	e.rawAnomalyMu.Lock()
+	defer e.rawAnomalyMu.Unlock()
+
+	e.rawAnomalies = nil
+	e.rawAnomalyIndex = nil
+	e.totalAnomalyCount = 0
+	e.uniqueAnomalySources = nil
+	e.currentDataTime = 0
+}
+
+// resetTelemetry clears accumulated telemetry.
+func (e *engine) resetTelemetry() {
+	e.telemetryMu.Lock()
+	defer e.telemetryMu.Unlock()
+	e.accumulatedTelemetry = nil
+}
+
+// resetFull resets all engine state: analysis progress, raw anomalies, and telemetry.
+// Storage is NOT cleared — the caller manages storage lifecycle.
+func (e *engine) resetFull() {
+	e.Reset()
+	e.resetRawAnomalies()
+	e.resetTelemetry()
+}
+
+// ReplayStoredData replays all data in storage through the scheduler policy,
+// using the same timing semantics as live ingestion. For each unique data
+// timestamp, it consults the scheduler to decide when to advance analysis.
+// After all timestamps are processed, calls onReplayEnd to flush remaining data.
+func (e *engine) ReplayStoredData() advanceResult {
+	var allAnomalies []observerdef.Anomaly
+	var allTelemetry []observerdef.ObserverTelemetry
+
+	timestamps := e.storage.DataTimestamps()
+	for _, ts := range timestamps {
+		e.trackLatestDataTime(ts)
+		requests := e.scheduler.onObservation(ts, e.schedulerState())
+		for _, req := range requests {
+			result := e.advanceWithReason(req.upToSec, req.reason)
+			allAnomalies = append(allAnomalies, result.anomalies...)
+			allTelemetry = append(allTelemetry, result.telemetry...)
+		}
+	}
+
+	// Final flush for any remaining data not yet analyzed.
+	endRequests := e.scheduler.onReplayEnd(e.schedulerState())
+	for _, req := range endRequests {
+		result := e.advanceWithReason(req.upToSec, req.reason)
+		allAnomalies = append(allAnomalies, result.anomalies...)
+		allTelemetry = append(allTelemetry, result.telemetry...)
+	}
+
+	return advanceResult{
+		anomalies: allAnomalies,
+		telemetry: allTelemetry,
+	}
+}

--- a/comp/observer/impl/events.go
+++ b/comp/observer/impl/events.go
@@ -1,0 +1,84 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// engineEventKind identifies the type of engine event.
+type engineEventKind int
+
+const (
+	eventAdvanceCompleted  engineEventKind = iota
+	eventAnomalyCreated
+	eventCorrelationUpdated
+)
+
+// engineEvent represents a meaningful state transition in the engine.
+// Events are lightweight notifications; consumers should query stateView for
+// full details when needed.
+type engineEvent struct {
+	kind      engineEventKind
+	timestamp int64 // event time (data time, not wall clock)
+
+	// Exactly one of these is non-nil based on kind.
+	advanceCompleted   *advanceCompletedEvent
+	anomalyCreated     *anomalyCreatedEvent
+	correlationUpdated *correlationUpdatedEvent
+}
+
+// advanceCompletedEvent is emitted after the engine finishes an Advance call.
+type advanceCompletedEvent struct {
+	advancedToSec  int64
+	reason         advanceReason
+	anomalyCount   int
+	telemetryCount int
+	// anomalies are the anomalies detected in this advance cycle.
+	// Included so event sinks can forward them without querying engine state.
+	anomalies []observerdef.Anomaly
+}
+
+// anomalyCreatedEvent is emitted for each anomaly detected during Advance.
+type anomalyCreatedEvent struct {
+	anomaly observerdef.Anomaly
+}
+
+// correlationUpdatedEvent is emitted after correlators flush and their state
+// may have changed.
+type correlationUpdatedEvent struct {
+	correlatorName string
+}
+
+// eventSink receives engine events.
+type eventSink interface {
+	onEngineEvent(engineEvent)
+}
+
+// reporterEventSink bridges engine events to the existing Reporter interface.
+// When an advance completes, it populates ReportOutput with anomalies from
+// the event and active correlations from the stateView, then calls Report
+// on all registered reporters.
+type reporterEventSink struct {
+	reporters []observerdef.Reporter
+	state     *stateView // for querying current correlations on advance
+}
+
+func (s *reporterEventSink) onEngineEvent(evt engineEvent) {
+	if evt.kind == eventAdvanceCompleted {
+		ac := evt.advanceCompleted
+		output := observerdef.ReportOutput{
+			AdvancedToSec: ac.advancedToSec,
+			NewAnomalies:  ac.anomalies,
+		}
+		if s.state != nil {
+			output.ActiveCorrelations = s.state.ActiveCorrelations()
+		}
+		for _, r := range s.reporters {
+			r.Report(output)
+		}
+	}
+}

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -1,0 +1,261 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"sync"
+	"testing"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// collectingSink collects all events for test assertions.
+type collectingSink struct {
+	mu     sync.Mutex
+	events []engineEvent
+}
+
+func (s *collectingSink) onEngineEvent(evt engineEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, evt)
+}
+
+func (s *collectingSink) getEvents() []engineEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := make([]engineEvent, len(s.events))
+	copy(result, s.events)
+	return result
+}
+
+func (s *collectingSink) eventsOfKind(kind engineEventKind) []engineEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []engineEvent
+	for _, evt := range s.events {
+		if evt.kind == kind {
+			result = append(result, evt)
+		}
+	}
+	return result
+}
+
+func TestSubscribeAndUnsubscribe(t *testing.T) {
+	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+
+	sink := &collectingSink{}
+	unsub := e.Subscribe(sink)
+
+	// Emit an event manually to verify delivery.
+	e.emit(engineEvent{kind: eventAdvanceCompleted, timestamp: 100})
+
+	events := sink.getEvents()
+	assert.Len(t, events, 1)
+	assert.Equal(t, eventAdvanceCompleted, events[0].kind)
+
+	// Unsubscribe and verify no more delivery.
+	unsub()
+	e.emit(engineEvent{kind: eventAdvanceCompleted, timestamp: 200})
+
+	events = sink.getEvents()
+	assert.Len(t, events, 1, "should not receive events after unsubscribe")
+}
+
+func TestMultipleSinksReceiveEvents(t *testing.T) {
+	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+
+	sink1 := &collectingSink{}
+	sink2 := &collectingSink{}
+	e.Subscribe(sink1)
+	e.Subscribe(sink2)
+
+	e.emit(engineEvent{kind: eventAnomalyCreated, timestamp: 50})
+
+	assert.Len(t, sink1.getEvents(), 1)
+	assert.Len(t, sink2.getEvents(), 1)
+}
+
+func TestUnsubscribeOnlyAffectsTargetSink(t *testing.T) {
+	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+
+	sink1 := &collectingSink{}
+	sink2 := &collectingSink{}
+	unsub1 := e.Subscribe(sink1)
+	e.Subscribe(sink2)
+
+	// Unsubscribe sink1 only.
+	unsub1()
+
+	e.emit(engineEvent{kind: eventAdvanceCompleted, timestamp: 100})
+
+	assert.Len(t, sink1.getEvents(), 0, "sink1 should not receive events after unsubscribe")
+	assert.Len(t, sink2.getEvents(), 1, "sink2 should still receive events")
+}
+
+// anomalyDetector produces anomalies on Detect for testing event emission.
+type anomalyDetector struct {
+	name      string
+	anomalies []observerdef.Anomaly
+}
+
+func (d *anomalyDetector) Name() string { return d.name }
+func (d *anomalyDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
+	return observerdef.DetectionResult{
+		Anomalies: d.anomalies,
+	}
+}
+
+func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
+	e := newEngine(engineConfig{
+		storage:   newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{&mockDetector{name: "noop"}},
+	})
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+
+	e.Advance(100)
+
+	advances := sink.eventsOfKind(eventAdvanceCompleted)
+	require.Len(t, advances, 1)
+	assert.Equal(t, int64(100), advances[0].timestamp)
+	assert.NotNil(t, advances[0].advanceCompleted)
+	assert.Equal(t, int64(100), advances[0].advanceCompleted.advancedToSec)
+	assert.Equal(t, 0, advances[0].advanceCompleted.anomalyCount)
+}
+
+func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
+	anomalies := []observerdef.Anomaly{
+		{Source: "cpu", DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|cpu|"},
+		{Source: "mem", DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|mem|"},
+	}
+
+	e := newEngine(engineConfig{
+		storage: newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{
+			&anomalyDetector{name: "test", anomalies: anomalies},
+		},
+	})
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+
+	e.Advance(100)
+
+	anomalyEvents := sink.eventsOfKind(eventAnomalyCreated)
+	assert.Len(t, anomalyEvents, 2)
+	assert.Equal(t, "cpu", string(anomalyEvents[0].anomalyCreated.anomaly.Source))
+	assert.Equal(t, "mem", string(anomalyEvents[1].anomalyCreated.anomaly.Source))
+}
+
+func TestAdvanceEmitsCorrelationUpdatedEvents(t *testing.T) {
+	e := newEngine(engineConfig{
+		storage:     newTimeSeriesStorage(),
+		correlators: []observerdef.Correlator{&mockCorrelator{name: "time_cluster"}},
+	})
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+
+	e.Advance(100)
+
+	corrEvents := sink.eventsOfKind(eventCorrelationUpdated)
+	require.Len(t, corrEvents, 1)
+	assert.Equal(t, "time_cluster", corrEvents[0].correlationUpdated.correlatorName)
+}
+
+func TestAdvanceWithReasonPreservesReason(t *testing.T) {
+	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+
+	e.advanceWithReason(100, advanceReasonInputDriven)
+
+	advances := sink.eventsOfKind(eventAdvanceCompleted)
+	require.Len(t, advances, 1)
+	assert.Equal(t, advanceReasonInputDriven, advances[0].advanceCompleted.reason)
+}
+
+func TestNoEventOnSkippedAdvance(t *testing.T) {
+	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	e.Advance(100) // advance first without sink
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+
+	// Advancing to same or earlier time should be a no-op.
+	e.Advance(100)
+	e.Advance(50)
+
+	assert.Len(t, sink.getEvents(), 0, "no events should be emitted for skipped advances")
+}
+
+func TestReplayStoredDataEmitsEventsViaScheduler(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	// Add data at timestamps 10, 11, 12, 13.
+	for sec := int64(10); sec <= 13; sec++ {
+		storage.Add("ns", "cpu", 1.0, sec, nil)
+	}
+
+	e := newEngine(engineConfig{storage: storage})
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+
+	e.ReplayStoredData()
+
+	advances := sink.eventsOfKind(eventAdvanceCompleted)
+	// currentBehaviorPolicy: observation at ts=10 -> advance to 9,
+	// ts=11 -> advance to 10, ts=12 -> advance to 11, ts=13 -> advance to 12
+	// onReplayEnd -> advance to 13 (latestDataTime)
+	require.Len(t, advances, 5)
+	assert.Equal(t, int64(9), advances[0].advanceCompleted.advancedToSec)
+	assert.Equal(t, advanceReasonInputDriven, advances[0].advanceCompleted.reason)
+	assert.Equal(t, int64(10), advances[1].advanceCompleted.advancedToSec)
+	assert.Equal(t, int64(11), advances[2].advanceCompleted.advancedToSec)
+	assert.Equal(t, int64(12), advances[3].advanceCompleted.advancedToSec)
+	assert.Equal(t, int64(13), advances[4].advanceCompleted.advancedToSec)
+	assert.Equal(t, advanceReasonReplayEnd, advances[4].advanceCompleted.reason)
+}
+
+func TestReporterEventSink(t *testing.T) {
+	reported := 0
+	reporter := &countingReporter{count: &reported}
+
+	sink := &reporterEventSink{
+		reporters: []observerdef.Reporter{reporter},
+	}
+
+	// advanceCompleted should trigger Report.
+	sink.onEngineEvent(engineEvent{
+		kind:             eventAdvanceCompleted,
+		timestamp:        100,
+		advanceCompleted: &advanceCompletedEvent{advancedToSec: 100},
+	})
+	assert.Equal(t, 1, reported)
+
+	// anomalyCreated should NOT trigger Report.
+	sink.onEngineEvent(engineEvent{
+		kind:      eventAnomalyCreated,
+		timestamp: 100,
+		anomalyCreated: &anomalyCreatedEvent{
+			anomaly: observerdef.Anomaly{Source: "cpu"},
+		},
+	})
+	assert.Equal(t, 1, reported, "anomaly events should not trigger reporter")
+}
+
+// countingReporter counts how many times Report is called.
+type countingReporter struct {
+	count *int
+}
+
+func (r *countingReporter) Name() string                        { return "counting" }
+func (r *countingReporter) Report(_ observerdef.ReportOutput) { *r.count++ }

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -111,6 +111,30 @@ func (d *anomalyDetector) Detect(_ observerdef.StorageReader, dataTime int64) ob
 	}
 }
 
+type resettableDetector struct {
+	name       string
+	resetCount int
+}
+
+func (d *resettableDetector) Name() string { return d.name }
+func (d *resettableDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
+	return observerdef.DetectionResult{}
+}
+func (d *resettableDetector) Reset() { d.resetCount++ }
+
+type resettableCorrelator struct {
+	name       string
+	resetCount int
+}
+
+func (c *resettableCorrelator) Name() string                         { return c.name }
+func (c *resettableCorrelator) ProcessAnomaly(_ observerdef.Anomaly) {}
+func (c *resettableCorrelator) Advance(_ int64)                      {}
+func (c *resettableCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation {
+	return nil
+}
+func (c *resettableCorrelator) Reset() { c.resetCount++ }
+
 func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
 	e := newEngine(engineConfig{
 		storage:   newTimeSeriesStorage(),
@@ -225,6 +249,21 @@ func TestReplayStoredDataEmitsEventsViaScheduler(t *testing.T) {
 	assert.Equal(t, advanceReasonReplayEnd, advances[4].advanceCompleted.reason)
 }
 
+func TestEngineResetResetsDetectorsAndCorrelators(t *testing.T) {
+	detector := &resettableDetector{name: "detector"}
+	correlator := &resettableCorrelator{name: "correlator"}
+	e := newEngine(engineConfig{
+		storage:     newTimeSeriesStorage(),
+		detectors:   []observerdef.Detector{detector},
+		correlators: []observerdef.Correlator{correlator},
+	})
+
+	e.Reset()
+
+	assert.Equal(t, 1, detector.resetCount)
+	assert.Equal(t, 1, correlator.resetCount)
+}
+
 func TestReporterEventSink(t *testing.T) {
 	reported := 0
 	reporter := &countingReporter{count: &reported}
@@ -257,5 +296,5 @@ type countingReporter struct {
 	count *int
 }
 
-func (r *countingReporter) Name() string                        { return "counting" }
+func (r *countingReporter) Name() string                      { return "counting" }
 func (r *countingReporter) Report(_ observerdef.ReportOutput) { *r.count++ }

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -12,17 +12,53 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-// BOCPDDetector detects changepoints using Bayesian Online Changepoint Detection.
-// This implementation uses a constant hazard function and a Gaussian predictive
-// model with known observation variance and Normal prior over the mean.
-type BOCPDDetector struct {
-	// MinPoints is the minimum number of points required before emitting.
-	// Default: 10
-	MinPoints int
+// bocpdSeriesState holds per-series streaming BOCPD state.
+type bocpdSeriesState struct {
+	key observer.SeriesKey
+	agg observer.Aggregate
 
-	// BaselineFraction is the fraction of points used for baseline variance estimation.
-	// Default: 0.25
-	BaselineFraction float64
+	// Cursor: how many points we've processed so far (count-based for safety).
+	lastProcessedTime  int64
+	lastProcessedCount int
+
+	// Warmup: Welford online mean/variance accumulation.
+	initialized    bool
+	warmupCount    int
+	warmupMean     float64
+	warmupM2       float64     // sum of squared deviations (Welford)
+	warmupBuffer   []float64   // buffered values for posterior replay after init
+
+	// Baseline (set once after warmup).
+	baselineMean   float64
+	baselineStddev float64
+	obsVar         float64
+	priorMean      float64
+	priorPrecision float64
+
+	// BOCPD posterior state (persists across advances).
+	runProbs   []float64
+	means      []float64
+	precisions []float64
+
+	// Pre-allocated swap buffers to avoid per-point allocation.
+	newRunProbs   []float64
+	newMeans      []float64
+	newPrecisions []float64
+
+	// Alert lifecycle.
+	inAlert        bool
+	alertStart     int64
+	recoveryCount  int // consecutive non-triggering points since last trigger
+}
+
+// BOCPDDetector detects changepoints using Bayesian Online Changepoint Detection.
+// This is a streaming, stateful Detector implementation that maintains per-series
+// posterior state and processes only newly visible points on each advance.
+type BOCPDDetector struct {
+	// WarmupPoints is the number of initial points used for baseline estimation.
+	// A longer warmup captures more of the metric's natural variability, reducing
+	// false positives from normal fluctuation. Default: 120 (~2 minutes at 1Hz).
+	WarmupPoints int
 
 	// Hazard is the constant changepoint hazard probability.
 	// Default: 0.05
@@ -37,8 +73,6 @@ type BOCPDDetector struct {
 	ShortRunLength int
 
 	// CPMassThreshold is the threshold for short-run posterior mass P(r_t <= k).
-	// This improves sensitivity to sustained regime shifts while remaining
-	// within BOCPD posterior-based detection.
 	// Default: 0.7
 	CPMassThreshold float64
 
@@ -49,19 +83,34 @@ type BOCPDDetector struct {
 	// PriorVarianceScale controls prior variance over the mean relative to observed variance.
 	// Default: 10.0
 	PriorVarianceScale float64
+
+	// RecoveryPoints is how many consecutive non-triggering points are needed
+	// to exit alert state. Default: 10
+	RecoveryPoints int
+
+	// Aggregations to run detection on. Default: [Average, Count]
+	Aggregations []observer.Aggregate
+
+	// per-series state keyed by "namespace|name|tags|agg"
+	series map[string]*bocpdSeriesState
 }
 
-// NewBOCPDDetector creates a BOCPD detector with defaults tuned for testbench use.
+// NewBOCPDDetector creates a streaming BOCPD detector with sensible defaults.
 func NewBOCPDDetector() *BOCPDDetector {
 	return &BOCPDDetector{
-		MinPoints:          10,
-		BaselineFraction:   0.25,
+		WarmupPoints:       120,
 		Hazard:             0.05,
 		CPThreshold:        0.6,
 		ShortRunLength:     5,
 		CPMassThreshold:    0.7,
 		MaxRunLength:       200,
 		PriorVarianceScale: 10.0,
+		RecoveryPoints:     10,
+		Aggregations: []observer.Aggregate{
+			observer.AggregateAverage,
+			observer.AggregateCount,
+		},
+		series: make(map[string]*bocpdSeriesState),
 	}
 }
 
@@ -70,159 +119,311 @@ func (b *BOCPDDetector) Name() string {
 	return "bocpd_detector"
 }
 
-// Analyze runs BOCPD and emits the first changepoint crossing CPThreshold.
-func (b *BOCPDDetector) Detect(series observer.Series) observer.DetectionResult {
-	minPoints := b.MinPoints
-	if minPoints <= 0 {
-		minPoints = 10
-	}
-	baselineFrac := b.BaselineFraction
-	if baselineFrac <= 0 {
-		baselineFrac = 0.25
-	}
-	hazard := b.Hazard
-	if hazard <= 0 || hazard >= 1 {
-		hazard = 0.05
-	}
-	threshold := b.CPThreshold
-	if threshold <= 0 || threshold >= 1 {
-		threshold = 0.6
-	}
-	shortRunLength := b.ShortRunLength
-	if shortRunLength <= 0 {
-		shortRunLength = 5
-	}
-	cpMassThreshold := b.CPMassThreshold
-	if cpMassThreshold <= 0 || cpMassThreshold >= 1 {
-		cpMassThreshold = 0.7
-	}
-	maxRunLength := b.MaxRunLength
-	if maxRunLength <= 0 {
-		maxRunLength = 200
-	}
-	priorVarScale := b.PriorVarianceScale
-	if priorVarScale <= 0 {
-		priorVarScale = 10.0
+// Detect implements Detector. It discovers series, reads only new points,
+// and updates per-series BOCPD posterior state incrementally.
+func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
+	b.ensureDefaults()
+
+	seriesKeys := storage.ListSeries(observer.SeriesFilter{})
+
+	var allAnomalies []observer.Anomaly
+	var allTelemetry []observer.ObserverTelemetry
+
+	for _, key := range seriesKeys {
+		for _, agg := range b.Aggregations {
+			stateKey := b.stateKey(key, agg)
+
+			// Get or create per-series state.
+			state, exists := b.series[stateKey]
+			if !exists {
+				state = b.newSeriesState(key, agg)
+				b.series[stateKey] = state
+			}
+
+			// Check if there are new points.
+			visibleCount := storage.PointCountUpTo(key, dataTime)
+			if visibleCount <= state.lastProcessedCount {
+				continue
+			}
+
+			// Read only new points since last processed time.
+			series := storage.GetSeriesRange(key, state.lastProcessedTime, dataTime, agg)
+			if series == nil || len(series.Points) == 0 {
+				continue
+			}
+
+			// Process each new point incrementally.
+			for _, p := range series.Points {
+				anomaly, telemetry := b.processPoint(state, p, series)
+				if anomaly != nil {
+					allAnomalies = append(allAnomalies, *anomaly)
+				}
+				allTelemetry = append(allTelemetry, telemetry...)
+			}
+
+			// Update cursor.
+			state.lastProcessedTime = series.Points[len(series.Points)-1].Timestamp
+			state.lastProcessedCount = visibleCount
+		}
 	}
 
-	n := len(series.Points)
-	if n < minPoints {
-		return observer.DetectionResult{}
+	return observer.DetectionResult{Anomalies: allAnomalies, Telemetry: allTelemetry}
+}
+
+// Reset clears all per-series state for replay/reanalysis.
+func (b *BOCPDDetector) Reset() {
+	b.series = make(map[string]*bocpdSeriesState)
+}
+
+// processPoint handles a single new observation for a series.
+// Returns an anomaly (if new alert onset) and telemetry for observability.
+func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, series *observer.Series) (*observer.Anomaly, []observer.ObserverTelemetry) {
+	x := p.Value
+
+	// Phase 1: Warmup — accumulate baseline statistics.
+	if !state.initialized {
+		return b.warmupPoint(state, x), nil
 	}
 
-	baselineEnd := int(float64(n) * baselineFrac)
-	if baselineEnd < 3 {
-		baselineEnd = 3
-	}
-	if baselineEnd >= n {
-		baselineEnd = n - 1
+	// Phase 2: Online BOCPD posterior update.
+	triggered, cpProb, shortRunMass := b.updatePosterior(state, x)
+
+	// Emit telemetry for cpProb and shortRunMass at each initialized point.
+	telemetry := []observer.ObserverTelemetry{
+		{
+			DetectorName: b.Name(),
+			Metric: &metricObs{
+				name:      "cp_prob",
+				value:     cpProb,
+				timestamp: p.Timestamp,
+			},
+		},
+		{
+			DetectorName: b.Name(),
+			Metric: &metricObs{
+				name:      "short_run_mass",
+				value:     shortRunMass,
+				timestamp: p.Timestamp,
+			},
+		},
 	}
 
-	baselinePoints := series.Points[:baselineEnd]
-	baselineMean := mean(baselinePoints)
-	baselineStddev := sampleStddev(baselinePoints, baselineMean)
+	// Phase 3: Alert lifecycle.
+	if triggered {
+		state.recoveryCount = 0
+		if !state.inAlert {
+			// New alert onset — emit anomaly.
+			state.inAlert = true
+			state.alertStart = p.Timestamp
+			return b.makeAnomaly(state, p, series, cpProb, shortRunMass), telemetry
+		}
+		// Already in alert — suppress repeated emission.
+		return nil, telemetry
+	}
+
+	// Not triggered on this point.
+	if state.inAlert {
+		state.recoveryCount++
+		if state.recoveryCount >= b.RecoveryPoints {
+			state.inAlert = false
+			state.recoveryCount = 0
+		}
+	}
+	return nil, telemetry
+}
+
+// warmupPoint accumulates a point during the warmup phase using Welford's algorithm.
+func (b *BOCPDDetector) warmupPoint(state *bocpdSeriesState, x float64) *observer.Anomaly {
+	state.warmupCount++
+	state.warmupBuffer = append(state.warmupBuffer, x)
+	delta := x - state.warmupMean
+	state.warmupMean += delta / float64(state.warmupCount)
+	delta2 := x - state.warmupMean
+	state.warmupM2 += delta * delta2
+
+	if state.warmupCount >= b.WarmupPoints {
+		b.initializeFromWarmup(state)
+	}
+	return nil
+}
+
+// initializeFromWarmup computes baseline parameters and initializes BOCPD posterior state.
+func (b *BOCPDDetector) initializeFromWarmup(state *bocpdSeriesState) {
+	variance := state.warmupM2 / float64(state.warmupCount-1) // sample variance (Bessel's correction)
+	stddev := math.Sqrt(variance)
+
 	const epsilon = 1e-10
-	if baselineStddev < epsilon {
-		if math.Abs(baselineMean) > epsilon {
-			baselineStddev = math.Abs(baselineMean) * 0.1
+	if stddev < epsilon {
+		if math.Abs(state.warmupMean) > epsilon {
+			stddev = math.Abs(state.warmupMean) * 0.1
 		} else {
-			return observer.DetectionResult{}
+			stddev = epsilon
 		}
+		variance = stddev * stddev
 	}
 
-	obsVar := baselineStddev * baselineStddev
-	priorMean := baselineMean
-	priorPrecision := 1.0 / (obsVar * priorVarScale)
+	state.baselineMean = state.warmupMean
+	state.baselineStddev = stddev
+	state.obsVar = variance
+	state.priorMean = state.warmupMean
+	state.priorPrecision = 1.0 / (variance * b.PriorVarianceScale)
 
-	// Pre-allocate buffers to maxRunLength+1 and swap between them
-	// to avoid per-point heap allocations in the hot loop.
-	bufSize := maxRunLength + 2 // +2 because we grow by 1 before truncating
-	runProbs := make([]float64, 1, bufSize)
-	means := make([]float64, 1, bufSize)
-	precisions := make([]float64, 1, bufSize)
-	runProbs[0] = 1.0
-	means[0] = priorMean
-	precisions[0] = priorPrecision
+	// Initialize posterior arrays.
+	bufSize := b.MaxRunLength + 2
+	state.runProbs = make([]float64, 1, bufSize)
+	state.means = make([]float64, 1, bufSize)
+	state.precisions = make([]float64, 1, bufSize)
+	state.runProbs[0] = 1.0
+	state.means[0] = state.priorMean
+	state.precisions[0] = state.priorPrecision
 
-	newRunProbs := make([]float64, 0, bufSize)
-	newMeans := make([]float64, 0, bufSize)
-	newPrecisions := make([]float64, 0, bufSize)
+	state.newRunProbs = make([]float64, 0, bufSize)
+	state.newMeans = make([]float64, 0, bufSize)
+	state.newPrecisions = make([]float64, 0, bufSize)
 
-	for i, p := range series.Points {
-		x := p.Value
-		predPrior := gaussianPDF(x, priorMean, obsVar+1.0/priorPrecision)
+	// Replay warmup points through the posterior to build up run-length
+	// hypotheses. This ensures the detector has context when it starts
+	// checking triggers on post-warmup points.
+	for _, val := range state.warmupBuffer {
+		b.updatePosterior(state, val)
+	}
+	state.warmupBuffer = nil // free memory
 
-		// Reuse pre-allocated buffer: reset length to len(runProbs)+1.
-		newLen := len(runProbs) + 1
-		newRunProbs = newRunProbs[:newLen]
-		newRunProbs[0] = hazard * predPrior
-		for r := range runProbs {
-			pred := gaussianPDF(x, means[r], obsVar+1.0/precisions[r])
-			newRunProbs[r+1] = runProbs[r] * (1.0 - hazard) * pred
-		}
+	state.initialized = true
+}
 
-		normalizeProbs(newRunProbs)
-		cpProb := newRunProbs[0]
-		shortRunMass := shortRunLengthMass(newRunProbs, shortRunLength)
+// updatePosterior performs one step of the BOCPD recurrence.
+// Returns (triggered, cpProb, shortRunMass).
+func (b *BOCPDDetector) updatePosterior(state *bocpdSeriesState, x float64) (bool, float64, float64) {
+	hazard := b.Hazard
+	predPrior := gaussianPDF(x, state.priorMean, state.obsVar+1.0/state.priorPrecision)
 
-		triggeredByPeak := cpProb >= threshold
-		triggeredByShift := shortRunMass >= cpMassThreshold
-		if i >= minPoints-1 && (triggeredByPeak || triggeredByShift) {
-			deviation := (x - baselineMean) / baselineStddev
-			triggerType := "short-run posterior mass"
-			triggerValue := shortRunMass
-			triggerThreshold := cpMassThreshold
-			if triggeredByPeak {
-				triggerType = "changepoint probability"
-				triggerValue = cpProb
-				triggerThreshold = threshold
-			}
-			anomaly := observer.Anomaly{
-				Source: observer.MetricName(series.Name),
-				Title:  fmt.Sprintf("BOCPD changepoint detected: %s", series.Name),
-				Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",
-					series.Name, triggerType, triggerValue, triggerThreshold, cpProb, shortRunLength, shortRunMass),
-				Tags:      series.Tags,
-				Timestamp: p.Timestamp,
-				DebugInfo: &observer.AnomalyDebugInfo{
-					BaselineStart:  series.Points[0].Timestamp,
-					BaselineEnd:    series.Points[baselineEnd-1].Timestamp,
-					BaselineMean:   baselineMean,
-					BaselineStddev: baselineStddev,
-					Threshold:      threshold,
-					CurrentValue:   x,
-					DeviationSigma: deviation,
-				},
-			}
-			return observer.DetectionResult{Anomalies: []observer.Anomaly{anomaly}}
-		}
-
-		// Reuse pre-allocated buffers for means and precisions.
-		newMeans = newMeans[:newLen]
-		newPrecisions = newPrecisions[:newLen]
-
-		// Run length 0 hypothesis: changepoint at current time, restart from prior.
-		newMeans[0], newPrecisions[0] = normalPosterior(priorMean, priorPrecision, x, obsVar)
-		// Growth hypotheses.
-		for r := range means {
-			newMeans[r+1], newPrecisions[r+1] = normalPosterior(means[r], precisions[r], x, obsVar)
-		}
-
-		if newLen > maxRunLength+1 {
-			newLen = maxRunLength + 1
-			newRunProbs = newRunProbs[:newLen]
-			newMeans = newMeans[:newLen]
-			newPrecisions = newPrecisions[:newLen]
-			normalizeProbs(newRunProbs)
-		}
-
-		// Swap buffers: current becomes "new" for next iteration.
-		runProbs, newRunProbs = newRunProbs, runProbs
-		means, newMeans = newMeans, means
-		precisions, newPrecisions = newPrecisions, precisions
+	// Compute new run-length probabilities.
+	newLen := len(state.runProbs) + 1
+	state.newRunProbs = state.newRunProbs[:newLen]
+	state.newRunProbs[0] = hazard * predPrior
+	for r := range state.runProbs {
+		pred := gaussianPDF(x, state.means[r], state.obsVar+1.0/state.precisions[r])
+		state.newRunProbs[r+1] = state.runProbs[r] * (1.0 - hazard) * pred
 	}
 
-	return observer.DetectionResult{}
+	normalizeProbs(state.newRunProbs)
+	cpProb := state.newRunProbs[0]
+	shortRunMass := shortRunLengthMass(state.newRunProbs, b.ShortRunLength)
+
+	// Update posterior means and precisions.
+	state.newMeans = state.newMeans[:newLen]
+	state.newPrecisions = state.newPrecisions[:newLen]
+	state.newMeans[0], state.newPrecisions[0] = normalPosterior(state.priorMean, state.priorPrecision, x, state.obsVar)
+	for r := range state.means {
+		state.newMeans[r+1], state.newPrecisions[r+1] = normalPosterior(state.means[r], state.precisions[r], x, state.obsVar)
+	}
+
+	// Truncate to MaxRunLength.
+	if newLen > b.MaxRunLength+1 {
+		newLen = b.MaxRunLength + 1
+		state.newRunProbs = state.newRunProbs[:newLen]
+		state.newMeans = state.newMeans[:newLen]
+		state.newPrecisions = state.newPrecisions[:newLen]
+		normalizeProbs(state.newRunProbs)
+	}
+
+	// Swap buffers.
+	state.runProbs, state.newRunProbs = state.newRunProbs, state.runProbs
+	state.means, state.newMeans = state.newMeans, state.means
+	state.precisions, state.newPrecisions = state.newPrecisions, state.precisions
+
+	// Check trigger conditions.
+	// Short-run mass is only meaningful when there are run-length hypotheses
+	// beyond the short-run window; otherwise all mass is trivially "short."
+	triggeredByPeak := cpProb >= b.CPThreshold
+	triggeredByShift := shortRunMass >= b.CPMassThreshold && len(state.runProbs) > b.ShortRunLength+1
+	triggered := triggeredByPeak || triggeredByShift
+	return triggered, cpProb, shortRunMass
+}
+
+// makeAnomaly constructs an Anomaly for a new alert onset.
+func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, cpProb, shortRunMass float64) *observer.Anomaly {
+	seriesName := series.Name + ":" + aggSuffix(state.agg)
+	deviation := (p.Value - state.baselineMean) / state.baselineStddev
+
+	triggerType := "short-run posterior mass"
+	triggerValue := shortRunMass
+	triggerThreshold := b.CPMassThreshold
+	if cpProb >= b.CPThreshold {
+		triggerType = "changepoint probability"
+		triggerValue = cpProb
+		triggerThreshold = b.CPThreshold
+	}
+
+	return &observer.Anomaly{
+		Type:           observer.AnomalyTypeMetric,
+		Source:         observer.MetricName(seriesName),
+		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
+		DetectorName:   b.Name(),
+		Title:          fmt.Sprintf("BOCPD changepoint detected: %s", seriesName),
+		Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",
+			seriesName, triggerType, triggerValue, triggerThreshold, cpProb, b.ShortRunLength, shortRunMass),
+		Tags:      series.Tags,
+		Timestamp: p.Timestamp,
+		DebugInfo: &observer.AnomalyDebugInfo{
+			BaselineMean:   state.baselineMean,
+			BaselineStddev: state.baselineStddev,
+			Threshold:      triggerThreshold,
+			CurrentValue:   p.Value,
+			DeviationSigma: deviation,
+		},
+	}
+}
+
+// stateKey returns a unique key for per-series state tracking.
+func (b *BOCPDDetector) stateKey(key observer.SeriesKey, agg observer.Aggregate) string {
+	return seriesKey(key.Namespace, key.Name, key.Tags) + "|" + aggSuffix(agg)
+}
+
+// newSeriesState creates a fresh per-series state entry.
+func (b *BOCPDDetector) newSeriesState(key observer.SeriesKey, agg observer.Aggregate) *bocpdSeriesState {
+	return &bocpdSeriesState{
+		key: key,
+		agg: agg,
+	}
+}
+
+// ensureDefaults fills in zero-valued config fields with sensible defaults.
+func (b *BOCPDDetector) ensureDefaults() {
+	if b.WarmupPoints <= 0 {
+		b.WarmupPoints = 120
+	}
+	if b.Hazard <= 0 || b.Hazard >= 1 {
+		b.Hazard = 0.05
+	}
+	if b.CPThreshold <= 0 || b.CPThreshold >= 1 {
+		b.CPThreshold = 0.6
+	}
+	if b.ShortRunLength <= 0 {
+		b.ShortRunLength = 5
+	}
+	if b.CPMassThreshold <= 0 || b.CPMassThreshold >= 1 {
+		b.CPMassThreshold = 0.7
+	}
+	if b.MaxRunLength <= 0 {
+		b.MaxRunLength = 200
+	}
+	if b.PriorVarianceScale <= 0 {
+		b.PriorVarianceScale = 10.0
+	}
+	if b.RecoveryPoints <= 0 {
+		b.RecoveryPoints = 10
+	}
+	if b.series == nil {
+		b.series = make(map[string]*bocpdSeriesState)
+	}
+	if len(b.Aggregations) == 0 {
+		b.Aggregations = []observer.Aggregate{
+			observer.AggregateAverage,
+			observer.AggregateCount,
+		}
+	}
 }
 
 func shortRunLengthMass(runProbs []float64, shortRunLength int) float64 {

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -84,6 +84,11 @@ type BOCPDDetector struct {
 	// Default: 10.0
 	PriorVarianceScale float64
 
+	// MinVariance is the floor for observation variance. When warmup data has
+	// near-zero variance (e.g. constant series), this prevents pathologically
+	// sharp PDFs that would flag any tiny fluctuation as anomalous. Default: 1.0
+	MinVariance float64
+
 	// RecoveryPoints is how many consecutive non-triggering points are needed
 	// to exit alert state. Default: 10
 	RecoveryPoints int
@@ -105,6 +110,7 @@ func NewBOCPDDetector() *BOCPDDetector {
 		CPMassThreshold:    0.7,
 		MaxRunLength:       200,
 		PriorVarianceScale: 10.0,
+		MinVariance:        1.0,
 		RecoveryPoints:     10,
 		Aggregations: []observer.Aggregate{
 			observer.AggregateAverage,
@@ -252,14 +258,9 @@ func (b *BOCPDDetector) initializeFromWarmup(state *bocpdSeriesState) {
 	variance := state.warmupM2 / float64(state.warmupCount-1) // sample variance (Bessel's correction)
 	stddev := math.Sqrt(variance)
 
-	const epsilon = 1e-10
-	if stddev < epsilon {
-		if math.Abs(state.warmupMean) > epsilon {
-			stddev = math.Abs(state.warmupMean) * 0.1
-		} else {
-			stddev = epsilon
-		}
-		variance = stddev * stddev
+	if variance < b.MinVariance {
+		variance = b.MinVariance
+		stddev = math.Sqrt(variance)
 	}
 
 	state.baselineMean = state.warmupMean

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -134,15 +134,27 @@ func (b *BOCPDDetector) Detect(series observer.Series) observer.DetectionResult 
 	priorMean := baselineMean
 	priorPrecision := 1.0 / (obsVar * priorVarScale)
 
-	runProbs := []float64{1.0}
-	means := []float64{priorMean}
-	precisions := []float64{priorPrecision}
+	// Pre-allocate buffers to maxRunLength+1 and swap between them
+	// to avoid per-point heap allocations in the hot loop.
+	bufSize := maxRunLength + 2 // +2 because we grow by 1 before truncating
+	runProbs := make([]float64, 1, bufSize)
+	means := make([]float64, 1, bufSize)
+	precisions := make([]float64, 1, bufSize)
+	runProbs[0] = 1.0
+	means[0] = priorMean
+	precisions[0] = priorPrecision
+
+	newRunProbs := make([]float64, 0, bufSize)
+	newMeans := make([]float64, 0, bufSize)
+	newPrecisions := make([]float64, 0, bufSize)
 
 	for i, p := range series.Points {
 		x := p.Value
 		predPrior := gaussianPDF(x, priorMean, obsVar+1.0/priorPrecision)
 
-		newRunProbs := make([]float64, len(runProbs)+1)
+		// Reuse pre-allocated buffer: reset length to len(runProbs)+1.
+		newLen := len(runProbs) + 1
+		newRunProbs = newRunProbs[:newLen]
 		newRunProbs[0] = hazard * predPrior
 		for r := range runProbs {
 			pred := gaussianPDF(x, means[r], obsVar+1.0/precisions[r])
@@ -185,8 +197,9 @@ func (b *BOCPDDetector) Detect(series observer.Series) observer.DetectionResult 
 			return observer.DetectionResult{Anomalies: []observer.Anomaly{anomaly}}
 		}
 
-		newMeans := make([]float64, len(newRunProbs))
-		newPrecisions := make([]float64, len(newRunProbs))
+		// Reuse pre-allocated buffers for means and precisions.
+		newMeans = newMeans[:newLen]
+		newPrecisions = newPrecisions[:newLen]
 
 		// Run length 0 hypothesis: changepoint at current time, restart from prior.
 		newMeans[0], newPrecisions[0] = normalPosterior(priorMean, priorPrecision, x, obsVar)
@@ -195,16 +208,18 @@ func (b *BOCPDDetector) Detect(series observer.Series) observer.DetectionResult 
 			newMeans[r+1], newPrecisions[r+1] = normalPosterior(means[r], precisions[r], x, obsVar)
 		}
 
-		if len(newRunProbs) > maxRunLength+1 {
-			newRunProbs = newRunProbs[:maxRunLength+1]
-			newMeans = newMeans[:maxRunLength+1]
-			newPrecisions = newPrecisions[:maxRunLength+1]
+		if newLen > maxRunLength+1 {
+			newLen = maxRunLength + 1
+			newRunProbs = newRunProbs[:newLen]
+			newMeans = newMeans[:newLen]
+			newPrecisions = newPrecisions[:newLen]
 			normalizeProbs(newRunProbs)
 		}
 
-		runProbs = newRunProbs
-		means = newMeans
-		precisions = newPrecisions
+		// Swap buffers: current becomes "new" for next iteration.
+		runProbs, newRunProbs = newRunProbs, runProbs
+		means, newMeans = newMeans, means
+		precisions, newPrecisions = newPrecisions, precisions
 	}
 
 	return observer.DetectionResult{}

--- a/comp/observer/impl/metrics_detector_bocpd_test.go
+++ b/comp/observer/impl/metrics_detector_bocpd_test.go
@@ -91,8 +91,11 @@ func TestBOCPDDetector_DetectsSustainedShiftViaShortRunMass(t *testing.T) {
 
 	storage := newTimeSeriesStorage()
 
+	// Use jittered warmup so the detector learns real variance (~10 stddev)
+	// rather than relying on the MinVariance floor. This keeps the 100→115
+	// shift small enough to trigger via short-run mass rather than cpProb.
 	for i := 0; i < 30; i++ {
-		storage.Add("ns", "test.metric", 100, int64(i+1), nil)
+		storage.Add("ns", "test.metric", 100+float64(i%3-1)*5, int64(i+1), nil)
 	}
 	for i := 30; i < 60; i++ {
 		storage.Add("ns", "test.metric", 115, int64(i+1), nil)

--- a/comp/observer/impl/metrics_detector_bocpd_test.go
+++ b/comp/observer/impl/metrics_detector_bocpd_test.go
@@ -10,7 +10,16 @@ import (
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// testBOCPDDetector returns a BOCPD detector with a short warmup suitable for
+// unit tests with small data sets.
+func testBOCPDDetector() *BOCPDDetector {
+	d := NewBOCPDDetector()
+	d.WarmupPoints = 20
+	return d
+}
 
 func TestBOCPDDetector_Name(t *testing.T) {
 	d := NewBOCPDDetector()
@@ -18,87 +27,215 @@ func TestBOCPDDetector_Name(t *testing.T) {
 }
 
 func TestBOCPDDetector_NotEnoughPoints(t *testing.T) {
-	d := NewBOCPDDetector()
-	series := observer.Series{
-		Name:   "test.metric",
-		Points: []observer.Point{{Timestamp: 1, Value: 100}},
-	}
+	d := testBOCPDDetector()
+	storage := newTimeSeriesStorage()
+	storage.Add("ns", "test.metric", 100, 1, nil)
 
-	result := d.Detect(series)
+	result := d.Detect(storage, 1)
 	assert.Empty(t, result.Anomalies)
 }
 
 func TestBOCPDDetector_StableData(t *testing.T) {
-	d := NewBOCPDDetector()
+	d := testBOCPDDetector()
+	storage := newTimeSeriesStorage()
 
-	points := make([]observer.Point, 40)
 	for i := 0; i < 40; i++ {
-		points[i] = observer.Point{Timestamp: int64(i + 1), Value: 100 + float64(i%3-1)}
+		storage.Add("ns", "test.metric", 100+float64(i%3-1), int64(i+1), nil)
 	}
 
-	series := observer.Series{Name: "test.metric", Points: points}
-	result := d.Detect(series)
+	result := d.Detect(storage, 40)
 	assert.Empty(t, result.Anomalies, "stable data should not trigger BOCPD")
 }
 
 func TestBOCPDDetector_DetectsStepChange(t *testing.T) {
-	d := NewBOCPDDetector()
+	d := testBOCPDDetector()
+	storage := newTimeSeriesStorage()
 
-	points := make([]observer.Point, 40)
 	for i := 0; i < 20; i++ {
-		points[i] = observer.Point{Timestamp: int64(i + 1), Value: 100}
+		storage.Add("ns", "test.metric", 100, int64(i+1), nil)
 	}
 	for i := 20; i < 40; i++ {
-		points[i] = observer.Point{Timestamp: int64(i + 1), Value: 140}
+		storage.Add("ns", "test.metric", 140, int64(i+1), nil)
 	}
 
-	series := observer.Series{Name: "test.metric", Points: points}
-	result := d.Detect(series)
+	result := d.Detect(storage, 40)
 
-	if assert.Len(t, result.Anomalies, 1) {
-		assert.Contains(t, result.Anomalies[0].Title, "BOCPD")
-		assert.GreaterOrEqual(t, result.Anomalies[0].Timestamp, int64(21))
-	}
+	require.NotEmpty(t, result.Anomalies, "should detect step change")
+	assert.Contains(t, result.Anomalies[0].Title, "BOCPD")
+	assert.GreaterOrEqual(t, result.Anomalies[0].Timestamp, int64(21))
 }
 
 func TestBOCPDDetector_DetectsDownwardStepChange(t *testing.T) {
-	d := NewBOCPDDetector()
+	d := testBOCPDDetector()
+	storage := newTimeSeriesStorage()
 
-	points := make([]observer.Point, 50)
 	for i := 0; i < 25; i++ {
-		points[i] = observer.Point{Timestamp: int64(i + 1), Value: 100}
+		storage.Add("ns", "test.metric", 100, int64(i+1), nil)
 	}
 	for i := 25; i < 50; i++ {
-		points[i] = observer.Point{Timestamp: int64(i + 1), Value: 70}
+		storage.Add("ns", "test.metric", 70, int64(i+1), nil)
 	}
 
-	series := observer.Series{Name: "test.metric", Points: points}
-	result := d.Detect(series)
+	result := d.Detect(storage, 50)
 
-	if assert.Len(t, result.Anomalies, 1) {
-		assert.Contains(t, result.Anomalies[0].Title, "BOCPD")
-		assert.Contains(t, result.Anomalies[0].Description, "exceeded threshold")
-	}
+	require.NotEmpty(t, result.Anomalies, "should detect downward step change")
+	assert.Contains(t, result.Anomalies[0].Title, "BOCPD")
+	assert.Contains(t, result.Anomalies[0].Description, "exceeded threshold")
 }
 
 func TestBOCPDDetector_DetectsSustainedShiftViaShortRunMass(t *testing.T) {
-	d := NewBOCPDDetector()
+	d := testBOCPDDetector()
 	d.CPThreshold = 0.99     // discourage pure r_t=0 triggers
 	d.CPMassThreshold = 0.55 // allow short-run posterior mass trigger
 	d.ShortRunLength = 6
 
-	points := make([]observer.Point, 60)
+	storage := newTimeSeriesStorage()
+
 	for i := 0; i < 30; i++ {
-		points[i] = observer.Point{Timestamp: int64(i + 1), Value: 100}
+		storage.Add("ns", "test.metric", 100, int64(i+1), nil)
 	}
 	for i := 30; i < 60; i++ {
-		points[i] = observer.Point{Timestamp: int64(i + 1), Value: 115}
+		storage.Add("ns", "test.metric", 115, int64(i+1), nil)
 	}
 
-	series := observer.Series{Name: "test.metric", Points: points}
-	result := d.Detect(series)
+	result := d.Detect(storage, 60)
 
-	if assert.Len(t, result.Anomalies, 1) {
-		assert.Contains(t, result.Anomalies[0].Description, "short-run posterior mass")
+	require.NotEmpty(t, result.Anomalies, "should detect sustained shift")
+	assert.Contains(t, result.Anomalies[0].Description, "short-run posterior mass")
+}
+
+func TestBOCPDDetector_SustainedIncidentEmitsOnce(t *testing.T) {
+	d := testBOCPDDetector()
+	storage := newTimeSeriesStorage()
+
+	// 20 stable points, then 40 shifted points.
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "test.metric", 100, int64(i+1), nil)
 	}
+	for i := 20; i < 60; i++ {
+		storage.Add("ns", "test.metric", 200, int64(i+1), nil)
+	}
+
+	result := d.Detect(storage, 60)
+
+	// Should emit at most one anomaly per series/agg despite sustained shift.
+	anomalyCount := 0
+	for _, a := range result.Anomalies {
+		if a.Source == "test.metric:avg" {
+			anomalyCount++
+		}
+	}
+	assert.Equal(t, 1, anomalyCount, "sustained incident should emit exactly one anomaly per series/agg")
+}
+
+func TestBOCPDDetector_IncrementalAdvance(t *testing.T) {
+	d := testBOCPDDetector()
+	storage := newTimeSeriesStorage()
+
+	// First advance: 20 stable points.
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "test.metric", 100, int64(i+1), nil)
+	}
+	result1 := d.Detect(storage, 20)
+	assert.Empty(t, result1.Anomalies, "no anomaly in stable data")
+
+	// Second advance: add a big jump.
+	for i := 20; i < 30; i++ {
+		storage.Add("ns", "test.metric", 200, int64(i+1), nil)
+	}
+	result2 := d.Detect(storage, 30)
+	assert.NotEmpty(t, result2.Anomalies, "should detect step change on second advance")
+
+	// Third advance: no new data — should emit nothing.
+	result3 := d.Detect(storage, 30)
+	assert.Empty(t, result3.Anomalies, "no new data should produce no anomalies")
+}
+
+func TestBOCPDDetector_RecoveryAndReAlert(t *testing.T) {
+	d := testBOCPDDetector()
+	d.RecoveryPoints = 5
+	storage := newTimeSeriesStorage()
+	ts := int64(0)
+
+	addN := func(n int, val float64) {
+		for i := 0; i < n; i++ {
+			ts++
+			storage.Add("ns", "m", val, ts, nil)
+		}
+	}
+
+	// Warmup + stable baseline.
+	addN(25, 100)
+	r1 := d.Detect(storage, ts)
+	assert.Empty(t, r1.Anomalies)
+
+	// First incident.
+	addN(10, 300)
+	r2 := d.Detect(storage, ts)
+	assert.NotEmpty(t, r2.Anomalies, "should detect first incident")
+
+	// Recovery: stable for enough points.
+	addN(20, 100)
+	r3 := d.Detect(storage, ts)
+
+	// Second incident.
+	addN(10, 300)
+	r4 := d.Detect(storage, ts)
+
+	// Count total anomalies for m:avg across r3 and r4.
+	avgAnomalies := 0
+	for _, a := range append(r3.Anomalies, r4.Anomalies...) {
+		if a.Source == "m:avg" {
+			avgAnomalies++
+		}
+	}
+	assert.GreaterOrEqual(t, avgAnomalies, 1, "should detect second incident after recovery")
+}
+
+func TestBOCPDDetector_Reset(t *testing.T) {
+	d := testBOCPDDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 30; i++ {
+		storage.Add("ns", "test.metric", 100, int64(i+1), nil)
+	}
+	d.Detect(storage, 30)
+	assert.NotEmpty(t, d.series, "should have state after detection")
+
+	d.Reset()
+	assert.Empty(t, d.series, "reset should clear all state")
+}
+
+func TestBOCPDDetector_DeterministicReplay(t *testing.T) {
+	makeDetector := func() *BOCPDDetector { return testBOCPDDetector() }
+
+	storage := newTimeSeriesStorage()
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "m", 100, int64(i+1), nil)
+	}
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "m", 200, int64(i+1), nil)
+	}
+
+	d1 := makeDetector()
+	r1 := d1.Detect(storage, 40)
+
+	d2 := makeDetector()
+	r2 := d2.Detect(storage, 40)
+
+	require.Equal(t, len(r1.Anomalies), len(r2.Anomalies), "replay should produce same anomaly count")
+	for i := range r1.Anomalies {
+		assert.Equal(t, r1.Anomalies[i].Timestamp, r2.Anomalies[i].Timestamp, "anomaly timestamps should match")
+		assert.Equal(t, r1.Anomalies[i].Source, r2.Anomalies[i].Source, "anomaly sources should match")
+	}
+}
+
+func TestBOCPDDetector_DefaultAggregations(t *testing.T) {
+	d := NewBOCPDDetector()
+	assert.Equal(t, []observer.Aggregate{observer.AggregateAverage, observer.AggregateCount}, d.Aggregations)
+}
+
+func TestBOCPDDetector_DefaultWarmup120(t *testing.T) {
+	d := NewBOCPDDetector()
+	assert.Equal(t, 120, d.WarmupPoints, "default warmup should be 120 points")
 }

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -433,6 +433,14 @@ func (a *seriesDetectorAdapter) Name() string {
 	return a.detector.Name()
 }
 
+// Reset clears adapter-local caches and resets the wrapped detector when supported.
+func (a *seriesDetectorAdapter) Reset() {
+	a.lastVisibleCount = make(map[string]int)
+	if resetter, ok := a.detector.(interface{ Reset() }); ok {
+		resetter.Reset()
+	}
+}
+
 func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	seriesKeys := storage.ListSeries(observerdef.SeriesFilter{})
 

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -194,11 +194,11 @@ func NewComponent(deps Requires) Provides {
 	}
 
 	eng := newEngine(engineConfig{
-		storage:    newTimeSeriesStorage(),
-		extractors: extractors,
-		detectors:  detectors,
+		storage:     newTimeSeriesStorage(),
+		extractors:  extractors,
+		detectors:   detectors,
 		correlators: correlators,
-		scheduler:  &currentBehaviorPolicy{},
+		scheduler:   &currentBehaviorPolicy{},
 	})
 
 	// Wire reporters via event subscription.
@@ -415,9 +415,9 @@ type seriesDetectorAdapter struct {
 
 	// Per-series caching: PointCountUpTo (binary search, no copying) tells us
 	// cheaply whether a series has new visible data. When it hasn't changed,
-	// we reuse the cached detection result for that series.
+	// we skip detection entirely so callers do not see duplicate anomaly or
+	// telemetry events for unchanged data.
 	lastVisibleCount map[string]int
-	lastSeriesResult map[string]observerdef.DetectionResult
 }
 
 func newSeriesDetectorAdapter(detector observerdef.SeriesDetector, aggregations []observerdef.Aggregate) *seriesDetectorAdapter {
@@ -426,7 +426,6 @@ func newSeriesDetectorAdapter(detector observerdef.SeriesDetector, aggregations 
 		aggregations:     aggregations,
 		windowSec:        defaultDetectorWindowSec,
 		lastVisibleCount: make(map[string]int),
-		lastSeriesResult: make(map[string]observerdef.DetectionResult),
 	}
 }
 
@@ -446,11 +445,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 		// Cheap check: has this series gained any newly visible points?
 		visibleCount := storage.PointCountUpTo(key, dataTime)
 		if prev, ok := a.lastVisibleCount[k]; ok && prev == visibleCount {
-			// No new data — reuse cached results for this series.
-			if cached, hasCached := a.lastSeriesResult[k]; hasCached {
-				allAnomalies = append(allAnomalies, cached.Anomalies...)
-				allTelemetry = append(allTelemetry, cached.Telemetry...)
-			}
+			// No new data — do not re-run the detector or re-emit prior outputs.
 			continue
 		}
 		a.lastVisibleCount[k] = visibleCount
@@ -483,10 +478,6 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 			seriesTelemetry = append(seriesTelemetry, result.Telemetry...)
 		}
 
-		a.lastSeriesResult[k] = observerdef.DetectionResult{
-			Anomalies: seriesAnomalies,
-			Telemetry: seriesTelemetry,
-		}
 		allAnomalies = append(allAnomalies, seriesAnomalies...)
 		allTelemetry = append(allTelemetry, seriesTelemetry...)
 	}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -173,43 +172,47 @@ func (l *logObs) GetTimestampUnixMilli() int64 {
 
 // NewComponent creates an observer.Component.
 func NewComponent(deps Requires) Provides {
-	correlator := NewCorrelator(CorrelatorConfig{})
-	reporter := &StdoutReporter{}
+	catalog := defaultCatalog()
+	detectors, correlators, _ := catalog.Instantiate(nil)
 
-	// Connect the reporter to the correlator's state
-	reporter.SetCorrelationState(correlator)
+	extractors := []observerdef.LogMetricsExtractor{
+		&LogMetricsExtractor{
+			MaxEvalBytes: 4096,
+			// Exclude metadata fields that shouldn't be metrics.
+			// These are common timestamp/ID fields that appear in event JSON.
+			ExcludeFields: map[string]struct{}{
+				"timestamp": {}, // event.Event.Ts serializes as "timestamp"
+				"ts":        {}, // alternate timestamp field name
+				"time":      {},
+				"pid":       {},
+				"ppid":      {},
+				"uid":       {},
+				"gid":       {},
+			},
+		},
+		&ConnectionErrorExtractor{},
+	}
+
+	eng := newEngine(engineConfig{
+		storage:    newTimeSeriesStorage(),
+		extractors: extractors,
+		detectors:  detectors,
+		correlators: correlators,
+		scheduler:  &currentBehaviorPolicy{},
+	})
+
+	// Wire reporters via event subscription.
+	// The reporterEventSink queries stateView for active correlations on each advance,
+	// so reporters receive all needed data through ReportOutput without backdoor access.
+	reporter := &StdoutReporter{}
+	eng.Subscribe(&reporterEventSink{
+		reporters: []observerdef.Reporter{reporter},
+		state:     eng.StateView(),
+	})
 
 	obs := &observerImpl{
-		extractors: []observerdef.LogMetricsExtractor{
-			&LogMetricsExtractor{
-				MaxEvalBytes: 4096,
-				// Exclude metadata fields that shouldn't be metrics.
-				// These are common timestamp/ID fields that appear in event JSON.
-				ExcludeFields: map[string]struct{}{
-					"timestamp": {}, // event.Event.Ts serializes as "timestamp"
-					"ts":        {}, // alternate timestamp field name
-					"time":      {},
-					"pid":       {},
-					"ppid":      {},
-					"uid":       {},
-					"gid":       {},
-				},
-			},
-			&ConnectionErrorExtractor{},
-		},
-		detectors: []observerdef.Detector{
-			newSeriesDetectorAdapter(NewCUSUMDetector(), defaultAggregations),
-			newSeriesDetectorAdapter(NewBOCPDDetector(), defaultAggregations),
-			NewRRCFDetector(DefaultRRCFConfig()),
-		},
-		correlators: []observerdef.Correlator{
-			correlator,
-		},
-		reporters: []observerdef.Reporter{
-			reporter,
-		},
-		storage: newTimeSeriesStorage(),
-		obsCh:   make(chan observation, 1000),
+		engine: eng,
+		obsCh:  make(chan observation, 1000),
 	}
 
 	cfg := pkgconfigsetup.Datadog()
@@ -350,37 +353,26 @@ func samplePass(rate float64, n uint64) bool {
 }
 
 // observerImpl is the implementation of the observer component.
+// It is a thin driver around the engine, which holds storage, extractors,
+// detectors, correlators, and raw anomaly tracking.
 type observerImpl struct {
-	extractors  []observerdef.LogMetricsExtractor
-	detectors   []observerdef.Detector
-	correlators []observerdef.Correlator
-	reporters   []observerdef.Reporter
-	storage     *timeSeriesStorage
-	obsCh       chan observation
-	handleFunc  observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
-
-	// Raw anomaly tracking for test bench display
-	rawAnomalies     []observerdef.Anomaly
-	rawAnomalyMu     sync.RWMutex
-	rawAnomalyWindow int64 // seconds to keep raw anomalies (0 = unlimited)
-	maxRawAnomalies  int   // max number of raw anomalies to keep (0 = unlimited)
-	currentDataTime  int64 // latest data timestamp seen
+	engine     *engine
+	obsCh      chan observation
+	handleFunc observerdef.HandleFunc // Handle factory (may wrap with recorder middleware)
 
 	// fetcher pulls traces/profiles from remote trace-agents
-	fetcher              *observerFetcher
-	totalAnomalyCount    int                             // total count of all anomalies ever detected (no cap)
-	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
-	lastAnalyzedDataTime int64                           // data timestamp up to which we've analyzed
+	fetcher *observerFetcher
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
 func (o *observerImpl) run() {
 	for obs := range o.obsCh {
+		var requests []advanceRequest
 		if obs.metric != nil {
-			o.processMetric(obs.source, obs.metric)
+			requests = o.engine.IngestMetric(obs.source, obs.metric)
 		}
 		if obs.log != nil {
-			o.processLog(obs.source, obs.log)
+			requests = append(requests, o.engine.IngestLog(obs.source, obs.log)...)
 		}
 		if obs.trace != nil {
 			o.processTrace(obs.source, obs.trace)
@@ -388,63 +380,15 @@ func (o *observerImpl) run() {
 		if obs.profile != nil {
 			o.processProfile(obs.source, obs.profile)
 		}
-	}
-}
-
-// processMetric handles a metric observation.
-func (o *observerImpl) processMetric(source string, m *metricObs) {
-	o.storage.Add(source, m.name, m.value, m.timestamp, m.tags)
-	o.maybeRunDetectors(m.timestamp)
-}
-
-// processLog handles a log observation.
-func (o *observerImpl) processLog(source string, l *logObs) {
-	view := &logView{obs: l}
-	for _, extractor := range o.extractors {
-		metrics := extractor.ProcessLog(view)
-		for _, m := range metrics {
-			// Virtual metrics coming from logs starts with _virtual.
-			o.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
+		for _, req := range requests {
+			o.engine.advanceWithReason(req.upToSec, req.reason)
 		}
 	}
-	// Allow detectors to observe logs directly
-	for _, d := range o.detectors {
-		if lo, ok := d.(observerdef.LogObserver); ok {
-			lo.ProcessLog(view)
-		}
-	}
-	o.maybeRunDetectors(l.timestampMs / 1000)
 }
 
-// maybeRunDetectors checks if data time has advanced enough to trigger detection.
-// We only analyze complete seconds - when we see data at time T, we analyze up to T-1.
-// This ensures deterministic output regardless of batch vs streaming ingestion.
-func (o *observerImpl) maybeRunDetectors(dataTime int64) {
-	// Only analyze complete seconds (everything strictly before current second)
-	analyzeUpTo := dataTime - 1
-
-	if analyzeUpTo <= o.lastAnalyzedDataTime {
-		return
-	}
-
-	o.runDetectorsUpTo(analyzeUpTo)
-	o.lastAnalyzedDataTime = analyzeUpTo
-}
-
-// runDetectorsUpTo runs all multi-series detectors, providing them access to storage
-// and the data timestamp up to which they should analyze.
-func (o *observerImpl) runDetectorsUpTo(upTo int64) {
-	for _, detector := range o.detectors {
-		result := detector.Detect(o.storage, upTo)
-		for _, anomaly := range result.Anomalies {
-			o.captureRawAnomaly(anomaly)
-			o.processAnomaly(anomaly)
-		}
-		// TODO: handle result.Telemetry in live observer (currently only used by testbench)
-	}
-
-	o.flushAndReport()
-}
+// defaultDetectorWindowSec is the default window (in seconds) that limits how
+// far back seriesDetectorAdapter reads when running detection. 300s = 5 minutes.
+const defaultDetectorWindowSec = 300
 
 // defaultAggregations is the standard set of aggregations used when adapting
 // a SeriesDetector into a Detector.
@@ -455,15 +399,34 @@ var defaultAggregations = []observerdef.Aggregate{
 
 // seriesDetectorAdapter wraps a stateless SeriesDetector to implement Detector.
 // It runs the wrapped detector on all series, handling aggregation suffixes.
+//
+// The adapter tracks the point count per series/aggregation so it can skip
+// re-running the detector when no new data has arrived. This is important
+// because stateless detectors re-analyze the full series from scratch each
+// call — without this guard, per-second advancement would be O(N²).
 type seriesDetectorAdapter struct {
 	detector     observerdef.SeriesDetector
 	aggregations []observerdef.Aggregate
+
+	// windowSec limits how far back GetSeriesRange reads. 0 means unbounded
+	// (read from timestamp 0). A positive value reads [dataTime-windowSec, dataTime],
+	// bounding per-call cost to O(windowSec) instead of O(totalPoints).
+	windowSec int64
+
+	// Per-series caching: PointCountUpTo (binary search, no copying) tells us
+	// cheaply whether a series has new visible data. When it hasn't changed,
+	// we reuse the cached detection result for that series.
+	lastVisibleCount map[string]int
+	lastSeriesResult map[string]observerdef.DetectionResult
 }
 
 func newSeriesDetectorAdapter(detector observerdef.SeriesDetector, aggregations []observerdef.Aggregate) *seriesDetectorAdapter {
 	return &seriesDetectorAdapter{
-		detector:     detector,
-		aggregations: aggregations,
+		detector:         detector,
+		aggregations:     aggregations,
+		windowSec:        defaultDetectorWindowSec,
+		lastVisibleCount: make(map[string]int),
+		lastSeriesResult: make(map[string]observerdef.DetectionResult),
 	}
 }
 
@@ -472,34 +435,60 @@ func (a *seriesDetectorAdapter) Name() string {
 }
 
 func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
+	seriesKeys := storage.ListSeries(observerdef.SeriesFilter{})
+
 	var allAnomalies []observerdef.Anomaly
 	var allTelemetry []observerdef.ObserverTelemetry
 
-	// Get all series (no filter = everything)
-	seriesKeys := storage.ListSeries(observerdef.SeriesFilter{})
-
 	for _, key := range seriesKeys {
+		k := seriesKey(key.Namespace, key.Name, key.Tags)
+
+		// Cheap check: has this series gained any newly visible points?
+		visibleCount := storage.PointCountUpTo(key, dataTime)
+		if prev, ok := a.lastVisibleCount[k]; ok && prev == visibleCount {
+			// No new data — reuse cached results for this series.
+			if cached, hasCached := a.lastSeriesResult[k]; hasCached {
+				allAnomalies = append(allAnomalies, cached.Anomalies...)
+				allTelemetry = append(allTelemetry, cached.Telemetry...)
+			}
+			continue
+		}
+		a.lastVisibleCount[k] = visibleCount
+
+		// Series has new data — run detector on each aggregation.
+		var seriesAnomalies []observerdef.Anomaly
+		var seriesTelemetry []observerdef.ObserverTelemetry
+
 		for _, agg := range a.aggregations {
-			// Get series up to dataTime
-			series := storage.GetSeriesRange(key, 0, dataTime, agg)
+			start := int64(0)
+			if a.windowSec > 0 {
+				start = dataTime - a.windowSec
+			}
+			series := storage.GetSeriesRange(key, start, dataTime, agg)
 			if series == nil || len(series.Points) == 0 {
 				continue
 			}
 
-			// Append aggregation suffix for distinct tracking
 			seriesWithAgg := *series
 			seriesWithAgg.Name = series.Name + ":" + aggSuffix(agg)
 
 			result := a.detector.Detect(seriesWithAgg)
-			for _, anomaly := range result.Anomalies {
-				anomaly.Type = observerdef.AnomalyTypeMetric
-				anomaly.DetectorName = a.detector.Name()
-				anomaly.Source = observerdef.MetricName(seriesWithAgg.Name)
-				anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
-				allAnomalies = append(allAnomalies, anomaly)
+			for i := range result.Anomalies {
+				result.Anomalies[i].Type = observerdef.AnomalyTypeMetric
+				result.Anomalies[i].DetectorName = a.detector.Name()
+				result.Anomalies[i].Source = observerdef.MetricName(seriesWithAgg.Name)
+				result.Anomalies[i].SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
 			}
-			allTelemetry = append(allTelemetry, result.Telemetry...)
+			seriesAnomalies = append(seriesAnomalies, result.Anomalies...)
+			seriesTelemetry = append(seriesTelemetry, result.Telemetry...)
 		}
+
+		a.lastSeriesResult[k] = observerdef.DetectionResult{
+			Anomalies: seriesAnomalies,
+			Telemetry: seriesTelemetry,
+		}
+		allAnomalies = append(allAnomalies, seriesAnomalies...)
+		allTelemetry = append(allTelemetry, seriesTelemetry...)
 	}
 
 	return observerdef.DetectionResult{
@@ -526,105 +515,19 @@ func aggSuffix(agg observerdef.Aggregate) string {
 	}
 }
 
-// processAnomaly sends an anomaly to all registered correlators.
-func (o *observerImpl) processAnomaly(anomaly observerdef.Anomaly) {
-	for _, correlator := range o.correlators {
-		correlator.Process(anomaly)
-	}
-}
-
-// captureRawAnomaly stores a raw anomaly for test bench display.
-// Deduplicates by Source+DetectorName, keeping the most recent.
-func (o *observerImpl) captureRawAnomaly(anomaly observerdef.Anomaly) {
-	o.rawAnomalyMu.Lock()
-	defer o.rawAnomalyMu.Unlock()
-
-	// Always increment total count (no cap)
-	o.totalAnomalyCount++
-
-	// Track unique sources
-	if o.uniqueAnomalySources == nil {
-		o.uniqueAnomalySources = make(map[observerdef.MetricName]bool)
-	}
-	o.uniqueAnomalySources[anomaly.Source] = true
-
-	// Update current data time
-	if anomaly.Timestamp > o.currentDataTime {
-		o.currentDataTime = anomaly.Timestamp
-	}
-
-	// Deduplicate by SourceSeriesID+DetectorName+Timestamp (keep all unique anomalies)
-	key := fmt.Sprintf("%s|%s|%d", anomaly.SourceSeriesID, anomaly.DetectorName, anomaly.Timestamp)
-	found := false
-	for i, existing := range o.rawAnomalies {
-		existingKey := fmt.Sprintf("%s|%s|%d", existing.SourceSeriesID, existing.DetectorName, existing.Timestamp)
-		if existingKey == key {
-			if anomaly.Timestamp > existing.Timestamp {
-				o.rawAnomalies[i] = anomaly
-			}
-			found = true
-			break
-		}
-	}
-	if !found {
-		o.rawAnomalies = append(o.rawAnomalies, anomaly)
-	}
-
-	// Evict old anomalies if window is set
-	if o.rawAnomalyWindow > 0 {
-		cutoff := o.currentDataTime - o.rawAnomalyWindow
-		newBuffer := o.rawAnomalies[:0]
-		for _, a := range o.rawAnomalies {
-			if a.Timestamp >= cutoff {
-				newBuffer = append(newBuffer, a)
-			}
-		}
-		o.rawAnomalies = newBuffer
-	}
-
-	// Cap at maxRawAnomalies if set
-	if o.maxRawAnomalies > 0 && len(o.rawAnomalies) > o.maxRawAnomalies {
-		// Keep most recent anomalies (tail of slice)
-		o.rawAnomalies = o.rawAnomalies[len(o.rawAnomalies)-o.maxRawAnomalies:]
-	}
-}
-
 // RawAnomalies returns a copy of currently tracked raw anomalies.
-// Implements observerdef.RawAnomalyState interface.
 func (o *observerImpl) RawAnomalies() []observerdef.Anomaly {
-	o.rawAnomalyMu.RLock()
-	defer o.rawAnomalyMu.RUnlock()
-
-	result := make([]observerdef.Anomaly, len(o.rawAnomalies))
-	copy(result, o.rawAnomalies)
-	return result
+	return o.engine.RawAnomalies()
 }
 
 // TotalAnomalyCount returns the total number of anomalies ever detected (no cap).
 func (o *observerImpl) TotalAnomalyCount() int {
-	o.rawAnomalyMu.RLock()
-	defer o.rawAnomalyMu.RUnlock()
-	return o.totalAnomalyCount
+	return o.engine.TotalAnomalyCount()
 }
 
 // UniqueAnomalySourceCount returns the number of unique sources that had anomalies.
 func (o *observerImpl) UniqueAnomalySourceCount() int {
-	o.rawAnomalyMu.RLock()
-	defer o.rawAnomalyMu.RUnlock()
-	return len(o.uniqueAnomalySources)
-}
-
-// flushAndReport flushes all correlators and notifies all reporters.
-// Reporters are called with an empty report to trigger state-based reporting.
-func (o *observerImpl) flushAndReport() {
-	// Flush correlators
-	for _, correlator := range o.correlators {
-		correlator.Flush()
-	}
-	// Always notify reporters so they can check correlation state
-	for _, reporter := range o.reporters {
-		reporter.Report(observerdef.ReportOutput{})
-	}
+	return o.engine.UniqueAnomalySourceCount()
 }
 
 // processTrace handles a trace observation.
@@ -676,14 +579,9 @@ func (h *noopObserveHandle) ObserveProfile(_ observerdef.ProfileView)       {}
 
 // DumpMetrics writes all stored metrics to the specified file as JSON.
 func (o *observerImpl) DumpMetrics(path string) error {
-	// Request dump via channel to ensure thread safety
-	type dumpReq struct {
-		path   string
-		result chan error
-	}
 	// For simplicity, just dump directly (storage access is single-threaded from run loop,
 	// but this is a debug tool so approximate snapshot is fine)
-	return o.storage.DumpToFile(path)
+	return o.engine.Storage().DumpToFile(path)
 }
 
 // handle is the lightweight observation interface passed to other components.

--- a/comp/observer/impl/observer_test.go
+++ b/comp/observer/impl/observer_test.go
@@ -43,6 +43,31 @@ func TestSeriesDetectorAdapter_DoesNotReemitOutputsWithoutNewData(t *testing.T) 
 	}
 }
 
+func TestSeriesDetectorAdapter_ResetClearsVisibleCountCache(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	storage.Add("ns", "cpu", 1.0, 100, nil)
+
+	adapter := newSeriesDetectorAdapter(&countingSeriesDetector{
+		anomalies: []observerdef.Anomaly{{
+			Title:       "spike",
+			Description: "detected spike",
+			Timestamp:   100,
+		}},
+	}, []observerdef.Aggregate{observerdef.AggregateAverage})
+
+	first := adapter.Detect(storage, 100)
+	if len(first.Anomalies) != 1 {
+		t.Fatalf("expected 1 anomaly on first detect, got %d", len(first.Anomalies))
+	}
+
+	adapter.Reset()
+
+	afterReset := adapter.Detect(storage, 100)
+	if len(afterReset.Anomalies) != 1 {
+		t.Fatalf("expected 1 anomaly after reset, got %d", len(afterReset.Anomalies))
+	}
+}
+
 type countingSeriesDetector struct {
 	anomalies []observerdef.Anomaly
 	telemetry []observerdef.ObserverTelemetry

--- a/comp/observer/impl/observer_test.go
+++ b/comp/observer/impl/observer_test.go
@@ -1,0 +1,58 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+func TestSeriesDetectorAdapter_DoesNotReemitOutputsWithoutNewData(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	storage.Add("ns", "cpu", 1.0, 100, nil)
+
+	adapter := newSeriesDetectorAdapter(&countingSeriesDetector{
+		anomalies: []observerdef.Anomaly{{
+			Title:       "spike",
+			Description: "detected spike",
+			Timestamp:   100,
+		}},
+		telemetry: []observerdef.ObserverTelemetry{{
+			DetectorName: "counting",
+		}},
+	}, []observerdef.Aggregate{observerdef.AggregateAverage})
+
+	first := adapter.Detect(storage, 100)
+	if len(first.Anomalies) != 1 {
+		t.Fatalf("expected 1 anomaly on first detect, got %d", len(first.Anomalies))
+	}
+	if len(first.Telemetry) != 1 {
+		t.Fatalf("expected 1 telemetry event on first detect, got %d", len(first.Telemetry))
+	}
+
+	second := adapter.Detect(storage, 101)
+	if len(second.Anomalies) != 0 {
+		t.Fatalf("expected 0 anomalies without new data, got %d", len(second.Anomalies))
+	}
+	if len(second.Telemetry) != 0 {
+		t.Fatalf("expected 0 telemetry events without new data, got %d", len(second.Telemetry))
+	}
+}
+
+type countingSeriesDetector struct {
+	anomalies []observerdef.Anomaly
+	telemetry []observerdef.ObserverTelemetry
+}
+
+func (d *countingSeriesDetector) Name() string { return "counting" }
+
+func (d *countingSeriesDetector) Detect(_ observerdef.Series) observerdef.DetectionResult {
+	return observerdef.DetectionResult{
+		Anomalies: append([]observerdef.Anomaly(nil), d.anomalies...),
+		Telemetry: append([]observerdef.ObserverTelemetry(nil), d.telemetry...),
+	}
+}

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -10,8 +10,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-
-	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
 // ObserverOutput is the top-level JSON structure produced by headless mode.
@@ -59,23 +57,22 @@ type ObserverAnomaly struct {
 // When verbose is false, correlations include only the time span (pattern, period_start, period_end).
 func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 	tb.mu.RLock()
-	correlations := make([]observerdef.ActiveCorrelation, len(tb.correlations))
-	copy(correlations, tb.correlations)
+	correlations := tb.engine.StateView().ActiveCorrelations()
 
 	scenario := tb.loadedScenario
-	timelineStart, timelineEnd, hasBounds := tb.storage.TimeBounds()
+	timelineStart, timelineEnd, hasBounds := tb.engine.Storage().TimeBounds()
 
 	// Collect enabled detector and correlator names
 	var detectorNames []string
 	var correlatorNames []string
-	for name, comp := range tb.components {
-		if !comp.Enabled {
+	for name, ci := range tb.components {
+		if !ci.enabled {
 			continue
 		}
-		switch comp.Registration.Category {
-		case "detector":
+		switch ci.entry.kind {
+		case componentDetector:
 			detectorNames = append(detectorNames, name)
-		case "correlator":
+		case componentCorrelator:
 			correlatorNames = append(correlatorNames, name)
 		}
 	}

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -57,7 +57,7 @@ type ObserverAnomaly struct {
 // When verbose is false, correlations include only the time span (pattern, period_start, period_end).
 func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 	tb.mu.RLock()
-	correlations := tb.engine.StateView().ActiveCorrelations()
+	correlations := tb.engine.StateView().CorrelationHistory()
 
 	scenario := tb.loadedScenario
 	timelineStart, timelineEnd, hasBounds := tb.engine.Storage().TimeBounds()

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -16,14 +16,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// staticCorrelator is a test correlator that returns fixed correlations.
+type staticCorrelator struct {
+	correlations []observerdef.ActiveCorrelation
+}
+
+func (c *staticCorrelator) Name() string                                        { return "static" }
+func (c *staticCorrelator) ProcessAnomaly(_ observerdef.Anomaly)                {}
+func (c *staticCorrelator) Advance(_ int64)                                     {}
+func (c *staticCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation { return c.correlations }
+func (c *staticCorrelator) Reset()                                              {}
+
 // newTestBenchForOutput creates a minimal TestBench with injected state for testing
 // observer output. No scenarios dir or registry needed.
 func newTestBenchForOutput() *TestBench {
+	eng := newEngine(engineConfig{storage: newTimeSeriesStorage()})
 	return &TestBench{
-		storage:           newTimeSeriesStorage(),
-		components:        make(map[string]*registeredComponent),
-		metricsAnomalies:  []observerdef.Anomaly{},
-		metricsByDetector: make(map[string][]observerdef.Anomaly),
+		engine:     eng,
+		catalog:    testbenchCatalog(),
+		components: make(map[string]*componentInstance),
 	}
 }
 
@@ -79,12 +90,13 @@ func TestWriteObserverOutput_EmptyScenario(t *testing.T) {
 func TestWriteObserverOutput_NonVerbose(t *testing.T) {
 	tb := newTestBenchForOutput()
 	tb.loadedScenario = "test_scenario"
-	tb.storage.Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"})
-	tb.storage.Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"})
-	tb.correlations = []observerdef.ActiveCorrelation{testCorrelation()}
-	tb.components["cusum"] = &registeredComponent{
-		Registration: ComponentRegistration{Name: "cusum", Category: "detector"},
-		Enabled:      true,
+	tb.engine.Storage().Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"})
+	tb.engine.Storage().Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"})
+	// Add a correlator that returns our test correlation
+	tb.engine.SetCorrelators([]observerdef.Correlator{&staticCorrelator{correlations: []observerdef.ActiveCorrelation{testCorrelation()}}})
+	tb.components["cusum"] = &componentInstance{
+		entry:   componentEntry{name: "cusum", kind: componentDetector},
+		enabled: true,
 	}
 
 	outPath := filepath.Join(t.TempDir(), "results.json")
@@ -113,20 +125,21 @@ func TestWriteObserverOutput_NonVerbose(t *testing.T) {
 func TestWriteObserverOutput_Verbose(t *testing.T) {
 	tb := newTestBenchForOutput()
 	tb.loadedScenario = "test_scenario"
-	tb.storage.Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"})
-	tb.storage.Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"})
-	tb.correlations = []observerdef.ActiveCorrelation{testCorrelation()}
-	tb.components["cusum"] = &registeredComponent{
-		Registration: ComponentRegistration{Name: "cusum", Category: "detector"},
-		Enabled:      true,
+	tb.engine.Storage().Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"})
+	tb.engine.Storage().Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"})
+	// Add a correlator that returns our test correlation
+	tb.engine.SetCorrelators([]observerdef.Correlator{&staticCorrelator{correlations: []observerdef.ActiveCorrelation{testCorrelation()}}})
+	tb.components["cusum"] = &componentInstance{
+		entry:   componentEntry{name: "cusum", kind: componentDetector},
+		enabled: true,
 	}
-	tb.components["time_cluster"] = &registeredComponent{
-		Registration: ComponentRegistration{Name: "time_cluster", Category: "correlator"},
-		Enabled:      true,
+	tb.components["time_cluster"] = &componentInstance{
+		entry:   componentEntry{name: "time_cluster", kind: componentCorrelator},
+		enabled: true,
 	}
-	tb.components["bocpd"] = &registeredComponent{
-		Registration: ComponentRegistration{Name: "bocpd", Category: "detector"},
-		Enabled:      false, // disabled — should not appear in metadata
+	tb.components["bocpd"] = &componentInstance{
+		entry:   componentEntry{name: "bocpd", kind: componentDetector},
+		enabled: false, // disabled — should not appear in metadata
 	}
 
 	outPath := filepath.Join(t.TempDir(), "results.json")
@@ -169,8 +182,8 @@ func TestWriteObserverOutput_Verbose(t *testing.T) {
 
 func TestWriteObserverOutput_TimelineBoundsFromStorage(t *testing.T) {
 	tb := newTestBenchForOutput()
-	tb.storage.Add("parquet", "disk.io", 10.0, 5000, []string{"device:sda"})
-	tb.storage.Add("parquet", "disk.io", 20.0, 9000, []string{"device:sda"})
+	tb.engine.Storage().Add("parquet", "disk.io", 10.0, 5000, []string{"device:sda"})
+	tb.engine.Storage().Add("parquet", "disk.io", 20.0, 9000, []string{"device:sda"})
 
 	outPath := filepath.Join(t.TempDir(), "results.json")
 	require.NoError(t, tb.WriteObserverOutput(outPath, false))
@@ -188,7 +201,7 @@ func TestWriteObserverOutput_TimelineBoundsFromStorage(t *testing.T) {
 func TestWriteObserverOutput_ValidJSON(t *testing.T) {
 	tb := newTestBenchForOutput()
 	tb.loadedScenario = "json_validity_check"
-	tb.correlations = []observerdef.ActiveCorrelation{
+	tb.engine.SetCorrelators([]observerdef.Correlator{&staticCorrelator{correlations: []observerdef.ActiveCorrelation{
 		{
 			Pattern:         "p1",
 			Title:           "Title with \"quotes\" and\nnewlines",
@@ -204,7 +217,7 @@ func TestWriteObserverOutput_ValidJSON(t *testing.T) {
 				},
 			},
 		},
-	}
+	}}})
 
 	// Both modes produce valid JSON
 	for _, verbose := range []bool{false, true} {

--- a/comp/observer/impl/profile_test.go
+++ b/comp/observer/impl/profile_test.go
@@ -1,0 +1,127 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// buildRealisticStorage creates storage mimicking the crash-loop scenario.
+func buildRealisticStorage(numMetrics, numSeconds int) *timeSeriesStorage {
+	rng := rand.New(rand.NewSource(42))
+	storage := newTimeSeriesStorage()
+
+	for sec := int64(0); sec < int64(numSeconds); sec++ {
+		for m := 0; m < numMetrics; m++ {
+			name := fmt.Sprintf("metric_%d", m)
+			value := 100.0 + rng.Float64()*10
+			if sec > int64(numSeconds*2/3) {
+				value = 200.0 + rng.Float64()*10
+			}
+			storage.Add("ns", name, value, sec, nil)
+		}
+	}
+	return storage
+}
+
+// buildRealisticEngine creates an engine with windowed or unbounded detectors.
+func buildRealisticEngine(numMetrics, numSeconds int, windowSec int64) *engine {
+	storage := buildRealisticStorage(numMetrics, numSeconds)
+
+	catalog := testbenchCatalog()
+	detectors, correlators, _ := catalog.Instantiate(nil)
+
+	// Apply window to all seriesDetectorAdapters.
+	if windowSec > 0 {
+		for i, d := range detectors {
+			if adapter, ok := d.(*seriesDetectorAdapter); ok {
+				adapter.windowSec = windowSec
+				detectors[i] = adapter
+			}
+		}
+	}
+
+	return newEngine(engineConfig{
+		storage:     storage,
+		detectors:   detectors,
+		correlators: correlators,
+	})
+}
+
+// BenchmarkReplayStoredData profiles the full replay path (unbounded).
+//
+//	go test -run=^$ -bench=BenchmarkReplayStoredData -cpuprofile=/tmp/observer_cpu.prof -benchtime=1x ./comp/observer/impl/
+//	go tool pprof -http=:8081 /tmp/observer_cpu.prof
+func BenchmarkReplayStoredData(b *testing.B) {
+	e := buildRealisticEngine(200, 576, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.Reset()
+		e.ReplayStoredData()
+	}
+}
+
+// BenchmarkReplayStoredData_Window300 profiles with a 300s window.
+func BenchmarkReplayStoredData_Window300(b *testing.B) {
+	e := buildRealisticEngine(200, 576, 300)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.Reset()
+		e.ReplayStoredData()
+	}
+}
+
+// BenchmarkReplayStoredData_Window60 profiles with a 60s window.
+func BenchmarkReplayStoredData_Window60(b *testing.B) {
+	e := buildRealisticEngine(200, 576, 60)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.Reset()
+		e.ReplayStoredData()
+	}
+}
+
+// BenchmarkReplayStoredData_Small is a smaller variant for quick iteration.
+func BenchmarkReplayStoredData_Small(b *testing.B) {
+	e := buildRealisticEngine(50, 100, 0)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		e.Reset()
+		e.ReplayStoredData()
+	}
+}
+
+// BenchmarkGetSeriesRange isolates storage read cost.
+func BenchmarkGetSeriesRange(b *testing.B) {
+	storage := newTimeSeriesStorage()
+	for sec := int64(0); sec < 576; sec++ {
+		storage.Add("ns", "metric_0", 100.0+rand.Float64()*10, sec, nil)
+	}
+	key := observerdef.SeriesKey{Namespace: "ns", Name: "metric_0"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		storage.GetSeriesRange(key, 0, 576, observerdef.AggregateAverage)
+	}
+}
+
+// BenchmarkPointCountUpTo isolates the cheap "has new data" check.
+func BenchmarkPointCountUpTo(b *testing.B) {
+	storage := newTimeSeriesStorage()
+	for sec := int64(0); sec < 576; sec++ {
+		storage.Add("ns", "metric_0", 100.0+rand.Float64()*10, sec, nil)
+	}
+	key := observerdef.SeriesKey{Namespace: "ns", Name: "metric_0"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		storage.PointCountUpTo(key, 300)
+	}
+}

--- a/comp/observer/impl/reporter_html.go
+++ b/comp/observer/impl/reporter_html.go
@@ -39,12 +39,13 @@ func sanitizeFloat(v float64) float64 {
 
 const maxReportBuffer = 100
 
-// timestampedReport wraps a ReportOutput with a timestamp.
+// timestampedReport wraps a ReportOutput with a wall-clock timestamp.
 type timestampedReport struct {
-	Title     string            `json:"title"`
-	Body      string            `json:"body"`
-	Timestamp time.Time         `json:"timestamp"`
-	Metadata  map[string]string `json:"metadata"`
+	AdvancedToSec      int64                        `json:"advanced_to_sec"`
+	NewAnomalyCount    int                          `json:"new_anomaly_count"`
+	CorrelationCount   int                          `json:"correlation_count"`
+	Timestamp          time.Time                    `json:"timestamp"`
+	ActiveCorrelations []observer.ActiveCorrelation `json:"active_correlations,omitempty"`
 }
 
 // HTMLReporter is an HTTP server that displays reports and metrics on a local webpage.
@@ -52,7 +53,7 @@ type HTMLReporter struct {
 	mu                    sync.RWMutex
 	reports               []timestampedReport
 	storage               *timeSeriesStorage
-	correlationState      observer.CorrelationState
+	correlationState      observer.Correlator
 	rawAnomalyState       observer.RawAnomalyState
 	timeClusterCorrelator *TimeClusterCorrelator
 	server                *http.Server
@@ -76,10 +77,11 @@ func (r *HTMLReporter) Report(report observer.ReportOutput) {
 	defer r.mu.Unlock()
 
 	tr := timestampedReport{
-		Title:     report.Title,
-		Body:      report.Body,
-		Timestamp: time.Now(),
-		Metadata:  report.Metadata,
+		AdvancedToSec:      report.AdvancedToSec,
+		NewAnomalyCount:    len(report.NewAnomalies),
+		CorrelationCount:   len(report.ActiveCorrelations),
+		Timestamp:          time.Now(),
+		ActiveCorrelations: report.ActiveCorrelations,
 	}
 
 	// Prepend to keep most recent first
@@ -99,7 +101,7 @@ func (r *HTMLReporter) SetStorage(storage *timeSeriesStorage) {
 }
 
 // SetCorrelationState sets the correlation state source for querying active correlations.
-func (r *HTMLReporter) SetCorrelationState(state observer.CorrelationState) {
+func (r *HTMLReporter) SetCorrelationState(state observer.Correlator) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.correlationState = state

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -26,10 +26,12 @@ func TestHTMLReporter_Report_AddsToBuffer(t *testing.T) {
 	r := NewHTMLReporter()
 
 	r.Report(observer.ReportOutput{
-		Title: "Test Report",
-		Body:  "Test Body",
-		Metadata: map[string]string{
-			"key": "value",
+		AdvancedToSec: 100,
+		NewAnomalies: []observer.Anomaly{
+			{Source: "cpu", DetectorName: "test"},
+		},
+		ActiveCorrelations: []observer.ActiveCorrelation{
+			{Pattern: "p1", Title: "Correlation 1"},
 		},
 	})
 
@@ -37,26 +39,26 @@ func TestHTMLReporter_Report_AddsToBuffer(t *testing.T) {
 	defer r.mu.RUnlock()
 
 	require.Len(t, r.reports, 1)
-	assert.Equal(t, "Test Report", r.reports[0].Title)
-	assert.Equal(t, "Test Body", r.reports[0].Body)
-	assert.Equal(t, "value", r.reports[0].Metadata["key"])
+	assert.Equal(t, int64(100), r.reports[0].AdvancedToSec)
+	assert.Equal(t, 1, r.reports[0].NewAnomalyCount)
+	assert.Equal(t, 1, r.reports[0].CorrelationCount)
 	assert.False(t, r.reports[0].Timestamp.IsZero())
 }
 
 func TestHTMLReporter_Report_MostRecentFirst(t *testing.T) {
 	r := NewHTMLReporter()
 
-	r.Report(observer.ReportOutput{Title: "First"})
-	r.Report(observer.ReportOutput{Title: "Second"})
-	r.Report(observer.ReportOutput{Title: "Third"})
+	r.Report(observer.ReportOutput{AdvancedToSec: 10})
+	r.Report(observer.ReportOutput{AdvancedToSec: 20})
+	r.Report(observer.ReportOutput{AdvancedToSec: 30})
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	require.Len(t, r.reports, 3)
-	assert.Equal(t, "Third", r.reports[0].Title)
-	assert.Equal(t, "Second", r.reports[1].Title)
-	assert.Equal(t, "First", r.reports[2].Title)
+	assert.Equal(t, int64(30), r.reports[0].AdvancedToSec)
+	assert.Equal(t, int64(20), r.reports[1].AdvancedToSec)
+	assert.Equal(t, int64(10), r.reports[2].AdvancedToSec)
 }
 
 func TestHTMLReporter_Report_BufferLimitedTo100(t *testing.T) {
@@ -65,7 +67,7 @@ func TestHTMLReporter_Report_BufferLimitedTo100(t *testing.T) {
 	// Add 105 reports
 	for i := 0; i < 105; i++ {
 		r.Report(observer.ReportOutput{
-			Title: "Report",
+			AdvancedToSec: int64(i),
 		})
 	}
 
@@ -78,26 +80,26 @@ func TestHTMLReporter_Report_BufferLimitedTo100(t *testing.T) {
 func TestHTMLReporter_Report_OldestEvicted(t *testing.T) {
 	r := NewHTMLReporter()
 
-	// Add 100 reports
+	// Add 100 reports with AdvancedToSec=0
 	for i := 0; i < 100; i++ {
 		r.Report(observer.ReportOutput{
-			Title: "Old",
+			AdvancedToSec: 0,
 		})
 	}
 
-	// Add one more
+	// Add one more with AdvancedToSec=999
 	r.Report(observer.ReportOutput{
-		Title: "New",
+		AdvancedToSec: 999,
 	})
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	// Should have 100 reports with "New" at the front
+	// Should have 100 reports with newest at the front
 	require.Len(t, r.reports, 100)
-	assert.Equal(t, "New", r.reports[0].Title)
-	// Last one should still be "Old" (oldest kept)
-	assert.Equal(t, "Old", r.reports[99].Title)
+	assert.Equal(t, int64(999), r.reports[0].AdvancedToSec)
+	// Last one should still be old (oldest kept)
+	assert.Equal(t, int64(0), r.reports[99].AdvancedToSec)
 }
 
 func TestHTMLReporter_Dashboard_ReturnsHTML(t *testing.T) {
@@ -147,10 +149,9 @@ func TestHTMLReporter_APIReports_ReturnsJSON(t *testing.T) {
 	r := NewHTMLReporter()
 
 	r.Report(observer.ReportOutput{
-		Title: "Test Report",
-		Body:  "Test Body",
-		Metadata: map[string]string{
-			"key": "value",
+		AdvancedToSec: 42,
+		NewAnomalies: []observer.Anomaly{
+			{Source: "cpu"},
 		},
 	})
 
@@ -167,9 +168,8 @@ func TestHTMLReporter_APIReports_ReturnsJSON(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, reports, 1)
-	assert.Equal(t, "Test Report", reports[0].Title)
-	assert.Equal(t, "Test Body", reports[0].Body)
-	assert.Equal(t, "value", reports[0].Metadata["key"])
+	assert.Equal(t, int64(42), reports[0].AdvancedToSec)
+	assert.Equal(t, 1, reports[0].NewAnomalyCount)
 }
 
 func TestHTMLReporter_APIReports_EmptyArray(t *testing.T) {
@@ -291,9 +291,7 @@ func TestHTMLReporter_IntegrationWithHTTPServer(t *testing.T) {
 
 	// Add test data
 	r.Report(observer.ReportOutput{
-		Title:    "Integration Test",
-		Body:     "Testing full HTTP stack",
-		Metadata: map[string]string{"test": "true"},
+		AdvancedToSec: 100,
 	})
 
 	storage := newTimeSeriesStorage()
@@ -389,19 +387,23 @@ func TestHTMLReporter_APISeriesList_NoStorage(t *testing.T) {
 	assert.Len(t, items, 0)
 }
 
-// mockCorrelationState implements CorrelationState for testing.
-type mockCorrelationState struct {
+// mockHTMLCorrelator implements Correlator for testing.
+type mockHTMLCorrelator struct {
 	correlations []observer.ActiveCorrelation
 }
 
-func (m *mockCorrelationState) ActiveCorrelations() []observer.ActiveCorrelation {
+func (m *mockHTMLCorrelator) Name() string                          { return "mock_correlator" }
+func (m *mockHTMLCorrelator) ProcessAnomaly(_ observer.Anomaly)     {}
+func (m *mockHTMLCorrelator) Advance(_ int64)                       {}
+func (m *mockHTMLCorrelator) Reset()                                {}
+func (m *mockHTMLCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	return m.correlations
 }
 
 func TestHTMLReporter_APICorrelations_ReturnsJSON(t *testing.T) {
 	r := NewHTMLReporter()
 
-	r.SetCorrelationState(&mockCorrelationState{
+	r.SetCorrelationState(&mockHTMLCorrelator{
 		correlations: []observer.ActiveCorrelation{
 			{
 				Pattern: "test_pattern",

--- a/comp/observer/impl/scheduler.go
+++ b/comp/observer/impl/scheduler.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+// schedulerPolicy decides when the engine should advance analysis.
+// It is the single home for time-advancement rules.
+type schedulerPolicy interface {
+	// onObservation is called when a new observation arrives. Returns advance
+	// requests that should be executed. The state parameter provides read-only
+	// access to scheduler-relevant engine state.
+	onObservation(dataTimeSec int64, st schedulerState) []advanceRequest
+
+	// onIdle is called when wall-clock time passes without new observations.
+	// Not used in current behavior, but the interface supports future periodic flushes.
+	onIdle(nowUnixNano int64, st schedulerState) []advanceRequest
+
+	// onReplayEnd is called when replay finishes. Returns final advance requests
+	// to flush any remaining data.
+	onReplayEnd(st schedulerState) []advanceRequest
+}
+
+// schedulerState provides read-only scheduler-relevant state.
+type schedulerState struct {
+	lastAnalyzedDataTime int64 // last time detectors ran up to
+	latestDataTime       int64 // latest data timestamp seen
+}
+
+// advanceRequest tells the engine to advance analysis to a specific time.
+type advanceRequest struct {
+	upToSec int64
+	reason  advanceReason
+}
+
+// advanceReason categorizes why an advance was requested.
+type advanceReason int
+
+const (
+	advanceReasonInputDriven   advanceReason = iota // data arrival triggered
+	advanceReasonPeriodicFlush                      // periodic timer triggered
+	advanceReasonReplayEnd                          // replay finished
+	advanceReasonManual                             // explicit test/debug trigger
+)
+
+// currentBehaviorPolicy reproduces the exact current scheduling semantics:
+// - On observation: if dataTimeSec-1 > lastAnalyzedDataTime, emit advance to dataTimeSec-1
+// - On idle: nothing (not currently used)
+// - On replay end: advance to latestDataTime (for batch/testbench replay)
+type currentBehaviorPolicy struct{}
+
+func (p *currentBehaviorPolicy) onObservation(dataTimeSec int64, st schedulerState) []advanceRequest {
+	analyzeUpTo := dataTimeSec - 1
+	if analyzeUpTo <= st.lastAnalyzedDataTime {
+		return nil
+	}
+	return []advanceRequest{{upToSec: analyzeUpTo, reason: advanceReasonInputDriven}}
+}
+
+func (p *currentBehaviorPolicy) onIdle(_ int64, _ schedulerState) []advanceRequest {
+	return nil
+}
+
+func (p *currentBehaviorPolicy) onReplayEnd(st schedulerState) []advanceRequest {
+	if st.latestDataTime <= st.lastAnalyzedDataTime {
+		return nil
+	}
+	return []advanceRequest{{upToSec: st.latestDataTime, reason: advanceReasonReplayEnd}}
+}

--- a/comp/observer/impl/scheduler_test.go
+++ b/comp/observer/impl/scheduler_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrentBehaviorPolicy_OnObservation(t *testing.T) {
+	p := &currentBehaviorPolicy{}
+
+	t.Run("advances when data time is ahead", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 10, latestDataTime: 10}
+		reqs := p.onObservation(15, st)
+		assert.Len(t, reqs, 1)
+		assert.Equal(t, int64(14), reqs[0].upToSec)
+		assert.Equal(t, advanceReasonInputDriven, reqs[0].reason)
+	})
+
+	t.Run("no advance when data time equals last analyzed plus one", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 10, latestDataTime: 10}
+		reqs := p.onObservation(11, st)
+		assert.Nil(t, reqs)
+	})
+
+	t.Run("no advance when data time is behind", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 10, latestDataTime: 10}
+		reqs := p.onObservation(5, st)
+		assert.Nil(t, reqs)
+	})
+
+	t.Run("out-of-order data does not trigger advance", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 20, latestDataTime: 25}
+		// Data arrives at t=15, which is behind lastAnalyzedDataTime
+		reqs := p.onObservation(15, st)
+		assert.Nil(t, reqs)
+	})
+
+	t.Run("sparse input triggers advance across gap", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 10, latestDataTime: 10}
+		// Data jumps from t=10 to t=1000
+		reqs := p.onObservation(1000, st)
+		assert.Len(t, reqs, 1)
+		assert.Equal(t, int64(999), reqs[0].upToSec)
+	})
+
+	t.Run("advancing timestamps produce sequential advances", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 0, latestDataTime: 0}
+
+		reqs := p.onObservation(5, st)
+		assert.Len(t, reqs, 1)
+		assert.Equal(t, int64(4), reqs[0].upToSec)
+
+		// Simulate engine advancing
+		st.lastAnalyzedDataTime = 4
+		st.latestDataTime = 5
+
+		reqs = p.onObservation(6, st)
+		assert.Len(t, reqs, 1)
+		assert.Equal(t, int64(5), reqs[0].upToSec)
+	})
+}
+
+func TestCurrentBehaviorPolicy_OnIdle(t *testing.T) {
+	p := &currentBehaviorPolicy{}
+
+	st := schedulerState{lastAnalyzedDataTime: 10, latestDataTime: 20}
+	reqs := p.onIdle(99999, st)
+	assert.Nil(t, reqs)
+}
+
+func TestCurrentBehaviorPolicy_OnReplayEnd(t *testing.T) {
+	p := &currentBehaviorPolicy{}
+
+	t.Run("advances to latest when data remains", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 10, latestDataTime: 20}
+		reqs := p.onReplayEnd(st)
+		assert.Len(t, reqs, 1)
+		assert.Equal(t, int64(20), reqs[0].upToSec)
+		assert.Equal(t, advanceReasonReplayEnd, reqs[0].reason)
+	})
+
+	t.Run("no advance when already caught up", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 20, latestDataTime: 20}
+		reqs := p.onReplayEnd(st)
+		assert.Nil(t, reqs)
+	})
+
+	t.Run("no advance when latest is behind analyzed", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 25, latestDataTime: 20}
+		reqs := p.onReplayEnd(st)
+		assert.Nil(t, reqs)
+	})
+
+	t.Run("no advance when both zero", func(t *testing.T) {
+		st := schedulerState{lastAnalyzedDataTime: 0, latestDataTime: 0}
+		reqs := p.onReplayEnd(st)
+		assert.Nil(t, reqs)
+	})
+}

--- a/comp/observer/impl/stateview.go
+++ b/comp/observer/impl/stateview.go
@@ -1,0 +1,166 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// stateView provides read-only access to engine state.
+// This is the primary introspection surface for consumers like the testbench UI.
+// It computes views over existing engine state rather than maintaining a separate copy.
+type stateView struct {
+	engine *engine
+}
+
+// StateView returns a stateView backed by this engine's current state.
+func (e *engine) StateView() *stateView {
+	return &stateView{engine: e}
+}
+
+// --- Storage access ---
+
+// ListSeries returns keys of all series matching the filter.
+func (sv *stateView) ListSeries(filter observerdef.SeriesFilter) []observerdef.SeriesKey {
+	return sv.engine.storage.ListSeries(filter)
+}
+
+// GetSeriesRange returns points within a time range for a series.
+func (sv *stateView) GetSeriesRange(key observerdef.SeriesKey, start, end int64, agg observerdef.Aggregate) *observerdef.Series {
+	return sv.engine.storage.GetSeriesRange(key, start, end, agg)
+}
+
+// ScenarioBounds returns the time bounds of stored data.
+func (sv *stateView) ScenarioBounds() (start int64, end int64, ok bool) {
+	return sv.engine.storage.TimeBounds()
+}
+
+// --- Anomaly access ---
+
+// Anomalies returns a copy of all currently tracked raw anomalies.
+func (sv *stateView) Anomalies() []observerdef.Anomaly {
+	return sv.engine.RawAnomalies()
+}
+
+// TotalAnomalyCount returns the total number of anomalies ever detected.
+func (sv *stateView) TotalAnomalyCount() int {
+	return sv.engine.TotalAnomalyCount()
+}
+
+// UniqueAnomalySourceCount returns the number of unique metric sources that had anomalies.
+func (sv *stateView) UniqueAnomalySourceCount() int {
+	return sv.engine.UniqueAnomalySourceCount()
+}
+
+// --- Detector info ---
+
+// detectorInfo describes a detector registered with the engine.
+type detectorInfo struct {
+	Name    string
+	Enabled bool
+}
+
+// ListDetectors returns info about all detectors currently in the engine.
+func (sv *stateView) ListDetectors() []detectorInfo {
+	result := make([]detectorInfo, len(sv.engine.detectors))
+	for i, d := range sv.engine.detectors {
+		result[i] = detectorInfo{
+			Name:    d.Name(),
+			Enabled: true, // detectors in the engine are always enabled
+		}
+	}
+	return result
+}
+
+// DetectorAnomalies returns anomalies from a specific detector, filtered from the
+// raw anomaly set. Computes on read rather than maintaining a per-detector index.
+func (sv *stateView) DetectorAnomalies(name string) []observerdef.Anomaly {
+	all := sv.engine.RawAnomalies()
+	var result []observerdef.Anomaly
+	for _, a := range all {
+		if a.DetectorName == name {
+			result = append(result, a)
+		}
+	}
+	return result
+}
+
+// AnomaliesByDetector returns all anomalies grouped by detector name.
+// Computes on read from the raw anomaly set.
+func (sv *stateView) AnomaliesByDetector() map[string][]observerdef.Anomaly {
+	all := sv.engine.RawAnomalies()
+	result := make(map[string][]observerdef.Anomaly)
+	for _, a := range all {
+		result[a.DetectorName] = append(result[a.DetectorName], a)
+	}
+	return result
+}
+
+// AnomaliesForSeries returns anomalies associated with a specific series ID.
+// Computes on read from the raw anomaly set.
+func (sv *stateView) AnomaliesForSeries(id observerdef.SeriesID) []observerdef.Anomaly {
+	all := sv.engine.RawAnomalies()
+	var result []observerdef.Anomaly
+	for _, a := range all {
+		if a.SourceSeriesID == id {
+			result = append(result, a)
+		}
+	}
+	return result
+}
+
+// --- Correlator info ---
+
+// correlatorInfo describes a correlator registered with the engine.
+type correlatorInfo struct {
+	Name    string
+	Enabled bool
+}
+
+// ListCorrelators returns info about all correlators currently in the engine.
+func (sv *stateView) ListCorrelators() []correlatorInfo {
+	result := make([]correlatorInfo, len(sv.engine.correlators))
+	for i, c := range sv.engine.correlators {
+		result[i] = correlatorInfo{
+			Name:    c.Name(),
+			Enabled: true, // correlators in the engine are always enabled
+		}
+	}
+	return result
+}
+
+// ActiveCorrelations returns active correlations from all correlators.
+func (sv *stateView) ActiveCorrelations() []observerdef.ActiveCorrelation {
+	var result []observerdef.ActiveCorrelation
+	for _, c := range sv.engine.correlators {
+		result = append(result, c.ActiveCorrelations()...)
+	}
+	return result
+}
+
+// --- Telemetry ---
+
+// Telemetry returns accumulated telemetry from detection runs.
+func (sv *stateView) Telemetry() []observerdef.ObserverTelemetry {
+	sv.engine.telemetryMu.RLock()
+	defer sv.engine.telemetryMu.RUnlock()
+
+	result := make([]observerdef.ObserverTelemetry, len(sv.engine.accumulatedTelemetry))
+	copy(result, sv.engine.accumulatedTelemetry)
+	return result
+}
+
+// --- Scheduling state ---
+
+// LastAnalyzedTime returns the data timestamp up to which detection has run.
+func (sv *stateView) LastAnalyzedTime() int64 {
+	return sv.engine.lastAnalyzedDataTime
+}
+
+// LatestDataTime returns the latest data timestamp seen across all ingested observations.
+func (sv *stateView) LatestDataTime() int64 {
+	return sv.engine.latestDataTime
+}

--- a/comp/observer/impl/stateview.go
+++ b/comp/observer/impl/stateview.go
@@ -132,13 +132,38 @@ func (sv *stateView) ListCorrelators() []correlatorInfo {
 	return result
 }
 
-// ActiveCorrelations returns active correlations from all correlators.
+// ActiveCorrelations returns current sliding-window correlations from all correlators.
 func (sv *stateView) ActiveCorrelations() []observerdef.ActiveCorrelation {
 	var result []observerdef.ActiveCorrelation
 	for _, c := range sv.engine.correlators {
 		result = append(result, c.ActiveCorrelations()...)
 	}
 	return result
+}
+
+// CorrelationHistory returns all correlations ever detected across the full run.
+// Unlike ActiveCorrelations, this preserves correlations that correlators have
+// evicted from their sliding windows, making it suitable for replay/testbench/headless use.
+// It merges the accumulated history with current correlator state so that
+// correlations injected outside the normal Advance flow are also visible.
+func (sv *stateView) CorrelationHistory() []observerdef.ActiveCorrelation {
+	accumulated := sv.engine.AccumulatedCorrelations()
+	seen := make(map[string]bool, len(accumulated))
+	for _, ac := range accumulated {
+		seen[ac.Pattern] = true
+	}
+
+	// Include any current correlator state not yet in the accumulated set.
+	for _, c := range sv.engine.correlators {
+		for _, ac := range c.ActiveCorrelations() {
+			if !seen[ac.Pattern] {
+				accumulated = append(accumulated, ac)
+				seen[ac.Pattern] = true
+			}
+		}
+	}
+
+	return accumulated
 }
 
 // --- Telemetry ---

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -1,0 +1,207 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+func TestStateView_StorageAccess(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	storage.Add("ns", "cpu", 1.0, 100, nil)
+	storage.Add("ns", "cpu", 2.0, 101, nil)
+	storage.Add("ns", "mem", 512.0, 100, []string{"host:a"})
+
+	e := newEngine(engineConfig{storage: storage})
+	sv := e.StateView()
+
+	// ListSeries
+	keys := sv.ListSeries(observerdef.SeriesFilter{Namespace: "ns"})
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 series, got %d", len(keys))
+	}
+
+	// GetSeriesRange
+	series := sv.GetSeriesRange(observerdef.SeriesKey{Namespace: "ns", Name: "cpu"}, 0, 200, observerdef.AggregateAverage)
+	if series == nil {
+		t.Fatal("expected series data, got nil")
+	}
+	if len(series.Points) != 2 {
+		t.Fatalf("expected 2 points, got %d", len(series.Points))
+	}
+
+	// ScenarioBounds
+	start, end, ok := sv.ScenarioBounds()
+	if !ok {
+		t.Fatal("expected bounds to be available")
+	}
+	if start != 100 || end != 101 {
+		t.Fatalf("expected bounds [100, 101], got [%d, %d]", start, end)
+	}
+}
+
+func TestStateView_Anomalies(t *testing.T) {
+	e := newEngine(engineConfig{
+		storage: newTimeSeriesStorage(),
+	})
+	sv := e.StateView()
+
+	// Initially empty
+	if len(sv.Anomalies()) != 0 {
+		t.Fatalf("expected 0 anomalies, got %d", len(sv.Anomalies()))
+	}
+	if sv.TotalAnomalyCount() != 0 {
+		t.Fatalf("expected 0 total anomalies, got %d", sv.TotalAnomalyCount())
+	}
+
+	// Add some anomalies via the engine
+	e.captureRawAnomaly(observerdef.Anomaly{
+		Source:       "cpu",
+		DetectorName: "cusum",
+		Timestamp:    100,
+	})
+	e.captureRawAnomaly(observerdef.Anomaly{
+		Source:       "mem",
+		DetectorName: "bocpd",
+		Timestamp:    101,
+	})
+
+	if len(sv.Anomalies()) != 2 {
+		t.Fatalf("expected 2 anomalies, got %d", len(sv.Anomalies()))
+	}
+	if sv.TotalAnomalyCount() != 2 {
+		t.Fatalf("expected 2 total anomalies, got %d", sv.TotalAnomalyCount())
+	}
+	if sv.UniqueAnomalySourceCount() != 2 {
+		t.Fatalf("expected 2 unique sources, got %d", sv.UniqueAnomalySourceCount())
+	}
+
+	// DetectorAnomalies filters correctly
+	cusumAnomalies := sv.DetectorAnomalies("cusum")
+	if len(cusumAnomalies) != 1 {
+		t.Fatalf("expected 1 cusum anomaly, got %d", len(cusumAnomalies))
+	}
+	if cusumAnomalies[0].DetectorName != "cusum" {
+		t.Fatalf("expected cusum, got %s", cusumAnomalies[0].DetectorName)
+	}
+
+	// AnomaliesByDetector groups correctly
+	byDetector := sv.AnomaliesByDetector()
+	if len(byDetector) != 2 {
+		t.Fatalf("expected 2 detector groups, got %d", len(byDetector))
+	}
+	if len(byDetector["cusum"]) != 1 {
+		t.Fatalf("expected 1 cusum anomaly, got %d", len(byDetector["cusum"]))
+	}
+	if len(byDetector["bocpd"]) != 1 {
+		t.Fatalf("expected 1 bocpd anomaly, got %d", len(byDetector["bocpd"]))
+	}
+
+	// AnomaliesForSeries filters by SourceSeriesID
+	e.captureRawAnomaly(observerdef.Anomaly{
+		Source:         "disk",
+		DetectorName:   "cusum",
+		Timestamp:      102,
+		SourceSeriesID: "ns|disk:avg|",
+	})
+	diskAnomalies := sv.AnomaliesForSeries("ns|disk:avg|")
+	if len(diskAnomalies) != 1 {
+		t.Fatalf("expected 1 disk anomaly, got %d", len(diskAnomalies))
+	}
+	if diskAnomalies[0].Source != "disk" {
+		t.Fatalf("expected disk source, got %s", diskAnomalies[0].Source)
+	}
+	// Empty SourceSeriesID should not match
+	emptyAnomalies := sv.AnomaliesForSeries("")
+	if len(emptyAnomalies) != 2 {
+		t.Fatalf("expected 2 anomalies with empty SourceSeriesID, got %d", len(emptyAnomalies))
+	}
+}
+
+func TestStateView_DetectorsAndCorrelators(t *testing.T) {
+	detector := &mockDetector{name: "mock_det"}
+	correlator := &mockCorrelator{name: "mock_corr"}
+
+	e := newEngine(engineConfig{
+		storage:     newTimeSeriesStorage(),
+		detectors:   []observerdef.Detector{detector},
+		correlators: []observerdef.Correlator{correlator},
+	})
+	sv := e.StateView()
+
+	detectors := sv.ListDetectors()
+	if len(detectors) != 1 || detectors[0].Name != "mock_det" {
+		t.Fatalf("unexpected detectors: %+v", detectors)
+	}
+
+	correlators := sv.ListCorrelators()
+	if len(correlators) != 1 || correlators[0].Name != "mock_corr" {
+		t.Fatalf("unexpected correlators: %+v", correlators)
+	}
+}
+
+func TestStateView_SchedulingState(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	storage.Add("ns", "cpu", 1.0, 100, nil)
+	storage.Add("ns", "cpu", 2.0, 200, nil)
+
+	e := newEngine(engineConfig{storage: storage})
+	sv := e.StateView()
+
+	if sv.LastAnalyzedTime() != 0 {
+		t.Fatalf("expected 0, got %d", sv.LastAnalyzedTime())
+	}
+
+	e.Advance(150)
+	if sv.LastAnalyzedTime() != 150 {
+		t.Fatalf("expected 150, got %d", sv.LastAnalyzedTime())
+	}
+}
+
+func TestStateView_Telemetry(t *testing.T) {
+	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	sv := e.StateView()
+
+	// Initially empty
+	if len(sv.Telemetry()) != 0 {
+		t.Fatalf("expected 0 telemetry, got %d", len(sv.Telemetry()))
+	}
+
+	// Manually accumulate telemetry
+	e.telemetryMu.Lock()
+	e.accumulatedTelemetry = append(e.accumulatedTelemetry, observerdef.ObserverTelemetry{
+		DetectorName: "test",
+	})
+	e.telemetryMu.Unlock()
+
+	tel := sv.Telemetry()
+	if len(tel) != 1 || tel[0].DetectorName != "test" {
+		t.Fatalf("unexpected telemetry: %+v", tel)
+	}
+}
+
+// mockDetector is a minimal Detector for testing.
+type mockDetector struct {
+	name string
+}
+
+func (d *mockDetector) Name() string { return d.name }
+func (d *mockDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
+	return observerdef.DetectionResult{}
+}
+
+// mockCorrelator is a minimal Correlator for testing.
+type mockCorrelator struct {
+	name string
+}
+
+func (c *mockCorrelator) Name() string                                        { return c.name }
+func (c *mockCorrelator) ProcessAnomaly(_ observerdef.Anomaly)                {}
+func (c *mockCorrelator) Advance(_ int64)                                     {}
+func (c *mockCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation { return nil }
+func (c *mockCorrelator) Reset()                                              {}

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -30,20 +30,24 @@ type timeSeriesStorage struct {
 }
 
 // seriesStats contains accumulated statistics for a time series (internal).
+// Data is stored in columnar layout: parallel arrays indexed by point position.
+// Timestamps are sorted and append-only, enabling binary search for range queries.
 type seriesStats struct {
 	Namespace string
 	Name      string
 	Tags      []string
-	Points    []statPoint
+
+	// Columnar storage — all slices have the same length, indexed by point position.
+	timestamps []int64
+	sums       []float64
+	counts     []int64
+	mins       []float64
+	maxes      []float64
 }
 
-// statPoint holds summary statistics for a single time bucket (internal).
-type statPoint struct {
-	Timestamp int64
-	Sum       float64
-	Count     int64
-	Min       float64
-	Max       float64
+// pointCount returns the number of stored points.
+func (s *seriesStats) pointCount() int {
+	return len(s.timestamps)
 }
 
 // Aggregate is an alias to the definition in the observer component for internal use.
@@ -58,22 +62,53 @@ const (
 	AggregateMax     = observer.AggregateMax
 )
 
-// aggregate extracts the specified statistic from this point.
-func (p *statPoint) aggregate(agg Aggregate) float64 {
+// aggregateColumn returns the pre-materialized column values for a given aggregate.
+// For Average, it computes sum/count on the fly. For others, it returns the column directly.
+func (s *seriesStats) aggregateColumn(agg Aggregate) []float64 {
+	switch agg {
+	case AggregateSum:
+		return s.sums
+	case AggregateMin:
+		return s.mins
+	case AggregateMax:
+		return s.maxes
+	case AggregateCount:
+		vals := make([]float64, len(s.counts))
+		for i, c := range s.counts {
+			vals[i] = float64(c)
+		}
+		return vals
+	case AggregateAverage:
+		vals := make([]float64, len(s.sums))
+		for i := range s.sums {
+			if s.counts[i] == 0 {
+				vals[i] = 0
+			} else {
+				vals[i] = s.sums[i] / float64(s.counts[i])
+			}
+		}
+		return vals
+	default:
+		return make([]float64, len(s.timestamps))
+	}
+}
+
+// aggregateAt extracts the specified statistic at index i.
+func (s *seriesStats) aggregateAt(i int, agg Aggregate) float64 {
 	switch agg {
 	case AggregateAverage:
-		if p.Count == 0 {
+		if s.counts[i] == 0 {
 			return 0
 		}
-		return p.Sum / float64(p.Count)
+		return s.sums[i] / float64(s.counts[i])
 	case AggregateSum:
-		return p.Sum
+		return s.sums[i]
 	case AggregateCount:
-		return float64(p.Count)
+		return float64(s.counts[i])
 	case AggregateMin:
-		return p.Min
+		return s.mins[i]
 	case AggregateMax:
-		return p.Max
+		return s.maxes[i]
 	default:
 		return 0
 	}
@@ -81,12 +116,14 @@ func (p *statPoint) aggregate(agg Aggregate) float64 {
 
 // toSeries converts internal stats to the simplified Series for analyses.
 func (s *seriesStats) toSeries(agg Aggregate) observer.Series {
-	points := make([]observer.Point, 0, len(s.Points))
-	for _, p := range s.Points {
-		points = append(points, observer.Point{
-			Timestamp: p.Timestamp,
-			Value:     p.aggregate(agg),
-		})
+	n := s.pointCount()
+	points := make([]observer.Point, n)
+	col := s.aggregateColumn(agg)
+	for i := 0; i < n; i++ {
+		points[i] = observer.Point{
+			Timestamp: s.timestamps[i],
+			Value:     col[i],
+		}
 	}
 	return observer.Series{
 		Namespace: s.Namespace,
@@ -97,14 +134,17 @@ func (s *seriesStats) toSeries(agg Aggregate) observer.Series {
 }
 
 // toSeriesUpTo returns a Series with only points where Timestamp <= upTo.
+// Uses binary search on the sorted timestamps column.
 func (s *seriesStats) toSeriesUpTo(agg Aggregate, upTo int64) observer.Series {
-	points := make([]observer.Point, 0, len(s.Points))
-	for _, p := range s.Points {
-		if p.Timestamp <= upTo {
-			points = append(points, observer.Point{
-				Timestamp: p.Timestamp,
-				Value:     p.aggregate(agg),
-			})
+	end := sort.Search(len(s.timestamps), func(i int) bool {
+		return s.timestamps[i] > upTo
+	})
+	points := make([]observer.Point, end)
+	col := s.aggregateColumn(agg)
+	for i := 0; i < end; i++ {
+		points[i] = observer.Point{
+			Timestamp: s.timestamps[i],
+			Value:     col[i],
 		}
 	}
 	return observer.Series{
@@ -113,6 +153,20 @@ func (s *seriesStats) toSeriesUpTo(agg Aggregate, upTo int64) observer.Series {
 		Tags:      s.Tags,
 		Points:    points,
 	}
+}
+
+// searchAfter returns the index of the first timestamp > value using binary search.
+func searchAfter(timestamps []int64, value int64) int {
+	return sort.Search(len(timestamps), func(i int) bool {
+		return timestamps[i] > value
+	})
+}
+
+// searchAtOrAfter returns the index of the first timestamp >= value using binary search.
+func searchAtOrAfter(timestamps []int64, value int64) int {
+	return sort.Search(len(timestamps), func(i int) bool {
+		return timestamps[i] >= value
+	})
 }
 
 // newTimeSeriesStorage creates a new time series storage.
@@ -148,7 +202,6 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 			Namespace: namespace,
 			Name:      name,
 			Tags:      copyTags(tags),
-			Points:    nil,
 		}
 		s.series[key] = stats
 	}
@@ -156,39 +209,45 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	// Bucket by second
 	bucket := timestamp
 
-	// Find or create the bucket
-	idx := -1
-	for i, p := range stats.Points {
-		if p.Timestamp == bucket {
-			idx = i
-			break
-		}
-	}
+	// Binary search for the bucket in the sorted timestamps array.
+	idx := sort.Search(len(stats.timestamps), func(i int) bool {
+		return stats.timestamps[i] >= bucket
+	})
 
-	if idx >= 0 {
-		// Update existing bucket
-		stats.Points[idx].Sum += value
-		stats.Points[idx].Count++
-		if value < stats.Points[idx].Min {
-			stats.Points[idx].Min = value
+	if idx < len(stats.timestamps) && stats.timestamps[idx] == bucket {
+		// Update existing bucket in-place.
+		stats.sums[idx] += value
+		stats.counts[idx]++
+		if value < stats.mins[idx] {
+			stats.mins[idx] = value
 		}
-		if value > stats.Points[idx].Max {
-			stats.Points[idx].Max = value
+		if value > stats.maxes[idx] {
+			stats.maxes[idx] = value
 		}
 	} else {
-		// Create new bucket
-		stats.Points = append(stats.Points, statPoint{
-			Timestamp: bucket,
-			Sum:       value,
-			Count:     1,
-			Min:       value,
-			Max:       value,
-		})
-		// Keep points sorted by timestamp
-		sort.Slice(stats.Points, func(i, j int) bool {
-			return stats.Points[i].Timestamp < stats.Points[j].Timestamp
-		})
+		// Insert new bucket at sorted position.
+		stats.timestamps = insertInt64(stats.timestamps, idx, bucket)
+		stats.sums = insertFloat64(stats.sums, idx, value)
+		stats.counts = insertInt64(stats.counts, idx, 1)
+		stats.mins = insertFloat64(stats.mins, idx, value)
+		stats.maxes = insertFloat64(stats.maxes, idx, value)
 	}
+}
+
+// insertInt64 inserts v at position idx in s, maintaining order.
+func insertInt64(s []int64, idx int, v int64) []int64 {
+	s = append(s, 0)
+	copy(s[idx+1:], s[idx:])
+	s[idx] = v
+	return s
+}
+
+// insertFloat64 inserts v at position idx in s, maintaining order.
+func insertFloat64(s []float64, idx int, v float64) []float64 {
+	s = append(s, 0)
+	copy(s[idx+1:], s[idx:])
+	s[idx] = v
+	return s
 }
 
 func (s *timeSeriesStorage) recordDroppedValue(reason, namespace, name string, value float64, timestamp int64, tags []string) {
@@ -263,15 +322,16 @@ func (s *timeSeriesStorage) GetSeriesSince(namespace, name string, tags []string
 		return &series
 	}
 
-	// Filter points to only those after 'since'
-	var points []observer.Point
-	for _, p := range stats.Points {
-		if p.Timestamp > since {
-			points = append(points, observer.Point{
-				Timestamp: p.Timestamp,
-				Value:     p.aggregate(agg),
-			})
-		}
+	// Binary search for the first timestamp > since.
+	startIdx := searchAfter(stats.timestamps, since)
+
+	n := stats.pointCount()
+	points := make([]observer.Point, 0, n-startIdx)
+	for i := startIdx; i < n; i++ {
+		points = append(points, observer.Point{
+			Timestamp: stats.timestamps[i],
+			Value:     stats.aggregateAt(i, agg),
+		})
 	}
 
 	return &observer.Series{
@@ -317,18 +377,23 @@ func (s *timeSeriesStorage) TimeBounds() (minTs int64, maxTs int64, ok bool) {
 	found := false
 
 	for _, stats := range s.series {
-		for _, p := range stats.Points {
-			if !found {
-				min = p.Timestamp
-				max = p.Timestamp
-				found = true
-				continue
+		n := stats.pointCount()
+		if n == 0 {
+			continue
+		}
+		// Timestamps are sorted, so first and last give bounds.
+		first := stats.timestamps[0]
+		last := stats.timestamps[n-1]
+		if !found {
+			min = first
+			max = last
+			found = true
+		} else {
+			if first < min {
+				min = first
 			}
-			if p.Timestamp < min {
-				min = p.Timestamp
-			}
-			if p.Timestamp > max {
-				max = p.Timestamp
+			if last > max {
+				max = last
 			}
 		}
 	}
@@ -340,8 +405,8 @@ func (s *timeSeriesStorage) TimeBounds() (minTs int64, maxTs int64, ok bool) {
 func (s *timeSeriesStorage) MaxTimestamp() int64 {
 	var max int64
 	for _, stats := range s.series {
-		if n := len(stats.Points); n > 0 {
-			if t := stats.Points[n-1].Timestamp; t > max {
+		if n := stats.pointCount(); n > 0 {
+			if t := stats.timestamps[n-1]; t > max {
 				max = t
 			}
 		}
@@ -420,13 +485,14 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 			Name:      st.Name,
 			Tags:      st.Tags,
 		}
-		for _, p := range st.Points {
+		n := st.pointCount()
+		for i := 0; i < n; i++ {
 			ds.Points = append(ds.Points, dumpPoint{
-				Timestamp: p.Timestamp,
-				Sum:       p.Sum,
-				Count:     p.Count,
-				Min:       p.Min,
-				Max:       p.Max,
+				Timestamp: st.timestamps[i],
+				Sum:       st.sums[i],
+				Count:     st.counts[i],
+				Min:       st.mins[i],
+				Max:       st.maxes[i],
 			})
 		}
 		out = append(out, ds)
@@ -437,6 +503,26 @@ func (s *timeSeriesStorage) DumpToFile(path string) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0644)
+}
+
+// DataTimestamps returns all unique timestamps that have data, sorted ascending.
+func (s *timeSeriesStorage) DataTimestamps() []int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	seen := make(map[int64]struct{})
+	for _, stats := range s.series {
+		for _, ts := range stats.timestamps {
+			seen[ts] = struct{}{}
+		}
+	}
+
+	timestamps := make([]int64, 0, len(seen))
+	for ts := range seen {
+		timestamps = append(timestamps, ts)
+	}
+	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
+	return timestamps
 }
 
 // StorageReader interface implementation
@@ -476,9 +562,25 @@ func (s *timeSeriesStorage) PointCount(key observer.SeriesKey) int {
 
 	k := seriesKey(key.Namespace, key.Name, key.Tags)
 	if stats, ok := s.series[k]; ok {
-		return len(stats.Points)
+		return stats.pointCount()
 	}
 	return 0
+}
+
+// PointCountUpTo returns the number of raw data points with timestamp <= endTime.
+// Uses binary search since timestamps are sorted.
+func (s *timeSeriesStorage) PointCountUpTo(key observer.SeriesKey, endTime int64) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	k := seriesKey(key.Namespace, key.Name, key.Tags)
+	stats, ok := s.series[k]
+	if !ok || stats.pointCount() == 0 {
+		return 0
+	}
+
+	// Binary search for the first timestamp > endTime.
+	return searchAfter(stats.timestamps, endTime)
 }
 
 // matchTags checks if tags contain all required key=value pairs.
@@ -502,6 +604,7 @@ func matchTags(tags []string, matchers map[string]string) bool {
 
 // GetSeriesRange returns points within a time range (start, end].
 // Start is exclusive, end is inclusive. Use start=0 to read from the beginning.
+// Uses binary search on the timestamps column for O(log N) range lookup.
 func (s *timeSeriesStorage) GetSeriesRange(key observer.SeriesKey, start, end int64, agg Aggregate) *observer.Series {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -512,15 +615,54 @@ func (s *timeSeriesStorage) GetSeriesRange(key observer.SeriesKey, start, end in
 		return nil
 	}
 
-	points := make([]observer.Point, 0)
-	for _, p := range stats.Points {
-		if p.Timestamp > start && p.Timestamp <= end {
-			points = append(points, observer.Point{
-				Timestamp: p.Timestamp,
-				Value:     p.aggregate(agg),
-			})
+	// Binary search: find first index where timestamp > start
+	lo := searchAfter(stats.timestamps, start)
+	// Binary search: find first index where timestamp > end
+	hi := searchAfter(stats.timestamps, end)
+
+	// Range is [lo, hi) in the arrays, corresponding to (start, end] in time.
+	resultLen := hi - lo
+	points := make([]observer.Point, resultLen)
+
+	// For aggregates that map directly to a column, avoid per-point switch.
+	switch agg {
+	case AggregateSum:
+		for i := 0; i < resultLen; i++ {
+			points[i] = observer.Point{
+				Timestamp: stats.timestamps[lo+i],
+				Value:     stats.sums[lo+i],
+			}
+		}
+	case AggregateMin:
+		for i := 0; i < resultLen; i++ {
+			points[i] = observer.Point{
+				Timestamp: stats.timestamps[lo+i],
+				Value:     stats.mins[lo+i],
+			}
+		}
+	case AggregateMax:
+		for i := 0; i < resultLen; i++ {
+			points[i] = observer.Point{
+				Timestamp: stats.timestamps[lo+i],
+				Value:     stats.maxes[lo+i],
+			}
+		}
+	case AggregateCount:
+		for i := 0; i < resultLen; i++ {
+			points[i] = observer.Point{
+				Timestamp: stats.timestamps[lo+i],
+				Value:     float64(stats.counts[lo+i]),
+			}
+		}
+	default: // AggregateAverage and any unknown
+		for i := 0; i < resultLen; i++ {
+			points[i] = observer.Point{
+				Timestamp: stats.timestamps[lo+i],
+				Value:     stats.aggregateAt(lo+i, agg),
+			}
 		}
 	}
+
 	return &observer.Series{
 		Namespace: stats.Namespace,
 		Name:      stats.Name,

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"testing"
 
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -157,23 +158,31 @@ func TestTimeSeriesStorage_AllSeries(t *testing.T) {
 	assert.Len(t, ns2Series, 1)
 }
 
-func TestStatPoint_aggregate(t *testing.T) {
-	p := &statPoint{
-		Sum:   100.0,
-		Count: 4,
-		Min:   10.0,
-		Max:   40.0,
+func TestSeriesStats_AggregateAt(t *testing.T) {
+	// Build a seriesStats with known columnar data to test aggregation.
+	ss := &seriesStats{
+		timestamps: []int64{1000},
+		sums:       []float64{100.0},
+		counts:     []int64{4},
+		mins:       []float64{10.0},
+		maxes:      []float64{40.0},
 	}
 
-	assert.Equal(t, 25.0, p.aggregate(AggregateAverage))
-	assert.Equal(t, 100.0, p.aggregate(AggregateSum))
-	assert.Equal(t, 4.0, p.aggregate(AggregateCount))
-	assert.Equal(t, 10.0, p.aggregate(AggregateMin))
-	assert.Equal(t, 40.0, p.aggregate(AggregateMax))
+	assert.Equal(t, 25.0, ss.aggregateAt(0, AggregateAverage))
+	assert.Equal(t, 100.0, ss.aggregateAt(0, AggregateSum))
+	assert.Equal(t, 4.0, ss.aggregateAt(0, AggregateCount))
+	assert.Equal(t, 10.0, ss.aggregateAt(0, AggregateMin))
+	assert.Equal(t, 40.0, ss.aggregateAt(0, AggregateMax))
 
 	// Zero count returns 0 for average
-	p2 := &statPoint{Count: 0, Sum: 10.0}
-	assert.Equal(t, 0.0, p2.aggregate(AggregateAverage))
+	ss2 := &seriesStats{
+		timestamps: []int64{1000},
+		sums:       []float64{10.0},
+		counts:     []int64{0},
+		mins:       []float64{0},
+		maxes:      []float64{0},
+	}
+	assert.Equal(t, 0.0, ss2.aggregateAt(0, AggregateAverage))
 }
 
 func TestAggSuffix(t *testing.T) {
@@ -218,4 +227,162 @@ func TestTimeSeriesStorage_DropsExtremeFiniteValuesWithStats(t *testing.T) {
 	assert.Equal(t, int64(0), nonFinite)
 	assert.Equal(t, int64(1), extreme)
 	assert.Equal(t, int64(1), byMetric["test|my.metric"])
+}
+
+// --- Binary-search-based range query tests ---
+
+func makeRangeStorage() *timeSeriesStorage {
+	s := newTimeSeriesStorage()
+	// Insert points at timestamps 10, 20, 30, 40, 50
+	for _, ts := range []int64{10, 20, 30, 40, 50} {
+		s.Add("ns", "m", float64(ts), ts, nil)
+	}
+	return s
+}
+
+var rangeKey = observer.SeriesKey{Namespace: "ns", Name: "m"}
+
+func TestGetSeriesRange_EmptySeries(t *testing.T) {
+	s := newTimeSeriesStorage()
+	result := s.GetSeriesRange(observer.SeriesKey{Namespace: "ns", Name: "m"}, 0, 100, AggregateSum)
+	assert.Nil(t, result)
+}
+
+func TestGetSeriesRange_SinglePoint(t *testing.T) {
+	s := newTimeSeriesStorage()
+	s.Add("ns", "m", 42.0, 100, nil)
+
+	key := observer.SeriesKey{Namespace: "ns", Name: "m"}
+
+	// Range that includes the point: (0, 100]
+	result := s.GetSeriesRange(key, 0, 100, AggregateSum)
+	require.NotNil(t, result)
+	require.Len(t, result.Points, 1)
+	assert.Equal(t, int64(100), result.Points[0].Timestamp)
+	assert.Equal(t, 42.0, result.Points[0].Value)
+
+	// Range that excludes the point: start == point timestamp (exclusive)
+	result = s.GetSeriesRange(key, 100, 200, AggregateSum)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Points)
+
+	// Range before the point
+	result = s.GetSeriesRange(key, 0, 99, AggregateSum)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Points)
+}
+
+func TestGetSeriesRange_StartExclusiveEndInclusive(t *testing.T) {
+	s := makeRangeStorage()
+
+	// (20, 40] should include 30, 40 but not 20
+	result := s.GetSeriesRange(rangeKey, 20, 40, AggregateSum)
+	require.NotNil(t, result)
+	require.Len(t, result.Points, 2)
+	assert.Equal(t, int64(30), result.Points[0].Timestamp)
+	assert.Equal(t, int64(40), result.Points[1].Timestamp)
+}
+
+func TestGetSeriesRange_ExactBoundaryHits(t *testing.T) {
+	s := makeRangeStorage()
+
+	// (10, 50] should include 20, 30, 40, 50 but not 10
+	result := s.GetSeriesRange(rangeKey, 10, 50, AggregateSum)
+	require.NotNil(t, result)
+	require.Len(t, result.Points, 4)
+	assert.Equal(t, int64(20), result.Points[0].Timestamp)
+	assert.Equal(t, int64(50), result.Points[3].Timestamp)
+
+	// (0, 10] should include only 10
+	result = s.GetSeriesRange(rangeKey, 0, 10, AggregateSum)
+	require.NotNil(t, result)
+	require.Len(t, result.Points, 1)
+	assert.Equal(t, int64(10), result.Points[0].Timestamp)
+}
+
+func TestGetSeriesRange_StartZeroReadsAll(t *testing.T) {
+	s := makeRangeStorage()
+
+	// (0, 999] with start=0 should include all 5 points
+	result := s.GetSeriesRange(rangeKey, 0, 999, AggregateSum)
+	require.NotNil(t, result)
+	assert.Len(t, result.Points, 5)
+}
+
+func TestGetSeriesRange_NoOverlap(t *testing.T) {
+	s := makeRangeStorage()
+
+	// Range entirely before data
+	result := s.GetSeriesRange(rangeKey, 0, 5, AggregateSum)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Points)
+
+	// Range entirely after data
+	result = s.GetSeriesRange(rangeKey, 50, 100, AggregateSum)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Points)
+}
+
+func TestGetSeriesRange_AllAggregates(t *testing.T) {
+	s := newTimeSeriesStorage()
+	// Two values in the same bucket: sum=30, count=2, min=10, max=20, avg=15
+	s.Add("ns", "m", 10.0, 100, nil)
+	s.Add("ns", "m", 20.0, 100, nil)
+
+	key := observer.SeriesKey{Namespace: "ns", Name: "m"}
+
+	for _, tc := range []struct {
+		agg      Aggregate
+		expected float64
+	}{
+		{AggregateSum, 30.0},
+		{AggregateCount, 2.0},
+		{AggregateMin, 10.0},
+		{AggregateMax, 20.0},
+		{AggregateAverage, 15.0},
+	} {
+		result := s.GetSeriesRange(key, 0, 200, tc.agg)
+		require.NotNil(t, result)
+		require.Len(t, result.Points, 1)
+		assert.Equal(t, tc.expected, result.Points[0].Value, "agg=%d", tc.agg)
+	}
+}
+
+func TestPointCountUpTo_BinarySearch(t *testing.T) {
+	s := makeRangeStorage()
+
+	// All points <= 50
+	assert.Equal(t, 5, s.PointCountUpTo(rangeKey, 50))
+	// Points <= 30: timestamps 10, 20, 30
+	assert.Equal(t, 3, s.PointCountUpTo(rangeKey, 30))
+	// Points <= 25: timestamps 10, 20
+	assert.Equal(t, 2, s.PointCountUpTo(rangeKey, 25))
+	// Points <= 9: none
+	assert.Equal(t, 0, s.PointCountUpTo(rangeKey, 9))
+	// Points <= 10: just one
+	assert.Equal(t, 1, s.PointCountUpTo(rangeKey, 10))
+	// Non-existent series
+	assert.Equal(t, 0, s.PointCountUpTo(observer.SeriesKey{Namespace: "x", Name: "y"}, 100))
+}
+
+func TestPointCount_ColumnarLayout(t *testing.T) {
+	s := makeRangeStorage()
+	assert.Equal(t, 5, s.PointCount(rangeKey))
+	assert.Equal(t, 0, s.PointCount(observer.SeriesKey{Namespace: "x", Name: "y"}))
+}
+
+func TestGetSeriesRange_OutOfOrderInsert(t *testing.T) {
+	s := newTimeSeriesStorage()
+	// Insert out of order — columnar storage should maintain sorted order.
+	s.Add("ns", "m", 30.0, 30, nil)
+	s.Add("ns", "m", 10.0, 10, nil)
+	s.Add("ns", "m", 20.0, 20, nil)
+
+	key := observer.SeriesKey{Namespace: "ns", Name: "m"}
+	result := s.GetSeriesRange(key, 0, 100, AggregateSum)
+	require.NotNil(t, result)
+	require.Len(t, result.Points, 3)
+	assert.Equal(t, int64(10), result.Points[0].Timestamp)
+	assert.Equal(t, int64(20), result.Points[1].Timestamp)
+	assert.Equal(t, int64(30), result.Points[2].Timestamp)
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -92,38 +92,22 @@ type TestBenchConfig struct {
 
 // TestBench is the main controller for the observer test bench.
 // It manages scenarios, components, and analysis results.
+// All orchestration (detection, correlation) is delegated to the engine.
 type TestBench struct {
 	config TestBenchConfig
 
 	mu             sync.RWMutex
-	storage        *timeSeriesStorage
+	engine         *engine
+	catalog        *componentCatalog
+	components     map[string]*componentInstance // from catalog
 	loadedScenario string
 	ready          bool
 	episodeInfo    *EpisodeInfo
 
-	// Components (log extractors are not registry-managed)
-	extractors []observerdef.LogMetricsExtractor
-
-	// Registry-managed components
-	components map[string]*registeredComponent
-
-	// Results (computed eagerly on scenario load)
-	metricsAnomalies  []observerdef.Anomaly                          // all anomalies from metrics detectors
-	correlations      []observerdef.ActiveCorrelation                // from correlators
-	metricsByDetector map[string][]observerdef.Anomaly               // metric anomalies grouped by detector
-	metricsBySeriesID map[observerdef.SeriesID][]observerdef.Anomaly // metric anomalies grouped by source series id
-
-	// Raw log entries (collected during log loading)
-	rawLogs []observer.LogView
-
-	// Log anomalies (collected during log loading, independent of metrics detection reruns)
+	// Logs and log anomalies (testbench-specific, not in engine)
+	rawLogs                []observer.LogView
 	logAnomalies           []observerdef.Anomaly            // all anomalies from log detectors
 	logAnomaliesByDetector map[string][]observerdef.Anomaly // anomalies grouped by detector name
-
-	// Async correlator processing
-	correlatorsProcessing bool       // true while background correlator goroutine is running
-	correlatorGen         int64      // generation counter, incremented each rerun
-	correlatorsDone       *sync.Cond // signaled when correlatorsProcessing transitions to false
 
 	// API server
 	api *TestBenchAPI
@@ -180,42 +164,35 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 		config.EnableOverrides = make(map[string]bool)
 	}
 
-	tb := &TestBench{
-		config:  config,
-		storage: newTimeSeriesStorage(),
+	catalog := testbenchCatalog()
+	detectors, correlators, components := catalog.Instantiate(config.EnableOverrides)
 
-		// Log extractors are not registry-managed
-		extractors: []observerdef.LogMetricsExtractor{
-			&LogMetricsExtractor{
-				MaxEvalBytes: 4096,
-				ExcludeFields: map[string]struct{}{
-					"timestamp": {}, "ts": {}, "time": {},
-					"pid": {}, "ppid": {}, "uid": {}, "gid": {},
-				},
+	extractors := []observerdef.LogMetricsExtractor{
+		&LogMetricsExtractor{
+			MaxEvalBytes: 4096,
+			ExcludeFields: map[string]struct{}{
+				"timestamp": {}, "ts": {}, "time": {},
+				"pid": {}, "ppid": {}, "uid": {}, "gid": {},
 			},
-			&ConnectionErrorExtractor{},
 		},
+		&ConnectionErrorExtractor{},
+	}
 
-		components:             make(map[string]*registeredComponent),
-		metricsAnomalies:       []observerdef.Anomaly{},
-		metricsByDetector:      make(map[string][]observerdef.Anomaly),
-		metricsBySeriesID:      make(map[observerdef.SeriesID][]observerdef.Anomaly),
+	eng := newEngine(engineConfig{
+		storage:     newTimeSeriesStorage(),
+		extractors:  extractors,
+		detectors:   detectors,
+		correlators: correlators,
+		scheduler:   &currentBehaviorPolicy{},
+	})
+
+	tb := &TestBench{
+		config:                 config,
+		engine:                 eng,
+		catalog:                catalog,
+		components:             components,
 		logAnomalies:           []observerdef.Anomaly{},
 		logAnomaliesByDetector: make(map[string][]observerdef.Anomaly),
-	}
-	tb.correlatorsDone = sync.NewCond(tb.mu.RLocker())
-
-	// Instantiate all registry components
-	for _, reg := range defaultRegistry {
-		enabled := reg.DefaultEnabled
-		if override, ok := config.EnableOverrides[reg.Name]; ok {
-			enabled = override
-		}
-		tb.components[reg.Name] = &registeredComponent{
-			Registration: reg,
-			Instance:     reg.Factory(tb),
-			Enabled:      enabled,
-		}
 	}
 
 	tb.api = NewTestBenchAPI(tb)
@@ -299,11 +276,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 	defer tb.mu.Unlock()
 
 	// Clear existing data
-	tb.storage = newTimeSeriesStorage()
-	tb.metricsAnomalies = []observerdef.Anomaly{}
-	tb.correlations = []observerdef.ActiveCorrelation{}
-	tb.metricsByDetector = make(map[string][]observerdef.Anomaly)
-	tb.metricsBySeriesID = make(map[observerdef.SeriesID][]observerdef.Anomaly)
+	tb.engine.storage = newTimeSeriesStorage()
 	tb.rawLogs = nil
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
@@ -348,7 +321,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 	tb.rerunDetectorsLocked()
 	fmt.Printf("  Detector phase took %s\n", time.Since(analysisStart))
 	fmt.Printf("  Total scenario load took %s (correlators running in background)\n", time.Since(scenarioStart))
-	fmt.Printf("Scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.metricsAnomalies), len(tb.rawLogs), len(tb.logAnomalies))
+	fmt.Printf("Scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
 
 	return nil
 }
@@ -359,6 +332,8 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 	if tb.config.Recorder == nil {
 		return fmt.Errorf("recorder component not configured - cannot load parquet files")
 	}
+
+	storage := tb.engine.Storage()
 
 	// Use batch loading - get all metrics at once
 	metrics, err := tb.config.Recorder.ReadAllMetrics(dir)
@@ -379,7 +354,7 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 			}
 		}
 
-		tb.storage.Add(
+		storage.Add(
 			"parquet", // namespace
 			metricName,
 			m.Value,
@@ -397,7 +372,7 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 	if len(traceStats) > 0 {
 		fmt.Printf("  Loading %d trace stat rows from parquet files\n", len(traceStats))
 
-		sh := &storageHandle{namespace: "parquet", storage: tb.storage}
+		sh := &storageHandle{namespace: "parquet", storage: storage}
 
 		// Group by (AgentHostname, AgentEnv) so each view carries the correct agent context
 		type agentKey struct{ hostname, env string }
@@ -496,29 +471,12 @@ func (r *parquetTraceStatRow) GetOkSummary() []byte          { return r.data.OkS
 func (r *parquetTraceStatRow) GetErrorSummary() []byte       { return r.data.ErrorSummary }
 func (r *parquetTraceStatRow) GetPeerTags() []string         { return r.data.PeerTags }
 
-// runLogExtractors runs all the log extractors on the raw logs.
-func (tb *TestBench) runLogExtractors() error {
-	for _, log := range tb.rawLogs {
-		// Process through log extractors
-		for _, extractor := range tb.extractors {
-			metrics := extractor.ProcessLog(log)
-			ts := log.GetTimestampUnixMilli()
-			for _, m := range metrics {
-				tb.storage.Add("logs", "_virtual."+m.Name, m.Value, ts/1000, m.Tags)
-			}
-		}
-	}
-
-	return nil
-}
 
 // resetAllState resets all registered components that support Reset().
 func (tb *TestBench) resetAllState() {
-	for _, comp := range tb.components {
-		if resetter, ok := comp.Instance.(interface{ Reset() }); ok {
+	for _, ci := range tb.components {
+		if resetter, ok := ci.instance.(interface{ Reset() }); ok {
 			resetter.Reset()
-		} else if flusher, ok := comp.Instance.(interface{ Flush() }); ok {
-			flusher.Flush()
 		}
 	}
 }
@@ -529,11 +487,11 @@ func (tb *TestBench) GetStatus() StatusResponse {
 	defer tb.mu.RUnlock()
 
 	compMap := make(map[string]bool)
-	for name, comp := range tb.components {
-		compMap[name] = comp.Enabled
+	for name, ci := range tb.components {
+		compMap[name] = ci.enabled
 	}
 
-	scenarioStart, scenarioEnd, hasBounds := tb.storage.TimeBounds()
+	scenarioStart, scenarioEnd, hasBounds := tb.engine.Storage().TimeBounds()
 
 	// Extend bounds to include log timestamps (parquet logs can fall outside the metrics range)
 	for _, l := range tb.rawLogs {
@@ -566,10 +524,10 @@ func (tb *TestBench) GetStatus() StatusResponse {
 		Ready:                 tb.ready,
 		Scenario:              tb.loadedScenario,
 		SeriesCount:           tb.seriesCount(),
-		AnomalyCount:          len(tb.metricsAnomalies),
+		AnomalyCount:          len(tb.engine.RawAnomalies()),
 		LogAnomalyCount:       len(tb.logAnomalies),
-		ComponentCount:        len(tb.extractors) + len(tb.components),
-		CorrelatorsProcessing: tb.correlatorsProcessing,
+		ComponentCount:        len(tb.engine.extractors) + len(tb.components),
+		CorrelatorsProcessing: false,
 		ScenarioStart:         scenarioStartPtr,
 		ScenarioEnd:           scenarioEndPtr,
 		EpisodeInfo:           tb.episodeInfo,
@@ -579,138 +537,51 @@ func (tb *TestBench) GetStatus() StatusResponse {
 	}
 }
 
-// rerunDetectorsLocked re-runs all detectors on current data. Caller must hold lock.
-// Detectors run synchronously (fast), then correlators run asynchronously in a
-// background goroutine so the UI is not blocked by slow correlators.
+// rerunDetectorsLocked re-runs all detectors and correlators on current data.
+// Caller must hold lock. All orchestration is delegated to the engine.
 func (tb *TestBench) rerunDetectorsLocked() {
-	// --- Logs ---
-	// We want to process logs first in case they produce metrics that are used by other detectors.
-	if err := tb.runLogExtractors(); err != nil {
-		fmt.Printf("  Warning: failed to run log extractors: %v\n", err)
-	}
-
-	// --- Metrics ---
-	// Clear existing results
-	tb.metricsAnomalies = tb.metricsAnomalies[:0]
-	tb.correlations = tb.correlations[:0]
-	for k := range tb.metricsByDetector {
-		delete(tb.metricsByDetector, k)
-	}
-	for k := range tb.metricsBySeriesID {
-		delete(tb.metricsBySeriesID, k)
-	}
+	// Configure engine with enabled components and reset state BEFORE
+	// ingesting logs, so that log observers on the correct detector set
+	// receive log data.
+	tb.engine.SetDetectors(catalogEnabledDetectors(tb.components, tb.catalog))
+	tb.engine.SetCorrelators(catalogEnabledCorrelators(tb.components, tb.catalog))
+	tb.engine.resetFull()
 
 	// Reset ALL components (not just enabled) so disabled ones clear stale state
 	tb.resetAllState()
 
-	// Run all detectors (both SeriesDetector-based via adapter and native Detector)
-	dataTime := tb.storage.MaxTimestamp()
-	for _, detector := range tb.enabledDetectors() {
-		result := detector.Detect(tb.storage, dataTime)
-		for _, anomaly := range result.Anomalies {
-			// If the anomaly has a Source (telemetry metric name) but no SourceSeriesID,
-			// resolve it to the telemetry series using the same naming convention as handleTelemetry.
-			if anomaly.SourceSeriesID == "" && anomaly.Source != "" {
-				telemetryName := "telemetry." + detector.Name() + "." + string(anomaly.Source)
-				anomaly.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
-			}
-			if anomaly.DetectorName == "" || anomaly.Source == "" || anomaly.Timestamp == 0 {
-				fmt.Printf("  Warning: dropping invalid anomaly (detector=%q source=%q ts=%d)\n",
-					anomaly.DetectorName, anomaly.Source, anomaly.Timestamp)
-				continue
-			}
-			tb.metricsAnomalies = append(tb.metricsAnomalies, anomaly)
-			tb.metricsByDetector[anomaly.DetectorName] = append(tb.metricsByDetector[anomaly.DetectorName], anomaly)
-			if anomaly.SourceSeriesID != "" {
-				tb.metricsBySeriesID[anomaly.SourceSeriesID] = append(tb.metricsBySeriesID[anomaly.SourceSeriesID], anomaly)
-			}
+	// Feed raw logs through the engine's IngestLog path so that extractors,
+	// log observers, and timestamp tracking all use the same code path as
+	// live ingestion. We ignore the returned advance requests because
+	// ReplayStoredData (below) will handle scheduling after all data is loaded.
+	for _, log := range tb.rawLogs {
+		obs := &logObs{
+			content:     log.GetContent(),
+			status:      log.GetStatus(),
+			tags:        log.GetTags(),
+			hostname:    log.GetHostname(),
+			timestampMs: log.GetTimestampUnixMilli(),
 		}
-		tb.handleTelemetry(result.Telemetry, detector.Name(), dataTime)
+		tb.engine.IngestLog("parquet", obs)
 	}
 
-	// --- Correlations ---
-	// Mark scenario ready now that detectors are done — anomalies are available
+	// Replay all stored data through the scheduler policy.
+	// The engine's captureRawAnomaly deduplicates anomalies internally,
+	// so stateView.Anomalies() returns a clean deduplicated set.
+	result := tb.engine.ReplayStoredData()
+
+	// Handle telemetry (write telemetry metrics to storage for UI)
+	dataTime := tb.engine.Storage().MaxTimestamp()
+	for _, t := range result.telemetry {
+		detName := t.DetectorName
+		if detName == "" {
+			detName = "unknown"
+		}
+		tb.handleTelemetry([]observerdef.ObserverTelemetry{t}, detName, dataTime)
+	}
+
+	// Mark scenario ready now that all analysis is complete
 	tb.ready = true
-
-	// Snapshot anomalies sorted by time for the background goroutine.
-	// Anomalies are collected per-series, not in time order. Sorting ensures
-	// correlators see events chronologically, matching the live observer's
-	// behavior and preventing premature eviction of early clusters.
-	anomalySnapshot := make([]observerdef.Anomaly, len(tb.metricsAnomalies))
-	copy(anomalySnapshot, tb.metricsAnomalies)
-	sort.Slice(anomalySnapshot, func(i, j int) bool {
-		return anomalySnapshot[i].Timestamp < anomalySnapshot[j].Timestamp
-	})
-	correlators := tb.enabledCorrelators()
-
-	// Phase 2 (async): Run correlators in a background goroutine
-	tb.correlatorGen++
-	gen := tb.correlatorGen
-	tb.correlatorsProcessing = true
-
-	go func() {
-		// Simulate the live observer's periodic flush+snapshot pattern.
-		// We process anomalies in time order, periodically flushing and
-		// capturing ActiveCorrelations so we see clusters that would have
-		// been observed before eviction — not just those alive at the end.
-		allCorrelations := make(map[string]observerdef.ActiveCorrelation) // keyed by Pattern
-
-		snapshotCorrelations := func() {
-			for _, proc := range correlators {
-				proc.Flush()
-			}
-			for _, proc := range correlators {
-				cs, ok := proc.(interface {
-					ActiveCorrelations() []observerdef.ActiveCorrelation
-				})
-				if !ok {
-					continue
-				}
-				for _, corr := range cs.ActiveCorrelations() {
-					// Keep the latest version of each correlation (most anomalies)
-					if existing, ok := allCorrelations[corr.Pattern]; ok {
-						if len(corr.Anomalies) >= len(existing.Anomalies) {
-							allCorrelations[corr.Pattern] = corr
-						}
-					} else {
-						allCorrelations[corr.Pattern] = corr
-					}
-				}
-			}
-		}
-
-		var lastFlushTime int64
-		const flushInterval int64 = 10 // seconds — matches live observer's ~per-observation cadence
-
-		for _, anomaly := range anomalySnapshot {
-			for _, proc := range correlators {
-				proc.Process(anomaly)
-			}
-			// Periodically flush and snapshot, simulating the live observer
-			if anomaly.Timestamp-lastFlushTime >= flushInterval {
-				snapshotCorrelations()
-				lastFlushTime = anomaly.Timestamp
-			}
-		}
-		// Final flush to capture anything remaining
-		snapshotCorrelations()
-
-		// Collect results under lock
-		tb.mu.Lock()
-		defer tb.mu.Unlock()
-
-		if tb.correlatorGen != gen {
-			return // Stale — a newer rerun is in progress or completed
-		}
-
-		tb.correlations = tb.correlations[:0]
-		for _, corr := range allCorrelations {
-			tb.correlations = append(tb.correlations, corr)
-		}
-
-		tb.correlatorsProcessing = false
-		tb.correlatorsDone.Broadcast()
-	}()
 }
 
 // This will handle custom telemetry created by the anomaly detectors.
@@ -732,7 +603,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				telemetryEvent.DetectorName = detectorName
 			}
 			// Save this for UI
-			tb.storage.Add("telemetry", "telemetry."+telemetryEvent.DetectorName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
+			tb.engine.Storage().Add("telemetry", "telemetry."+telemetryEvent.DetectorName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
 		}
 
 		if telemetryEvent.Log != nil {
@@ -741,7 +612,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				timestamp = baseTimestampMs
 			}
 			logTags := telemetryEvent.Log.GetTags()
-			tagsCopy := make([]string, 0, len(logTags)+2)
+			tagsCopy := make([]string, len(logTags), len(logTags)+2)
 			copy(tagsCopy, logTags)
 			tagsCopy = append(tagsCopy, "detector:"+detectorName)
 			tagsCopy = append(tagsCopy, "telemetry:true")
@@ -771,17 +642,21 @@ func (tb *TestBench) GetComponents() []ComponentInfo {
 
 	var components []ComponentInfo
 
-	// Return registry components in registry order
-	for _, reg := range defaultRegistry {
-		comp := tb.components[reg.Name]
-		if comp == nil {
+	// Return components in catalog order
+	for _, entry := range tb.catalog.Entries() {
+		ci := tb.components[entry.name]
+		if ci == nil {
 			continue
 		}
+		category := "detector"
+		if entry.kind == componentCorrelator {
+			category = "correlator"
+		}
 		components = append(components, ComponentInfo{
-			Name:        reg.Name,
-			DisplayName: reg.DisplayName,
-			Category:    reg.Category,
-			Enabled:     comp.Enabled,
+			Name:        entry.name,
+			DisplayName: entry.displayName,
+			Category:    category,
+			Enabled:     ci.enabled,
 		})
 	}
 
@@ -792,7 +667,7 @@ func (tb *TestBench) GetComponents() []ComponentInfo {
 func (tb *TestBench) GetStorage() *timeSeriesStorage {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
-	return tb.storage
+	return tb.engine.Storage()
 }
 
 // GetMetricsAnomalies returns all metric anomalies detected by TS detectors.
@@ -800,9 +675,7 @@ func (tb *TestBench) GetMetricsAnomalies() []observerdef.Anomaly {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	result := make([]observerdef.Anomaly, len(tb.metricsAnomalies))
-	copy(result, tb.metricsAnomalies)
-	return result
+	return tb.resolveAnomalySeriesIDs(tb.engine.StateView().Anomalies())
 }
 
 // GetMetricsAnomaliesByDetector returns metric anomalies grouped by detector name.
@@ -810,13 +683,11 @@ func (tb *TestBench) GetMetricsAnomaliesByDetector() map[string][]observerdef.An
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	result := make(map[string][]observerdef.Anomaly)
-	for k, v := range tb.metricsByDetector {
-		copied := make([]observerdef.Anomaly, len(v))
-		copy(copied, v)
-		result[k] = copied
+	byDetector := tb.engine.StateView().AnomaliesByDetector()
+	for k, v := range byDetector {
+		byDetector[k] = tb.resolveAnomalySeriesIDs(v)
 	}
-	return result
+	return byDetector
 }
 
 // GetMetricsAnomaliesForSeries returns metric anomalies associated with a specific series id.
@@ -824,10 +695,32 @@ func (tb *TestBench) GetMetricsAnomaliesForSeries(seriesID observerdef.SeriesID)
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	anomalies := tb.metricsBySeriesID[seriesID]
-	result := make([]observerdef.Anomaly, len(anomalies))
-	copy(result, anomalies)
+	// Resolve SourceSeriesIDs first, then filter by the requested series ID.
+	// We resolve all anomalies because the engine may store them with empty
+	// SourceSeriesID (e.g. RRCF anomalies) that resolve to the requested ID.
+	resolved := tb.resolveAnomalySeriesIDs(tb.engine.StateView().Anomalies())
+	var result []observerdef.Anomaly
+	for _, a := range resolved {
+		if a.SourceSeriesID == seriesID {
+			result = append(result, a)
+		}
+	}
 	return result
+}
+
+// resolveAnomalySeriesIDs applies testbench-specific SourceSeriesID resolution
+// to anomalies that have an empty SourceSeriesID. Detectors like RRCF that
+// operate on the full storage don't set SourceSeriesID; this maps them to the
+// corresponding telemetry series using the naming convention from handleTelemetry.
+func (tb *TestBench) resolveAnomalySeriesIDs(anomalies []observerdef.Anomaly) []observerdef.Anomaly {
+	for i := range anomalies {
+		a := &anomalies[i]
+		if a.SourceSeriesID == "" && a.Source != "" {
+			telemetryName := "telemetry." + a.DetectorName + "." + string(a.Source)
+			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
+		}
+	}
+	return anomalies
 }
 
 // GetLogAnomalies returns all anomalies emitted directly by log detectors.
@@ -861,27 +754,25 @@ func (tb *TestBench) GetDetectorComponentMap() map[string]string {
 	defer tb.mu.RUnlock()
 
 	result := make(map[string]string)
-	for componentName, comp := range tb.components {
-		if comp.Registration.Category != "detector" {
+	for componentName, ci := range tb.components {
+		if ci.entry.kind != componentDetector {
 			continue
 		}
-		if detector, ok := comp.Instance.(observerdef.Detector); ok {
+		if detector, ok := ci.instance.(observerdef.Detector); ok {
 			result[detector.Name()] = componentName
-		} else if detector, ok := comp.Instance.(observerdef.SeriesDetector); ok {
+		} else if detector, ok := ci.instance.(observerdef.SeriesDetector); ok {
 			result[detector.Name()] = componentName
 		}
 	}
 	return result
 }
 
-// GetCorrelations returns all detected correlations.
+// GetCorrelations returns all detected correlations from the engine's correlators.
 func (tb *TestBench) GetCorrelations() []observerdef.ActiveCorrelation {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	result := make([]observerdef.ActiveCorrelation, len(tb.correlations))
-	copy(result, tb.correlations)
-	return result
+	return tb.engine.StateView().ActiveCorrelations()
 }
 
 // GetCompressedCorrelations returns compressed group descriptions for all active correlations.
@@ -889,12 +780,14 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	if tb.storage == nil || len(tb.correlations) == 0 {
+	correlations := tb.engine.StateView().ActiveCorrelations()
+	storage := tb.engine.Storage()
+	if storage == nil || len(correlations) == 0 {
 		return []CompressedGroup{}
 	}
 
 	// Build universe from storage
-	universe := tb.storage.ListAllSeriesCompact()
+	universe := storage.ListAllSeriesCompact()
 
 	// Expand the universe to include aggregated variants (since anomalies use "name:agg" keys)
 	var expandedUniverse []seriesCompact
@@ -909,7 +802,7 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 	}
 
 	var groups []CompressedGroup
-	for i, corr := range tb.correlations {
+	for i, corr := range correlations {
 		// Resolve member series from anomaly SourceSeriesIDs
 		memberSet := make(map[string]struct{})
 		var members []seriesCompact
@@ -946,10 +839,11 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 
 // seriesCount returns the number of unique series (must be called with lock held).
 func (tb *TestBench) seriesCount() int {
-	if tb.storage == nil {
+	storage := tb.engine.Storage()
+	if storage == nil {
 		return 0
 	}
-	return len(tb.storage.series)
+	return len(storage.series)
 }
 
 // GetLeadLagEdges returns lead-lag edges if the correlator is enabled.
@@ -976,9 +870,9 @@ func (tb *TestBench) GetCorrelatorStats() map[string]interface{} {
 	defer tb.mu.RUnlock()
 
 	stats := make(map[string]interface{})
-	for name, comp := range tb.components {
-		if comp.Registration.Category == "correlator" {
-			if statter, ok := comp.Instance.(interface {
+	for name, ci := range tb.components {
+		if ci.entry.kind == componentCorrelator {
+			if statter, ok := ci.instance.(interface {
 				GetStats() map[string]interface{}
 			}); ok {
 				stats[name] = statter.GetStats()
@@ -988,28 +882,19 @@ func (tb *TestBench) GetCorrelatorStats() map[string]interface{} {
 	return stats
 }
 
-// IsCorrelatorsProcessing returns true if correlators are running in the background.
+// IsCorrelatorsProcessing returns false — correlators now run synchronously via the engine.
 func (tb *TestBench) IsCorrelatorsProcessing() bool {
-	tb.mu.Lock()
-	defer tb.mu.Unlock()
-	return tb.correlatorsProcessing
+	return false
 }
 
 // RunHeadless runs a scenario synchronously without the HTTP server and writes output.
 // If verbose is true, the output file includes full correlation detail (title, members, anomalies).
 // If verbose is false, correlations include only the anomalous time span.
 func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) error {
-	// LoadScenario runs detectors synchronously and kicks off correlators async.
+	// LoadScenario runs detectors and correlators synchronously via the engine.
 	if err := tb.LoadScenario(scenario); err != nil {
 		return fmt.Errorf("loading scenario %q: %w", scenario, err)
 	}
-
-	// Wait for correlators to finish (they run in a background goroutine).
-	tb.mu.RLock()
-	for tb.correlatorsProcessing {
-		tb.correlatorsDone.Wait()
-	}
-	tb.mu.RUnlock()
 
 	// Write structured JSON output.
 	if outputPath != "" {
@@ -1027,15 +912,15 @@ func (tb *TestBench) ToggleComponent(name string) error {
 	tb.mu.Lock()
 	defer tb.mu.Unlock()
 
-	comp, ok := tb.components[name]
+	ci, ok := tb.components[name]
 	if !ok {
 		return fmt.Errorf("unknown component: %s", name)
 	}
 
-	comp.Enabled = !comp.Enabled
+	ci.enabled = !ci.enabled
 
 	// Re-run analyses if a scenario is loaded
-	if tb.ready && tb.storage != nil {
+	if tb.ready && tb.engine.Storage() != nil {
 		tb.rerunDetectorsLocked()
 	}
 
@@ -1048,11 +933,7 @@ func (tb *TestBench) loadDemoScenario() error {
 	defer tb.mu.Unlock()
 
 	// Clear existing data
-	tb.storage = newTimeSeriesStorage()
-	tb.metricsAnomalies = []observerdef.Anomaly{}
-	tb.correlations = []observerdef.ActiveCorrelation{}
-	tb.metricsByDetector = make(map[string][]observerdef.Anomaly)
-	tb.metricsBySeriesID = make(map[observerdef.SeriesID][]observerdef.Anomaly)
+	tb.engine.storage = newTimeSeriesStorage()
 	tb.rawLogs = nil
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
@@ -1064,6 +945,8 @@ func (tb *TestBench) loadDemoScenario() error {
 
 	fmt.Println("Generating demo scenario data...")
 
+	storage := tb.engine.Storage()
+
 	// Generate data for each second of the 70-second scenario
 	baseTimestamp := int64(1000000)
 	const totalSeconds = 70
@@ -1074,44 +957,44 @@ func (tb *TestBench) loadDemoScenario() error {
 
 		// Heap usage (host:web-1)
 		heapValue := getDemoHeapValue(elapsed)
-		tb.storage.Add("demo", "runtime.heap.used_mb", heapValue, timestamp, []string{"host:web-1"})
+		storage.Add("demo", "runtime.heap.used_mb", heapValue, timestamp, []string{"host:web-1"})
 
 		// GC pause time (host:web-1)
 		gcValue := getDemoGCPauseValue(elapsed)
-		tb.storage.Add("demo", "runtime.gc.pause_ms", gcValue, timestamp, []string{"host:web-1"})
+		storage.Add("demo", "runtime.gc.pause_ms", gcValue, timestamp, []string{"host:web-1"})
 
 		// CPU usage (host:web-1)
 		cpuValue := getDemoCPUValue(elapsed)
-		tb.storage.Add("demo", "system.cpu.user_percent", cpuValue, timestamp, []string{"host:web-1"})
+		storage.Add("demo", "system.cpu.user_percent", cpuValue, timestamp, []string{"host:web-1"})
 
 		// Request latency — two service variants
 		latencyValue := getDemoLatencyValue(elapsed)
-		tb.storage.Add("demo", "app.request.latency_p99_ms", latencyValue*1.2, timestamp, []string{"service:api"})
-		tb.storage.Add("demo", "app.request.latency_p99_ms", latencyValue*0.8, timestamp, []string{"service:worker"})
+		storage.Add("demo", "app.request.latency_p99_ms", latencyValue*1.2, timestamp, []string{"service:api"})
+		storage.Add("demo", "app.request.latency_p99_ms", latencyValue*0.8, timestamp, []string{"service:worker"})
 
 		// Error rate — two service variants
 		errorValue := getDemoErrorRateValue(elapsed)
-		tb.storage.Add("demo", "app.request.error_rate", errorValue*1.5, timestamp, []string{"service:api"})
-		tb.storage.Add("demo", "app.request.error_rate", errorValue*0.7, timestamp, []string{"service:worker"})
+		storage.Add("demo", "app.request.error_rate", errorValue*1.5, timestamp, []string{"service:api"})
+		storage.Add("demo", "app.request.error_rate", errorValue*0.7, timestamp, []string{"service:worker"})
 
 		// Throughput — two service variants
 		throughputValue := getDemoThroughputValue(elapsed)
-		tb.storage.Add("demo", "app.request.throughput_rps", throughputValue*1.4, timestamp, []string{"service:api"})
-		tb.storage.Add("demo", "app.request.throughput_rps", throughputValue*0.6, timestamp, []string{"service:worker"})
+		storage.Add("demo", "app.request.throughput_rps", throughputValue*1.4, timestamp, []string{"service:api"})
+		storage.Add("demo", "app.request.throughput_rps", throughputValue*0.6, timestamp, []string{"service:worker"})
 
 		// Correlator-targeted metrics (trigger kernel_bottleneck / network_degradation patterns)
 		// network.retransmits → analyzed as "network.retransmits:avg" — host-level
 		retransmits := getDemoNetworkRetransmitsValue(elapsed)
-		tb.storage.Add("demo", "network.retransmits", retransmits, timestamp, []string{"host:web-1"})
+		storage.Add("demo", "network.retransmits", retransmits, timestamp, []string{"host:web-1"})
 
 		// ebpf.lock_contention_ns → analyzed as "ebpf.lock_contention_ns:avg" — host-level
 		lockContention := getDemoLockContentionValue(elapsed)
-		tb.storage.Add("demo", "ebpf.lock_contention_ns", lockContention, timestamp, []string{"host:web-1"})
+		storage.Add("demo", "ebpf.lock_contention_ns", lockContention, timestamp, []string{"host:web-1"})
 
 		// connection.errors → analyzed as "connection.errors:count" — two service variants
 		connErrors := getDemoConnectionErrorsValue(elapsed)
-		tb.storage.Add("demo", "connection.errors", connErrors, timestamp, []string{"service:api"})
-		tb.storage.Add("demo", "connection.errors", connErrors*0.6, timestamp, []string{"service:worker"})
+		storage.Add("demo", "connection.errors", connErrors, timestamp, []string{"service:api"})
+		storage.Add("demo", "connection.errors", connErrors*0.6, timestamp, []string{"service:worker"})
 	}
 
 	fmt.Printf("  Generated %d seconds of demo data\n", totalSeconds)
@@ -1197,7 +1080,7 @@ func (tb *TestBench) loadDemoScenario() error {
 
 	// Run analyses on all loaded data (detectors sync, correlators async)
 	tb.rerunDetectorsLocked()
-	fmt.Printf("Demo scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies (correlators running in background)\n", tb.seriesCount(), len(tb.metricsAnomalies), len(tb.rawLogs), len(tb.logAnomalies))
+	fmt.Printf("Demo scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies (correlators running in background)\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
 
 	return nil
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -276,7 +276,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 	defer tb.mu.Unlock()
 
 	// Clear existing data
-	tb.engine.storage = newTimeSeriesStorage()
+	tb.engine.storage = newTimeSeriesStorage() // TODO: encapsulate behind engine method
 	tb.rawLogs = nil
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
@@ -320,7 +320,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 	analysisStart := time.Now()
 	tb.rerunDetectorsLocked()
 	fmt.Printf("  Detector phase took %s\n", time.Since(analysisStart))
-	fmt.Printf("  Total scenario load took %s (correlators running in background)\n", time.Since(scenarioStart))
+	fmt.Printf("  Total scenario load took %s\n", time.Since(scenarioStart))
 	fmt.Printf("Scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
 
 	return nil
@@ -933,7 +933,7 @@ func (tb *TestBench) loadDemoScenario() error {
 	defer tb.mu.Unlock()
 
 	// Clear existing data
-	tb.engine.storage = newTimeSeriesStorage()
+	tb.engine.storage = newTimeSeriesStorage() // TODO: encapsulate behind engine method
 	tb.rawLogs = nil
 	tb.logAnomalies = []observerdef.Anomaly{}
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
@@ -1080,7 +1080,7 @@ func (tb *TestBench) loadDemoScenario() error {
 
 	// Run analyses on all loaded data (detectors sync, correlators async)
 	tb.rerunDetectorsLocked()
-	fmt.Printf("Demo scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies (correlators running in background)\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
+	fmt.Printf("Demo scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
 
 	return nil
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -767,20 +767,20 @@ func (tb *TestBench) GetDetectorComponentMap() map[string]string {
 	return result
 }
 
-// GetCorrelations returns all detected correlations from the engine's correlators.
+// GetCorrelations returns all correlations detected across the full run.
 func (tb *TestBench) GetCorrelations() []observerdef.ActiveCorrelation {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	return tb.engine.StateView().ActiveCorrelations()
+	return tb.engine.StateView().CorrelationHistory()
 }
 
-// GetCompressedCorrelations returns compressed group descriptions for all active correlations.
+// GetCompressedCorrelations returns compressed group descriptions for all correlations.
 func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGroup {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	correlations := tb.engine.StateView().ActiveCorrelations()
+	correlations := tb.engine.StateView().CorrelationHistory()
 	storage := tb.engine.Storage()
 	if storage == nil || len(correlations) == 0 {
 		return []CompressedGroup{}

--- a/comp/observer/impl/testbench_registry.go
+++ b/comp/observer/impl/testbench_registry.go
@@ -5,156 +5,22 @@
 
 package observerimpl
 
-import observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
-
-// ComponentRegistration describes how to create and identify a testbench component.
-type ComponentRegistration struct {
-	Name           string // unique identifier (e.g. "cusum", "lead_lag")
-	DisplayName    string // human-readable name (e.g. "CUSUM", "Lead-Lag")
-	Category       string // "detector", "correlator", or "processing"
-	DefaultEnabled bool
-	Factory        func(tb *TestBench) interface{}
-}
-
-// registeredComponent is a component instance paired with its registration and enabled state.
-type registeredComponent struct {
-	Registration ComponentRegistration
-	Instance     interface{}
-	Enabled      bool
-}
-
 // ComponentDataProvider is implemented by components that expose extra data
 // beyond what their primary interface provides (e.g. edges, clusters, scores).
 type ComponentDataProvider interface {
 	GetExtraData() interface{}
 }
 
-// defaultRegistry defines all available testbench components.
-var defaultRegistry = []ComponentRegistration{
-	// Detectors
-	{
-		Name:           "cusum",
-		DisplayName:    "CUSUM",
-		Category:       "detector",
-		DefaultEnabled: true,
-		Factory: func(_ *TestBench) interface{} {
-			return NewCUSUMDetector()
-		},
-	},
-	{
-		Name:           "bocpd",
-		DisplayName:    "BOCPD",
-		Category:       "detector",
-		DefaultEnabled: true,
-		Factory: func(tb *TestBench) interface{} {
-			return NewBOCPDDetector()
-		},
-	},
-	{
-		Name:           "rrcf",
-		DisplayName:    "RRCF",
-		Category:       "detector",
-		DefaultEnabled: false,
-		Factory: func(_ *TestBench) interface{} {
-			config := DefaultRRCFConfig()
-			config.Metrics = TestBenchRRCFMetrics()
-			return NewRRCFDetector(config)
-		},
-	},
-	// Correlators
-	{
-		Name:           "time_cluster",
-		DisplayName:    "TimeCluster",
-		Category:       "correlator",
-		DefaultEnabled: true,
-		Factory: func(_ *TestBench) interface{} {
-			return NewTimeClusterCorrelator(TimeClusterConfig{
-				ProximitySeconds: 10,
-				WindowSeconds:    120,
-			})
-		},
-	},
-	{
-		Name:           "lead_lag",
-		DisplayName:    "Lead-Lag",
-		Category:       "correlator",
-		DefaultEnabled: false,
-		Factory: func(_ *TestBench) interface{} {
-			return NewLeadLagCorrelator(LeadLagConfig{
-				MaxLagSeconds:       30,
-				MinObservations:     3,
-				ConfidenceThreshold: 0.6,
-				WindowSeconds:       120,
-			})
-		},
-	},
-	{
-		Name:           "surprise",
-		DisplayName:    "Surprise",
-		Category:       "correlator",
-		DefaultEnabled: false,
-		Factory: func(_ *TestBench) interface{} {
-			return NewSurpriseCorrelator(SurpriseConfig{
-				WindowSizeSeconds: 10,
-				MinLift:           2.0,
-				MinSupport:        2,
-			})
-		},
-	},
-}
-
-// enabledDetectors returns all enabled Detector instances.
-// SeriesDetector implementations are wrapped with seriesDetectorAdapter.
-func (tb *TestBench) enabledDetectors() []observerdef.Detector {
-	var result []observerdef.Detector
-	for _, comp := range tb.components {
-		if comp.Enabled && comp.Registration.Category == "detector" {
-			if d, ok := comp.Instance.(observerdef.Detector); ok {
-				result = append(result, d)
-			} else if sd, ok := comp.Instance.(observerdef.SeriesDetector); ok {
-				result = append(result, newSeriesDetectorAdapter(sd, defaultAggregations))
-			}
-		}
-	}
-	return result
-}
-
-// enabledCorrelators returns all enabled Correlator instances.
-func (tb *TestBench) enabledCorrelators() []observerdef.Correlator {
-	var result []observerdef.Correlator
-	for _, comp := range tb.components {
-		if comp.Enabled && comp.Registration.Category == "correlator" {
-			if p, ok := comp.Instance.(observerdef.Correlator); ok {
-				result = append(result, p)
-			}
-		}
-	}
-	return result
-}
-
-// allCorrelators returns all Correlator instances (enabled or not), for reset.
-func (tb *TestBench) allCorrelators() []observerdef.Correlator {
-	var result []observerdef.Correlator
-	for _, comp := range tb.components {
-		if comp.Registration.Category == "correlator" {
-			if p, ok := comp.Instance.(observerdef.Correlator); ok {
-				result = append(result, p)
-			}
-		}
-	}
-	return result
-}
-
 // GetComponentData returns the extra data and enabled status for a named component.
 func (tb *TestBench) GetComponentData(name string) (data interface{}, enabled bool) {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
-	comp, ok := tb.components[name]
+	ci, ok := tb.components[name]
 	if !ok {
 		return nil, false
 	}
-	if provider, ok := comp.Instance.(ComponentDataProvider); ok {
-		return provider.GetExtraData(), comp.Enabled
+	if provider, ok := ci.instance.(ComponentDataProvider); ok {
+		return provider.GetExtraData(), ci.enabled
 	}
-	return nil, comp.Enabled
+	return nil, ci.enabled
 }


### PR DESCRIPTION
## Summary

Introduces a shared execution engine that both the live observer and testbench
delegate to, replacing the previous design where each maintained independent
pipeline orchestration logic. The primary goal is execution fidelity: what you
see in the testbench should match what the live observer would produce.

The main challenge this surfaced was scheduling. Previously, the testbench
bulk-loaded scenario data and ran detectors in a single pass, while the live
observer ran detection incrementally as data arrived. Unifying these required
the testbench to replay data through the engine step-by-step — which initially
caused a massive slowdown (1.5+ hours for a single scenario). Several rounds of
optimization brought this down to ~5 seconds.

### Key changes

- **Shared engine with scheduler, events, stateview, and component catalog** —
  New orchestration core encapsulating storage, detectors, correlators, anomaly
  tracking, pub-sub events, and read-only state introspection.
- **Wire engine into live observer and testbench** — Both now delegate to the
  engine. The live observer becomes a thin driver; the testbench uses
  `ReplayStoredData`. Removes ~220 lines of duplicated orchestration logic.
- **Evolve Correlator/Reporter contracts** — Rename and extend interfaces so
  engine consumers work from event data rather than querying internal state.
- **Columnar storage with binary search** — Rewrite storage from row-oriented
  to parallel arrays with O(log N) range queries, replacing O(N) linear scans.
- **Convert BOCPD to streaming stateful detector** — BOCPD now implements
  `Detector` directly, managing per-series state, warmup, and alert lifecycle
  (hysteresis) for incremental processing instead of re-running over the full
  window each tick.
- **Various performance optimizations** — Buffer reuse, O(1) anomaly dedup, and
  other fixes that collectively bring scenario replay from ~1h41m to ~5s.

## Open questions

The "simple" batch-mode time series detectors (CUSUM, ZScore) don't have an
obvious path forward under unified scheduling — re-running them from scratch
over a long baseline for every series every second is prohibitively expensive.
BOCPD has been converted to streaming; the others may need similar treatment or
deprecation.

## Test plan

- [ ] `go test ./comp/observer/impl/` passes
- [ ] `go build ./cmd/observer-testbench/` succeeds
- [ ] Load a scenario in the testbench and verify detection results are
      consistent across replays (determinism)
- [ ] Verify live observer still runs correctly with `./bin/agent/agent run`