### PR TITLE
don't log in teeconfig when "compare" is a subset of "base"

### DIFF
--- a/pkg/config/teeconfig/go.mod
+++ b/pkg/config/teeconfig/go.mod
@@ -5,15 +5,19 @@ go 1.25.0
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.64.0-devel
 	github.com/DataDog/datadog-agent/pkg/util/log v0.64.0-devel
+	github.com/stretchr/testify v1.11.1
 )
 
 require (
 	github.com/DataDog/datadog-agent/pkg/template v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/scrubber v0.64.1 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.62.3 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/time v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 // This section was automatically added by 'dda inv modules.add-all-replace' command, do not edit manually

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -230,8 +230,30 @@ func (t *teeConfig) compareResult(key, method string, base, compare interface{})
 				}
 			}
 		}
+		// Don't log when compare is a strict superset of base
+		if baseMap, ok := base.(map[string]interface{}); ok {
+			if compareMap, ok := compare.(map[string]interface{}); ok {
+				if mapIsSubset(baseMap, compareMap) {
+					return
+				}
+			}
+		}
 		t.warnOnce(method, key, "base[%s]: %#v | compare[%s] %#v | from %s", t.baseline.GetSource(key), base, t.compare.GetSource(key), compare, getLocation(2))
 	}
+}
+
+// mapIsSubset returns true if every key in base exists in superset with an identical value
+func mapIsSubset(base, superset map[string]interface{}) bool {
+	for k, v := range base {
+		sv, ok := superset[k]
+		if !ok {
+			return false
+		}
+		if !reflect.DeepEqual(v, sv) {
+			return false
+		}
+	}
+	return true
 }
 
 // Get wraps Viper for concurrent access

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -230,10 +230,14 @@ func (t *teeConfig) compareResult(key, method string, base, compare interface{})
 				}
 			}
 		}
-		// Don't log when compare is a strict superset of base
+		// Skip logging when NTMs result is a superset of vipers
 		if baseMap, ok := base.(map[string]interface{}); ok {
 			if compareMap, ok := compare.(map[string]interface{}); ok {
-				if mapIsSubset(baseMap, compareMap) {
+				viperMap, ntmMap := baseMap, compareMap
+				if t.baseline.GetLibType() != "viper" {
+					viperMap, ntmMap = compareMap, baseMap
+				}
+				if mapIsSubset(viperMap, ntmMap) {
 					return
 				}
 			}

--- a/pkg/config/teeconfig/teeconfig_test.go
+++ b/pkg/config/teeconfig/teeconfig_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package teeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapIsSubset(t *testing.T) {
+	t.Run("empty base is subset of anything", func(t *testing.T) {
+		assert.True(t, mapIsSubset(
+			map[string]interface{}{},
+			map[string]interface{}{"a": 1},
+		))
+	})
+
+	t.Run("identical maps", func(t *testing.T) {
+		assert.True(t, mapIsSubset(
+			map[string]interface{}{"a": 1, "b": "two"},
+			map[string]interface{}{"a": 1, "b": "two"},
+		))
+	})
+
+	t.Run("base is strict subset of superset", func(t *testing.T) {
+		assert.True(t, mapIsSubset(
+			map[string]interface{}{"a": 1},
+			map[string]interface{}{"a": 1, "b": 2, "c": 3},
+		))
+	})
+
+	t.Run("base has key missing from superset", func(t *testing.T) {
+		assert.False(t, mapIsSubset(
+			map[string]interface{}{"a": 1, "missing": 2},
+			map[string]interface{}{"a": 1},
+		))
+	})
+
+	t.Run("same keys but different values", func(t *testing.T) {
+		assert.False(t, mapIsSubset(
+			map[string]interface{}{"a": 1},
+			map[string]interface{}{"a": 99},
+		))
+	})
+
+	t.Run("nested map values compared deeply", func(t *testing.T) {
+		assert.True(t, mapIsSubset(
+			map[string]interface{}{"nested": map[string]interface{}{"x": 1}},
+			map[string]interface{}{"nested": map[string]interface{}{"x": 1}, "extra": true},
+		))
+		assert.False(t, mapIsSubset(
+			map[string]interface{}{"nested": map[string]interface{}{"x": 1}},
+			map[string]interface{}{"nested": map[string]interface{}{"x": 2}},
+		))
+	})
+}


### PR DESCRIPTION
### What does this PR do?
addresses: https://datadoghq.atlassian.net/browse/AGENTCFG-676

### Motivation
reduces logging noise in teeconfig in the agent

### Describe how you validated your changes
added unit tests

### Additional Notes
