### PR TITLE
feat(changelog): Phase 1 — add new release notes tooling alongside reno

### DIFF
--- a/.gitlab/build/lint/technical_linters.yml
+++ b/.gitlab/build/lint/technical_linters.yml
@@ -81,3 +81,17 @@ lint_releasenotes_rst:
   rules: !reference [.on_releasenotes_changes]
   script:
     - dda inv -- -e linter.rst-releasenotes --only-changed
+
+lint_releasenotes_md:
+  extends: .lint
+  rules: !reference [.on_releasenotes_changes]
+  allow_failure: true
+  script:
+    - dda inv -- -e linter.lint-releasenotes-md --only-changed
+
+compare_assemblers:
+  extends: .lint
+  rules: !reference [.on_releasenotes_changes]
+  allow_failure: true
+  script:
+    - dda inv -- -e linter.compare-assemblers

--- a/CHANGELOG-DCA.md
+++ b/CHANGELOG-DCA.md
@@ -1,0 +1,4 @@
+# Datadog Cluster Agent Changelog
+
+This file is populated by the shadow Markdown assembler during the reno migration period.
+See `CHANGELOG-DCA.rst` for the authoritative changelog.

--- a/CHANGELOG-INSTALLSCRIPT.md
+++ b/CHANGELOG-INSTALLSCRIPT.md
@@ -1,0 +1,4 @@
+# Datadog Agent Install Script Changelog
+
+This file is populated by the shadow Markdown assembler during the reno migration period.
+See `CHANGELOG-INSTALLSCRIPT.rst` for the authoritative changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Datadog Agent Changelog
+
+This file is populated by the shadow Markdown assembler during the reno migration period.
+See `CHANGELOG.rst` for the authoritative changelog.

--- a/docs/public/guidelines/contributing.md
+++ b/docs/public/guidelines/contributing.md
@@ -128,6 +128,14 @@ Each PR should include a `releasenotes` file created with `reno`, unless the PR 
 
 To install reno: `pip install reno`
 
+Alternatively, if you have the development tools installed, you can use the built-in task instead of `reno new`:
+
+```bash
+$> dda inv notes.new <topic-of-my-pr>
+```
+
+This creates the same YAML template without requiring reno to be installed. Either approach produces a file in `releasenotes/notes/` ready to fill in.
+
 Ultra quick `Reno` HOWTO:
 
 ```bash

--- a/tasks/libs/linter/releasenotes_md.py
+++ b/tasks/libs/linter/releasenotes_md.py
@@ -1,0 +1,240 @@
+"""Structural linter for release note YAML fragments.
+
+Validates that release notes follow the expected YAML structure: known sections,
+correct types, and non-empty content. Content format (RST or Markdown) is NOT
+validated — this linter accepts both during the reno migration period.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+from tasks.libs.releasing.notes import CHANGELOG_SECTIONS as _ASSEMBLER_SECTIONS
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+# Known sections that can appear in a fragment.
+# Derived from the assembler's CHANGELOG_SECTIONS to ensure linter and assembler
+# stay in sync. 'prelude' is handled separately during assembly.
+CHANGELOG_SECTIONS = frozenset(key for key, _ in _ASSEMBLER_SECTIONS) | {"prelude"}
+
+
+class LintError:
+    """Represents a single linting error."""
+
+    def __init__(self, line: int | None, level: str, message: str):
+        self.line = line
+        self.level = level
+        self.message = message
+
+    def __repr__(self) -> str:
+        line_str = f"Line {self.line}" if self.line is not None else "Unknown line"
+        return f"{line_str}: ({self.level.upper()}) {self.message}"
+
+
+class ReleasenoteError:
+    """Represents errors found in a release note section."""
+
+    def __init__(self, section: str, errors: list[LintError]):
+        self.section = section
+        self.errors = errors
+
+
+class ReleasenoteFileResult:
+    """Represents all linting results for a single release note file."""
+
+    def __init__(self, file_path: str, section_errors: list[ReleasenoteError]):
+        self.file_path = file_path
+        self.section_errors = section_errors
+
+    @property
+    def has_errors(self) -> bool:
+        return any(e.level == "error" for section_error in self.section_errors for e in section_error.errors)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(e.level == "warning" for section_error in self.section_errors for e in section_error.errors)
+
+    def format_output(self) -> str:
+        """Format errors and warnings for display."""
+        if not self.section_errors:
+            return ""
+
+        lines = [f"{self.file_path}:"]
+        for section_error in self.section_errors:
+            for error in section_error.errors:
+                line_str = f"Line {error.line}" if error.line is not None else "Unknown line"
+                lines.append(f"  [{section_error.section}] {line_str}: ({error.level.upper()}) {error.message}")
+        return "\n".join(lines)
+
+
+def validate_fragment_structure(content: dict) -> list[ReleasenoteError]:
+    """Validate that the YAML content follows the expected fragment format.
+
+    Checks:
+    - Content is a dict
+    - Only known sections are present
+    - Each section contains a list of strings (or a string for 'prelude')
+    - No empty sections
+    """
+    errors = []
+
+    if not isinstance(content, dict):
+        return [
+            ReleasenoteError(
+                section="yaml",
+                errors=[
+                    LintError(
+                        line=None,
+                        level="error",
+                        message=f"Release note must be a YAML mapping, got {type(content).__name__}",
+                    )
+                ],
+            )
+        ]
+
+    unknown_sections = set(content.keys()) - CHANGELOG_SECTIONS
+    if unknown_sections:
+        section_errors = [
+            LintError(
+                line=None,
+                level="error",
+                message=f"Unknown section '{s}'. Valid sections: {', '.join(sorted(CHANGELOG_SECTIONS))}",
+            )
+            for s in sorted(unknown_sections)
+        ]
+        errors.append(ReleasenoteError(section="structure", errors=section_errors))
+
+    for section, section_content in content.items():
+        if section not in CHANGELOG_SECTIONS:
+            continue
+
+        section_errors = []
+
+        if section_content is None:
+            section_errors.append(
+                LintError(
+                    line=None,
+                    level="warning",
+                    message=f"Section '{section}' is empty (null). Remove it or add content.",
+                )
+            )
+        elif section == "prelude":
+            if not isinstance(section_content, str):
+                section_errors.append(
+                    LintError(
+                        line=None,
+                        level="error",
+                        message=f"Section 'prelude' must be a string, got {type(section_content).__name__}",
+                    )
+                )
+            elif not section_content.strip():
+                section_errors.append(
+                    LintError(
+                        line=None,
+                        level="warning",
+                        message="Section 'prelude' is empty or whitespace-only",
+                    )
+                )
+        elif not isinstance(section_content, list):
+            section_errors.append(
+                LintError(
+                    line=None,
+                    level="error",
+                    message=f"Section '{section}' must be a list of strings, got {type(section_content).__name__}",
+                )
+            )
+        elif not section_content:
+            section_errors.append(
+                LintError(
+                    line=None,
+                    level="warning",
+                    message=f"Section '{section}' is an empty list. Remove it or add content.",
+                )
+            )
+        else:
+            for i, item in enumerate(section_content):
+                if not isinstance(item, str):
+                    section_errors.append(
+                        LintError(
+                            line=None,
+                            level="error",
+                            message=f"Item {i} in section '{section}' must be a string, got {type(item).__name__}",
+                        )
+                    )
+                elif not item.strip():
+                    section_errors.append(
+                        LintError(
+                            line=None,
+                            level="warning",
+                            message=f"Item {i} in section '{section}' is empty or whitespace-only",
+                        )
+                    )
+
+        if section_errors:
+            errors.append(ReleasenoteError(section=section, errors=section_errors))
+
+    return errors
+
+
+def lint_releasenote_file(file_path: str | Path) -> ReleasenoteFileResult:
+    """Lint a single release note YAML file.
+
+    Parses the YAML file and validates structure only: known sections, correct
+    types, non-empty content. Content format (RST or Markdown) is accepted.
+    """
+    file_path = Path(file_path)
+    section_errors: list[ReleasenoteError] = []
+
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            content = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        section_errors.append(
+            ReleasenoteError(
+                section="yaml",
+                errors=[LintError(line=None, level="error", message=f"YAML parsing error: {e}")],
+            )
+        )
+        return ReleasenoteFileResult(file_path=str(file_path), section_errors=section_errors)
+    except OSError as e:
+        section_errors.append(
+            ReleasenoteError(
+                section="file",
+                errors=[LintError(line=None, level="error", message=f"File read error: {e}")],
+            )
+        )
+        return ReleasenoteFileResult(file_path=str(file_path), section_errors=section_errors)
+
+    if content is None:
+        return ReleasenoteFileResult(file_path=str(file_path), section_errors=section_errors)
+
+    structure_errors = validate_fragment_structure(content)
+    section_errors.extend(structure_errors)
+
+    return ReleasenoteFileResult(file_path=str(file_path), section_errors=section_errors)
+
+
+def lint_releasenotes(
+    files: Iterable[str | Path],
+) -> tuple[list[ReleasenoteFileResult], list[ReleasenoteFileResult]]:
+    """Lint multiple release note files.
+
+    Returns a tuple of (errors, warnings) where each is a list of
+    ReleasenoteFileResult objects for files with errors or warnings respectively.
+    Files that have only warnings are not included in the errors list.
+    """
+    errors = []
+    warnings = []
+    for file_path in files:
+        result = lint_releasenote_file(file_path)
+        if result.has_errors:
+            errors.append(result)
+        elif result.has_warnings:
+            warnings.append(result)
+    return errors, warnings

--- a/tasks/libs/releasing/notes.py
+++ b/tasks/libs/releasing/notes.py
@@ -12,6 +12,77 @@ from tasks.libs.common.constants import DEFAULT_INTEGRATIONS_CORE_BRANCH, GITHUB
 from tasks.libs.common.git import get_default_branch
 from tasks.libs.releasing.version import current_version
 
+# TODO: migrate to preferred AI Gateway client (ai_gateway_py) once included
+# in dda as a dependency.
+_AI_GATEWAY_URL = "https://ai-gateway.us1.staging.dog/v1"
+_AI_GATEWAY_MODEL = "anthropic/claude-haiku-4-5"
+
+_REVIEW_SYSTEM_PROMPT = """\
+You are a technical writer reviewing Datadog Agent release note fragments.
+Each fragment is a YAML file with one or more of these sections:
+  upgrade, features, enhancements, issues, known_issues, deprecations, security, fixes, critical, other
+
+Evaluate the fragment and give concise, actionable feedback on:
+1. Clarity and usefulness to an end-user reading a changelog (avoid jargon, be specific about impact)
+2. Correct section choice (e.g. a bug fix should not be under 'features'; an API change belongs in 'upgrade')
+3. RST formatting issues (e.g. broken links, improperly indented blocks, missing blank lines)
+4. If an 'upgrade' section is present, whether it includes concrete steps for affected users
+
+Keep your response short — a few bullet points is ideal. Start with an overall verdict (LGTM / Needs work).
+"""
+
+
+def _get_ai_gateway_token() -> str:
+    """Retrieve an AI Gateway auth token via ddtool."""
+    import subprocess
+
+    result = subprocess.run(
+        ["ddtool", "auth", "token", "rapid-ai-platform", "--datacenter", "us1.ddbuild.io"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"ddtool auth token failed: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def review_fragment(content: str) -> str:
+    """Send a release note fragment to AI Gateway for LLM review.
+
+    Returns the LLM's feedback as a string, or a warning message if the
+    call fails (so callers can continue without blocking the workflow).
+    """
+    import httpx
+
+    try:
+        token = _get_ai_gateway_token()
+    except Exception as e:  # noqa: BLE001
+        return f"WARNING: could not obtain AI Gateway token ({e}); skipping AI review."
+
+    try:
+        response = httpx.post(
+            f"{_AI_GATEWAY_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "source": "datadog-agent-release-notes",
+                "org-id": "2",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": _AI_GATEWAY_MODEL,
+                "messages": [
+                    {"role": "system", "content": _REVIEW_SYSTEM_PROMPT},
+                    {"role": "user", "content": f"Please review this release note fragment:\n\n```yaml\n{content}\n```"},
+                ],
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()["choices"][0]["message"]["content"]
+    except Exception as e:  # noqa: BLE001
+        return f"WARNING: AI Gateway request failed ({e}); skipping AI review."
+
+
 # Section ordering and display names for the Markdown changelog assembler.
 # This is the canonical list of sections. tasks/libs/linter/releasenotes_md.py
 # derives its CHANGELOG_SECTIONS frozenset from this list (plus 'prelude').

--- a/tasks/libs/releasing/notes.py
+++ b/tasks/libs/releasing/notes.py
@@ -1,10 +1,104 @@
-from datetime import date
+from __future__ import annotations
 
+import secrets
+import sys
+from datetime import date
+from pathlib import Path
+
+import yaml
 from invoke import Failure
 
 from tasks.libs.common.constants import DEFAULT_INTEGRATIONS_CORE_BRANCH, GITHUB_REPO_NAME
 from tasks.libs.common.git import get_default_branch
 from tasks.libs.releasing.version import current_version
+
+# Section ordering and display names for the Markdown changelog assembler.
+# This is the canonical list of sections. tasks/libs/linter/releasenotes_md.py
+# derives its CHANGELOG_SECTIONS frozenset from this list (plus 'prelude').
+CHANGELOG_SECTIONS = [
+    ('upgrade', 'Upgrade Notes'),
+    ('features', 'New Features'),
+    ('enhancements', 'Enhancement Notes'),
+    ('issues', 'Issues'),
+    ('known_issues', 'Known Issues'),
+    ('deprecations', 'Deprecation Notes'),
+    ('security', 'Security Notes'),
+    ('fixes', 'Bug Fixes'),
+    ('critical', 'Critical Notes'),
+    ('other', 'Other Notes'),
+]
+
+
+def _new_fragment_path(changelog_dir: str, slug: str) -> Path:
+    """Return a new fragment file path with a unique 16-char hex suffix."""
+    uid = secrets.token_hex(8)
+    slug = slug.replace('/', '-')
+    return Path(changelog_dir) / 'notes' / f'{slug}-{uid}.yaml'
+
+
+def _assemble_changelog(fragment_dir: str | Path, version: str) -> str:
+    """Collect all fragment YAML files and render them into a Markdown section.
+
+    This is the new pure-Python assembler. During the migration period it runs
+    alongside reno (which remains authoritative). Fragment content is passed
+    through verbatim — RST or Markdown — so the structural comparison holds
+    regardless of content format.
+    """
+    notes_path = Path(fragment_dir) / 'notes'
+    fragment_files = sorted(notes_path.glob('*.yaml'))
+
+    sections = {key: [] for key, _ in CHANGELOG_SECTIONS}
+    prelude = None
+
+    for fragment_file in fragment_files:
+        try:
+            with open(fragment_file, encoding='utf-8') as f:
+                content = yaml.safe_load(f)
+        except (yaml.YAMLError, OSError) as e:
+            raise RuntimeError(f"Failed to read fragment {fragment_file}: {e}") from e
+
+        if not content or not isinstance(content, dict):
+            continue
+
+        if 'prelude' in content and isinstance(content['prelude'], str):
+            if prelude is not None:
+                print(
+                    f"WARNING: multiple fragments contain 'prelude'; last one wins: {fragment_file}", file=sys.stderr
+                )
+            prelude = content['prelude'].strip()
+
+        for section_key, _ in CHANGELOG_SECTIONS:
+            if section_key in content:
+                items = content[section_key]
+                if isinstance(items, list):
+                    for item in items:
+                        if isinstance(item, str):
+                            if item.strip():
+                                sections[section_key].append(item.strip())
+                        elif item is not None:
+                            print(
+                                f"WARNING: non-string item in '{section_key}' of {fragment_file}: {item!r}",
+                                file=sys.stderr,
+                            )
+
+    lines = [f'## {version}', '']
+
+    if prelude:
+        lines.append(prelude)
+        lines.append('')
+
+    for section_key, section_title in CHANGELOG_SECTIONS:
+        if sections[section_key]:
+            lines.append(f'### {section_title}')
+            lines.append('')
+            for item in sections[section_key]:
+                item_lines = item.split('\n')
+                lines.append(f'- {item_lines[0]}')
+                for extra in item_lines[1:]:
+                    lines.append(f'  {extra}' if extra.strip() else '')
+            lines.append('')
+
+    return '\n'.join(lines) + '\n'
 
 
 def _add_prelude(ctx, version, release_date=None):

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -276,6 +276,97 @@ def rst_releasenotes(ctx, files=None, only_changed=False):
 
 
 @task
+def lint_releasenotes_md(ctx, files=None, only_changed=False):
+    """Check release notes for structural issues (YAML structure only).
+
+    Validates that release notes are valid YAML with known sections and correct
+    content types. Content format (RST or Markdown) is NOT validated — this task
+    works on existing RST fragments during the reno migration period.
+
+    Args:
+        files: Optional comma-separated list of files to lint. If not provided,
+               lints all .yaml files in releasenotes/notes/, releasenotes-dca/notes/,
+               and releasenotes-installscript/notes/.
+        only_changed: If True, only lint release note files modified compared to
+                      the base branch. Used in CI to only check PR files.
+    """
+    from tasks.libs.linter.releasenotes_md import lint_releasenotes as _lint_files
+
+    if files:
+        file_list = [f.strip() for f in files.split(',') if f.strip()]
+    elif only_changed:
+        base_branch = get_ancestor_base_branch()
+        merge_base = get_common_ancestor(ctx, "HEAD", f"origin/{base_branch}")
+        result = ctx.run(
+            f"git diff --name-only --diff-filter=AM {merge_base} | grep -E '^releasenotes(-dca|-installscript)?/notes/.*\\.yaml$'",
+            warn=True,
+            hide=True,
+        )
+        file_list = [f.strip() for f in (result.stdout or "").splitlines() if f.strip()]
+    else:
+        file_list = (
+            list(glob('releasenotes/notes/*.yaml'))
+            + list(glob('releasenotes-dca/notes/*.yaml'))
+            + list(glob('releasenotes-installscript/notes/*.yaml'))
+        )
+
+    if not file_list:
+        print(color_message("No release note files to lint", "yellow"))
+        return
+
+    errors, warnings = _lint_files(file_list)
+
+    if warnings:
+        print(color_message("Warnings in release notes:", "yellow"))
+        print()
+        for result in warnings:
+            print(result.format_output())
+            print()
+
+    if errors:
+        print(color_message("Errors found in release notes:", "red"))
+        print()
+        for result in errors:
+            print(result.format_output())
+            print()
+        raise Exit(code=1)
+
+    print(color_message(f"All {len(file_list)} release note files pass structural validation", "green"))
+
+
+@task
+def compare_assemblers(ctx, changelog_dir='releasenotes'):
+    """Run both reno and the new Markdown assembler on the same fragments.
+
+    Outputs both RST (reno) and Markdown (new assembler) for side-by-side
+    comparison. The two outputs differ in format but should contain the same
+    fragments, sections, and items.
+
+    Args:
+        changelog_dir: The releasenotes directory to assemble. One of:
+                       releasenotes, releasenotes-dca, releasenotes-installscript.
+
+    Example::
+
+        dda inv linter.compare-assemblers
+        dda inv linter.compare-assemblers --changelog-dir releasenotes-dca
+    """
+    from tasks.libs.releasing.notes import _assemble_changelog
+
+    print(color_message(f"=== reno report (RST) for {changelog_dir} ===", "bold"))
+    ctx.run(f"reno -q --rel-notes-dir {changelog_dir} report --ignore-cache", warn=True)
+
+    print()
+    print(color_message(f"=== New assembler (Markdown) for {changelog_dir} ===", "bold"))
+    try:
+        md_output = _assemble_changelog(changelog_dir, 'draft')
+        print(md_output)
+    except Exception as e:
+        print(color_message(f"New assembler failed: {e}", "red"))
+        raise Exit(code=1) from e
+
+
+@task
 def github_actions_shellcheck(
     ctx,
     exclude=DEFAULT_SHELLCHECK_EXCLUDES,

--- a/tasks/notes.py
+++ b/tasks/notes.py
@@ -1,5 +1,6 @@
 import sys
 from datetime import date
+from pathlib import Path
 
 from invoke import Failure, task
 from invoke.exceptions import Exit
@@ -13,13 +14,14 @@ from tasks.libs.releasing.notes import (
     _add_dca_prelude,
     _add_prelude,
     _new_fragment_path,
+    review_fragment,
     update_changelog_generic,
 )
 from tasks.libs.releasing.version import deduce_version
 
 
 @task
-def new(ctx, slug, dca=False, installscript=False):  # noqa: U100
+def new(ctx, slug, dca=False, installscript=False, review=False):  # noqa: U100
     """Create a new release note fragment.
 
     Creates a YAML template in releasenotes/notes/ (or releasenotes-dca/notes/
@@ -59,6 +61,34 @@ def new(ctx, slug, dca=False, installscript=False):  # noqa: U100
 
     print(f"Created release note: {note_path}")
     print("Edit the file, fill in the relevant sections, and commit it with your PR.")
+
+    if review:
+        import os
+        import subprocess
+
+        editor = os.environ.get('VISUAL') or os.environ.get('EDITOR')
+        if not editor:
+            print("NOTE: $EDITOR not set; skipping review. Run: dda inv notes.review <path>")
+            return
+        subprocess.run(f"{editor} {note_path}", shell=True, check=False)
+        feedback = review_fragment(note_path.read_text(encoding='utf-8'))
+        print(f"\n--- AI Review ---\n{feedback}")
+
+
+@task
+def review(ctx, path):  # noqa: U100
+    """Review a release note fragment using AI Gateway.
+
+    Reads the YAML fragment at PATH and sends it to the Datadog AI Gateway for
+    LLM-driven feedback on clarity, section correctness, and RST formatting.
+
+    Example::
+
+        dda inv notes.review releasenotes/notes/my-feature-abc123.yaml
+    """
+    content = Path(path).read_text(encoding='utf-8')
+    feedback = review_fragment(content)
+    print(feedback)
 
 
 @task

--- a/tasks/notes.py
+++ b/tasks/notes.py
@@ -8,8 +8,57 @@ from tasks.libs.ciproviders.github_api import create_release_pr
 from tasks.libs.common.color import color_message
 from tasks.libs.common.git import get_current_branch, try_git_command
 from tasks.libs.common.worktree import agent_context
-from tasks.libs.releasing.notes import _add_dca_prelude, _add_prelude, update_changelog_generic
+from tasks.libs.releasing.notes import (
+    CHANGELOG_SECTIONS,
+    _add_dca_prelude,
+    _add_prelude,
+    _new_fragment_path,
+    update_changelog_generic,
+)
 from tasks.libs.releasing.version import deduce_version
+
+
+@task
+def new(ctx, slug, dca=False, installscript=False):  # noqa: U100
+    """Create a new release note fragment.
+
+    Creates a YAML template in releasenotes/notes/ (or releasenotes-dca/notes/
+    if --dca is set, or releasenotes-installscript/notes/ if --installscript is set).
+    Fill in the relevant sections and delete the rest.
+
+    Note: Content should be written in reStructuredText (RST) while reno remains
+    the authoritative changelog assembler.
+
+    Example::
+
+        dda inv notes.new my-feature
+        dda inv notes.new my-fix --dca
+    """
+    if dca:
+        changelog_dir = 'releasenotes-dca'
+    elif installscript:
+        changelog_dir = 'releasenotes-installscript'
+    else:
+        changelog_dir = 'releasenotes'
+
+    note_path = _new_fragment_path(changelog_dir, slug)
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+
+    section_lines = []
+    for key, title in CHANGELOG_SECTIONS:
+        if key == 'upgrade':
+            section_lines.append(f"# {key}:\n#   - |\n#     {title}: include steps users can follow if affected.\n")
+        else:
+            section_lines.append(f"# {key}:\n#   - |\n#     {title}.\n")
+
+    template = "---\n# Fill in the relevant section(s) below. Delete sections that don't apply.\n# Content should be written in RST (reStructuredText).\n\n"
+    template += "".join(section_lines)
+
+    with open(note_path, 'w', encoding='utf-8') as f:
+        f.write(template)
+
+    print(f"Created release note: {note_path}")
+    print("Edit the file, fill in the relevant sections, and commit it with your PR.")
 
 
 @task


### PR DESCRIPTION
Adds new release notes tooling as shadow infrastructure while reno remains the authoritative changelog assembler. Both systems run in parallel so the team can validate the new implementation before committing to the switch.

## New tasks:
  - `dda inv notes.new <slug>` — creates a fragment template without requiring reno installed
  - `dda inv notes.new <slug> --review` — creates fragment, opens $EDITOR, then prints LLM feedback on save
  - `dda inv notes.review <path>` — review any existing fragment via AI Gateway
  - `dda inv linter.lint-releasenotes-md` — structural YAML validation (accepts RST or Markdown content)
  - `dda inv linter.compare-assemblers` — runs both reno report and the new assembler side-by-side

  New CI jobs (`allow_failure: true`): lint_releasenotes_md, compare_assemblers

  No reno functions removed. All existing tasks (rst_releasenotes, releasenote, update_changelog, etc.) are untouched. The .rst files remain authoritative.

## AI review example

  Given a fragment with a bug fix filed under features and a vague upgrade note:
```yaml
  features:
    - |
      Fixed a bug where the agent crashed when the config file was missing.
  upgrade:
    - |
      Users should update their config.
```
  `dda inv notes.review` responds:
```md
  **Needs work**

  - **Section misplacement**: The item under `features` is a bug fix, not a feature. Move it to `fixes`.
  - **Vague upgrade guidance**: The `upgrade` section doesn't explain *why* users should update or
    *what* they need to do. Clarify: "Update to version X.X to avoid crashes when the config file
    is missing" or remove it if no action is required.
  - **Missing detail in fix**: Specify *which* config file and *when* it goes missing (e.g., "on
    startup", "after deletion") to help users understand the impact.
```
  ---
## Migration plan

  This PR implements Phase 1 of the migration plan. See https://github.com/DataDog/datadog-agent/pull/47694 for context on the reno replacement spike.

## Phase 1 (this PR): Add new tooling alongside reno

  - `tasks/libs/releasing/notes.py` — add `CHANGELOG_SECTIONS`, `_new_fragment_path`, `_assemble_changelog`, and `review_fragment` alongside existing `reno` functions
  - `tasks/libs/linter/releasenotes_md.py` (new) — structural linter; validates YAML shape only, not content format
  - `tasks/notes.py` — add `notes.new` and `notes.review` tasks; `reno` tasks unchanged
  - `tasks/linter.py` — add `lint_releasenotes_md` and `compare_assemblers` shadow tasks
  - `.gitlab/build/lint/technical_linters.yml` — shadow CI jobs with `allow_failure: true`
  - `CHANGELOG.md`, `CHANGELOG-DCA.md`, `CHANGELOG-INSTALLSCRIPT.md` — placeholder files for shadow assembly
  - `docs/public/guidelines/contributing.md` — mention `dda inv notes.new` as `reno`-free alternative

## Phase 2: Shadow assembly during releases (1–2 cycles)

  Modify `update_changelog_generic` to run both assemblers: `reno` → `.rst` (authoritative) and `_assemble_changelog` → `.md` (shadow). Release coordinators compare outputs to build confidence.

## Phase 3: Cutover (after validation)

  Single PR that removes `reno`, promotes the new assembler, runs `notes.migrate-rst` to convert existing fragments to Markdown, and drops `pandoc` from the release pipeline.

## Verification checklist for Phase 1

  - `dda inv notes.new test-fragment` creates a valid YAML file
  - `dda inv notes.new test-fragment --review` opens editor and prints LLM feedback on save
  - `dda inv notes.review <path>` reviews an existing fragment
  - `dda inv linter.lint-releasenotes-md` passes on existing RST fragments
  - `dda inv linter.compare-assemblers` shows output from both assemblers
  - Shadow CI jobs pass (or `allow_failure` absorbs any issues)