### PR TITLE
Fix `rules_cc` leftovers from #47716 for Bazel 9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -176,6 +176,7 @@ git_override(
         "//bazel/patches:gcc-toolchain/0002-fix-c-x86_64-header-locations-with-our-ctng-toolchai.patch",
         "//bazel/patches:gcc-toolchain/0003-add-nostdinc-to-asmflags.patch",
         "//bazel/patches:gcc-toolchain/0004-fix-re-fetching.patch",  # https://github.com/f0rmiga/gcc-toolchain/pull/207
+        "//bazel/patches:gcc-toolchain/0005-fix-bazel-9-compat.patch",
     ],
     remote = "https://github.com/f0rmiga/gcc-toolchain.git",
 )

--- a/bazel/patches/gcc-toolchain/0005-fix-bazel-9-compat.patch
+++ b/bazel/patches/gcc-toolchain/0005-fix-bazel-9-compat.patch
@@ -1,0 +1,25 @@
+diff --git a/toolchain/cc_toolchain_config.bzl b/toolchain/cc_toolchain_config.bzl
+index b8ae535..4839532 100644
+--- a/toolchain/cc_toolchain_config.bzl
++++ b/toolchain/cc_toolchain_config.bzl
+@@ -29,6 +29,7 @@ load(
+     "tool_path",
+     "with_feature_set",
+ )
++load("@rules_cc//cc:defs.bzl", "CcToolchainConfigInfo", "cc_common")
+ 
+ all_compile_actions = [
+     ACTION_NAMES.c_compile,
+diff --git a/toolchain/defs.bzl b/toolchain/defs.bzl
+index 65095db..c5b7ee0 100644
+--- a/toolchain/defs.bzl
++++ b/toolchain/defs.bzl
+@@ -433,7 +433,7 @@ ARCHS = struct(
+ )
+ 
+ _TOOLCHAIN_BUILD_FILE_CONTENT = """\
+-load("@rules_cc//cc:defs.bzl", "cc_toolchain")
++load("@rules_cc//cc:defs.bzl", "cc_library", "cc_toolchain")
+ load("@{gcc_toolchain_workspace_name}//toolchain:cc_toolchain_config.bzl", "cc_toolchain_config")
+ load("//:tool_paths.bzl", "tool_paths")
+ 

--- a/bazel/rules/foreign_cc_shared_wrapper.bzl
+++ b/bazel/rules/foreign_cc_shared_wrapper.bzl
@@ -1,5 +1,4 @@
-load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
-load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
 load("@rules_cc//cc/common:cc_shared_library_info.bzl", "CcSharedLibraryInfo")
 
 def _foreign_cc_shared_wrapper_impl(ctx):

--- a/bazel/rules/preprocessor.bzl
+++ b/bazel/rules/preprocessor.bzl
@@ -1,14 +1,13 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@rules_cc//cc:action_names.bzl", "C_COMPILE_ACTION_NAME")
-load("@rules_cc//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_ATTRS", "find_cpp_toolchain", "use_cc_toolchain")
-load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
-load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
+load("@rules_cc//cc:defs.bzl", "CcInfo", "cc_common")
+load("@rules_cc//cc:find_cc_toolchain.bzl", "CC_TOOLCHAIN_ATTRS", "find_cc_toolchain", "use_cc_toolchain")
 
 def _c_preprocessor_impl(ctx):
     out = ctx.outputs.output
     source = ctx.file.input
     include_dirs = [paths.dirname(f.path) for f in ctx.files.deps]
-    cc_toolchain = find_cpp_toolchain(ctx)
+    cc_toolchain = find_cc_toolchain(ctx)
     compilation_ctx = cc_common.create_compilation_context(
         headers = depset(ctx.files.deps),
     )

--- a/bazel/toolchains/mingw/toolchain.bzl
+++ b/bazel/toolchains/mingw/toolchain.bzl
@@ -11,7 +11,7 @@ load(
     "tool_path",
 )
 load("@rules_cc//cc:action_names.bzl", "ACTION_NAMES")
-load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
+load("@rules_cc//cc:defs.bzl", "CcToolchainConfigInfo", "cc_common")
 
 def _impl(ctx):
     tools = [


### PR DESCRIPTION
### What does this PR do?
Completes the full `rules_cc` migration started in #47716, covering the cases I missed: our own `.bzl` rule files and the `gcc-toolchain` external dependency.

### Motivation
#47716 covered our `BUILD.bazel` files but left other files still relying on injected globals, absent from Bazel 9+.

### Additional Notes
The additional patch to `gcc-toolchain` will disappear once f0rmiga/gcc-toolchain#217 gets merged.