### PR TITLE
Exclude `[ms-]go-build` paths from progressive cache

### DIFF
--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -19,6 +19,6 @@ runs:
         key: bazel-${{ hashFiles('.go-version', '.python-version') }}
         path: |
           .cache/bazel/*/cache
-          .cache/go*
-          .cache/ms-go*
+          .cache/go
+          .cache/ms-go
           .cache/pip

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -24,8 +24,8 @@
         files: [ .go-version, .python-version ]
       paths:
         - .cache/bazel/*/cache
-        - .cache/go*
-        - .cache/ms-go*
+        - .cache/go
+        - .cache/ms-go
         - .cache/pip
       policy: pull$BAZEL_CACHE_POLICY_SUFFIX
       when: on_success


### PR DESCRIPTION
### What does this PR do?
Replace `.cache/go*` / `.cache/ms-go*` globs with explicit `.cache/go` / `.cache/ms-go` paths in both the GitLab progressive cache config and its GitHub Actions counterpart.

### Motivation
The Go build directory (`.cache/go-build`, `.cache/ms-go-build`) accounts for ~94% of the progressive cache (~16 GB uncompressed).
It grows without bound because Go's time-based GC only fires when the `go` command is invoked with that `GOCACHE` path, which never happens in a Bazel-centric CI where `rules_go` compiles inside sandboxes.

### Additional Notes
This change is **intentionally minimal**: once merged, the next cache push will contain only the remaining ~6% (module download cache + toolchain), flushing the accumulated go-build bloat from S3.
That reduced footprint is a prerequisite for safely reverting the cache key from `bazel-$CI_JOB_NAME` back to
`bazel-$CI_RUNNER_DESCRIPTION` (see TODO comment added in #47022).