### PR TITLE
[WINA-2479] softinv: add race reproduction test for cached inventory data

### DIFF
--- a/comp/softwareinventory/impl/inventorysoftware_test.go
+++ b/comp/softwareinventory/impl/inventorysoftware_test.go
@@ -32,9 +32,17 @@ import (
 
 type testFixture struct {
 	t                 *testing.T
-	sysProbeClient    *mockSysProbeClient
+	sysProbeClient    sysProbeClient
 	eventPlatformMock *mockEventPlatform
 	reqs              Requires
+}
+
+func (tf *testFixture) sysProbeClientAsMock() *mockSysProbeClient {
+	return tf.sysProbeClient.(*mockSysProbeClient)
+}
+
+type callCounter interface {
+	GetCallCount() int
 }
 
 type mockEventPlatform struct {
@@ -111,7 +119,7 @@ type softwareInventoryTestHelper struct {
 // WaitForSystemProbe waits for the GetCheck method to be called on the sys probe client
 func (h *softwareInventoryTestHelper) WaitForSystemProbe() *softwareInventoryTestHelper {
 	require.Eventually(h.fixture.t, func() bool {
-		return h.fixture.sysProbeClient.GetCallCount() > 0
+		return h.fixture.sysProbeClient.(callCounter).GetCallCount() > 0
 	}, time.Second, 10*time.Millisecond, "Expected GetCheck to be called")
 	return h
 }
@@ -170,8 +178,9 @@ func TestFlareProviderOutputDisabled(t *testing.T) {
 
 func TestFlareProviderOutputFailed(t *testing.T) {
 	f := newFixtureWithData(t, true, []software.Entry{{DisplayName: "TestApp"}})
-	f.sysProbeClient = &mockSysProbeClient{}
-	f.sysProbeClient.On("GetCheck", sysconfig.SoftwareInventoryModule).Return(nil, errors.New("error"))
+	sp := &mockSysProbeClient{}
+	sp.On("GetCheck", sysconfig.SoftwareInventoryModule).Return(nil, errors.New("error"))
+	f.sysProbeClient = sp
 	sut := f.sut().WaitForSystemProbe()
 
 	flareProvider := sut.FlareProvider()

--- a/comp/softwareinventory/impl/race_reproduction_test.go
+++ b/comp/softwareinventory/impl/race_reproduction_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+package softwareinventoryimpl
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/inventory/software"
+	"github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// racyMock wraps a mockSysProbeClient and blocks after the inner mock records
+// the call but before returning to the caller. This lets the test thread
+// observe the window where GetCallCount() > 0 but cachedInventory is still nil.
+type racyMock struct {
+	inner       *mockSysProbeClient
+	afterRecord chan struct{}
+}
+
+func (m *racyMock) GetCheck(module types.ModuleName) ([]software.Entry, error) {
+	result, err := m.inner.GetCheck(module)
+	<-m.afterRecord
+	return result, err
+}
+
+func (m *racyMock) GetCallCount() int {
+	return m.inner.GetCallCount()
+}
+
+// TestCachedInventoryRequiresPayloadSync is a regression test for a race
+// condition where WaitForSystemProbe (checking GetCallCount) could return
+// before cachedInventory was populated, causing status pages to show
+// "0 entries" instead of the actual count.
+//
+// The fix is to use WaitForPayload (checking SendEventPlatformEvent) which
+// guarantees cachedInventory has been written.
+//
+// Timeline with racyMock (blocks GetCheck after recording the call):
+//
+//	Goroutine                              Test thread
+//	─────────                              ───────────
+//	GetCheck() → inner mock records call
+//	             (GetCallCount() = 1)
+//	<blocked on afterRecord channel>       GetCallCount() > 0 ✓
+//	                                       reads cachedInventory → nil → "0 entries"
+//	<test closes afterRecord>
+//	GetCheck returns → writes cachedInventory
+//	                                       SendEventPlatformEvent called ✓
+//	                                       reads cachedInventory → data → "2 entries"
+func TestCachedInventoryRequiresPayloadSync(t *testing.T) {
+	afterRecord := make(chan struct{})
+	f := newFixtureWithData(t, true, []software.Entry{
+		{DisplayName: "FooApp", ProductCode: "foo", Source: "app"},
+		{DisplayName: "BarApp", ProductCode: "bar", Source: "pkg"},
+	})
+
+	f.sysProbeClient = &racyMock{
+		inner:       f.sysProbeClientAsMock(),
+		afterRecord: afterRecord,
+	}
+
+	sut := f.sut()
+
+	// ── Phase 1: WaitForSystemProbe does NOT guarantee data is cached ────
+	sut.WaitForSystemProbe()
+
+	// GetCheck was called and recorded, but hasn't returned yet (blocked by racyMock).
+	// cachedInventory is still nil, so the status page shows 0 entries.
+	var buf bytes.Buffer
+	err := sut.HTML(false, &buf)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "<strong>Summary:</strong> 0 entries",
+		"cachedInventory must be nil while GetCheck hasn't returned")
+
+	// ── Phase 2: WaitForPayload DOES guarantee data is cached ────────────
+	close(afterRecord)
+	sut.WaitForPayload()
+
+	buf.Reset()
+	err = sut.HTML(false, &buf)
+	assert.NoError(t, err)
+	assert.Contains(t, buf.String(), "<strong>Summary:</strong> 2 entries",
+		"cachedInventory must be populated after payload is sent")
+}

--- a/comp/softwareinventory/impl/status_test.go
+++ b/comp/softwareinventory/impl/status_test.go
@@ -27,7 +27,7 @@ func TestGetPayloadRefreshesCachedValues(t *testing.T) {
 		{DisplayName: "FooApp", ProductCode: "foo", Source: "app"},
 		{DisplayName: "BarApp", ProductCode: "bar", Source: "pkg"},
 	})
-	is := f.sut().WaitForSystemProbe()
+	is := f.sut().WaitForPayload()
 
 	// Status JSON should trigger a refresh of cached values
 	stats := make(map[string]interface{})
@@ -42,7 +42,7 @@ func TestGetPayloadRefreshesCachedValues(t *testing.T) {
 	assert.Equal(t, 2, stats["software_inventory_total"])
 	// Note: The exact structure of stats depends on how the JSON is marshaled
 	// This test may need adjustment based on the actual output format
-	f.sysProbeClient.AssertNumberOfCalls(t, "GetCheck", 1)
+	f.sysProbeClientAsMock().AssertNumberOfCalls(t, "GetCheck", 1)
 }
 
 func TestStatusTemplates(t *testing.T) {
@@ -111,7 +111,7 @@ func TestStatusTemplates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFixtureWithData(t, true, tt.mockData)
-			is := f.sut().WaitForSystemProbe()
+			is := f.sut().WaitForPayload()
 
 			// Test Text template
 			var buf bytes.Buffer
@@ -129,14 +129,14 @@ func TestStatusTemplates(t *testing.T) {
 			}
 
 			// Verify that we only call GetCheck once per test case
-			f.sysProbeClient.AssertNumberOfCalls(t, "GetCheck", 1)
+			f.sysProbeClientAsMock().AssertNumberOfCalls(t, "GetCheck", 1)
 		})
 	}
 }
 
 func TestStatusTemplateWithNoSoftwareInventoryMetadata(t *testing.T) {
 	f := newFixtureWithData(t, true, []software.Entry{})
-	is := f.sut().WaitForSystemProbe()
+	is := f.sut().WaitForPayload()
 
 	// Test Text template
 	var buf bytes.Buffer
@@ -154,7 +154,7 @@ func TestStatusTemplateWithNoSoftwareInventoryMetadata(t *testing.T) {
 	assert.Contains(t, buf.String(), "<strong>Summary:</strong> 0 entries")
 
 	// The populateStatus caches the values once.
-	f.sysProbeClient.AssertNumberOfCalls(t, "GetCheck", 1)
+	f.sysProbeClientAsMock().AssertNumberOfCalls(t, "GetCheck", 1)
 }
 
 func TestStatusStatsComputation(t *testing.T) {
@@ -167,7 +167,7 @@ func TestStatusStatsComputation(t *testing.T) {
 		{DisplayName: "curl", ProductCode: "curl", Source: "homebrew"},
 		{DisplayName: "Python Driver", ProductCode: "python-driver", Source: "pkg"},
 	})
-	is := f.sut().WaitForSystemProbe()
+	is := f.sut().WaitForPayload()
 
 	stats := make(map[string]interface{})
 	err := is.JSON(false, stats)
@@ -196,7 +196,7 @@ func TestStatusBrokenCount(t *testing.T) {
 		{DisplayName: "AnotherGood", ProductCode: "good2", Source: "pkg", Status: "installed"},
 		{DisplayName: "AnotherBroken", ProductCode: "broken2", Source: "pkg", Status: "broken"},
 	})
-	is := f.sut().WaitForSystemProbe()
+	is := f.sut().WaitForPayload()
 
 	stats := make(map[string]interface{})
 	err := is.JSON(false, stats)
@@ -217,7 +217,7 @@ func TestStatusTextTemplateWithStats(t *testing.T) {
 		{DisplayName: "App2", ProductCode: "app2", Source: "app"},
 		{DisplayName: "Brew1", ProductCode: "brew1", Source: "homebrew"},
 	})
-	is := f.sut().WaitForSystemProbe()
+	is := f.sut().WaitForPayload()
 
 	var buf bytes.Buffer
 	err := is.Text(false, &buf)
@@ -235,7 +235,7 @@ func TestStatusTextTemplateWithBrokenEntries(t *testing.T) {
 		{DisplayName: "GoodApp", ProductCode: "good", Source: "app", Status: "installed"},
 		{DisplayName: "BrokenApp", ProductCode: "broken", Source: "app", Status: "broken"},
 	})
-	is := f.sut().WaitForSystemProbe()
+	is := f.sut().WaitForPayload()
 
 	var buf bytes.Buffer
 	err := is.Text(false, &buf)
@@ -251,7 +251,7 @@ func TestStatusHTMLTemplateWithStats(t *testing.T) {
 		{DisplayName: "App1", ProductCode: "app1", Source: "app"},
 		{DisplayName: "Brew1", ProductCode: "brew1", Source: "homebrew"},
 	})
-	is := f.sut().WaitForSystemProbe()
+	is := f.sut().WaitForPayload()
 
 	var buf bytes.Buffer
 	err := is.HTML(false, &buf)


### PR DESCRIPTION
## Summary
- Adds a regression test (`TestCachedInventoryRequiresPayloadSync`) that proves `WaitForSystemProbe` (checking `GetCallCount`) can return before `cachedInventory` is populated, while `WaitForPayload` (checking `SendEventPlatformEvent`) correctly guarantees data availability.
- Introduces a `racyMock` wrapper that blocks `GetCheck` after recording the call but before returning, exposing the window where the call is counted but `cachedInventory` is still nil.
- Refactors `testFixture.sysProbeClient` to use the `sysProbeClient` interface (instead of the concrete mock type), enabling the wrapper pattern. Adds `sysProbeClientAsMock()` helper and `callCounter` interface for type-safe access to mock-specific methods.
- Fixes `status_test.go` tests to use `WaitForPayload` instead of `WaitForSystemProbe` for consistency.

## Tracking
https://datadoghq.atlassian.net/browse/WINA-2479

## Test plan
- [x] `go test ./comp/softwareinventory/impl/ -v -timeout 60s -tags test` — all 15 tests pass
- [x] `gofmt` clean on all changed files
- [x] Pre-commit hooks pass