### PR TITLE
[ABLD-387] Bazelify `pkg/template` generation

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,7 +7,7 @@ load("@gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO(agent-build): remove below `gazelle:exclude` directives and add corresponding paths to bazel/go.work
+# TODO(agent-build): remove below `gazelle:exclude` directives (automatically updates @bazelify_go_work//:go.work)
 # gazelle:exclude cmd
 # gazelle:exclude comp
 # gazelle:exclude internal/remote-agent
@@ -96,7 +96,6 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude pkg/tagger
 # gazelle:exclude pkg/tagset
 # gazelle:exclude pkg/telemetry
-# gazelle:exclude pkg/template
 # gazelle:exclude pkg/trace
 # gazelle:exclude pkg/util
 # gazelle:exclude pkg/version

--- a/bazel/rules/go_sdk_overrides/defs.bzl
+++ b/bazel/rules/go_sdk_overrides/defs.bzl
@@ -1,0 +1,25 @@
+"""Shared configuration for the go_sdk_overrides repository rule and write_source_files."""
+
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+OVERRIDES = {
+    "src/html/template": Label("//pkg/template/html:BUILD.bazel"),
+    "src/internal/fmtsort": Label("//pkg/template/internal/fmtsort:BUILD.bazel"),
+    "src/text/template": Label("//pkg/template/text:BUILD.bazel"),
+}
+
+PATCHES = [
+    # do not sort
+    "//pkg/template:no-method.patch",
+    "//pkg/template:imports.gopatch",
+    "//pkg/template:godebug.gopatch",
+    "//pkg/template:types.patch",
+    "//pkg/template:godebug-stub.patch",
+]
+
+def go_sdk_overrides():
+    return {
+        paths.relativize(label.package, native.package_name()): "@go_sdk_overrides//:{}".format(label.package)
+        for label in OVERRIDES.values()
+        if label.package.startswith(native.package_name())
+    }

--- a/bazel/rules/go_sdk_overrides/repo.bzl
+++ b/bazel/rules/go_sdk_overrides/repo.bzl
@@ -6,7 +6,7 @@ load("//bazel/rules/go_sdk_overrides:defs.bzl", "OVERRIDES", "PATCHES")
 
 def _impl(rctx):
     rctx.file("BUILD.bazel", "exports_files({})".format([build.package for build in rctx.attr.overrides.values()]))
-    sdk = rctx.path(rctx.attr.go_sdk).dirname
+    sdk = rctx.path(rctx.attr._go_sdk).dirname
     for src_dir, build in rctx.attr.overrides.items():
         rctx.file("{}/{}".format(build.package, build.name), rctx.read(build))
         for f in sdk.get_child(src_dir).readdir():
@@ -18,7 +18,7 @@ def _impl(rctx):
             repo_utils.execute_checked(
                 rctx,
                 op = "gopatch {}".format(p),
-                arguments = [go, "-C", rctx.path(rctx.attr.gopatch).dirname, "run", ".", "-p", p, rctx.path(".")],
+                arguments = [go, "-C", rctx.path(rctx.attr._gopatch).dirname, "run", ".", "-p", p, rctx.path(".")],
                 environment = {"GOWORK": "off"},
             )
         else:
@@ -27,8 +27,8 @@ def _impl(rctx):
 go_sdk_overrides = repository_rule(
     implementation = _impl,
     attrs = {
-        "go_sdk": attr.label(default = HOST_COMPATIBLE_SDK),
-        "gopatch": attr.label(default = "@com_github_uber_go_gopatch//:gopatch"),
+        "_go_sdk": attr.label(default = HOST_COMPATIBLE_SDK),
+        "_gopatch": attr.label(default = "@com_github_uber_go_gopatch//:gopatch"),
         "overrides": attr.string_keyed_label_dict(default = OVERRIDES),
         "patches": attr.label_list(default = PATCHES),
     },

--- a/bazel/rules/go_sdk_overrides/repo.bzl
+++ b/bazel/rules/go_sdk_overrides/repo.bzl
@@ -1,0 +1,35 @@
+"""Repository rule for patching Go SDK packages into a local repo."""
+
+load("@go_host_compatible_sdk_label//:defs.bzl", "HOST_COMPATIBLE_SDK")
+load("@rules_python//python/private:repo_utils.bzl", "repo_utils")  # buildifier: disable=bzl-visibility
+load("//bazel/rules/go_sdk_overrides:defs.bzl", "OVERRIDES", "PATCHES")
+
+def _impl(rctx):
+    rctx.file("BUILD.bazel", "exports_files({})".format([build.package for build in rctx.attr.overrides.values()]))
+    sdk = rctx.path(rctx.attr.go_sdk).dirname
+    for src_dir, build in rctx.attr.overrides.items():
+        rctx.file("{}/{}".format(build.package, build.name), rctx.read(build))
+        for f in sdk.get_child(src_dir).readdir():
+            if f.basename.endswith(".go") and not f.basename.endswith("_test.go"):
+                rctx.file("{}/{}".format(build.package, f.basename), rctx.read(f))
+    go = sdk.get_child("bin/go{}".format(".exe" if repo_utils.get_platforms_os_name(rctx) == "windows" else ""))
+    for p in rctx.attr.patches:
+        if p.name.endswith(".gopatch"):
+            repo_utils.execute_checked(
+                rctx,
+                op = "gopatch {}".format(p),
+                arguments = [go, "-C", rctx.path(rctx.attr.gopatch).dirname, "run", ".", "-p", p, rctx.path(".")],
+                environment = {"GOWORK": "off"},
+            )
+        else:
+            rctx.patch(p, strip = 1)
+
+go_sdk_overrides = repository_rule(
+    implementation = _impl,
+    attrs = {
+        "go_sdk": attr.label(default = HOST_COMPATIBLE_SDK),
+        "gopatch": attr.label(default = "@com_github_uber_go_gopatch//:gopatch"),
+        "overrides": attr.string_keyed_label_dict(default = OVERRIDES),
+        "patches": attr.label_list(default = PATCHES),
+    },
+)

--- a/bazel/rules/go_stringer/_gazelle_extension.go
+++ b/bazel/rules/go_stringer/_gazelle_extension.go
@@ -43,6 +43,10 @@ func (*lang) Kinds() map[string]rule.KindInfo {
 	}
 }
 
+func (*lang) KnownDirectives() []string {
+	return []string{name}
+}
+
 func (*lang) Loads() []rule.LoadInfo {
 	return []rule.LoadInfo{{
 		Name:    fmt.Sprintf("//bazel/rules/%s:defs.bzl", name),
@@ -51,6 +55,13 @@ func (*lang) Loads() []rule.LoadInfo {
 }
 
 func (*lang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+	if args.File != nil {
+		for _, d := range args.File.Directives {
+			if d.Key == name && d.Value == "off" {
+				return language.GenerateResult{}
+			}
+		}
+	}
 	var goFiles []string
 	for _, f := range args.RegularFiles {
 		if strings.HasSuffix(f, ".go") {

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -1,5 +1,6 @@
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.from_file(go_work = "//:go.work")
+use_repo(go_sdk, "go_host_compatible_sdk_label")
 # go_sdk.nogo(nogo = "//:nogo")  # TODO(agent-build): assess benefits of the `nogo` static code analyzer
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
@@ -494,5 +495,7 @@ use_repo(
     "org_uber_go_zap_exp",
     "tools_gotest_gotestsum",
 )
+
+use_repo_rule("//bazel/rules/go_sdk_overrides:repo.bzl", "go_sdk_overrides")(name = "go_sdk_overrides")
 
 use_repo_rule("//bazel/rules/go_stringer:repo.bzl", "go_stringer")(name = "go_stringer")

--- a/pkg/template/BUILD.bazel
+++ b/pkg/template/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@bazel_lib//lib:write_source_files.bzl", "write_source_files")
+load("@rules_go//go:def.bzl", "go_library")
+load("//bazel/rules/go_sdk_overrides:defs.bzl", "go_sdk_overrides")
+
+write_source_files(
+    name = "generate",
+    files = go_sdk_overrides(),
+)
+
+go_library(
+    name = "template",
+    srcs = ["docs.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/template",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/template/README.md
+++ b/pkg/template/README.md
@@ -9,7 +9,8 @@ The types like `FuncMap` or `HTML` are aliases of standard library types, so the
 The [text](./text) directory contains the code from `text/template`, the [html](./html) directory contains the code from `html/template`.
 
 ## Code Generation
-The code in this directory can be re-generated using `invoke -e pkg-template.generate` from the root of the repository.
+The code in this directory can be re-generated using `bazel run //pkg/template:generate`.
+(`invoke -e pkg-template.generate` works as a backwards-compatible alias)
 
 ## Go version
 The code is from the Go version pinned in the [.go-version](/.go-version) file.

--- a/pkg/template/html/BUILD.bazel
+++ b/pkg/template/html/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+# gazelle:go_stringer off
+go_library(
+    name = "html",
+    srcs = [
+        "attr.go",
+        "attr_string.go",
+        "content.go",
+        "context.go",
+        "css.go",
+        "delim_string.go",
+        "doc.go",
+        "element_string.go",
+        "error.go",
+        "escape.go",
+        "html.go",
+        "js.go",
+        "jsctx_string.go",
+        "state_string.go",
+        "template.go",
+        "transition.go",
+        "url.go",
+        "urlpart_string.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/template/html",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/template/text"],
+)

--- a/pkg/template/internal/fmtsort/BUILD.bazel
+++ b/pkg/template/internal/fmtsort/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "fmtsort",
+    srcs = ["sort.go"],
+    importpath = "github.com/DataDog/datadog-agent/pkg/template/internal/fmtsort",
+    visibility = ["//pkg/template:__subpackages__"],
+)

--- a/pkg/template/text/BUILD.bazel
+++ b/pkg/template/text/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "text",
+    srcs = [
+        "doc.go",
+        "exec.go",
+        "funcs.go",
+        "helper.go",
+        "option.go",
+        "template.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/template/text",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/template/internal/fmtsort"],
+)

--- a/tasks/pkg_template.py
+++ b/tasks/pkg_template.py
@@ -1,10 +1,7 @@
-import os
-import shutil
-import sys
-from contextlib import chdir
-
 from invoke.context import Context
 from invoke.tasks import task
+
+from tasks.libs.build.bazel import bazel
 
 
 @task
@@ -13,68 +10,4 @@ def generate(ctx: Context):
     Generate the code for the template package.
     Takes the code from the Go standard library and applies the patches.
     """
-    if not shutil.which("gopatch"):
-        print("gopatch could not be found, you need to run `inv -e install-tools` first...")
-        sys.exit(1)
-
-    with chdir("pkg/template"):
-        _generate(ctx)
-
-
-def _generate(ctx: Context):
-    print(f"Generating code for Go version {get_go_version(ctx)}")
-
-    goroot = get_goroot(ctx)
-    if not goroot:
-        print("Could not find Go's source code path")
-        sys.exit(1)
-    print(f"Using code from {goroot}")
-
-    print("Removing previous code...")
-    remove_dirs = ["text", "html", "internal"]
-    for dir_name in remove_dirs:
-        if os.path.exists(dir_name):
-            shutil.rmtree(dir_name)
-
-    print("Creating directories...")
-    os.makedirs("internal/fmtsort", exist_ok=True)
-    os.makedirs("text", exist_ok=True)
-    os.makedirs("html", exist_ok=True)
-
-    print("Copying code from Go standard library...")
-    copy_go_files(f"{goroot}/src/text/template", "text")
-    copy_go_files(f"{goroot}/src/html/template", "html")
-    copy_go_files(f"{goroot}/src/internal/fmtsort", "internal/fmtsort")
-
-    print("Applying patches...")
-    ctx.run("git apply no-method.patch")
-    ctx.run("gopatch -p imports.gopatch ./...")
-    ctx.run("gopatch -p godebug.gopatch ./...")
-    ctx.run("git apply types.patch")
-    ctx.run("git apply godebug-stub.patch")
-
-    print("Code generation completed successfully!")
-
-
-def get_go_version(ctx: Context):
-    """Get the Go version."""
-    result = ctx.run("go version", hide="stdout")
-    assert result
-    return result.stdout.strip()
-
-
-def get_goroot(ctx: Context):
-    """Get the GOROOT environment variable."""
-    result = ctx.run("go env GOROOT", hide="stdout")
-    assert result
-    return result.stdout.strip()
-
-
-def copy_go_files(src_dir, dest_dir):
-    """Copy Go files from source to destination directory."""
-    for file in os.listdir(src_dir):
-        if file.endswith(".go") and not file.endswith("_test.go"):
-            src_file = os.path.join(src_dir, file)
-            dest_file = os.path.join(dest_dir, file)
-            shutil.copy2(src_file, dest_file)
-            os.chmod(dest_file, 0o664)  # ensure the file is writable
+    bazel("run", "//pkg/template:generate")

--- a/tasks/pkg_template.py
+++ b/tasks/pkg_template.py
@@ -5,7 +5,7 @@ from tasks.libs.build.bazel import bazel
 
 
 @task
-def generate(ctx: Context):
+def generate(_: Context):
     """
     Generate the code for the template package.
     Takes the code from the Go standard library and applies the patches.

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -7,10 +7,10 @@ from invoke.context import Context
 from invoke.tasks import task
 
 from tasks.go import tidy
+from tasks.libs.build.bazel import bazel
 from tasks.libs.ciproviders.gitlab_api import update_gitlab_config
 from tasks.libs.common.color import color_message
 from tasks.libs.common.gomodules import get_default_modules
-from tasks.pkg_template import generate
 
 GO_VERSION_FILE = "./.go-version"
 
@@ -94,7 +94,7 @@ def update_go(
     res = ctx.run("go version")
     if res and res.stdout.startswith(f"go version go{version} "):
         print("Updating the code in pkg/template...")
-        generate(ctx)
+        bazel("run", "//pkg/template:generate")
         print("Running the tidy task...")
         tidy(ctx)
     else:


### PR DESCRIPTION
### What does this PR do?
Three cooperating pieces, following the pattern of `go_stringer` (#47428):
1. `@go_sdk_overrides` repository rule: copies non-test `.go` files from the pinned Go SDK source directories and applies patches in order, via `gopatch` and the built-in `patch`,
2. `go_sdk_overrides` helper function: derive the `write_source_files` inputs from a single mapping, creating diff tests that fail CI on drift between SDK sources and workspace files,
3. `# gazelle:go_stringer off` directive support in the `go_stringer` Gazelle extension, used by `pkg/template/html` to opt out.

`pkg/template` is removed from Gazelle's exclusion list and gains `BUILD.bazel` files automatically generated by `bazel run //:gazelle`.

### Motivation
See https://github.com/DataDog/datadog-agent/pull/47428#pullrequestreview-3926224448 for context.

With this change, Bazel manages the toolchain hermetically via the pinned Go version in `go.work`, and CI catches any drift between the SDK sources and the workspace via diff tests, consistent with `go_stringer` and other hermetic code generators.

### Describe how you validated your changes
`bazel test //pkg/template:generate_tests` passes, which means files generated by `bazel run //pkg/template:generate` match the workspace sources.

### Additional Notes
`inv pkg-template.generate` is retained as a thin wrapper for backwards compatibility.