### PR TITLE
[CI] Disable redundant architecture-specific lint jobs

### DIFF
--- a/.gitlab/.ci-linters.yml
+++ b/.gitlab/.ci-linters.yml
@@ -27,9 +27,7 @@ needs-rules:
     - lint_flavor_dogstatsd_linux-x64
     - lint_flavor_heroku_linux-x64
     - lint_flavor_iot_linux-x64
-    - lint_linux-arm64
     - lint_linux-x64
-    - lint_macos_gitlab_amd64
     - new-e2e-cleanup-on-failure
     - lint_macos_gitlab_arm64
     - protobuf_test

--- a/.gitlab/build/lint/linux.yml
+++ b/.gitlab/build/lint/linux.yml
@@ -31,15 +31,6 @@ lint_linux-x64:
     - .linux_lint
     - .linux_x64
 
-lint_linux-arm64:
-  extends:
-    - .linux_lint
-    - .linux_arm64
-  needs: ["go_deps", "go_tools_deps_arm64"]
-  before_script:
-    - !reference [.retrieve_linux_go_deps]
-    - !reference [.retrieve_linux_go_tools_deps_arm64]
-
 lint_flavor_iot_linux-x64:
   extends:
     - .linux_lint

--- a/.gitlab/build/lint/macos.yml
+++ b/.gitlab/build/lint/macos.yml
@@ -12,10 +12,6 @@ include:
     - dda inv -- -e linter.go --cpus 12 --debug --timeout 60
   retry: !reference [.retry_only_infra_failure, retry]
 
-lint_macos_gitlab_amd64:
-  extends: .lint_macos_gitlab
-  tags: ["macos:sonoma-amd64", "specific:true"]
-
 lint_macos_gitlab_arm64:
   extends: .lint_macos_gitlab
   tags: ["macos:sonoma-arm64", "specific:true"]

--- a/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
+++ b/.gitlab/deploy/e2e_testing_deploy/e2e_deploy.yml
@@ -88,7 +88,7 @@ deploy_deb_testing-a7_arm64:
     - !reference [.manual]
   extends:
     - .deploy_deb_testing-a7
-  needs: ["installer_deb-arm64", "agent_deb-arm64-a7", "agent_deb-arm64-a7-fips", "lint_linux-arm64", "ddot_deb-arm64"]
+  needs: ["installer_deb-arm64", "agent_deb-arm64-a7", "agent_deb-arm64-a7-fips", "lint_linux-x64", "ddot_deb-arm64"]
   script:
     # setup_signing_keys_package must be done *before* setup_signing
     # because setup_signing replaces gpg with gpg-vault
@@ -143,7 +143,7 @@ deploy_rpm_testing-a7_arm64:
     - !reference [.manual]
   extends:
     - .deploy_rpm_testing-a7
-  needs: ["installer_rpm-arm64", "agent_rpm-arm64-a7", "agent_rpm-arm64-a7-fips", "lint_linux-arm64", "ddot_rpm-arm64"]
+  needs: ["installer_rpm-arm64", "agent_rpm-arm64-a7", "agent_rpm-arm64-a7-fips", "lint_linux-x64", "ddot_rpm-arm64"]
   script:
     - *setup_signing
     - |
@@ -190,7 +190,7 @@ deploy_suse_rpm_testing_arm64-a7:
   stage: e2e_deploy
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/gitlab_agent_deploy$CI_IMAGE_GITLAB_AGENT_DEPLOY_SUFFIX:$CI_IMAGE_GITLAB_AGENT_DEPLOY
   tags: ["arch:amd64", "specific:true"]
-  needs: ["installer_suse_rpm-arm64", "agent_suse-arm64-a7", "agent_suse-arm64-a7-fips", "lint_linux-arm64", "ddot_suse_rpm-arm64"]
+  needs: ["installer_suse_rpm-arm64", "agent_suse-arm64-a7", "agent_suse-arm64-a7-fips", "lint_linux-x64", "ddot_suse_rpm-arm64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -264,7 +264,7 @@ linters:
               "-SA6002", # TODO: Fix sync.Pools
               "-SA4025", # TODO: Fix trace unit test
               "-SA4011", "-SA4031", # Disabling these to re-enable golanci-lint default tests
-              "-SA4023",  # Fix the lint_macos_gitlab_amd64 linter discrepancy while we find the issue (see https://github.com/dominikh/go-tools/issues/847)
+              "-SA4023",  # Fix macOS linter discrepancy while we find the issue (see https://github.com/dominikh/go-tools/issues/847)
               "-QF1001", "-QF1002", "-QF1003", "-QF1004", "-QF1005","-QF1006","-QF1007","-QF1008","-QF1009", "-QF1010", "-QF1011", "-QF1012"] # Exclude this rule for the golangci-lint v2 migrations
     govet:
       settings:


### PR DESCRIPTION
## Summary
- Remove `lint_linux-arm64` job (keep only x64 for Linux linting)
- Remove `lint_macos_gitlab_amd64` job (keep only arm64 for macOS linting)
- Update e2e deploy jobs to depend on `lint_linux-x64` instead

## Motivation
Linting is architecture-independent (it checks code style, syntax, and static analysis), so running on multiple architectures per platform is redundant and wastes CI resources.

## Test plan
- [ ] Verify CI pipeline runs successfully with only the kept lint jobs
- [ ] Confirm linting still catches issues on x64 Linux and arm64 macOS

Addresses [ACIX-1296](https://datadoghq.atlassian.net/browse/ACIX-1296)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACIX-1296]: https://datadoghq.atlassian.net/browse/ACIX-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ