### PR TITLE
Update GKE configuration to use smaller IP pools

### DIFF
--- a/test/e2e-framework/resources/gcp/gke/cluster.go
+++ b/test/e2e-framework/resources/gcp/gke/cluster.go
@@ -8,10 +8,11 @@ package gke
 import (
 	"strings"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
-	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/gcp"
 	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/container"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/common/config"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/gcp"
 )
 
 const (
@@ -57,6 +58,10 @@ func NewCluster(e gcp.Environment, name string, autopilot bool, opts ...pulumi.R
 					DisplayName: pulumi.String("ddbuild vpn private ips"),
 				},
 			},
+		},
+		IpAllocationPolicy: &container.ClusterIpAllocationPolicyArgs{
+			ClusterIpv4CidrBlock:  pulumi.String("/22"),
+			ServicesIpv4CidrBlock: pulumi.String("/24"),
 		},
 		ResourceLabels: clusterLabels,
 	}

--- a/test/e2e-framework/resources/gcp/gke/cluster.go
+++ b/test/e2e-framework/resources/gcp/gke/cluster.go
@@ -60,7 +60,7 @@ func NewCluster(e gcp.Environment, name string, autopilot bool, opts ...pulumi.R
 			},
 		},
 		IpAllocationPolicy: &container.ClusterIpAllocationPolicyArgs{
-			ClusterIpv4CidrBlock:  pulumi.String("/22"),
+			ClusterIpv4CidrBlock:  pulumi.String("/21"),
 			ServicesIpv4CidrBlock: pulumi.String("/24"),
 		},
 		ResourceLabels: clusterLabels,


### PR DESCRIPTION
### What does this PR do?

Update GKE configuration to use smaller IP pool for pods and services

### Motivation

Avoid issue because we no longer have ip pools available when spinning up GKE clusters

### Describe how you validated your changes

### Additional Notes
