### PR TITLE
fix(diskv2): fix race condition in partition enumeration timeout

### DIFF
--- a/pkg/collector/corechecks/system/disk/diskv2/disk.go
+++ b/pkg/collector/corechecks/system/disk/diskv2/disk.go
@@ -551,12 +551,12 @@ func (c *Check) getDiskPartitionsWithTimeout(includeAllDevices bool) ([]gopsutil
 	resultCh := make(chan partitionsResult, 1)
 	timeout := time.Duration(c.instanceConfig.Timeout) * time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 	if c.instanceConfig.ProcMountInfoPath != "" {
 		ctx = context.WithValue(ctx, common.EnvKey, common.EnvMap{common.HostProcMountinfo: c.instanceConfig.ProcMountInfoPath})
 	}
 	go func() {
 		defer c.partitionEnumInFlight.Store(false)
-		defer cancel()
 		partitions, err := c.diskPartitionsWithContext(ctx, includeAllDevices)
 		resultCh <- partitionsResult{partitions, err}
 	}()


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition in `getDiskPartitionsWithTimeout` where `defer cancel()` inside the goroutine canceled the context before the parent's `select` ran. When the partition call completes quickly, both `resultCh` and `ctx.Done()` become ready simultaneously, and Go's `select` picks randomly, sometimes choosing the timeout path and returning a spurious error.

The fix moves `defer cancel()` from the goroutine to the parent function, so the context is only canceled after the `select` completes.

### Motivation

CI tests were failing intermittently due to this race, especially under high parallelism with the race detector enabled (`-race -p 16 -parallel 16`). The affected test was `TestGivenADiskCheckWithDefaultConfig_WhenCheckRunsAndPartitionsSystemReturnsNoneDevice_ThenNoUsageMetricsAreReportedForThatPartition`.

### Describe how you validated your changes

Ran full diskv2 test suite locally with race detector (`dda inv test --targets=./pkg/collector/corechecks/system/disk/diskv2 --race`) and all 117 tests pass.

### Additional Notes

Follow-up to #47720 which introduced `getDiskPartitionsWithTimeout`.