### PR TITLE
[FA] Add custom config history 

### DIFF
--- a/pkg/fleet/installer/config/config_nix.go
+++ b/pkg/fleet/installer/config/config_nix.go
@@ -23,6 +23,23 @@ const (
 	deploymentIDFile = ".deployment-id"
 )
 
+// RecordStartup records a history entry if any YAML files in the stable config
+// directory have changed since the last recorded state. Call this once at
+// installer startup to capture local edits made between installer runs.
+func (d *Directories) RecordStartup(_ context.Context) {
+	if !isHistoryEnabled(d.StablePath) {
+		return
+	}
+	hist, err := newHistory(d.StablePath)
+	if err != nil {
+		log.Warnf("fleet-installer: could not initialize config history for startup: %v", err)
+		return
+	}
+	if err := hist.recordFromSnapshot(d.StablePath); err != nil {
+		log.Warnf("fleet-installer: could not record config history at startup: %v", err)
+	}
+}
+
 // GetState returns the state of the directories.
 func (d *Directories) GetState() (State, error) {
 	stablePath := filepath.Join(d.StablePath, deploymentIDFile)
@@ -57,6 +74,11 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 	if err != nil {
 		return err
 	}
+	// The history directory must not carry over into the experiment; it belongs
+	// only to the stable directory.
+	if rmErr := os.RemoveAll(filepath.Join(d.ExperimentPath, historyDirName)); rmErr != nil {
+		log.Warnf("fleet-installer: could not remove history dir from experiment: %v", rmErr)
+	}
 
 	operations.FileOperations = append(buildOperationsFromLegacyInstaller(d.StablePath), operations.FileOperations...)
 
@@ -64,6 +86,16 @@ func (d *Directories) WriteExperiment(ctx context.Context, operations Operations
 	if err != nil {
 		return err
 	}
+
+	if isHistoryEnabled(d.StablePath) {
+		hist, histErr := newHistory(d.StablePath)
+		if histErr != nil {
+			log.Warnf("fleet-installer: could not initialize config history: %v", histErr)
+		} else if histErr = hist.record(operations.DeploymentID, d.StablePath, d.ExperimentPath); histErr != nil {
+			log.Warnf("fleet-installer: could not record config history: %v", histErr)
+		}
+	}
+
 	err = os.WriteFile(filepath.Join(d.ExperimentPath, deploymentIDFile), []byte(operations.DeploymentID), 0640)
 	if err != nil {
 		return err

--- a/pkg/fleet/installer/config/config_windows.go
+++ b/pkg/fleet/installer/config/config_windows.go
@@ -181,3 +181,6 @@ func secureCreateTargetDirectoryWithSourcePermissions(sourcePath, targetPath str
 func setFileOwnershipAndPermissions(_ context.Context, _ *os.Root, _ string, _ *configFileSpec) error {
 	return nil
 }
+
+// RecordStartup is a no-op on Windows (history recording is Linux-only for now).
+func (d *Directories) RecordStartup(_ context.Context) {}

--- a/pkg/fleet/installer/config/history.go
+++ b/pkg/fleet/installer/config/history.go
@@ -1,0 +1,247 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/pmezard/go-difflib/difflib"
+	"go.yaml.in/yaml/v2"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	historyDirName    = ".config_history"
+	snapshotDirName   = ".snapshot"
+	maxHistoryEntries = 100
+)
+
+// history records unified diffs of config changes in a dedicated directory.
+type history struct {
+	dir string
+}
+
+// newHistory initializes the history directory and returns a history recorder.
+func newHistory(configDir string) (*history, error) {
+	dir := filepath.Join(configDir, historyDirName)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return nil, fmt.Errorf("could not create history directory: %w", err)
+	}
+	return &history{dir: dir}, nil
+}
+
+// record computes unified diffs between stablePath and experimentPath for all YAML
+// files and writes a single combined diff entry to the history directory.
+// It then updates the snapshot to the experiment state so that a subsequent
+// startup check does not re-record the same RC-pushed changes.
+func (h *history) record(deploymentID, stablePath, experimentPath string) error {
+	before, err := collectYAMLFiles(stablePath)
+	if err != nil {
+		return fmt.Errorf("could not collect stable yaml files: %w", err)
+	}
+	after, err := collectYAMLFiles(experimentPath)
+	if err != nil {
+		return fmt.Errorf("could not collect experiment yaml files: %w", err)
+	}
+	if _, err := h.writeDiffEntry(deploymentID, before, after); err != nil {
+		return err
+	}
+	return h.updateSnapshot(experimentPath)
+}
+
+// recordFromSnapshot compares the current stablePath against the persisted
+// snapshot. If the files differ (i.e. local edits were made since the last
+// recorded entry), it writes a diff entry tagged "local" and refreshes the
+// snapshot. On the very first call (no snapshot yet) it silently initialises
+// the snapshot without writing an entry.
+func (h *history) recordFromSnapshot(stablePath string) error {
+	snapshotDir := filepath.Join(h.dir, snapshotDirName)
+
+	snapshot, err := collectYAMLFiles(snapshotDir)
+	if err != nil {
+		return fmt.Errorf("could not read snapshot: %w", err)
+	}
+	current, err := collectYAMLFiles(stablePath)
+	if err != nil {
+		return fmt.Errorf("could not collect stable yaml files: %w", err)
+	}
+
+	// First run: no snapshot yet — initialise silently.
+	if len(snapshot) == 0 {
+		return h.updateSnapshot(stablePath)
+	}
+
+	wrote, err := h.writeDiffEntry("local", snapshot, current)
+	if err != nil {
+		return err
+	}
+	if wrote {
+		return h.updateSnapshot(stablePath)
+	}
+	return nil
+}
+
+// writeDiffEntry builds a combined unified diff from before/after YAML maps and
+// writes it to the history directory. Returns true if an entry was written.
+func (h *history) writeDiffEntry(deploymentID string, before, after map[string][]byte) (bool, error) {
+	seen := make(map[string]struct{}, len(before)+len(after))
+	for p := range before {
+		seen[p] = struct{}{}
+	}
+	for p := range after {
+		seen[p] = struct{}{}
+	}
+	allPaths := make([]string, 0, len(seen))
+	for p := range seen {
+		allPaths = append(allPaths, p)
+	}
+	sort.Strings(allPaths)
+
+	now := time.Now().UTC()
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# deployment_id: %s\n", deploymentID)
+	fmt.Fprintf(&sb, "# timestamp: %s\n", now.Format(time.RFC3339))
+
+	hasDiff := false
+	for _, relPath := range allPaths {
+		ud := difflib.UnifiedDiff{
+			A:        difflib.SplitLines(string(before[relPath])),
+			B:        difflib.SplitLines(string(after[relPath])),
+			FromFile: relPath,
+			ToFile:   relPath,
+			Context:  3,
+		}
+		diffText, err := difflib.GetUnifiedDiffString(ud)
+		if err != nil {
+			return false, fmt.Errorf("could not compute diff for %s: %w", relPath, err)
+		}
+		if diffText == "" {
+			continue
+		}
+		hasDiff = true
+		sb.WriteString("\n")
+		sb.WriteString(diffText)
+	}
+
+	if !hasDiff {
+		return false, nil
+	}
+
+	fileName := fmt.Sprintf("%018d.diff", now.UnixNano())
+	if err := os.WriteFile(filepath.Join(h.dir, fileName), []byte(sb.String()), 0640); err != nil {
+		return false, fmt.Errorf("could not write history entry: %w", err)
+	}
+	return true, h.prune()
+}
+
+// updateSnapshot replaces the snapshot with a fresh copy of all YAML files in dir.
+func (h *history) updateSnapshot(dir string) error {
+	snapshotDir := filepath.Join(h.dir, snapshotDirName)
+	if err := os.RemoveAll(snapshotDir); err != nil {
+		return fmt.Errorf("could not clear snapshot: %w", err)
+	}
+	files, err := collectYAMLFiles(dir)
+	if err != nil {
+		return fmt.Errorf("could not collect yaml files for snapshot: %w", err)
+	}
+	for relPath, content := range files {
+		destPath := filepath.Join(snapshotDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0750); err != nil {
+			return fmt.Errorf("could not create snapshot subdirectory: %w", err)
+		}
+		if err := os.WriteFile(destPath, content, 0640); err != nil {
+			return fmt.Errorf("could not write snapshot file %s: %w", relPath, err)
+		}
+	}
+	return nil
+}
+
+// prune removes the oldest entries keeping at most maxHistoryEntries.
+func (h *history) prune() error {
+	entries, err := os.ReadDir(h.dir)
+	if err != nil {
+		return fmt.Errorf("could not read history directory: %w", err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".diff") {
+			files = append(files, e.Name())
+		}
+	}
+	sort.Strings(files)
+
+	if len(files) <= maxHistoryEntries {
+		return nil
+	}
+
+	for _, name := range files[:len(files)-maxHistoryEntries] {
+		if err := os.Remove(filepath.Join(h.dir, name)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("could not remove old history entry %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// collectYAMLFiles returns the byte content of every .yaml file under dir,
+// keyed by path relative to dir. The history directory itself is skipped.
+// A non-existent dir is treated as empty (returns empty map, no error).
+func collectYAMLFiles(dir string) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == historyDirName {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".yaml") {
+			return nil
+		}
+		relPath, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		result[relPath] = content
+		return nil
+	})
+	if os.IsNotExist(err) {
+		return result, nil
+	}
+	return result, err
+}
+
+// isHistoryEnabled reads datadog.yaml from stablePath and reports whether
+// config_history.enabled is set to true.
+func isHistoryEnabled(stablePath string) bool {
+	data, err := os.ReadFile(filepath.Join(stablePath, "datadog.yaml"))
+	if err != nil {
+		return false
+	}
+	var cfg struct {
+		ConfigHistory struct {
+			Enabled bool `yaml:"enabled"`
+		} `yaml:"config_history"`
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		log.Warnf("fleet-installer: could not parse datadog.yaml for config_history flag: %v", err)
+		return false
+	}
+	return cfg.ConfigHistory.Enabled
+}

--- a/pkg/fleet/installer/config/history_test.go
+++ b/pkg/fleet/installer/config/history_test.go
@@ -1,0 +1,345 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHistory(t *testing.T) {
+	dir := t.TempDir()
+	h, err := newHistory(dir)
+	require.NoError(t, err)
+	assert.DirExists(t, filepath.Join(dir, historyDirName))
+	assert.NotNil(t, h)
+}
+
+func TestHistoryRecord_WritesDiffFile(t *testing.T) {
+	stableDir := t.TempDir()
+	expDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("api_key: old\n"), 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(expDir, "datadog.yaml"), []byte("api_key: new\n"), 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+
+	err = h.record("deploy-1", stableDir, expDir)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	var diffFiles []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".diff") {
+			diffFiles = append(diffFiles, e.Name())
+		}
+	}
+	require.Len(t, diffFiles, 1)
+
+	content, err := os.ReadFile(filepath.Join(stableDir, historyDirName, diffFiles[0]))
+	require.NoError(t, err)
+
+	body := string(content)
+	assert.Contains(t, body, "# deployment_id: deploy-1")
+	assert.Contains(t, body, "# timestamp:")
+	assert.Contains(t, body, "datadog.yaml")
+	assert.Contains(t, body, "-api_key: old")
+	assert.Contains(t, body, "+api_key: new")
+}
+
+func TestHistoryRecord_NoFileWrittenWhenNoDiff(t *testing.T) {
+	stableDir := t.TempDir()
+	expDir := t.TempDir()
+
+	content := []byte("api_key: same\n")
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), content, 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(expDir, "datadog.yaml"), content, 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+
+	err = h.record("deploy-1", stableDir, expDir)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".diff"), "no diff expected when content is identical")
+	}
+}
+
+func TestHistoryRecord_MultipleFilesInOneDiff(t *testing.T) {
+	stableDir := t.TempDir()
+	expDir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(stableDir, "conf.d"), 0755))
+	require.NoError(t, os.MkdirAll(filepath.Join(expDir, "conf.d"), 0755))
+
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("k: v1\n"), 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(expDir, "datadog.yaml"), []byte("k: v2\n"), 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "conf.d", "check.yaml"), []byte("enabled: false\n"), 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(expDir, "conf.d", "check.yaml"), []byte("enabled: true\n"), 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+
+	err = h.record("deploy-multi", stableDir, expDir)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	var diffFiles []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".diff") {
+			diffFiles = append(diffFiles, e.Name())
+		}
+	}
+	// All file diffs in a single entry.
+	require.Len(t, diffFiles, 1)
+
+	body, err := os.ReadFile(filepath.Join(stableDir, historyDirName, diffFiles[0]))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "datadog.yaml")
+	assert.Contains(t, string(body), filepath.Join("conf.d", "check.yaml"))
+}
+
+func TestHistoryRecord_NewFileShowsFullContentAsAddition(t *testing.T) {
+	stableDir := t.TempDir()
+	expDir := t.TempDir()
+
+	// File only exists in experiment (newly created by an operation).
+	require.NoError(t, os.WriteFile(filepath.Join(expDir, "otel-config.yaml"), []byte("receivers: []\n"), 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+
+	err = h.record("deploy-new", stableDir, expDir)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	var diffFiles []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".diff") {
+			diffFiles = append(diffFiles, e.Name())
+		}
+	}
+	require.Len(t, diffFiles, 1)
+
+	body, err := os.ReadFile(filepath.Join(stableDir, historyDirName, diffFiles[0]))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "+receivers: []")
+}
+
+func TestHistoryRecord_DeletedFileShowsFullContentAsRemoval(t *testing.T) {
+	stableDir := t.TempDir()
+	expDir := t.TempDir()
+
+	// File only exists in stable (deleted by an operation).
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "otel-config.yaml"), []byte("receivers: []\n"), 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+
+	err = h.record("deploy-del", stableDir, expDir)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	body, err := os.ReadFile(filepath.Join(stableDir, historyDirName, entries[0].Name()))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "-receivers: []")
+}
+
+func TestHistoryPrune_KeepsLast100(t *testing.T) {
+	dir := t.TempDir()
+	h, err := newHistory(dir)
+	require.NoError(t, err)
+
+	// Pre-populate 105 diff files.
+	for i := range 105 {
+		name := fmt.Sprintf("%018d.diff", i)
+		require.NoError(t, os.WriteFile(filepath.Join(h.dir, name), []byte("# placeholder"), 0640))
+	}
+
+	require.NoError(t, h.prune())
+
+	remaining, err := os.ReadDir(h.dir)
+	require.NoError(t, err)
+	assert.Len(t, remaining, 100)
+
+	// Oldest files (0–4) must be gone; newest (5–104) must survive.
+	names := make([]string, 0, len(remaining))
+	for _, e := range remaining {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	assert.Equal(t, fmt.Sprintf("%018d.diff", 5), names[0])
+	assert.Equal(t, fmt.Sprintf("%018d.diff", 104), names[99])
+}
+
+func TestHistoryRecord_HistoryDirSkippedInCollect(t *testing.T) {
+	stableDir := t.TempDir()
+	expDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("k: v1\n"), 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(expDir, "datadog.yaml"), []byte("k: v2\n"), 0640))
+
+	// Plant a .yaml file inside the history dir to ensure it is not collected.
+	histDir := filepath.Join(stableDir, historyDirName)
+	require.NoError(t, os.MkdirAll(histDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(histDir, "stray.yaml"), []byte("should: be ignored\n"), 0640))
+
+	files, err := collectYAMLFiles(stableDir)
+	require.NoError(t, err)
+
+	for p := range files {
+		assert.False(t, strings.Contains(p, historyDirName), "history dir must not appear in collected files")
+	}
+}
+
+func TestHistoryRecordFromSnapshot_FirstRun_InitialisesSnapshotSilently(t *testing.T) {
+	stableDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("api_key: abc\n"), 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+
+	// No snapshot exists yet — should silently create one without writing a diff.
+	require.NoError(t, h.recordFromSnapshot(stableDir))
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	diffFiles := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".diff") {
+			diffFiles++
+		}
+	}
+	assert.Equal(t, 0, diffFiles, "first run must not write a diff entry")
+
+	// Snapshot should now contain the stable file.
+	snapshotContent, err := os.ReadFile(filepath.Join(stableDir, historyDirName, snapshotDirName, "datadog.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "api_key: abc\n", string(snapshotContent))
+}
+
+func TestHistoryRecordFromSnapshot_LocalEdit_RecordsDiff(t *testing.T) {
+	stableDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("api_key: original\n"), 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+
+	// Initialise snapshot.
+	require.NoError(t, h.recordFromSnapshot(stableDir))
+
+	// Simulate a local edit to the stable file.
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("api_key: edited\n"), 0640))
+
+	// Second startup — should detect the change.
+	require.NoError(t, h.recordFromSnapshot(stableDir))
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	var diffFiles []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".diff") {
+			diffFiles = append(diffFiles, e.Name())
+		}
+	}
+	require.Len(t, diffFiles, 1)
+
+	body, err := os.ReadFile(filepath.Join(stableDir, historyDirName, diffFiles[0]))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "# deployment_id: local")
+	assert.Contains(t, string(body), "-api_key: original")
+	assert.Contains(t, string(body), "+api_key: edited")
+}
+
+func TestHistoryRecordFromSnapshot_NoChange_NoDiff(t *testing.T) {
+	stableDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("api_key: same\n"), 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+	require.NoError(t, h.recordFromSnapshot(stableDir))
+
+	// Second startup — nothing changed.
+	require.NoError(t, h.recordFromSnapshot(stableDir))
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".diff"), "no diff expected when nothing changed")
+	}
+}
+
+func TestHistoryRecord_UpdatesSnapshot(t *testing.T) {
+	stableDir := t.TempDir()
+	expDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("api_key: old\n"), 0640))
+	require.NoError(t, os.WriteFile(filepath.Join(expDir, "datadog.yaml"), []byte("api_key: new\n"), 0640))
+
+	h, err := newHistory(stableDir)
+	require.NoError(t, err)
+	require.NoError(t, h.record("deploy-1", stableDir, expDir))
+
+	// Snapshot should reflect the experiment state.
+	snapshotContent, err := os.ReadFile(filepath.Join(stableDir, historyDirName, snapshotDirName, "datadog.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "api_key: new\n", string(snapshotContent))
+
+	// After promote (stable = experiment), startup should not record a duplicate.
+	require.NoError(t, os.WriteFile(filepath.Join(stableDir, "datadog.yaml"), []byte("api_key: new\n"), 0640))
+	require.NoError(t, h.recordFromSnapshot(stableDir))
+
+	entries, err := os.ReadDir(filepath.Join(stableDir, historyDirName))
+	require.NoError(t, err)
+	diffCount := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".diff") {
+			diffCount++
+		}
+	}
+	assert.Equal(t, 1, diffCount, "promote then restart must not produce a duplicate entry")
+}
+
+func TestIsHistoryEnabled(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "datadog.yaml"), []byte("config_history:\n  enabled: true\n"), 0640))
+		assert.True(t, isHistoryEnabled(dir))
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "datadog.yaml"), []byte("config_history:\n  enabled: false\n"), 0640))
+		assert.False(t, isHistoryEnabled(dir))
+	})
+
+	t.Run("missing_key", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "datadog.yaml"), []byte("api_key: abc\n"), 0640))
+		assert.False(t, isHistoryEnabled(dir))
+	})
+
+	t.Run("missing_file", func(t *testing.T) {
+		dir := t.TempDir()
+		assert.False(t, isHistoryEnabled(dir))
+	})
+}

--- a/pkg/fleet/installer/go.mod
+++ b/pkg/fleet/installer/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/uuid v1.6.0
 	github.com/shirou/gopsutil/v4 v4.26.2
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.4.3
@@ -45,7 +46,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/pkg/fleet/installer/go.mod
+++ b/pkg/fleet/installer/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/fatih/color v1.18.0
 	github.com/google/go-containerregistry v0.20.7
 	github.com/google/uuid v1.6.0
-	github.com/shirou/gopsutil/v4 v4.26.2
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/shirou/gopsutil/v4 v4.26.2
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.4.3

--- a/pkg/fleet/installer/installer.go
+++ b/pkg/fleet/installer/installer.go
@@ -115,6 +115,7 @@ func NewInstaller(ctx context.Context, env *env.Env) (Installer, error) {
 		userConfigsDir: paths.DefaultUserConfigsDir,
 		packagesDir:    paths.PackagesPath,
 	}
+	i.config.RecordStartup(ctx)
 	return i, nil
 }
 

--- a/test/new-e2e/tests/fleet/config_history_test.go
+++ b/test/new-e2e/tests/fleet/config_history_test.go
@@ -1,0 +1,219 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package fleet
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/backend"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/fleet/suite"
+)
+
+const agentHistoryDir = "/etc/datadog-agent/.config_history"
+
+type configHistorySuite struct {
+	suite.FleetSuite
+}
+
+func newConfigHistorySuite() e2e.Suite[environments.Host] {
+	return &configHistorySuite{}
+}
+
+func TestFleetConfigHistory(t *testing.T) {
+	suite.Run(t, newConfigHistorySuite, suite.LinuxPlatforms)
+}
+
+// SetupTest skips the test on Windows since config history is Linux-only.
+func (s *configHistorySuite) SetupTest() {
+	if s.Env().RemoteHost.OSFamily == e2eos.WindowsFamily {
+		s.T().Skip("Config history is Linux-only")
+	}
+}
+
+// enableHistory appends config_history.enabled: true to the stable datadog.yaml.
+func (s *configHistorySuite) enableHistory() {
+	_, err := s.Env().RemoteHost.Execute(`printf '\nconfig_history:\n  enabled: true\n' >> /etc/datadog-agent/datadog.yaml`)
+	require.NoError(s.T(), err)
+}
+
+// listDiffFiles returns the absolute paths of all .diff files in the history directory.
+func (s *configHistorySuite) listDiffFiles() []string {
+	out, err := s.Env().RemoteHost.Execute(`find ` + agentHistoryDir + ` -maxdepth 1 -name '*.diff' -type f 2>/dev/null`)
+	require.NoError(s.T(), err)
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil
+	}
+	return strings.Split(out, "\n")
+}
+
+// TestConfigHistory_ExperimentCreatesEntry verifies that starting a config
+// experiment writes a single unified-diff entry into the history directory,
+// tagged with the deployment ID and showing the changed lines.
+func (s *configHistorySuite) TestConfigHistory_ExperimentCreatesEntry() {
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+	s.enableHistory()
+
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID: "hist-exp-1",
+		FileOperations: []backend.FileOperation{
+			{FileOperationType: backend.FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "debug"}`)},
+		},
+	}, nil)
+	require.NoError(s.T(), err)
+
+	dirExists, err := s.Host.DirExists(agentHistoryDir)
+	require.NoError(s.T(), err)
+	require.True(s.T(), dirExists, "history directory must exist after WriteExperiment")
+
+	diffFiles := s.listDiffFiles()
+	require.Len(s.T(), diffFiles, 1, "expected one diff entry after WriteExperiment")
+
+	raw, err := s.Env().RemoteHost.ReadFile(diffFiles[0])
+	require.NoError(s.T(), err)
+	body := string(raw)
+	assert.Contains(s.T(), body, "# deployment_id: hist-exp-1")
+	assert.Contains(s.T(), body, "+log_level: debug")
+}
+
+// TestConfigHistory_PromoteDoesNotAddEntry verifies that promoting an experiment
+// to stable does not write an additional history entry.
+func (s *configHistorySuite) TestConfigHistory_PromoteDoesNotAddEntry() {
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+	s.enableHistory()
+
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID: "hist-promote-1",
+		FileOperations: []backend.FileOperation{
+			{FileOperationType: backend.FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "debug"}`)},
+		},
+	}, nil)
+	require.NoError(s.T(), err)
+
+	err = s.Backend.PromoteConfigExperiment()
+	require.NoError(s.T(), err)
+
+	assert.Len(s.T(), s.listDiffFiles(), 1, "promote must not append a diff entry")
+}
+
+// TestConfigHistory_RollbackPreservesEntry verifies that rolling back a config
+// experiment (StopConfigExperiment) does not erase the diff entry that was
+// written when the experiment started, and that the configuration is reverted.
+func (s *configHistorySuite) TestConfigHistory_RollbackPreservesEntry() {
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+	s.enableHistory()
+
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID: "hist-rollback-1",
+		FileOperations: []backend.FileOperation{
+			{FileOperationType: backend.FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "debug"}`)},
+		},
+	}, nil)
+	require.NoError(s.T(), err)
+
+	config, err := s.Agent.Configuration()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), "debug", config["log_level"])
+	require.Len(s.T(), s.listDiffFiles(), 1, "expected one diff entry before rollback")
+
+	err = s.Backend.StopConfigExperiment()
+	require.NoError(s.T(), err)
+
+	// Config must be reverted to the pre-experiment value.
+	config, err = s.Agent.Configuration()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), "info", config["log_level"])
+
+	// The original entry must still be present; rollback must not erase history.
+	diffFiles := s.listDiffFiles()
+	require.Len(s.T(), diffFiles, 1, "history entry must persist after rollback")
+
+	raw, err := s.Env().RemoteHost.ReadFile(diffFiles[0])
+	require.NoError(s.T(), err)
+	body := string(raw)
+	assert.Contains(s.T(), body, "# deployment_id: hist-rollback-1")
+	assert.Contains(s.T(), body, "+log_level: debug")
+}
+
+// TestConfigHistory_MultipleExperimentsMultipleEntries verifies that each
+// successive experiment-promote cycle produces a distinct history entry.
+func (s *configHistorySuite) TestConfigHistory_MultipleExperimentsMultipleEntries() {
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+	s.enableHistory()
+
+	levels := []string{"debug", "warn", "error"}
+	for i, level := range levels {
+		err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+			DeploymentID: fmt.Sprintf("hist-multi-%d", i),
+			FileOperations: []backend.FileOperation{
+				{FileOperationType: backend.FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: fmt.Appendf(nil, `{"log_level": "%s"}`, level)},
+			},
+		}, nil)
+		require.NoError(s.T(), err)
+		err = s.Backend.PromoteConfigExperiment()
+		require.NoError(s.T(), err)
+	}
+
+	assert.Len(s.T(), s.listDiffFiles(), len(levels), "expected one diff entry per experiment")
+}
+
+// TestConfigHistory_MultipleRollbacks verifies that rolling back multiple
+// successive experiments leaves a complete audit trail. Each experiment that
+// was started — whether later promoted or rolled back — must have a diff entry.
+func (s *configHistorySuite) TestConfigHistory_MultipleRollbacks() {
+	s.Agent.MustInstall()
+	defer s.Agent.MustUninstall()
+	s.enableHistory()
+
+	// First experiment: promote.
+	err := s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID: "hist-rb-promote",
+		FileOperations: []backend.FileOperation{
+			{FileOperationType: backend.FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "debug"}`)},
+		},
+	}, nil)
+	require.NoError(s.T(), err)
+	err = s.Backend.PromoteConfigExperiment()
+	require.NoError(s.T(), err)
+	require.Len(s.T(), s.listDiffFiles(), 1)
+
+	// Second experiment: roll back.
+	err = s.Backend.StartConfigExperiment(backend.ConfigOperations{
+		DeploymentID: "hist-rb-rollback",
+		FileOperations: []backend.FileOperation{
+			{FileOperationType: backend.FileOperationMergePatch, FilePath: "/datadog.yaml", Patch: []byte(`{"log_level": "warn"}`)},
+		},
+	}, nil)
+	require.NoError(s.T(), err)
+
+	config, err := s.Agent.Configuration()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), "warn", config["log_level"])
+
+	err = s.Backend.StopConfigExperiment()
+	require.NoError(s.T(), err)
+
+	// Config reverts to the promoted value.
+	config, err = s.Agent.Configuration()
+	require.NoError(s.T(), err)
+	require.Equal(s.T(), "debug", config["log_level"])
+
+	// Both experiments must be represented in history.
+	diffFiles := s.listDiffFiles()
+	require.Len(s.T(), diffFiles, 2, "both experiments must have a diff entry regardless of rollback")
+}

--- a/test/new-e2e/tests/fleet/config_history_test.go
+++ b/test/new-e2e/tests/fleet/config_history_test.go
@@ -43,7 +43,7 @@ func (s *configHistorySuite) SetupTest() {
 
 // enableHistory appends config_history.enabled: true to the stable datadog.yaml.
 func (s *configHistorySuite) enableHistory() {
-	_, err := s.Env().RemoteHost.Execute(`printf '\nconfig_history:\n  enabled: true\n' >> /etc/datadog-agent/datadog.yaml`)
+	_, err := s.Env().RemoteHost.Execute(`printf '\nconfig_history:\n  enabled: true\n' | sudo tee -a /etc/datadog-agent/datadog.yaml > /dev/null`)
 	require.NoError(s.T(), err)
 }
 


### PR DESCRIPTION
### What does this PR do?

This pull request introduces a new feature for recording configuration change history in the installer, specifically for Linux environments. The feature tracks changes to YAML files in the stable config directory, records unified diffs of those changes, and maintains a history directory with up to 100 entries. It also ensures that local edits made between installer runs are captured, and that the experiment directory does not retain history entries. Comprehensive tests are included to validate all aspects of this functionality.

Configuration history feature:

* Added a new `history.go` module implementing unified diff recording for YAML config changes, snapshot management, and pruning of history entries, with up to 100 diffs retained (`pkg/fleet/installer/config/history.go`).
* Integrated history recording at installer startup and after experiment writes, including logic to capture local edits and ensure the experiment directory does not retain history state (`pkg/fleet/installer/config/config_nix.go`, `pkg/fleet/installer/installer.go`). [[1]](diffhunk://#diff-6f118bea884c17727bbb6e3a1bcd9a6ec03e3eae53b6d41d175aa1432159b67dR26-R42) [[2]](diffhunk://#diff-6f118bea884c17727bbb6e3a1bcd9a6ec03e3eae53b6d41d175aa1432159b67dR77-R98) [[3]](diffhunk://#diff-5097e32b945d38543ad437011a6c5e9e11312ede815b9788d7788164c871627aR118)
* Provided a no-op implementation for history recording on Windows, as the feature is Linux-only for now (`pkg/fleet/installer/config/config_windows.go`).

Testing and dependencies:

* Added a comprehensive test suite for the history feature, covering diff creation, snapshot updates, pruning, and config flag handling (`pkg/fleet/installer/config/history_test.go`).
* Updated module dependencies to add `github.com/pmezard/go-difflib` for unified diff generation and removed its indirect listing (`pkg/fleet/installer/go.mod`). [[1]](diffhunk://#diff-ba169b3f7f8f328feff3c01b7dce50836af4e76367cd5eba32b24c1172aaeff4R16) [[2]](diffhunk://#diff-ba169b3f7f8f328feff3c01b7dce50836af4e76367cd5eba32b24c1172aaeff4L48)

### Motivation

### Describe how you validated your changes

### Additional Notes
