### PR TITLE
CAP-3483 fix shared cache issue for otel

### DIFF
--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/logs_exporter.go
@@ -27,16 +27,16 @@ import (
 
 // Exporter defines fields for the logs agent exporter
 type Exporter struct {
-	set                component.TelemetrySettings
-	logsAgentChannel   chan *message.Message
-	logSource          *sources.LogSource
-	translator         *logsmapping.Translator
-	gatewaysUsage      otel.GatewayUsage
-	orchestratorConfig OrchestratorConfig
-	reporter           *inframetadata.Reporter
-	cfg                *Config
-	coatGwUsageMetric  telemetry.Gauge
-	buildInfo          component.BuildInfo
+	set                  component.TelemetrySettings
+	logsAgentChannel     chan *message.Message
+	logSource            *sources.LogSource
+	translator           *logsmapping.Translator
+	gatewaysUsage        otel.GatewayUsage
+	orchestratorExporter orchestratorExporter
+	reporter             *inframetadata.Reporter
+	cfg                  *Config
+	coatGwUsageMetric    telemetry.Gauge
+	buildInfo            component.BuildInfo
 }
 
 // NewExporter initializes a new logs agent exporter with the given parameters
@@ -67,15 +67,15 @@ func NewExporterWithGatewayUsage(
 	}
 
 	return &Exporter{
-		set:                set,
-		logsAgentChannel:   logsAgentChannel,
-		logSource:          logSource,
-		translator:         translator,
-		gatewaysUsage:      gatewaysUsage,
-		coatGwUsageMetric:  coatGwUsageMetric,
-		buildInfo:          buildInfo,
-		orchestratorConfig: cfg.OrchestratorConfig,
-		cfg:                cfg,
+		set:                  set,
+		logsAgentChannel:     logsAgentChannel,
+		logSource:            logSource,
+		translator:           translator,
+		gatewaysUsage:        gatewaysUsage,
+		coatGwUsageMetric:    coatGwUsageMetric,
+		buildInfo:            buildInfo,
+		orchestratorExporter: newOrchestratorExporter(cfg.OrchestratorConfig),
+		cfg:                  cfg,
 	}, nil
 }
 
@@ -84,7 +84,7 @@ func (e *Exporter) ConsumeLogs(ctx context.Context, ld plog.Logs) (err error) {
 	scope := getLogsScope(ld)
 	switch scope {
 	case K8sObjectsReceiver:
-		if e.orchestratorConfig.Enabled {
+		if e.orchestratorExporter.config.Enabled {
 			return e.consumeK8sObjects(ctx, ld)
 		}
 		fallthrough

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
 	gocache "github.com/patrickmn/go-cache"
@@ -35,27 +34,31 @@ const (
 	maxPayloadSizeBytes = 10 * 1000 * 1000
 )
 
-var (
+type orchestratorExporter struct {
+	config OrchestratorConfig
+
 	// manifestCache provides an in-memory cache to avoid sending the same manifest multiple times
 	// within a short period. Uses UID + resourceVersion as the cache key.
-	manifestCache     *gocache.Cache
-	manifestCacheOnce sync.Once
-)
+	manifestCache *gocache.Cache
+}
 
-// getManifestCache returns the singleton manifest cache instance
-func getManifestCache() *gocache.Cache {
-	manifestCacheOnce.Do(func() {
-		manifestCache = gocache.New(manifestCacheTTL, manifestCachePurge)
-	})
-	return manifestCache
+func newOrchestratorExporter(config OrchestratorConfig) orchestratorExporter {
+	exporter := orchestratorExporter{
+		config: config,
+	}
+
+	if config.Enabled {
+		exporter.manifestCache = gocache.New(manifestCacheTTL, manifestCachePurge)
+	}
+	return exporter
 }
 
 // shouldSkipManifest checks if the manifest was already sent recently.
 // Returns true if the manifest should be skipped (cache hit with same resourceVersion).
 // This follows the same pattern as pkg/orchestrator.SkipKubernetesResource.
 // Watch log events always bypass the cache to ensure real-time updates are sent.
-func shouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool) bool {
-	if manifest == nil || manifest.Uid == "" {
+func shouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool, cache *gocache.Cache) bool {
+	if cache == nil || manifest == nil || manifest.Uid == "" {
 		return false
 	}
 
@@ -64,7 +67,6 @@ func shouldSkipManifest(manifest *agentmodel.Manifest, isWatchEvent bool) bool {
 		return false
 	}
 
-	cache := getManifestCache()
 	cacheKey := manifest.Uid
 
 	// Check if we have this resource in cache
@@ -179,7 +181,7 @@ func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) (err err
 
 				// Check cache to avoid sending the same manifest multiple times within 3 minutes
 				// Watch events bypass the cache to ensure real-time updates
-				if shouldSkipManifest(manifest, isWatchEvent) {
+				if shouldSkipManifest(manifest, isWatchEvent, e.orchestratorExporter.manifestCache) {
 					e.set.Logger.Debug("Skipping manifest (cache hit)",
 						zap.String("uid", manifest.Uid),
 						zap.String("kind", manifest.Kind),
@@ -203,7 +205,7 @@ func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) (err err
 		clusterManifest := logsmapping.CreateClusterManifest(clusterID, nodes, e.set.Logger)
 
 		// Check cache for the cluster manifest too (not a watch event)
-		if !shouldSkipManifest(clusterManifest, false) {
+		if !shouldSkipManifest(clusterManifest, false, e.orchestratorExporter.manifestCache) {
 			manifests = append(manifests, clusterManifest)
 			e.set.Logger.Debug("Added Cluster manifest to payload",
 				zap.String("uid", clusterManifest.Uid),
@@ -211,7 +213,7 @@ func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) (err err
 		}
 	}
 
-	hostname, err := e.orchestratorConfig.Hostname.Get(ctx)
+	hostname, err := e.orchestratorExporter.config.Hostname.Get(ctx)
 	if err != nil || hostname == "" {
 		e.set.Logger.Error("Failed to get hostname from config", zap.Error(err))
 	}
@@ -235,7 +237,7 @@ func (e *Exporter) consumeK8sObjects(ctx context.Context, ld plog.Logs) (err err
 
 		payload := logsmapping.ToManifestPayload(chunk, hostname, clusterName, clusterID)
 
-		if err := sendManifestPayload(ctx, e.orchestratorConfig.Endpoint, e.orchestratorConfig.Key, payload, hostname, clusterID, e.set.Logger); err != nil {
+		if err := sendManifestPayload(ctx, e.orchestratorExporter.config.Endpoint, e.orchestratorExporter.config.Key, payload, hostname, clusterID, e.set.Logger); err != nil {
 			e.set.Logger.Error("Failed to send collector manifest chunk",
 				zap.Int("chunk_index", i),
 				zap.Int("chunk_size", len(chunk)),

--- a/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
+++ b/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter_test.go
@@ -7,7 +7,6 @@ package logsagentexporter
 
 import (
 	"encoding/json"
-	"sync"
 	"testing"
 	"time"
 
@@ -22,20 +21,8 @@ import (
 	logsmapping "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/logs"
 )
 
-func TestGetManifestCache(t *testing.T) {
-	cache := getManifestCache()
-	assert.NotNil(t, cache)
-
-	// Test singleton pattern - should return the same instance
-	cache2 := getManifestCache()
-	assert.Equal(t, cache, cache2)
-}
-
 func TestShouldSkipManifest(t *testing.T) {
-	// Reset cache for tests
-	manifestCacheOnce = sync.Once{}
-	manifestCache = nil
-
+	cache := gocache.New(manifestCacheTTL, manifestCachePurge)
 	tests := []struct {
 		name           string
 		manifest       *agentmodel.Manifest
@@ -79,7 +66,6 @@ func TestShouldSkipManifest(t *testing.T) {
 			},
 			isWatchEvent: false,
 			setupCache: func() {
-				cache := getManifestCache()
 				cache.Set("test-uid-2", "v1", manifestCacheTTL)
 			},
 			expectedSkip:   true,
@@ -94,7 +80,6 @@ func TestShouldSkipManifest(t *testing.T) {
 			},
 			isWatchEvent: false,
 			setupCache: func() {
-				cache := getManifestCache()
 				cache.Set("test-uid-3", "v1", manifestCacheTTL)
 			},
 			expectedSkip:   false,
@@ -109,7 +94,6 @@ func TestShouldSkipManifest(t *testing.T) {
 			},
 			isWatchEvent: true,
 			setupCache: func() {
-				cache := getManifestCache()
 				cache.Set("test-uid-4", "v1", manifestCacheTTL)
 			},
 			expectedSkip: false, // Watch events always bypass cache
@@ -131,12 +115,11 @@ func TestShouldSkipManifest(t *testing.T) {
 				tt.setupCache()
 			}
 
-			skip := shouldSkipManifest(tt.manifest, tt.isWatchEvent)
+			skip := shouldSkipManifest(tt.manifest, tt.isWatchEvent, cache)
 			assert.Equal(t, tt.expectedSkip, skip)
 
 			// Verify cache state after the operation (only for non-watch events)
 			if !tt.isWatchEvent && tt.manifest != nil && tt.manifest.Uid != "" && tt.expectedCached {
-				cache := getManifestCache()
 				val, found := cache.Get(tt.manifest.Uid)
 				assert.True(t, found)
 				assert.Equal(t, tt.cachedVersion, val)


### PR DESCRIPTION
### What does this PR do?

Before this change, we had a global cache `manifestCache *gocache.Cache`. 
https://github.com/DataDog/datadog-agent/blob/7.78.0-devel/comp/otelcol/otlp/components/exporter/logsagentexporter/orchestrator_exporter.go#L41

When users configure two Datadog exporter instances for dual-shipping, for example:

```
exporters:
  datadog/sandbox:
    api:
      key: ${env:DD_API_KEY_SANDBOX}
    orchestrator_explorer:
      enabled: true
  datadog/prod:
    api:
      key: ${env:DD_API_KEY_PROD}
    orchestrator_explorer:
      enabled: true
```

Both exporters run in the same process, which means the global `manifestCache *gocache.Cache` was shared between the two exporter instances. We use this cache to skip sending unchanged data to the backend, so one exporter may skip sending data because the other exporter has already cached it.  **This is not the expected behavior.** 

This PR fixes the issue by creating a new cache when a new exporter instance is created. As a result, each exporter maintains its own cache and no longer interferes with the others.

