### PR TITLE
[WINA-2482] fix(softwareinventory): set IngestionTimestamp to time.Now() instead of 0

### DIFF
--- a/comp/softwareinventory/impl/inventorysoftware.go
+++ b/comp/softwareinventory/impl/inventorysoftware.go
@@ -284,7 +284,7 @@ func (is *softwareInventory) sendPayload() error {
 		return err
 	}
 
-	msg := message.NewMessage(jsonPayload, nil, "", 0)
+	msg := message.NewMessage(jsonPayload, nil, "", time.Now().UnixNano())
 
 	// Send the message through the event platform
 	if err = forwarder.SendEventPlatformEvent(msg, eventplatform.EventTypeSoftwareInventory); err != nil {

--- a/comp/softwareinventory/impl/inventorysoftware_test.go
+++ b/comp/softwareinventory/impl/inventorysoftware_test.go
@@ -243,3 +243,22 @@ func TestGetPayload(t *testing.T) {
 	assert.True(t, ok)
 	assert.Len(t, p.Metadata.Software, 0)
 }
+
+func TestSendPayloadSetsIngestionTimestamp(t *testing.T) {
+	f := newFixtureWithData(t, true, []software.Entry{{DisplayName: "TestApp"}})
+
+	var capturedMsg *message.Message
+	f.eventPlatformMock.ExpectedCalls = nil
+	f.eventPlatformMock.On("SendEventPlatformEvent", mock.Anything, eventplatform.EventTypeSoftwareInventory).
+		Run(func(args mock.Arguments) {
+			capturedMsg = args.Get(0).(*message.Message)
+		}).
+		Return(nil)
+
+	sut := f.sut().WaitForPayload()
+	_ = sut
+
+	require.NotNil(t, capturedMsg, "expected SendEventPlatformEvent to be called")
+	assert.Greater(t, capturedMsg.IngestionTimestamp, int64(0),
+		"IngestionTimestamp must be set to a valid non-zero value (nanoseconds since epoch)")
+}


### PR DESCRIPTION
## Summary

- Fix `IngestionTimestamp` being set to `0` when creating event platform messages in `sendPayload()`, which caused the `dd-message-timestamp` HTTP header to be `0` (Unix epoch 1970-01-01)
- The event platform intake rejects events with a functional timestamp before `2000-01-01`, so all software inventory payloads were silently dropped
- Every other caller of `message.NewMessage` in the codebase correctly passes `time.Now().UnixNano()` — this was the only one passing `0`

## Context

Events for the `softinv` tracktype in `us1.staging` were being produced with `timestamp.@.logmatic.date.date = 0`. This is the functional timestamp derived from the `dd-message-timestamp` HTTP header, which the agent sets from `Message.IngestionTimestamp`.

## Tracking
https://datadoghq.atlassian.net/browse/WINA-2482

## Test plan

- [x] Added `TestSendPayloadSetsIngestionTimestamp` that captures the message sent to the event platform forwarder and asserts `IngestionTimestamp > 0`
- [x] All existing tests pass