### PR TITLE
Get testbench usable with large scenarios

### DIFF
--- a/cmd/observer-testbench/ui/src/App.tsx
+++ b/cmd/observer-testbench/ui/src/App.tsx
@@ -475,6 +475,32 @@ function App() {
         </div>
       </header>
 
+      {/* Loading progress bar */}
+      {state.connectionState === 'loading' && state.loadProgress && state.loadProgress.phase !== '' && (
+        <div className="px-4 py-2 bg-slate-800 border-b border-slate-700">
+          <div className="flex items-center gap-3 text-sm">
+            <span className="text-blue-400">
+              {state.loadProgress.phase === 'loading' ? 'Loading data...' :
+               state.loadProgress.phase === 'detecting' ? 'Running detectors...' : 'Finishing...'}
+            </span>
+            {state.loadProgress.phase === 'detecting' && state.loadProgress.timestampsTotal > 0 && (
+              <>
+                <div className="flex-1 h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-blue-500 rounded-full transition-all duration-300"
+                    style={{ width: `${(state.loadProgress.timestampsDone / state.loadProgress.timestampsTotal) * 100}%` }}
+                  />
+                </div>
+                <span className="text-slate-400 tabular-nums">
+                  {state.loadProgress.timestampsDone}/{state.loadProgress.timestampsTotal} timestamps,{' '}
+                  {state.loadProgress.advances} advances, {state.loadProgress.anomalies} anomalies
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
       {/* Episode info panel (shown when episode.json is present) */}
       {episodeInfo && <EpisodeInfoPanel info={episodeInfo} />}
 

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -128,6 +128,25 @@ export interface LogEntry {
   tags: string[];
 }
 
+// LogsResponse is the paginated response from /api/logs.
+export interface LogsResponse {
+  logs: LogEntry[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export type LogKind = 'all' | 'raw' | 'telemetry';
+
+// LogsSummary is the summary response from /api/logs/summary.
+export interface LogsSummary {
+  totalCount: number;
+  countByLevel: Record<string, number>;
+  timeRange: { start: number; end: number };
+  histogram: { timestampMs: number; count: number }[];
+  tagGroups: Record<string, string[]>;
+}
+
 // LogAnomaly is an anomaly emitted directly by a log detector (not via metrics detection).
 export interface LogAnomaly {
   source: string;
@@ -202,6 +221,15 @@ export interface ComponentDataResponse {
   data: unknown;
 }
 
+// Replay progress (lock-free, available during load).
+export interface ReplayProgress {
+  phase: string; // "", "loading", "detecting", "done"
+  timestampsDone: number;
+  timestampsTotal: number;
+  advances: number;
+  anomalies: number;
+}
+
 // Stats response from correlators
 export interface CorrelatorStats {
   [key: string]: Record<string, unknown>;
@@ -219,6 +247,10 @@ class ApiClient {
 
   async getStatus(): Promise<StatusResponse> {
     return this.fetch('/status');
+  }
+
+  async getProgress(): Promise<ReplayProgress> {
+    return this.fetch('/progress');
   }
 
   async getScenarios(): Promise<ScenarioInfo[]> {
@@ -258,9 +290,28 @@ class ApiClient {
     return this.fetch(`/anomalies${params}`);
   }
 
-  async getLogs(level?: string): Promise<LogEntry[]> {
-    const params = level ? `?level=${encodeURIComponent(level)}` : '';
-    return this.fetch(`/logs${params}`);
+  async getLogs(params?: { kind?: LogKind; level?: string; start?: number; end?: number; limit?: number; offset?: number; tags?: string }): Promise<LogsResponse> {
+    const searchParams = new URLSearchParams();
+    if (params?.kind) searchParams.set('kind', params.kind);
+    if (params?.level) searchParams.set('level', params.level);
+    if (params?.start !== undefined) searchParams.set('start', String(params.start));
+    if (params?.end !== undefined) searchParams.set('end', String(params.end));
+    if (params?.limit !== undefined) searchParams.set('limit', String(params.limit));
+    if (params?.offset !== undefined) searchParams.set('offset', String(params.offset));
+    if (params?.tags) searchParams.set('tags', params.tags);
+    const qs = searchParams.toString();
+    return this.fetch(`/logs${qs ? '?' + qs : ''}`);
+  }
+
+  async getLogsSummary(params?: { kind?: LogKind; level?: string; start?: number; end?: number; tags?: string }): Promise<LogsSummary> {
+    const searchParams = new URLSearchParams();
+    if (params?.kind) searchParams.set('kind', params.kind);
+    if (params?.level) searchParams.set('level', params.level);
+    if (params?.start !== undefined) searchParams.set('start', String(params.start));
+    if (params?.end !== undefined) searchParams.set('end', String(params.end));
+    if (params?.tags) searchParams.set('tags', params.tags);
+    const qs = searchParams.toString();
+    return this.fetch(`/logs/summary${qs ? '?' + qs : ''}`);
   }
 
   async getLogAnomalies(detector?: string): Promise<LogAnomaly[]> {

--- a/cmd/observer-testbench/ui/src/components/LogView.tsx
+++ b/cmd/observer-testbench/ui/src/components/LogView.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 import * as d3 from 'd3';
-import type { ScenarioInfo, LogAnomaly, LogEntry } from '../api/client';
+import { api } from '../api/client';
+import type { ScenarioInfo, LogAnomaly, LogEntry, LogsSummary } from '../api/client';
 import type { ObserverState, ObserverActions } from '../hooks/useObserver';
 import type { PhaseMarker } from './ChartWithAnomalyDetails';
 import { MAIN_TAG_FILTER_KEYS } from '../constants';
-import { parseTagFilter, extractTagGroups, toggleTagInInput, matchesTagFilter } from '../filters';
+import { parseTagFilter, toggleTagInInput, matchesTagFilter } from '../filters';
 import { TagFilterGroups } from './TagFilterGroups';
 
 interface TimeRange {
@@ -99,6 +100,8 @@ function LogRateChart({
   timeRange,
   onTimeRangeChange,
   phaseMarkers = [],
+  logsSummary,
+  totalLogCount,
 }: {
   logs: LogEntry[];
   anomalies: LogAnomaly[];
@@ -109,6 +112,8 @@ function LogRateChart({
   timeRange?: TimeRange | null;
   onTimeRangeChange?: (range: TimeRange | null) => void;
   phaseMarkers?: PhaseMarker[];
+  logsSummary?: LogsSummary | null;
+  totalLogCount?: number;
 }) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -122,6 +127,23 @@ function LogRateChart({
   onTimeRangeChangeRef.current = onTimeRangeChange;
 
   const buckets = useMemo(() => {
+    // When summary histogram is available, use pre-computed server-side data
+    if (logsSummary?.histogram && logsSummary.histogram.length > 0) {
+      const hist = logsSummary.histogram;
+      // Compute bucket size from consecutive timestamps (assume uniform)
+      const bucketSizeMs = hist.length > 1 ? hist[1].timestampMs - hist[0].timestampMs : 1000;
+      return hist.map((h) => ({
+        total: h.count,
+        error: 0,
+        warn: 0,
+        info: 0,
+        debug: h.count, // Without per-level histogram data, attribute all to debug (neutral color)
+        startTs: h.timestampMs / 1000,
+        endTs: (h.timestampMs + bucketSizeMs) / 1000,
+      }));
+    }
+
+    // Fallback: compute from provided logs array (used when summary is not yet available)
     let displayStart = timeRange?.start ?? scenarioStart;
     let displayEnd = timeRange?.end ?? scenarioEnd;
     // Fall back to log timestamp bounds when no other bounds are available
@@ -155,12 +177,13 @@ function LogRateChart({
       startTs: displayStart + i * bucketSize,
       endTs: displayStart + (i + 1) * bucketSize,
     }));
-  }, [logs, scenarioStart, scenarioEnd, timeRange]);
+  }, [logs, logsSummary, scenarioStart, scenarioEnd, timeRange]);
 
   const detectors = useMemo(
     () => Array.from(new Set(anomalies.map((a) => a.detectorName))),
     [anomalies]
   );
+  const usesSummaryHistogram = Boolean(logsSummary?.histogram && logsSummary.histogram.length > 0);
 
   // D3 chart drawing
   useEffect(() => {
@@ -193,7 +216,6 @@ function LogRateChart({
     const maxTotal = Math.max(1, ...buckets.map((b) => b.total));
     const barsG = g.append('g').attr('clip-path', 'url(#log-rate-clip)');
 
-    // Status layers — bottom to top: debug, info, warn, error
     const STATUS_LAYERS = [
       { key: 'debug' as const, color: 'rgba(100, 116, 139, 0.6)' },
       { key: 'info'  as const, color: 'rgba(59, 130, 246, 0.65)' },
@@ -201,7 +223,8 @@ function LogRateChart({
       { key: 'error' as const, color: 'rgba(239, 68, 68, 0.85)'  },
     ] as const;
 
-    // Stacked bars per bucket
+    // Stacked bars per bucket when per-level data exists; otherwise render a
+    // single-color volume bar so the chart does not imply a level breakdown.
     buckets.forEach((b) => {
       const x = xScale(b.startTs * 1000);
       const bw = Math.max(0, xScale(b.endTs * 1000) - x - 1);
@@ -216,6 +239,14 @@ function LogRateChart({
       }
 
       const totalH = Math.max(4, (b.total / maxTotal) * innerHeight);
+      if (usesSummaryHistogram) {
+        barsG.append('rect')
+          .attr('x', x).attr('width', bw)
+          .attr('y', innerHeight - totalH).attr('height', totalH)
+          .attr('fill', 'rgba(45, 212, 191, 0.65)');
+        return;
+      }
+
       let yBottom = innerHeight;
       for (const { key, color } of STATUS_LAYERS) {
         const count = b[key];
@@ -337,7 +368,7 @@ function LogRateChart({
       .attr('fill', 'rgba(45, 212, 191, 0.2)')
       .attr('stroke', '#2dd4bf')
       .attr('stroke-width', 1);
-  }, [buckets, anomalies, scenarioStart, scenarioEnd, timeRange, hoveredTimestamp, hoveredAnomalyIndex, phaseMarkers]);
+  }, [buckets, anomalies, scenarioStart, scenarioEnd, timeRange, hoveredTimestamp, hoveredAnomalyIndex, phaseMarkers, usesSummaryHistogram]);
 
   // Panning (middle-click or cmd+left-drag)
   useEffect(() => {
@@ -416,13 +447,20 @@ function LogRateChart({
   return (
     <div className="bg-slate-800/60 rounded p-3 mb-4">
       <div className="flex items-center gap-4 text-xs text-slate-400 mb-1.5">
-        <span>Log rate ({logs.length} log{logs.length !== 1 ? 's' : ''} total)</span>
-        <span className="flex items-center gap-2">
-          <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-red-500/80" />error</span>
-          <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-amber-500/75" />warn</span>
-          <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-blue-500/65" />info</span>
-          <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-slate-500/60" />debug</span>
-        </span>
+        <span>Log rate ({totalLogCount ?? logs.length} log{(totalLogCount ?? logs.length) !== 1 ? 's' : ''} total)</span>
+        {usesSummaryHistogram ? (
+          <span className="flex items-center gap-1">
+            <span className="inline-block w-2 h-2 rounded-sm bg-teal-400/70" />
+            total volume
+          </span>
+        ) : (
+          <span className="flex items-center gap-2">
+            <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-red-500/80" />error</span>
+            <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-amber-500/75" />warn</span>
+            <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-blue-500/65" />info</span>
+            <span className="flex items-center gap-1"><span className="inline-block w-2 h-2 rounded-sm bg-slate-500/60" />debug</span>
+          </span>
+        )}
         {detectors.map((name) => (
           <span key={name} className="flex items-center gap-1">
             <span className="inline-block w-2 h-2 rounded-sm" style={{ backgroundColor: detectorLineColor(name) }} />
@@ -600,15 +638,8 @@ function LogAnomalyCard({ anomaly, isExpanded, onToggle, onHoverEnter, onHoverLe
 
 const LOG_PAGE_SIZE = 50;
 
-/** Synthesize a `status:<value>` tag from the entry's status field so it can be filtered like any other tag. */
-function getEffectiveTags(tags: string[], status: string): string[] {
-  const statusTag = `status:${status.toLowerCase()}`;
-  return tags.includes(statusTag) ? tags : [statusTag, ...tags];
-}
-
 export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeChange, phaseMarkers }: LogViewProps) {
   const scenarios = state.scenarios ?? [];
-  const allLogs = state.logs ?? [];
   const allLogAnomalies = state.logAnomalies ?? [];
 
   const [tagFilterInput, setTagFilterInput] = useState('');
@@ -624,6 +655,69 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
   const [expandedTelemetryLogIndex, setExpandedTelemetryLogIndex] = useState<number | null>(null);
   const initializedScenarioRef = useRef<string | null>(null);
 
+  const [rawLogsPage, setRawLogsPage] = useState<LogEntry[]>([]);
+  const [rawLogsTotal, setRawLogsTotal] = useState(0);
+  const [telemetryLogsPage, setTelemetryLogsPage] = useState<LogEntry[]>([]);
+  const [telemetryLogsTotal, setTelemetryLogsTotal] = useState(0);
+  const [logsSummary, setLogsSummary] = useState<LogsSummary | null>(state.logsSummary);
+
+  // Fetch raw and telemetry pages independently so pagination matches the UI panes.
+  useEffect(() => {
+    if (state.connectionState !== 'ready') return;
+
+    let cancelled = false;
+    const baseParams: { start?: number; end?: number; tags?: string } = {};
+    if (timeRange) {
+      baseParams.start = Math.floor(timeRange.start * 1000);
+      baseParams.end = Math.floor(timeRange.end * 1000);
+    }
+    const trimmedTagFilter = tagFilterInput.trim();
+    if (trimmedTagFilter) {
+      baseParams.tags = trimmedTagFilter;
+    }
+
+    api.getLogs({
+      ...baseParams,
+      kind: 'raw',
+      limit: LOG_PAGE_SIZE,
+      offset: (logPage - 1) * LOG_PAGE_SIZE,
+    }).then((resp) => {
+      if (!cancelled) {
+        setRawLogsPage(resp.logs);
+        setRawLogsTotal(resp.total);
+      }
+    }).catch((err) => {
+      console.error('Failed to fetch raw logs page:', err);
+    });
+
+    api.getLogs({
+      ...baseParams,
+      kind: 'telemetry',
+      limit: LOG_PAGE_SIZE,
+      offset: (telemetryLogPage - 1) * LOG_PAGE_SIZE,
+    }).then((resp) => {
+      if (!cancelled) {
+        setTelemetryLogsPage(resp.logs);
+        setTelemetryLogsTotal(resp.total);
+      }
+    }).catch((err) => {
+      console.error('Failed to fetch telemetry logs page:', err);
+    });
+
+    api.getLogsSummary({
+      ...baseParams,
+      kind: 'all',
+    }).then((resp) => {
+      if (!cancelled) {
+        setLogsSummary(resp);
+      }
+    }).catch((err) => {
+      console.error('Failed to fetch logs summary:', err);
+    });
+
+    return () => { cancelled = true; };
+  }, [logPage, telemetryLogPage, timeRange, tagFilterInput, state.connectionState, state.activeScenario, state.scenarioDataVersion]);
+
   // Reset state when scenario changes
   useEffect(() => {
     if (state.activeScenario && initializedScenarioRef.current !== state.activeScenario) {
@@ -634,32 +728,29 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
       setLogPage(1);
       setTelemetryLogPage(1);
       setExpandedTelemetryLogIndex(null);
+      setRawLogsPage([]);
+      setRawLogsTotal(0);
+      setTelemetryLogsPage([]);
+      setTelemetryLogsTotal(0);
+      setLogsSummary(null);
     }
   }, [state.activeScenario]);
 
   const logTagGroups = useMemo(() => {
-    const all = extractTagGroups(allLogs.map((l) => getEffectiveTags(l.tags ?? [], l.status)));
+    const all = new Map<string, string[]>(
+      Object.entries(logsSummary?.tagGroups ?? {}).map(([key, values]) => [key, [...values]])
+    );
     return new Map([...all.entries()].filter(([k]) => MAIN_TAG_FILTER_KEYS.has(k)));
-  }, [allLogs]);
-
-  const filteredLogs = useMemo(() => {
-    const filter = parseTagFilter(tagFilterInput);
-    return allLogs
-      .filter((l) => {
-        if (filter.include.size === 0 && filter.exclude.size === 0) return true;
-        return matchesTagFilter(getEffectiveTags(l.tags ?? [], l.status), filter);
-      })
-      .sort((a, b) => a.timestampMs - b.timestampMs);
-  }, [allLogs, tagFilterInput]);
+  }, [logsSummary]);
 
   const regularLogs = useMemo(
-    () => filteredLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true')),
-    [filteredLogs]
+    () => [...rawLogsPage].sort((a, b) => a.timestampMs - b.timestampMs),
+    [rawLogsPage]
   );
 
   const telemetryLogs = useMemo(
-    () => filteredLogs.filter((l) => (l.tags ?? []).includes('telemetry:true')),
-    [filteredLogs]
+    () => [...telemetryLogsPage].sort((a, b) => a.timestampMs - b.timestampMs),
+    [telemetryLogsPage]
   );
 
   const sortedAnomalies = useMemo(() => {
@@ -672,16 +763,6 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
 
   const scenarioStart = state.status?.scenarioStart ?? null;
   const scenarioEnd = state.status?.scenarioEnd ?? null;
-
-  const visibleRegularLogs = useMemo(() => {
-    if (!timeRange) return regularLogs;
-    return regularLogs.filter((l) => l.timestampMs / 1000 >= timeRange.start && l.timestampMs / 1000 <= timeRange.end);
-  }, [regularLogs, timeRange]);
-
-  const visibleTelemetryLogs = useMemo(() => {
-    if (!timeRange) return telemetryLogs;
-    return telemetryLogs.filter((l) => l.timestampMs / 1000 >= timeRange.start && l.timestampMs / 1000 <= timeRange.end);
-  }, [telemetryLogs, timeRange]);
 
   const visibleAnomalies = useMemo(() => {
     if (!timeRange) return sortedAnomalies;
@@ -714,13 +795,14 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
                 setTagFilterInput(e.target.value);
                 setExpandedLogIndex(null);
                 setLogPage(1);
+                setTelemetryLogPage(1);
               }}
               placeholder="host:web-1 service:api"
               className="w-full bg-slate-700 text-slate-200 text-xs rounded px-2 py-1.5 placeholder-slate-500 focus:outline-none focus:ring-1 focus:ring-teal-500 font-mono pr-6"
             />
             {tagFilterInput && (
               <button
-                onClick={() => { setTagFilterInput(''); setLogPage(1); }}
+                onClick={() => { setTagFilterInput(''); setLogPage(1); setTelemetryLogPage(1); }}
                 className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
               >
                 ×
@@ -734,6 +816,7 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
               setTagFilterInput(toggleTagInInput(tagFilterInput, tag));
               setExpandedLogIndex(null);
               setLogPage(1);
+              setTelemetryLogPage(1);
             }}
             accentColor="teal"
             statusAware
@@ -747,12 +830,15 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
           </h2>
           <div className="space-y-1.5">
             <div className="text-sm text-slate-300">
-              {allLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true')).length} log{allLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true')).length !== 1 ? 's' : ''} total
+              {logsSummary?.totalCount ?? rawLogsTotal + telemetryLogsTotal} log{(logsSummary?.totalCount ?? rawLogsTotal + telemetryLogsTotal) !== 1 ? 's' : ''} total
             </div>
-            {allLogs.some((l) => (l.tags ?? []).includes('telemetry:true')) && (
-              <div className="text-sm text-purple-400 flex items-center gap-1.5">
-                <span className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full bg-purple-600 text-white text-[8px] font-bold">T</span>
-                {allLogs.filter((l) => (l.tags ?? []).includes('telemetry:true')).length} telemetry log{allLogs.filter((l) => (l.tags ?? []).includes('telemetry:true')).length !== 1 ? 's' : ''}
+            {logsSummary?.countByLevel && Object.keys(logsSummary.countByLevel).length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {Object.entries(logsSummary.countByLevel).map(([level, count]) => (
+                  <span key={level} className={`text-xs px-1.5 py-0.5 rounded font-medium ${levelBadgeColor(level)}`}>
+                    {level}: {count}
+                  </span>
+                ))}
               </div>
             )}
             <div className="text-sm text-slate-300">
@@ -792,7 +878,7 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
           <div>
             {/* Log rate + anomaly timeline */}
             <LogRateChart
-              logs={allLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true'))}
+              logs={[]}
               anomalies={sortedAnomalies}
               scenarioStart={scenarioStart ?? null}
               scenarioEnd={scenarioEnd ?? null}
@@ -801,6 +887,8 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
               timeRange={timeRange}
               onTimeRangeChange={onTimeRangeChange}
               phaseMarkers={phaseMarkers}
+              logsSummary={logsSummary}
+              totalLogCount={logsSummary?.totalCount ?? rawLogsTotal + telemetryLogsTotal}
             />
 
             {/* Detected Anomalies collapsible section */}
@@ -839,22 +927,22 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
                 className="flex items-center gap-2 text-sm font-medium text-slate-300 hover:text-white mb-3 transition-colors"
               >
                 <span className="text-slate-500">{logsExpanded ? '▼' : '▶'}</span>
-                Raw Logs ({visibleRegularLogs.length}{visibleRegularLogs.length !== allLogs.length - telemetryLogs.length ? ` of ${allLogs.length - telemetryLogs.length}` : ''})
+                Raw Logs (page {logPage} of {Math.max(1, Math.ceil(rawLogsTotal / LOG_PAGE_SIZE))}, {rawLogsTotal} total)
               </button>
 
               {logsExpanded && (
-                allLogs.filter((l) => !(l.tags ?? []).includes('telemetry:true')).length === 0 ? (
+                rawLogsTotal === 0 && rawLogsPage.length === 0 ? (
                   <div className="text-center py-8 text-slate-500 text-sm">
                     No log entries. Load a scenario with log files or the demo scenario.
                   </div>
-                ) : visibleRegularLogs.length === 0 ? (
+                ) : regularLogs.length === 0 ? (
                   <div className="text-center py-8 text-slate-500 text-sm">
                     No logs match the selected filters.
                   </div>
                 ) : (
                   <>
                     <div className="overflow-y-auto max-h-[480px] space-y-0.5 pr-1">
-                      {visibleRegularLogs.slice(0, logPage * LOG_PAGE_SIZE).map((entry, idx) => (
+                      {regularLogs.map((entry, idx) => (
                         <LogEntryRow
                           key={`${entry.timestampMs}-${idx}`}
                           entry={entry}
@@ -865,21 +953,33 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
                         />
                       ))}
                     </div>
-                    {visibleRegularLogs.length > logPage * LOG_PAGE_SIZE && (
+                    {/* Pagination controls */}
+                    <div className="flex items-center justify-between mt-2">
+                      <button
+                        onClick={() => setLogPage((p) => Math.max(1, p - 1))}
+                        disabled={logPage <= 1}
+                        className="px-3 py-1.5 text-xs text-slate-400 hover:text-slate-200 bg-slate-700/40 hover:bg-slate-700/70 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                      >
+                        Previous
+                      </button>
+                      <span className="text-xs text-slate-500">
+                        {rawLogsTotal === 0 ? 0 : (logPage - 1) * LOG_PAGE_SIZE + 1}&ndash;{Math.min(logPage * LOG_PAGE_SIZE, rawLogsTotal)} of {rawLogsTotal}
+                      </span>
                       <button
                         onClick={() => setLogPage((p) => p + 1)}
-                        className="mt-2 w-full py-1.5 text-xs text-slate-400 hover:text-slate-200 bg-slate-700/40 hover:bg-slate-700/70 rounded transition-colors"
+                        disabled={logPage * LOG_PAGE_SIZE >= rawLogsTotal}
+                        className="px-3 py-1.5 text-xs text-slate-400 hover:text-slate-200 bg-slate-700/40 hover:bg-slate-700/70 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                       >
-                        Show more ({visibleRegularLogs.length - logPage * LOG_PAGE_SIZE} remaining)
+                        Next
                       </button>
-                    )}
+                    </div>
                   </>
                 )
               )}
             </div>
 
             {/* Telemetry log entries */}
-            {(allLogs.some((l) => (l.tags ?? []).includes('telemetry:true')) || telemetryLogs.length > 0) && (
+            {(telemetryLogsTotal > 0 || telemetryLogs.length > 0) && (
               <div>
                 <div className="flex items-center gap-3 mb-3">
                   <div className="flex-1 border-t border-purple-800/50" />
@@ -889,20 +989,20 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
                   >
                     <span className="text-purple-600">{telemetryLogsExpanded ? '▼' : '▶'}</span>
                     <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-purple-600 text-white text-[9px] font-bold">T</span>
-                    Telemetry Logs ({visibleTelemetryLogs.length}{visibleTelemetryLogs.length !== telemetryLogs.length ? ` of ${telemetryLogs.length}` : ''})
+                    Telemetry Logs (page {telemetryLogPage} of {Math.max(1, Math.ceil(telemetryLogsTotal / LOG_PAGE_SIZE))}, {telemetryLogsTotal} total)
                   </button>
                   <div className="flex-1 border-t border-purple-800/50" />
                 </div>
 
                 {telemetryLogsExpanded && (
-                  visibleTelemetryLogs.length === 0 ? (
+                  telemetryLogsTotal === 0 && telemetryLogs.length === 0 ? (
                     <div className="text-center py-8 text-slate-500 text-sm">
                       No telemetry logs match the current filters.
                     </div>
                   ) : (
                     <>
                       <div className="overflow-y-auto max-h-[480px] space-y-0.5 pr-1">
-                        {visibleTelemetryLogs.slice(0, telemetryLogPage * LOG_PAGE_SIZE).map((entry, idx) => (
+                        {telemetryLogs.map((entry, idx) => (
                           <LogEntryRow
                             key={`telem-${entry.timestampMs}-${idx}`}
                             entry={entry}
@@ -914,14 +1014,25 @@ export function LogView({ state, actions, sidebarWidth, timeRange, onTimeRangeCh
                           />
                         ))}
                       </div>
-                      {visibleTelemetryLogs.length > telemetryLogPage * LOG_PAGE_SIZE && (
+                      <div className="flex items-center justify-between mt-2">
+                        <button
+                          onClick={() => setTelemetryLogPage((p) => Math.max(1, p - 1))}
+                          disabled={telemetryLogPage <= 1}
+                          className="px-3 py-1.5 text-xs text-purple-300 hover:text-purple-100 bg-purple-900/20 hover:bg-purple-900/40 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          Previous
+                        </button>
+                        <span className="text-xs text-slate-500">
+                          {telemetryLogsTotal === 0 ? 0 : (telemetryLogPage - 1) * LOG_PAGE_SIZE + 1}&ndash;{Math.min(telemetryLogPage * LOG_PAGE_SIZE, telemetryLogsTotal)} of {telemetryLogsTotal}
+                        </span>
                         <button
                           onClick={() => setTelemetryLogPage((p) => p + 1)}
-                          className="mt-2 w-full py-1.5 text-xs text-purple-400 hover:text-purple-200 bg-purple-900/20 hover:bg-purple-900/40 rounded transition-colors"
+                          disabled={telemetryLogPage * LOG_PAGE_SIZE >= telemetryLogsTotal}
+                          className="px-3 py-1.5 text-xs text-purple-300 hover:text-purple-100 bg-purple-900/20 hover:bg-purple-900/40 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                         >
-                          Show more ({visibleTelemetryLogs.length - telemetryLogPage * LOG_PAGE_SIZE} remaining)
+                          Next
                         </button>
-                      )}
+                      </div>
                     </>
                   )
                 )}

--- a/cmd/observer-testbench/ui/src/hooks/useObserver.ts
+++ b/cmd/observer-testbench/ui/src/hooks/useObserver.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '../api/client';
 import type {
-  StatusResponse, ScenarioInfo, ComponentInfo, SeriesInfo, Anomaly, LogAnomaly, LogEntry, Correlation,
-  CompressedGroup, ComponentDataResponse, CorrelatorStats
+  StatusResponse, ScenarioInfo, ComponentInfo, SeriesInfo, Anomaly, LogAnomaly, LogEntry, LogsSummary, Correlation,
+  CompressedGroup, ComponentDataResponse, CorrelatorStats, ReplayProgress
 } from '../api/client';
 
 export type ConnectionState = 'disconnected' | 'connected' | 'loading' | 'ready';
@@ -15,14 +15,16 @@ export interface ObserverState {
   series: SeriesInfo[];
   anomalies: Anomaly[];
   logs: LogEntry[];
+  logsSummary: LogsSummary | null;
   logAnomalies: LogAnomaly[];
   correlations: Correlation[];
-  // Generic component data keyed by component name
   componentData: Map<string, ComponentDataResponse>;
   compressedGroups: CompressedGroup[];
   correlatorStats: CorrelatorStats | null;
+  scenarioDataVersion: number;
   activeScenario: string | null;
   error: string | null;
+  loadProgress: ReplayProgress | null;
 }
 
 export interface ObserverActions {
@@ -30,8 +32,6 @@ export interface ObserverActions {
   refresh: () => Promise<void>;
   toggleComponent: (name: string) => Promise<void>;
 }
-
-const POLL_INTERVAL = 2000;
 
 export function useObserver(): [ObserverState, ObserverActions] {
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
@@ -41,48 +41,54 @@ export function useObserver(): [ObserverState, ObserverActions] {
   const [series, setSeries] = useState<SeriesInfo[]>([]);
   const [anomalies, setAnomalies] = useState<Anomaly[]>([]);
   const [logs, setLogs] = useState<LogEntry[]>([]);
+  const [logsSummary, setLogsSummary] = useState<LogsSummary | null>(null);
   const [logAnomalies, setLogAnomalies] = useState<LogAnomaly[]>([]);
   const [correlations, setCorrelations] = useState<Correlation[]>([]);
   const [componentData, setComponentData] = useState<Map<string, ComponentDataResponse>>(new Map());
   const [compressedGroups, setCompressedGroups] = useState<CompressedGroup[]>([]);
   const [correlatorStats, setCorrelatorStats] = useState<CorrelatorStats | null>(null);
+  const [scenarioDataVersion, setScenarioDataVersion] = useState(0);
   const [activeScenario, setActiveScenario] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loadProgress, setLoadProgress] = useState<ReplayProgress | null>(null);
 
-  // Use refs to avoid recreating callbacks on every state change
-  const connectionStateRef = useRef(connectionState);
-  const activeScenarioRef = useRef(activeScenario);
+  const fetchingRef = useRef(false);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  useEffect(() => {
-    connectionStateRef.current = connectionState;
-  }, [connectionState]);
+  const clearRetryTimer = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+  }, []);
 
-  useEffect(() => {
-    activeScenarioRef.current = activeScenario;
-  }, [activeScenario]);
+  const scheduleScenarioRetry = useCallback((delayMs = 3000) => {
+    if (retryTimerRef.current) return;
+    retryTimerRef.current = setTimeout(() => {
+      retryTimerRef.current = null;
+      fetchScenarioDataRef.current();
+    }, delayMs);
+  }, []);
 
-  const fetchAll = useCallback(async (): Promise<boolean> => {
+  const fetchScenarioData = useCallback(async () => {
+    if (fetchingRef.current) return null;
+    fetchingRef.current = true;
     try {
-      // First fetch components and basic data
       const [
-        statusData, scenariosData, componentsData, seriesData,
-        anomaliesData, logsData, logAnomaliesData, correlationsData, compressedGroupsData, statsData
+        componentsData, anomaliesData, logsSummaryData, logAnomaliesData,
+        correlationsData, compressedGroupsData, statsData, seriesData
       ] = await Promise.all([
-          api.getStatus(),
-          api.getScenarios(),
-          api.getComponents(),
-          api.getSeries(),
-          api.getAnomalies(),
-          api.getLogs(),
-          api.getLogAnomalies(),
-          api.getCorrelations(),
-          api.getCompressedCorrelations(),
-          api.getStats(),
-        ]);
+        api.getComponents(),
+        api.getAnomalies(),
+        api.getLogsSummary(),
+        api.getLogAnomalies(),
+        api.getCorrelations(),
+        api.getCompressedCorrelations(),
+        api.getStats(),
+        api.getSeries(),
+      ]);
 
-      // Fetch data for ALL components (any component may provide extra data)
       const componentNames = componentsData.map((c: ComponentInfo) => c.name);
-
       const componentDataResults = await Promise.all(
         componentNames.map(async (name: string) => {
           try {
@@ -94,113 +100,140 @@ export function useObserver(): [ObserverState, ObserverActions] {
         })
       );
 
-      setStatus(statusData);
-      setScenarios(scenariosData);
       setComponents(componentsData);
       setSeries(seriesData);
       setAnomalies(anomaliesData);
-      setLogs(logsData);
+      setLogs([]);
+      setLogsSummary(logsSummaryData);
       setLogAnomalies(logAnomaliesData);
       setCorrelations(correlationsData);
       setCompressedGroups(compressedGroupsData);
       setComponentData(new Map(componentDataResults));
       setCorrelatorStats(statsData);
+      setScenarioDataVersion((v) => v + 1);
+      clearRetryTimer();
+      setError(null);
+      return true;
+    } catch (e) {
+      console.error('fetchScenarioData failed:', e);
+      setError(e instanceof Error ? e.message : 'Failed to refresh scenario data');
+      scheduleScenarioRetry();
+      return false;
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, [clearRetryTimer, scheduleScenarioRetry]);
+
+  // Stable ref so SSE listener always calls the latest fetchScenarioData without re-subscribing.
+  const fetchScenarioDataRef = useRef(fetchScenarioData);
+  fetchScenarioDataRef.current = fetchScenarioData;
+
+  // Reconciliation: after a mutating action, if no SSE status arrives within
+  // this timeout, fall back to a direct fetch so the UI never stays stale.
+  const reconcile = useCallback(async () => {
+    try {
+      const statusData = await api.getStatus();
+      setStatus(statusData);
+      setError(null);
+      if (statusData.ready && statusData.scenario) {
+        setConnectionState('ready');
+        setActiveScenario(statusData.scenario);
+        setLoadProgress(null);
+        const ok = await fetchScenarioData();
+        if (ok === false) {
+          scheduleScenarioRetry();
+        }
+      } else if (statusData.scenario) {
+        setConnectionState('loading');
+      } else {
+        setConnectionState('connected');
+      }
+    } catch (e) {
+      console.error('reconcile failed:', e);
+      setError(e instanceof Error ? e.message : 'Failed to reconcile observer state');
+      scheduleScenarioRetry();
+    }
+  }, [fetchScenarioData, scheduleScenarioRetry]);
+
+  // SSE connection — single persistent stream replaces all polling.
+  useEffect(() => {
+    const es = new EventSource('/api/events');
+
+    es.addEventListener('status', (e: MessageEvent) => {
+      const statusData: StatusResponse = JSON.parse(e.data);
+      setStatus(statusData);
       setError(null);
 
       if (statusData.ready && statusData.scenario) {
         setConnectionState('ready');
         setActiveScenario(statusData.scenario);
+        setLoadProgress(null);
+        fetchScenarioDataRef.current();
+      } else if (statusData.scenario) {
+        setConnectionState('loading');
+        setActiveScenario(statusData.scenario);
       } else {
         setConnectionState('connected');
       }
-      return true;
-    } catch (e) {
-      console.error('fetchAll failed:', e);
-      return false;
-    }
-  }, []);
+    });
 
-  const poll = useCallback(async () => {
-    const currentState = connectionStateRef.current;
-    const currentScenario = activeScenarioRef.current;
+    es.addEventListener('progress', (e: MessageEvent) => {
+      const progress: ReplayProgress = JSON.parse(e.data);
+      setLoadProgress(progress);
+    });
 
-    try {
-      const statusData = await api.getStatus();
-
-      // We just reconnected
-      if (currentState === 'disconnected') {
-        // If we had an active scenario and it's not loaded, reload it
-        if (currentScenario && statusData.scenario !== currentScenario) {
-          console.log(`Reconnected - reloading scenario: ${currentScenario}`);
-          setConnectionState('loading');
-          try {
-            await api.loadScenario(currentScenario);
-          } catch (e) {
-            console.error('Failed to reload scenario:', e);
-          }
-        }
-
-        // Fetch all data
-        await fetchAll();
-      } else if (currentState === 'loading') {
-        // Check if loading is complete
-        if (statusData.ready) {
-          await fetchAll();
-        }
-      } else {
-        // Normal polling - just update status and data
-        setStatus(statusData);
-        if (statusData.ready !== (currentState === 'ready')) {
-          await fetchAll();
-        }
-      }
-
+    es.onopen = () => {
       setError(null);
-    } catch (e) {
-      if (currentState !== 'disconnected') {
-        console.log('Connection lost');
-      }
+    };
+
+    es.onerror = () => {
       setConnectionState('disconnected');
-      setError('Unable to connect to observer');
-    }
-  }, [fetchAll]);
+      setError('Connection lost. Reconnecting...');
+      // EventSource auto-reconnects; on reconnect the hub replays latest status.
+    };
 
-  useEffect(() => {
-    // Initial poll
-    poll();
+    // Fetch scenarios once (rarely change, not worth pushing via SSE).
+    api.getScenarios().then(setScenarios).catch(() => {});
 
-    // Set up polling interval
-    const interval = setInterval(poll, POLL_INTERVAL);
-    return () => clearInterval(interval);
-  }, [poll]);
+    return () => {
+      clearRetryTimer();
+      es.close();
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const loadScenario = useCallback(async (name: string) => {
     setConnectionState('loading');
     setActiveScenario(name);
+    setSeries([]);
+    setLoadProgress(null);
     setError(null);
 
     try {
       await api.loadScenario(name);
-      await fetchAll();
+      // SSE status event normally handles the transition to 'ready'.
+      // Fall back to direct fetch in case the SSE event was missed.
+      await reconcile();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load scenario');
       setConnectionState('connected');
     }
-  }, [fetchAll]);
+  }, [reconcile]);
 
   const refresh = useCallback(async () => {
-    await fetchAll();
-  }, [fetchAll]);
+    await fetchScenarioData();
+  }, [fetchScenarioData]);
 
   const toggleComponent = useCallback(async (name: string) => {
     try {
       await api.toggleComponent(name);
-      await fetchAll();
+      // SSE status event normally triggers refresh.
+      // Fall back to direct fetch in case the SSE event was missed.
+      await reconcile();
     } catch (e) {
       console.error('Failed to toggle component:', e);
       setError(e instanceof Error ? e.message : 'Failed to toggle component');
     }
-  }, [fetchAll]);
+  }, [reconcile]);
 
   return [
     {
@@ -211,13 +244,16 @@ export function useObserver(): [ObserverState, ObserverActions] {
       series,
       anomalies,
       logs,
+      logsSummary,
       logAnomalies,
       correlations,
       componentData,
       compressedGroups,
       correlatorStats,
+      scenarioDataVersion,
       activeScenario,
       error,
+      loadProgress,
     },
     {
       loadScenario,

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -460,10 +460,16 @@ type StorageReader interface {
 	PointCountUpTo(key SeriesKey, endTime int64) int
 
 	// WriteGeneration returns a per-series counter that increments on every
-	// write, including same-bucket merges. Detectors use this to detect value
-	// changes that don't create new buckets. Returns 0 if the series is not found.
+	// write to that series, including same-bucket merges. Use this to detect
+	// updates to an existing series even when its point count does not change.
+	// Returns 0 if the series is not found.
 	WriteGeneration(key SeriesKey) int64
-}
+
+	// SeriesGeneration returns a global counter that increments only when the
+	// set of known series changes. Use this to cache ListSeries results and
+	// refresh them only when new series keys appear.
+	SeriesGeneration() uint64
+ }
 
 // Detector is the flexible detection interface where detectors pull data from storage.
 // This supports multivariate detection across multiple series.

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"math"
 	"sync"
+	"sync/atomic"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
@@ -79,6 +80,13 @@ type engine struct {
 	// Event subscription management.
 	sinks   []eventSink
 	sinksMu sync.RWMutex
+
+	// Replay progress counters (atomic, lock-free reads).
+	replayTimestampsDone  atomic.Int64
+	replayTimestampsTotal atomic.Int64
+	replayAdvances        atomic.Int64
+	replayAnomalies       atomic.Int64
+	replayPhase           atomic.Value // string: "", "loading", "detecting", "done"
 }
 
 // engineConfig holds the parameters for constructing an engine.
@@ -536,6 +544,27 @@ func (e *engine) resetFull() {
 	e.resetCorrelations()
 }
 
+// ReplayProgress holds lock-free replay progress counters.
+type ReplayProgress struct {
+	Phase           string `json:"phase"` // "", "loading", "detecting", "done"
+	TimestampsDone  int64  `json:"timestampsDone"`
+	TimestampsTotal int64  `json:"timestampsTotal"`
+	Advances        int64  `json:"advances"`
+	Anomalies       int64  `json:"anomalies"`
+}
+
+// GetReplayProgress returns the current replay progress (lock-free).
+func (e *engine) GetReplayProgress() ReplayProgress {
+	phase, _ := e.replayPhase.Load().(string)
+	return ReplayProgress{
+		Phase:           phase,
+		TimestampsDone:  e.replayTimestampsDone.Load(),
+		TimestampsTotal: e.replayTimestampsTotal.Load(),
+		Advances:        e.replayAdvances.Load(),
+		Anomalies:       e.replayAnomalies.Load(),
+	}
+}
+
 // ReplayStoredData replays all data in storage through the scheduler policy,
 // using the same timing semantics as live ingestion. For each unique data
 // timestamp, it consults the scheduler to decide when to advance analysis.
@@ -545,14 +574,26 @@ func (e *engine) ReplayStoredData() advanceResult {
 	var allTelemetry []observerdef.ObserverTelemetry
 
 	timestamps := e.storage.DataTimestamps()
-	for _, ts := range timestamps {
+
+	e.replayPhase.Store("detecting")
+	e.replayTimestampsTotal.Store(int64(len(timestamps)))
+	e.replayTimestampsDone.Store(0)
+	e.replayAdvances.Store(0)
+	e.replayAnomalies.Store(0)
+
+	advances := 0
+	for i, ts := range timestamps {
 		e.trackLatestDataTime(ts)
 		requests := e.scheduler.onObservation(ts, e.schedulerState())
 		for _, req := range requests {
 			result := e.advanceWithReason(req.upToSec, req.reason)
 			allAnomalies = append(allAnomalies, result.anomalies...)
 			allTelemetry = append(allTelemetry, result.telemetry...)
+			advances++
 		}
+		e.replayTimestampsDone.Store(int64(i + 1))
+		e.replayAdvances.Store(int64(advances))
+		e.replayAnomalies.Store(int64(len(allAnomalies)))
 	}
 
 	// Final flush for any remaining data not yet analyzed.
@@ -561,7 +602,12 @@ func (e *engine) ReplayStoredData() advanceResult {
 		result := e.advanceWithReason(req.upToSec, req.reason)
 		allAnomalies = append(allAnomalies, result.anomalies...)
 		allTelemetry = append(allTelemetry, result.telemetry...)
+		advances++
 	}
+
+	e.replayAdvances.Store(int64(advances))
+	e.replayAnomalies.Store(int64(len(allAnomalies)))
+	e.replayPhase.Store("done")
 
 	return advanceResult{
 		anomalies: allAnomalies,

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -99,6 +99,11 @@ type BOCPDDetector struct {
 
 	// per-series state keyed by "namespace|name|tags|agg"
 	series map[string]*bocpdSeriesState
+
+	// Cache the discovered series list across Detect calls. Refresh when storage
+	// reports that new series were added.
+	cachedKeys []observer.SeriesKey
+	cachedGen  uint64
 }
 
 // NewBOCPDDetector creates a streaming BOCPD detector with sensible defaults.
@@ -126,12 +131,20 @@ func (b *BOCPDDetector) Name() string {
 	return "bocpd_detector"
 }
 
-// Detect implements Detector. It discovers series, reads only new points,
-// and updates per-series BOCPD posterior state incrementally.
+// Detect implements Detector. It discovers series, reads only newly visible
+// points, and updates per-series BOCPD posterior state incrementally.
+//
+// Correctness takes priority over positional cursoring: storage may insert
+// points into existing history, so this detector gates incremental work on
+// visible point counts rather than raw slice positions.
 func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
 	b.ensureDefaults()
-
-	seriesKeys := storage.ListSeries(observer.SeriesFilter{})
+	gen := storage.SeriesGeneration()
+	if b.cachedKeys == nil || gen != b.cachedGen {
+		b.cachedKeys = storage.ListSeries(observer.SeriesFilter{})
+		b.cachedGen = gen
+	}
+	seriesKeys := b.cachedKeys
 
 	var allAnomalies []observer.Anomaly
 	var allTelemetry []observer.ObserverTelemetry
@@ -210,6 +223,8 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 // Reset clears all per-series state for replay/reanalysis.
 func (b *BOCPDDetector) Reset() {
 	b.series = make(map[string]*bocpdSeriesState)
+	b.cachedKeys = nil
+	b.cachedGen = 0
 }
 
 // processPoint handles a single new observation for a series.

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -418,10 +418,9 @@ var defaultAggregations = []observerdef.Aggregate{
 // seriesDetectorAdapter wraps a stateless SeriesDetector to implement Detector.
 // It runs the wrapped detector on all series, handling aggregation suffixes.
 //
-// The adapter tracks the point count per series/aggregation so it can skip
-// re-running the detector when no new data has arrived. This is important
-// because stateless detectors re-analyze the full series from scratch each
-// call — without this guard, per-second advancement would be O(N²).
+// The adapter tracks the visible point count per series so it can skip
+// re-running the detector when no new data has arrived. This keeps the
+// stateless detector path simple and correct even as storage internals evolve.
 type seriesDetectorAdapter struct {
 	detector     observerdef.SeriesDetector
 	aggregations []observerdef.Aggregate
@@ -431,10 +430,6 @@ type seriesDetectorAdapter struct {
 	// bounding per-call cost to O(windowSec) instead of O(totalPoints).
 	windowSec int64
 
-	// Per-series caching: PointCountUpTo (binary search, no copying) tells us
-	// cheaply whether a series has new visible data. When it hasn't changed,
-	// we skip detection entirely so callers do not see duplicate anomaly or
-	// telemetry events for unchanged data.
 	lastVisibleCount map[string]int
 }
 
@@ -466,20 +461,14 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 	var allTelemetry []observerdef.ObserverTelemetry
 
 	for _, key := range seriesKeys {
-		k := seriesKey(key.Namespace, key.Name, key.Tags)
-
-		// Cheap check: has this series gained any newly visible points?
+		keyStr := seriesKey(key.Namespace, key.Name, key.Tags)
 		visibleCount := storage.PointCountUpTo(key, dataTime)
-		if prev, ok := a.lastVisibleCount[k]; ok && prev == visibleCount {
-			// No new data — do not re-run the detector or re-emit prior outputs.
+		if prev, ok := a.lastVisibleCount[keyStr]; ok && prev == visibleCount {
 			continue
 		}
-		a.lastVisibleCount[k] = visibleCount
+		a.lastVisibleCount[keyStr] = visibleCount
 
 		// Series has new data — run detector on each aggregation.
-		var seriesAnomalies []observerdef.Anomaly
-		var seriesTelemetry []observerdef.ObserverTelemetry
-
 		for _, agg := range a.aggregations {
 			start := int64(0)
 			if a.windowSec > 0 {
@@ -494,18 +483,15 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 			seriesWithAgg.Name = series.Name + ":" + aggSuffix(agg)
 
 			result := a.detector.Detect(seriesWithAgg)
-			for i := range result.Anomalies {
-				result.Anomalies[i].Type = observerdef.AnomalyTypeMetric
-				result.Anomalies[i].DetectorName = a.detector.Name()
-				result.Anomalies[i].Source = observerdef.MetricName(seriesWithAgg.Name)
-				result.Anomalies[i].SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
+			for j := range result.Anomalies {
+				result.Anomalies[j].Type = observerdef.AnomalyTypeMetric
+				result.Anomalies[j].DetectorName = a.detector.Name()
+				result.Anomalies[j].Source = observerdef.MetricName(seriesWithAgg.Name)
+				result.Anomalies[j].SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
 			}
-			seriesAnomalies = append(seriesAnomalies, result.Anomalies...)
-			seriesTelemetry = append(seriesTelemetry, result.Telemetry...)
+			allAnomalies = append(allAnomalies, result.Anomalies...)
+			allTelemetry = append(allTelemetry, result.Telemetry...)
 		}
-
-		allAnomalies = append(allAnomalies, seriesAnomalies...)
-		allTelemetry = append(allTelemetry, seriesTelemetry...)
 	}
 
 	return observerdef.DetectionResult{

--- a/comp/observer/impl/sse.go
+++ b/comp/observer/impl/sse.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"sync"
+)
+
+// sseEvent is a message sent to SSE clients.
+type sseEvent struct {
+	Event string // "status", "progress", "heartbeat"
+	Data  []byte // JSON payload
+}
+
+// sseHub manages a set of SSE client channels and broadcasts events to all of them.
+//
+// Status events are stored separately from the buffered channel so that:
+//   - New subscribers always receive the latest status immediately.
+//   - A slow client's full channel cannot block the broadcaster.
+//   - Status is never lost — readers always get the latest value on wakeup.
+//
+// Ephemeral events (progress, heartbeat) go through the buffered channel with
+// non-blocking sends; slow clients skip them, which is acceptable.
+type sseHub struct {
+	mu           sync.Mutex
+	clients      map[*sseClient]struct{}
+	latestStatus []byte // most recent status JSON, nil until first broadcast
+}
+
+// sseClient represents one connected SSE consumer.
+// statusNotify is a 1-buffered channel used as a wakeup signal when new status
+// is available. The actual payload is read from hub.latestStatus under lock.
+type sseClient struct {
+	events       chan sseEvent // buffered channel for ephemeral events
+	statusNotify chan struct{} // 1-buffered; signals new status available
+}
+
+func newSSEHub() *sseHub {
+	return &sseHub{clients: make(map[*sseClient]struct{})}
+}
+
+// subscribe registers a new client. Returns the client (for reading) and an
+// unsubscribe function. If a status has been broadcast previously, the client's
+// statusNotify channel is pre-signaled so the reader picks it up immediately.
+func (h *sseHub) subscribe() (c *sseClient, unsubscribe func()) {
+	c = &sseClient{
+		events:       make(chan sseEvent, 64),
+		statusNotify: make(chan struct{}, 1),
+	}
+	h.mu.Lock()
+	h.clients[c] = struct{}{}
+	if h.latestStatus != nil {
+		// Signal so reader picks up initial status on first select.
+		select {
+		case c.statusNotify <- struct{}{}:
+		default:
+		}
+	}
+	h.mu.Unlock()
+	return c, func() {
+		h.mu.Lock()
+		delete(h.clients, c)
+		h.mu.Unlock()
+	}
+}
+
+// latestStatusData returns the current status payload. Safe to call from the
+// SSE handler's read loop after receiving a statusNotify signal.
+func (h *sseHub) latestStatusData() []byte {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.latestStatus
+}
+
+// broadcast sends an event to all connected clients.
+//
+// Status events: stored in latestStatus, then each client's statusNotify is
+// signaled (non-blocking). The reader goroutine picks up the payload from
+// latestStatus, so delivery is guaranteed and never blocks the broadcaster.
+//
+// Other events: non-blocking send to the buffered channel; slow clients skip.
+func (h *sseHub) broadcast(msg sseEvent) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if msg.Event == "status" {
+		h.latestStatus = msg.Data
+		for c := range h.clients {
+			select {
+			case c.statusNotify <- struct{}{}:
+			default:
+				// Already signaled, reader will pick up latest.
+			}
+		}
+	} else {
+		for c := range h.clients {
+			select {
+			case c.events <- msg:
+			default:
+			}
+		}
+	}
+}

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -7,6 +7,7 @@ package observerimpl
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"math"
 	"os"
@@ -23,9 +24,16 @@ type timeSeriesStorage struct {
 	series map[string]*seriesStats
 
 	// observationTimestamps tracks all timestamps where observations occurred,
-	// including log timestamps that produced no virtual metrics. This ensures
-	// DataTimestamps() includes all observation times for replay fidelity.
+	// even if no metric series was written for that timestamp.
 	observationTimestamps map[int64]struct{}
+
+	// Compact numeric IDs for API responses; unrelated to generation tracking.
+	seriesIDs    map[string]int // internal key → numeric ID
+	seriesIDKeys []string       // numeric ID → internal key (index = ID)
+
+	// Global generation for the series catalog; increments only when a new
+	// series key is created, not on every write to an existing series.
+	seriesGen uint64
 
 	// Drop accounting for invalid/unsafe input values.
 	droppedNonFinite int64
@@ -36,14 +44,14 @@ type timeSeriesStorage struct {
 
 // seriesStats contains accumulated statistics for a time series (internal).
 // Data is stored in columnar layout: parallel arrays indexed by point position.
-// Timestamps are sorted and append-only, enabling binary search for range queries.
+// Timestamps are stored in sorted order, enabling binary search for range queries.
 type seriesStats struct {
 	Namespace string
 	Name      string
 	Tags      []string
 
-	// writeGeneration increments on every Add (including same-bucket merges).
-	// Used by detectors to detect value changes that don't create new buckets.
+	// writeGeneration is per-series and increments on every Add, including
+	// same-bucket merges into an existing point.
 	writeGeneration int64
 
 	// Columnar storage — all slices have the same length, indexed by point position.
@@ -183,6 +191,7 @@ func newTimeSeriesStorage() *timeSeriesStorage {
 	return &timeSeriesStorage{
 		series:                make(map[string]*seriesStats),
 		observationTimestamps: make(map[int64]struct{}),
+		seriesIDs:             make(map[string]int),
 		droppedByMetric:       make(map[string]int64),
 		sampledDrops:          make(map[string]int),
 	}
@@ -190,6 +199,8 @@ func newTimeSeriesStorage() *timeSeriesStorage {
 
 // Add records a data point for a named metric in a namespace.
 // Invalid values are dropped at ingest with accounting and sampled logging.
+// Timestamps are maintained in sorted order so replay and live ingestion remain
+// correct even when data arrives out of order.
 func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp int64, tags []string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -211,13 +222,18 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		stats = &seriesStats{
 			Namespace: namespace,
 			Name:      name,
-			Tags:      copyTags(tags),
+			Tags:      canonicalizeTags(tags),
 		}
 		s.series[key] = stats
+		// Assign a compact numeric ID for API responses.
+		id := len(s.seriesIDKeys)
+		s.seriesIDs[key] = id
+		s.seriesIDKeys = append(s.seriesIDKeys, key)
+		s.seriesGen++
 	}
 	stats.writeGeneration++
 
-	// Bucket by second
+	// Bucket by second.
 	bucket := timestamp
 
 	// Binary search for the bucket in the sorted timestamps array.
@@ -235,14 +251,14 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		if value > stats.maxes[idx] {
 			stats.maxes[idx] = value
 		}
-	} else {
-		// Insert new bucket at sorted position.
-		stats.timestamps = insertInt64(stats.timestamps, idx, bucket)
-		stats.sums = insertFloat64(stats.sums, idx, value)
-		stats.counts = insertInt64(stats.counts, idx, 1)
-		stats.mins = insertFloat64(stats.mins, idx, value)
-		stats.maxes = insertFloat64(stats.maxes, idx, value)
+		return
 	}
+
+	stats.timestamps = insertInt64(stats.timestamps, idx, bucket)
+	stats.sums = insertFloat64(stats.sums, idx, value)
+	stats.counts = insertInt64(stats.counts, idx, 1)
+	stats.mins = insertFloat64(stats.mins, idx, value)
+	stats.maxes = insertFloat64(stats.maxes, idx, value)
 }
 
 // insertInt64 inserts v at position idx in s, maintaining order.
@@ -401,8 +417,13 @@ func (s *timeSeriesStorage) TimeBounds() (minTs int64, maxTs int64, ok bool) {
 		if n == 0 {
 			continue
 		}
-		// Timestamps are sorted, so first and last give bounds.
-		first := stats.timestamps[0]
+		// Timestamps are sorted, but some series may start with default/non-data
+		// zero timestamps. Ignore only the non-positive prefix, not the series.
+		firstIdx := searchAfter(stats.timestamps, 0)
+		if firstIdx >= n {
+			continue
+		}
+		first := stats.timestamps[firstIdx]
 		last := stats.timestamps[n-1]
 		if !found {
 			min = first
@@ -439,9 +460,10 @@ func (s *timeSeriesStorage) MaxTimestamp() int64 {
 
 // seriesKey creates a unique key for a series.
 func seriesKey(namespace, name string, tags []string) string {
-	sortedTags := copyTags(tags)
-	sort.Strings(sortedTags)
-	return namespace + "|" + name + "|" + strings.Join(sortedTags, ",")
+	if len(tags) > 1 && !tagsSorted(tags) {
+		tags = canonicalizeTags(tags)
+	}
+	return namespace + "|" + name + "|" + joinTags(tags)
 }
 
 // parseSeriesKey parses a series key back into its parts.
@@ -467,6 +489,93 @@ func copyTags(tags []string) []string {
 	result := make([]string, len(tags))
 	copy(result, tags)
 	return result
+}
+
+func canonicalizeTags(tags []string) []string {
+	if len(tags) <= 1 {
+		return copyTags(tags)
+	}
+	result := copyTags(tags)
+	sort.Strings(result)
+	return result
+}
+
+func tagsSorted(tags []string) bool {
+	for i := 1; i < len(tags); i++ {
+		if tags[i-1] > tags[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func joinTags(tags []string) string {
+	switch len(tags) {
+	case 0:
+		return ""
+	case 1:
+		return tags[0]
+	default:
+		return strings.Join(tags, ",")
+	}
+}
+
+// seriesMeta is lightweight series metadata including point count,
+// used for API listing without materializing point data.
+type seriesMeta struct {
+	ID         int // compact numeric ID
+	Namespace  string
+	Name       string
+	Tags       []string
+	PointCount int
+}
+
+// ListSeriesMetadata returns lightweight metadata for all series in a namespace.
+// Unlike AllSeries, this does not materialize point data — it only reads point counts.
+func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []seriesMeta
+	for key, stats := range s.series {
+		if stats.Namespace == namespace {
+			result = append(result, seriesMeta{
+				ID:         s.seriesIDs[key],
+				Namespace:  stats.Namespace,
+				Name:       stats.Name,
+				Tags:       copyTags(stats.Tags),
+				PointCount: stats.pointCount(),
+			})
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].ID != result[j].ID {
+			return result[i].ID < result[j].ID
+		}
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return strings.Join(result[i].Tags, ",") < strings.Join(result[j].Tags, ",")
+	})
+	return result
+}
+
+// GetSeriesByNumericID looks up a series by its compact numeric ID and returns
+// the data using the specified aggregation.
+func (s *timeSeriesStorage) GetSeriesByNumericID(id int, agg Aggregate) *observer.Series {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if id < 0 || id >= len(s.seriesIDKeys) {
+		return nil
+	}
+	key := s.seriesIDKeys[id]
+	stats := s.series[key]
+	if stats == nil {
+		return nil
+	}
+	series := stats.toSeries(agg)
+	return &series
 }
 
 // ListAllSeriesCompact returns lightweight metadata for every stored series.
@@ -553,6 +662,60 @@ func (s *timeSeriesStorage) DataTimestamps() []int64 {
 	}
 	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
 	return timestamps
+}
+
+// SeriesGeneration returns a counter that increments whenever a new series key
+// is created. Callers can use this to safely cache ListSeries results.
+func (s *timeSeriesStorage) SeriesGeneration() uint64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.seriesGen
+}
+
+// CompactSeriesID translates a full series key (as used in SourceSeriesID) to its
+// compact numeric ID string. The full key format is "namespace|name:agg|tags" where
+// the storage key is "namespace|name|tags" (without the agg suffix). This method
+// strips the agg suffix, looks up the numeric ID, and returns "numericID:agg".
+// Returns the original key unchanged if no mapping exists.
+func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	namespace, nameWithAgg, tags, ok := parseSeriesKey(fullKey)
+	if !ok {
+		return fullKey
+	}
+
+	// Split off the aggregation suffix from the name.
+	baseName := nameWithAgg
+	aggStr := ""
+	if idx := strings.LastIndex(nameWithAgg, ":"); idx > 0 {
+		baseName = nameWithAgg[:idx]
+		aggStr = nameWithAgg[idx+1:]
+	}
+
+	// Look up the storage key (without agg suffix).
+	storageKey := seriesKey(namespace, baseName, tags)
+	numID, found := s.seriesIDs[storageKey]
+	if !found {
+		return fullKey
+	}
+
+	if aggStr != "" {
+		return fmt.Sprintf("%d:%s", numID, aggStr)
+	}
+	return fmt.Sprintf("%d", numID)
+}
+
+// FullKeyForNumericID returns the internal storage key for a compact numeric ID.
+func (s *timeSeriesStorage) FullKeyForNumericID(id int) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if id < 0 || id >= len(s.seriesIDKeys) {
+		return "", false
+	}
+	return s.seriesIDKeys[id], true
 }
 
 // StorageReader interface implementation

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -108,6 +108,24 @@ func TestTimeSeriesStorage_AddDifferentBuckets(t *testing.T) {
 	assert.Equal(t, 30.0, series.Points[2].Value)
 }
 
+func TestTimeSeriesStorage_PreservesOutOfOrderBuckets(t *testing.T) {
+	s := newTimeSeriesStorage()
+
+	s.Add("test", "my.metric", 10.0, 1000, nil)
+	s.Add("test", "my.metric", 20.0, 1002, nil)
+	s.Add("test", "my.metric", 30.0, 1001, nil) // inserted in order
+	s.Add("test", "my.metric", 40.0, 1002, nil) // same bucket: aggregated
+
+	series := s.GetSeries("test", "my.metric", nil, AggregateAverage)
+	require.NotNil(t, series)
+	require.Len(t, series.Points, 3)
+	assert.Equal(t, int64(1000), series.Points[0].Timestamp)
+	assert.Equal(t, int64(1001), series.Points[1].Timestamp)
+	assert.Equal(t, int64(1002), series.Points[2].Timestamp)
+	assert.Equal(t, 30.0, series.Points[1].Value)
+	assert.Equal(t, 30.0, series.Points[2].Value)
+}
+
 func TestTimeSeriesStorage_DifferentTags(t *testing.T) {
 	s := newTimeSeriesStorage()
 
@@ -374,7 +392,7 @@ func TestPointCount_ColumnarLayout(t *testing.T) {
 
 func TestGetSeriesRange_OutOfOrderInsert(t *testing.T) {
 	s := newTimeSeriesStorage()
-	// Insert out of order — columnar storage should maintain sorted order.
+	// Insert out of order — storage keeps buckets sorted.
 	s.Add("ns", "m", 30.0, 30, nil)
 	s.Add("ns", "m", 10.0, 10, nil)
 	s.Add("ns", "m", 20.0, 20, nil)
@@ -527,4 +545,17 @@ func TestFindingM5_NegativeMaxFloat64NotFiltered(t *testing.T) {
 		"sum of two -MaxFloat64 values is -Inf (%v), storage should filter -MaxFloat64 like it filters +MaxFloat64", sum)
 	assert.False(t, math.IsNaN(sum),
 		"sum of two -MaxFloat64 values is NaN (%v), storage should filter -MaxFloat64", sum)
+}
+
+func TestTimeBoundsSkipsNonPositivePrefixOnly(t *testing.T) {
+	s := newTimeSeriesStorage()
+
+	s.Add("test", "metric", 1, 0, nil)
+	s.Add("test", "metric", 2, 10, nil)
+	s.Add("test", "metric", 3, 20, nil)
+
+	minTs, maxTs, ok := s.TimeBounds()
+	assert.True(t, ok)
+	assert.Equal(t, int64(10), minTs)
+	assert.Equal(t, int64(20), maxTs)
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -113,6 +113,16 @@ type TestBench struct {
 	logAnomalies           []observerdef.Anomaly            // all anomalies from log detectors
 	logAnomaliesByDetector map[string][]observerdef.Anomaly // anomalies grouped by detector name
 
+	// Cached compressed correlations (expensive to recompute)
+	compCorrCache      []CompressedGroup
+	compCorrThreshold  float64
+	compCorrGeneration uint64
+	corrGeneration     uint64 // bumped after each rerunDetectorsLocked
+
+	// SSE broadcast hub for pushing events to connected browsers.
+	sse     *sseHub
+	sseStop chan struct{}
+
 	// API server
 	api *TestBenchAPI
 }
@@ -190,6 +200,9 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 		scheduler:   &currentBehaviorPolicy{},
 	})
 
+	hub := newSSEHub()
+	stop := make(chan struct{})
+
 	tb := &TestBench{
 		config:                 config,
 		engine:                 eng,
@@ -197,9 +210,28 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 		components:             components,
 		logAnomalies:           []observerdef.Anomaly{},
 		logAnomaliesByDetector: make(map[string][]observerdef.Anomaly),
+		sse:                    hub,
+		sseStop:                stop,
 	}
 
+	// Heartbeat goroutine — lets SSE clients detect stale connections.
+	go func() {
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				hub.broadcast(sseEvent{Event: "heartbeat", Data: []byte(`{}`)})
+			case <-stop:
+				return
+			}
+		}
+	}()
+
 	tb.api = NewTestBenchAPI(tb)
+
+	// Seed the SSE hub with initial status so the first subscriber gets it.
+	tb.broadcastStatus()
 
 	return tb, nil
 }
@@ -209,9 +241,25 @@ func (tb *TestBench) Start() error {
 	return tb.api.Start(tb.config.HTTPAddr)
 }
 
-// Stop stops the test bench HTTP server.
+// Stop stops the test bench HTTP server and background goroutines.
 func (tb *TestBench) Stop() error {
+	close(tb.sseStop)
 	return tb.api.Stop()
+}
+
+// broadcastStatus sends the current status to all SSE clients.
+// Must be called without holding tb.mu (GetStatus acquires its own read lock).
+func (tb *TestBench) broadcastStatus() {
+	status := tb.GetStatus()
+	data, _ := json.Marshal(status)
+	tb.sse.broadcast(sseEvent{Event: "status", Data: data})
+}
+
+// broadcastProgress sends current replay progress to all SSE clients.
+func (tb *TestBench) broadcastProgress() {
+	progress := tb.engine.GetReplayProgress()
+	data, _ := json.Marshal(progress)
+	tb.sse.broadcast(sseEvent{Event: "progress", Data: data})
 }
 
 // ListScenarios returns all available scenarios.
@@ -277,7 +325,6 @@ func (tb *TestBench) LoadScenario(name string) error {
 	}
 
 	tb.mu.Lock()
-	defer tb.mu.Unlock()
 
 	// Clear existing data
 	tb.engine.storage = newTimeSeriesStorage() // TODO: encapsulate behind engine method
@@ -286,6 +333,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 	tb.logAnomaliesByDetector = make(map[string][]observerdef.Anomaly)
 	tb.ready = false
 	tb.loadedScenario = name
+	tb.engine.replayPhase.Store("loading")
 
 	// Try to read optional episode.json metadata
 	tb.episodeInfo = nil
@@ -299,6 +347,36 @@ func (tb *TestBench) LoadScenario(name string) error {
 	// Reset ALL components so disabled ones clear stale state
 	tb.resetAllState()
 
+	// Release lock briefly to broadcast "loading" status to all SSE clients,
+	// then reacquire for the heavy work.
+	tb.mu.Unlock()
+	tb.broadcastStatus()
+	tb.mu.Lock()
+
+	// Broadcast progress to SSE clients while loading (reads atomic counters, no lock needed).
+	progressDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(250 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				tb.broadcastProgress()
+			case <-progressDone:
+				return
+			}
+		}
+	}()
+
+	loadFailed := func(err error) error {
+		tb.engine.replayPhase.Store("")
+		tb.loadedScenario = "" // roll back so status doesn't look like "loading"
+		close(progressDone)
+		tb.mu.Unlock()
+		tb.broadcastStatus() // notify clients of failure
+		return err
+	}
+
 	// Load data from scenario
 	scenarioStart := time.Now()
 	fmt.Printf("Loading scenario: %s\n", name)
@@ -308,13 +386,13 @@ func (tb *TestBench) LoadScenario(name string) error {
 	parquetStart := time.Now()
 	if _, err := os.Stat(parquetDir); err == nil {
 		if err := tb.loadParquetDir(parquetDir); err != nil {
-			return fmt.Errorf("failed to load parquet data: %w", err)
+			return loadFailed(fmt.Errorf("failed to load parquet data: %w", err))
 		}
 	} else {
 		// Check for parquet files directly in scenario directory
 		if files, _ := filepath.Glob(filepath.Join(scenarioPath, "*.parquet")); len(files) > 0 {
 			if err := tb.loadParquetDir(scenarioPath); err != nil {
-				return fmt.Errorf("failed to load parquet data: %w", err)
+				return loadFailed(fmt.Errorf("failed to load parquet data: %w", err))
 			}
 		}
 	}
@@ -326,6 +404,12 @@ func (tb *TestBench) LoadScenario(name string) error {
 	fmt.Printf("  Detector phase took %s\n", time.Since(analysisStart))
 	fmt.Printf("  Total scenario load took %s\n", time.Since(scenarioStart))
 	fmt.Printf("Scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
+
+	close(progressDone)
+	tb.mu.Unlock()
+
+	// Broadcast final status to SSE clients (outside lock).
+	tb.broadcastStatus()
 
 	return nil
 }
@@ -584,6 +668,9 @@ func (tb *TestBench) rerunDetectorsLocked() {
 		tb.handleTelemetry([]observerdef.ObserverTelemetry{t}, detName, dataTime)
 	}
 
+	// Invalidate compressed correlations cache
+	tb.corrGeneration++
+
 	// Mark scenario ready now that all analysis is complete
 	tb.ready = true
 }
@@ -782,12 +869,31 @@ func (tb *TestBench) GetCorrelations() []observerdef.ActiveCorrelation {
 // GetCompressedCorrelations returns compressed group descriptions for all correlations.
 func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGroup {
 	tb.mu.RLock()
-	defer tb.mu.RUnlock()
+
+	// Check cache: same threshold and generation means the result is still valid.
+	if tb.compCorrCache != nil && tb.compCorrThreshold == threshold && tb.compCorrGeneration == tb.corrGeneration {
+		cached := tb.compCorrCache
+		tb.mu.RUnlock()
+		return cached
+	}
+	tb.mu.RUnlock()
+
+	// Cache miss — need write lock to compute and store.
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	// Double-check after acquiring write lock.
+	if tb.compCorrCache != nil && tb.compCorrThreshold == threshold && tb.compCorrGeneration == tb.corrGeneration {
+		return tb.compCorrCache
+	}
 
 	correlations := tb.engine.StateView().CorrelationHistory()
 	storage := tb.engine.Storage()
 	if storage == nil || len(correlations) == 0 {
-		return []CompressedGroup{}
+		tb.compCorrCache = []CompressedGroup{}
+		tb.compCorrThreshold = threshold
+		tb.compCorrGeneration = tb.corrGeneration
+		return tb.compCorrCache
 	}
 
 	// Build universe from storage
@@ -837,6 +943,11 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 		cg.LastUpdated = corr.LastUpdated
 		groups = append(groups, cg)
 	}
+
+	// Store in cache
+	tb.compCorrCache = groups
+	tb.compCorrThreshold = threshold
+	tb.compCorrGeneration = tb.corrGeneration
 
 	return groups
 }
@@ -933,10 +1044,10 @@ func (tb *TestBench) RunSendAnomalyEvents(scenario string) error {
 // ToggleComponent toggles a component's enabled state and re-runs analyses if needed.
 func (tb *TestBench) ToggleComponent(name string) error {
 	tb.mu.Lock()
-	defer tb.mu.Unlock()
 
 	ci, ok := tb.components[name]
 	if !ok {
+		tb.mu.Unlock()
 		return fmt.Errorf("unknown component: %s", name)
 	}
 
@@ -947,13 +1058,17 @@ func (tb *TestBench) ToggleComponent(name string) error {
 		tb.rerunDetectorsLocked()
 	}
 
+	tb.mu.Unlock()
+
+	// Notify SSE clients of the state change (outside lock).
+	tb.broadcastStatus()
+
 	return nil
 }
 
 // loadDemoScenario generates synthetic demo data directly into storage.
 func (tb *TestBench) loadDemoScenario() error {
 	tb.mu.Lock()
-	defer tb.mu.Unlock()
 
 	// Clear existing data
 	tb.engine.storage = newTimeSeriesStorage() // TODO: encapsulate behind engine method
@@ -1105,6 +1220,8 @@ func (tb *TestBench) loadDemoScenario() error {
 	tb.rerunDetectorsLocked()
 	fmt.Printf("Demo scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
 
+	tb.mu.Unlock()
+	tb.broadcastStatus()
 	return nil
 }
 

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -8,10 +8,12 @@ package observerimpl
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"math"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -35,6 +37,8 @@ func (api *TestBenchAPI) Start(addr string) error {
 	mux := http.NewServeMux()
 
 	// Wrap all handlers with CORS middleware
+	mux.HandleFunc("/api/events", api.handleSSE) // SSE — no CORS wrapper (needs http.Flusher)
+	mux.HandleFunc("/api/progress", api.cors(api.handleProgress))
 	mux.HandleFunc("/api/status", api.cors(api.handleStatus))
 	mux.HandleFunc("/api/scenarios", api.cors(api.handleScenarios))
 	mux.HandleFunc("/api/scenarios/", api.cors(api.handleScenarioAction))
@@ -43,6 +47,7 @@ func (api *TestBenchAPI) Start(addr string) error {
 	mux.HandleFunc("/api/series/id/", api.cors(api.handleSeriesDataByID))
 	mux.HandleFunc("/api/series/", api.cors(api.handleSeriesData))
 	mux.HandleFunc("/api/anomalies", api.cors(api.handleAnomalies))
+	mux.HandleFunc("/api/logs/summary", api.cors(api.handleLogsSummary))
 	mux.HandleFunc("/api/logs", api.cors(api.handleLogs))
 	mux.HandleFunc("/api/log-anomalies", api.cors(api.handleLogAnomalies))
 	mux.HandleFunc("/api/correlations", api.cors(api.handleCorrelations))
@@ -76,7 +81,7 @@ func (api *TestBenchAPI) Stop() error {
 	return api.server.Shutdown(ctx)
 }
 
-// cors wraps a handler with CORS headers.
+// cors wraps a handler with CORS headers and request timing.
 func (api *TestBenchAPI) cors(handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -90,6 +95,245 @@ func (api *TestBenchAPI) cors(handler http.HandlerFunc) http.HandlerFunc {
 
 		handler(w, r)
 	}
+}
+
+type parsedLogTagFilter struct {
+	include map[string]map[string]struct{}
+	exclude map[string]struct{}
+}
+
+type logsQuery struct {
+	level     string
+	kind      string
+	startMs   int64
+	endMs     int64
+	limit     int
+	offset    int
+	tagFilter parsedLogTagFilter
+}
+
+func parseLogsQuery(query url.Values) logsQuery {
+	result := logsQuery{
+		level:     query.Get("level"),
+		kind:      query.Get("kind"),
+		limit:     1000,
+		tagFilter: parseLogTagFilter(query.Get("tags")),
+	}
+	if result.kind == "" {
+		result.kind = "all"
+	}
+
+	if s := query.Get("start"); s != "" {
+		if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+			result.startMs = v
+		}
+	}
+	if s := query.Get("end"); s != "" {
+		if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+			result.endMs = v
+		}
+	}
+	if s := query.Get("limit"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v > 0 {
+			result.limit = v
+		}
+	}
+	if result.limit > 5000 {
+		result.limit = 5000
+	}
+	if s := query.Get("offset"); s != "" {
+		if v, err := strconv.Atoi(s); err == nil && v >= 0 {
+			result.offset = v
+		}
+	}
+
+	return result
+}
+
+func parseLogTagFilter(input string) parsedLogTagFilter {
+	filter := parsedLogTagFilter{
+		include: make(map[string]map[string]struct{}),
+		exclude: make(map[string]struct{}),
+	}
+	for _, token := range strings.Fields(strings.TrimSpace(input)) {
+		if strings.HasPrefix(token, "-") && len(token) > 1 {
+			filter.exclude[token[1:]] = struct{}{}
+			continue
+		}
+		idx := strings.Index(token, ":")
+		if idx <= 0 || idx == len(token)-1 {
+			continue
+		}
+		key := token[:idx]
+		if _, ok := filter.include[key]; !ok {
+			filter.include[key] = make(map[string]struct{})
+		}
+		filter.include[key][token] = struct{}{}
+	}
+	return filter
+}
+
+func effectiveLogTags(logView observerdef.LogView) []string {
+	tags := append([]string{}, logView.GetTags()...)
+	if tags == nil {
+		tags = []string{}
+	}
+
+	statusTag := "status:" + strings.ToLower(logView.GetStatus())
+	hasStatus := false
+	for _, tag := range tags {
+		if tag == statusTag {
+			hasStatus = true
+			break
+		}
+	}
+	if !hasStatus {
+		tags = append(tags, statusTag)
+	}
+
+	if host := logView.GetHostname(); host != "" {
+		hostTag := "host:" + host
+		hasHost := false
+		for _, tag := range tags {
+			if tag == hostTag {
+				hasHost = true
+				break
+			}
+		}
+		if !hasHost {
+			tags = append(tags, hostTag)
+		}
+	}
+
+	return tags
+}
+
+func matchesLogTagFilter(tags []string, filter parsedLogTagFilter) bool {
+	if len(filter.include) == 0 && len(filter.exclude) == 0 {
+		return true
+	}
+
+	tagSet := make(map[string]struct{}, len(tags))
+	for _, tag := range tags {
+		tagSet[tag] = struct{}{}
+	}
+
+	for excluded := range filter.exclude {
+		if strings.Contains(excluded, ":") {
+			if _, ok := tagSet[excluded]; ok {
+				return false
+			}
+			continue
+		}
+		prefix := excluded + ":"
+		for tag := range tagSet {
+			if strings.HasPrefix(tag, prefix) {
+				return false
+			}
+		}
+	}
+
+	for _, values := range filter.include {
+		matched := false
+		for value := range values {
+			if _, ok := tagSet[value]; ok {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchesLogsQuery(logView observerdef.LogView, query logsQuery) bool {
+	if query.level != "" && logView.GetStatus() != query.level {
+		return false
+	}
+	isTelemetry := false
+	for _, tag := range logView.GetTags() {
+		if tag == "telemetry:true" {
+			isTelemetry = true
+			break
+		}
+	}
+	switch query.kind {
+	case "raw":
+		if isTelemetry {
+			return false
+		}
+	case "telemetry":
+		if !isTelemetry {
+			return false
+		}
+	}
+	ts := logView.GetTimestampUnixMilli()
+	if query.startMs != 0 && ts < query.startMs {
+		return false
+	}
+	if query.endMs != 0 && ts > query.endMs {
+		return false
+	}
+	return matchesLogTagFilter(effectiveLogTags(logView), query.tagFilter)
+}
+
+func cloneCompressedGroups(groups []CompressedGroup) []CompressedGroup {
+	cloned := make([]CompressedGroup, len(groups))
+	for i, group := range groups {
+		cloned[i] = group
+		if group.CommonTags != nil {
+			cloned[i].CommonTags = make(map[string]string, len(group.CommonTags))
+			for key, value := range group.CommonTags {
+				cloned[i].CommonTags[key] = value
+			}
+		}
+		cloned[i].Patterns = append([]MetricPattern(nil), group.Patterns...)
+		cloned[i].MemberSources = append([]string(nil), group.MemberSources...)
+	}
+	return cloned
+}
+
+// handleSSE serves a Server-Sent Events stream for real-time updates.
+func (api *TestBenchAPI) handleSSE(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	// Subscribe — if a status exists, the client's statusNotify is pre-signaled.
+	client, unsubscribe := api.tb.sse.subscribe()
+	defer unsubscribe()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-client.statusNotify:
+			data := api.tb.sse.latestStatusData()
+			if data != nil {
+				fmt.Fprintf(w, "event: status\ndata: %s\n\n", data)
+				flusher.Flush()
+			}
+		case msg := <-client.events:
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", msg.Event, msg.Data)
+			flusher.Flush()
+		}
+	}
+}
+
+// handleProgress returns replay progress counters (lock-free, safe to call during load).
+func (api *TestBenchAPI) handleProgress(w http.ResponseWriter, _ *http.Request) {
+	api.writeJSON(w, api.tb.engine.GetReplayProgress())
 }
 
 // handleStatus returns the current status.
@@ -162,18 +406,20 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, r *http.Request
 
 	var allSeries []seriesInfo
 
-	// Get series from all namespaces with both aggregations
+	// Get series metadata from all namespaces — no point data materialized.
+	// Use compact numeric IDs: "{numericID}:{aggSuffix}" (e.g. "42:avg").
 	for _, ns := range storage.Namespaces() {
-		for _, agg := range []Aggregate{AggregateAverage, AggregateCount} {
-			series := storage.AllSeries(ns, agg)
-			for _, s := range series {
-				nameWithAgg := s.Name + ":" + aggSuffix(agg)
+		metas := storage.ListSeriesMetadata(ns)
+		for _, m := range metas {
+			for _, agg := range []Aggregate{AggregateAverage, AggregateCount} {
+				nameWithAgg := m.Name + ":" + aggSuffix(agg)
+				compactID := strconv.Itoa(m.ID) + ":" + aggSuffix(agg)
 				allSeries = append(allSeries, seriesInfo{
-					ID:         seriesKey(s.Namespace, nameWithAgg, s.Tags),
-					Namespace:  s.Namespace,
+					ID:         compactID,
+					Namespace:  m.Namespace,
 					Name:       nameWithAgg,
-					Tags:       s.Tags,
-					PointCount: len(s.Points),
+					Tags:       m.Tags,
+					PointCount: m.PointCount,
 				})
 			}
 		}
@@ -183,6 +429,7 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, r *http.Request
 }
 
 // handleSeriesDataByID returns data for a specific series by canonical id.
+// Supports both compact numeric IDs ("42:avg") and legacy full key IDs.
 func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Request) {
 	encodedID := strings.TrimPrefix(r.URL.Path, "/api/series/id/")
 	if encodedID == "" {
@@ -194,12 +441,131 @@ func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Req
 		api.writeError(w, http.StatusBadRequest, "invalid series id encoding")
 		return
 	}
+
+	// Try compact numeric ID format: "{numericID}:{aggSuffix}" (e.g. "42:avg")
+	if colonIdx := strings.LastIndex(seriesID, ":"); colonIdx > 0 {
+		prefix := seriesID[:colonIdx]
+		if numericID, parseErr := strconv.Atoi(prefix); parseErr == nil {
+			aggStr := seriesID[colonIdx+1:]
+			api.handleNumericSeriesData(w, numericID, aggStr, seriesID)
+			return
+		}
+	}
+
+	// Fall back to legacy full key format: "namespace|name:agg|tags"
 	namespace, nameWithAgg, tags, ok := parseSeriesKey(seriesID)
 	if !ok {
 		api.writeError(w, http.StatusBadRequest, "invalid series id")
 		return
 	}
 	api.handleSeriesDataForSeries(w, namespace, nameWithAgg, tags, observerdef.SeriesID(seriesID))
+}
+
+// handleNumericSeriesData resolves a compact numeric ID to series data.
+func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID int, aggStr string, originalID string) {
+	var agg Aggregate
+	switch aggStr {
+	case "avg":
+		agg = AggregateAverage
+	case "count":
+		agg = AggregateCount
+	case "sum":
+		agg = AggregateSum
+	case "min":
+		agg = AggregateMin
+	case "max":
+		agg = AggregateMax
+	default:
+		api.writeError(w, http.StatusBadRequest, "invalid aggregation suffix")
+		return
+	}
+
+	storage := api.tb.GetStorage()
+	if storage == nil {
+		api.writeError(w, http.StatusServiceUnavailable, "no data loaded")
+		return
+	}
+
+	series := storage.GetSeriesByNumericID(numericID, agg)
+	if series == nil {
+		api.writeError(w, http.StatusNotFound, "series not found")
+		return
+	}
+
+	nameWithAgg := series.Name + ":" + aggStr
+	seriesID := observerdef.SeriesID(originalID)
+
+	// Look up anomalies using the full key format that detectors produce
+	// (e.g. "parquet|metric:avg|tags"), not the compact numeric ID.
+	fullKey, _ := storage.FullKeyForNumericID(numericID)
+	var fullKeyWithAgg string
+	if ns, name, tags, ok := parseSeriesKey(fullKey); ok {
+		fullKeyWithAgg = seriesKey(ns, name+":"+aggStr, tags)
+	}
+	anomalyLookupID := seriesID
+	if fullKeyWithAgg != "" {
+		anomalyLookupID = observerdef.SeriesID(fullKeyWithAgg)
+	}
+	anomalies := api.tb.GetMetricsAnomaliesForSeries(anomalyLookupID)
+
+	type anomalyMarker struct {
+		Timestamp         int64  `json:"timestamp"`
+		DetectorName      string `json:"detectorName"`
+		DetectorComponent string `json:"detectorComponent"`
+		SourceSeriesID    string `json:"sourceSeriesId"`
+		Title             string `json:"title"`
+	}
+
+	var markers []anomalyMarker
+	detectorComponentMap := api.tb.GetDetectorComponentMap()
+	for _, a := range anomalies {
+		if a.DetectorName == "" || a.Timestamp == 0 {
+			continue
+		}
+		markers = append(markers, anomalyMarker{
+			Timestamp:         a.Timestamp,
+			DetectorName:      a.DetectorName,
+			DetectorComponent: detectorComponentMap[a.DetectorName],
+			SourceSeriesID:    string(seriesID),
+			Title:             a.Title,
+		})
+	}
+
+	type pointOutput struct {
+		Timestamp int64   `json:"timestamp"`
+		Value     float64 `json:"value"`
+	}
+
+	type seriesResponse struct {
+		ID        string          `json:"id"`
+		Namespace string          `json:"namespace"`
+		Name      string          `json:"name"`
+		Tags      []string        `json:"tags"`
+		Points    []pointOutput   `json:"points"`
+		Anomalies []anomalyMarker `json:"anomalies"`
+	}
+
+	resp := seriesResponse{
+		ID:        string(seriesID),
+		Namespace: series.Namespace,
+		Name:      nameWithAgg,
+		Tags:      series.Tags,
+		Points:    make([]pointOutput, len(series.Points)),
+		Anomalies: markers,
+	}
+
+	for i, p := range series.Points {
+		value := p.Value
+		if math.IsInf(value, 0) || math.IsNaN(value) {
+			value = 0
+		}
+		resp.Points[i] = pointOutput{
+			Timestamp: p.Timestamp,
+			Value:     value,
+		}
+	}
+
+	api.writeJSON(w, resp)
 }
 
 // handleSeriesData returns data for a specific series.
@@ -353,11 +719,16 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 	}
 
 	detectorComponentMap := api.tb.GetDetectorComponentMap()
+	storage := api.tb.GetStorage()
 
 	toResponse := func(a observerdef.Anomaly) anomalyResponse {
+		sourceSeriesID := string(a.SourceSeriesID)
+		if storage != nil {
+			sourceSeriesID = storage.CompactSeriesID(sourceSeriesID)
+		}
 		resp := anomalyResponse{
 			Source:            string(a.Source),
-			SourceSeriesID:    string(a.SourceSeriesID),
+			SourceSeriesID:    sourceSeriesID,
 			DetectorName:      a.DetectorName,
 			DetectorComponent: detectorComponentMap[a.DetectorName],
 			Title:             a.Title,
@@ -452,9 +823,9 @@ func (api *TestBenchAPI) handleLogAnomalies(w http.ResponseWriter, r *http.Reque
 	api.writeJSON(w, response)
 }
 
-// handleLogs returns raw log entries.
+// handleLogs returns raw log entries with server-side filtering and pagination.
 func (api *TestBenchAPI) handleLogs(w http.ResponseWriter, r *http.Request) {
-	levelFilter := r.URL.Query().Get("level")
+	query := parseLogsQuery(r.URL.Query())
 
 	type logEntryResponse struct {
 		TimestampMs int64    `json:"timestampMs"`
@@ -465,38 +836,125 @@ func (api *TestBenchAPI) handleLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logs := api.tb.GetRawLogs()
-	response := make([]logEntryResponse, 0, len(logs))
+
+	// First pass: count total matches and collect the paginated window.
+	total := 0
+	result := make([]logEntryResponse, 0, query.limit)
 	for _, l := range logs {
-		if levelFilter != "" && l.GetStatus() != levelFilter {
-			continue
+		if matchesLogsQuery(l, query) {
+			if total >= query.offset && len(result) < query.limit {
+				tags := effectiveLogTags(l)
+				ts := l.GetTimestampUnixMilli()
+				result = append(result, logEntryResponse{
+					TimestampMs: ts,
+					Status:      l.GetStatus(),
+					Content:     string(l.GetContent()),
+					Hostname:    l.GetHostname(),
+					Tags:        tags,
+				})
+			}
+			total++
 		}
-		tags := l.GetTags()
-		if tags == nil {
-			tags = []string{}
-		}
-		// Add host / status tags
-		if l.GetHostname() != "" {
-			tags = append(tags, "host:"+l.GetHostname())
-		}
-		// TODO(celian): Refactor status / hostname to be only tags
-		// if l.Status != "" {
-		// 	tags = append(tags, "status:"+l.Status)
-		// }
-		response = append(response, logEntryResponse{
-			TimestampMs: l.GetTimestampUnixMilli(),
-			Status:      l.GetStatus(),
-			Content:     string(l.GetContent()),
-			Hostname:    l.GetHostname(),
-			Tags:        tags,
-		})
 	}
 
-	api.writeJSON(w, response)
+	api.writeJSON(w, map[string]interface{}{
+		"logs":   result,
+		"total":  total,
+		"limit":  query.limit,
+		"offset": query.offset,
+	})
+}
+
+// handleLogsSummary returns lightweight summary data about logs without bodies.
+func (api *TestBenchAPI) handleLogsSummary(w http.ResponseWriter, r *http.Request) {
+	query := parseLogsQuery(r.URL.Query())
+	logs := api.tb.GetRawLogs()
+
+	totalCount := 0
+	countByLevel := make(map[string]int)
+	tagGroups := make(map[string]map[string]struct{})
+	var minTs, maxTs int64
+
+	for _, l := range logs {
+		if !matchesLogsQuery(l, query) {
+			continue
+		}
+		totalCount++
+		countByLevel[l.GetStatus()]++
+		ts := l.GetTimestampUnixMilli()
+		if minTs == 0 || ts < minTs {
+			minTs = ts
+		}
+		if ts > maxTs {
+			maxTs = ts
+		}
+		for _, tag := range effectiveLogTags(l) {
+			if idx := strings.Index(tag, ":"); idx > 0 {
+				key := tag[:idx]
+				if _, ok := tagGroups[key]; !ok {
+					tagGroups[key] = make(map[string]struct{})
+				}
+				tagGroups[key][tag] = struct{}{}
+			}
+		}
+	}
+
+	// Build histogram with ~100 buckets.
+	const numBuckets = 100
+	type histBucket struct {
+		TimestampMs int64 `json:"timestampMs"`
+		Count       int   `json:"count"`
+	}
+
+	histogram := make([]histBucket, 0)
+	if totalCount > 0 && maxTs > minTs {
+		bucketWidth := (maxTs - minTs + numBuckets) / numBuckets // ceil division
+		histogram = make([]histBucket, numBuckets)
+		for i := range histogram {
+			histogram[i].TimestampMs = minTs + int64(i)*bucketWidth
+		}
+		for _, l := range logs {
+			if !matchesLogsQuery(l, query) {
+				continue
+			}
+			ts := l.GetTimestampUnixMilli()
+			idx := int((ts - minTs) / bucketWidth)
+			if idx >= numBuckets {
+				idx = numBuckets - 1
+			}
+			histogram[idx].Count++
+		}
+	} else if totalCount > 0 {
+		// All logs have the same timestamp — single bucket.
+		histogram = []histBucket{{TimestampMs: minTs, Count: totalCount}}
+	}
+
+	sortedTagGroups := make(map[string][]string, len(tagGroups))
+	for key, values := range tagGroups {
+		group := make([]string, 0, len(values))
+		for value := range values {
+			group = append(group, value)
+		}
+		sort.Strings(group)
+		sortedTagGroups[key] = group
+	}
+
+	api.writeJSON(w, map[string]interface{}{
+		"totalCount":   totalCount,
+		"countByLevel": countByLevel,
+		"timeRange": map[string]int64{
+			"start": minTs,
+			"end":   maxTs,
+		},
+		"histogram": histogram,
+		"tagGroups": sortedTagGroups,
+	})
 }
 
 // handleCorrelations returns detected correlations.
 func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, r *http.Request) {
 	correlations := api.tb.GetCorrelations()
+	storage := api.tb.GetStorage()
 
 	type anomalyOutput struct {
 		Source      string   `json:"source"`
@@ -534,10 +992,16 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, r *http.Reque
 				Tags:        tags,
 			}
 		}
+		memberIDs := seriesIDsToStrings(c.MemberSeriesIDs)
+		if storage != nil {
+			for k, id := range memberIDs {
+				memberIDs[k] = storage.CompactSeriesID(id)
+			}
+		}
 		response[i] = correlationResponse{
 			Pattern:         c.Pattern,
 			Title:           c.Title,
-			MemberSeriesIDs: seriesIDsToStrings(c.MemberSeriesIDs),
+			MemberSeriesIDs: memberIDs,
 			MetricNames:     metricNamesToStrings(c.MetricNames),
 			Anomalies:       anomalies,
 			FirstSeen:       c.FirstSeen,
@@ -640,7 +1104,15 @@ func (api *TestBenchAPI) handleCompressedCorrelations(w http.ResponseWriter, r *
 			threshold = parsed
 		}
 	}
-	groups := api.tb.GetCompressedCorrelations(threshold)
+	groups := cloneCompressedGroups(api.tb.GetCompressedCorrelations(threshold))
+	// Translate MemberSources from full keys to compact numeric IDs.
+	if storage := api.tb.GetStorage(); storage != nil {
+		for i := range groups {
+			for j, src := range groups[i].MemberSources {
+				groups[i].MemberSources[j] = storage.CompactSeriesID(src)
+			}
+		}
+	}
 	api.writeJSON(w, groups)
 }
 

--- a/comp/observer/impl/testbench_api_test.go
+++ b/comp/observer/impl/testbench_api_test.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubLogView struct {
+	status    string
+	timestamp int64
+	tags      []string
+	hostname  string
+	content   []byte
+}
+
+func (l stubLogView) GetContent() []byte           { return l.content }
+func (l stubLogView) GetTags() []string            { return l.tags }
+func (l stubLogView) GetTimestampUnixMilli() int64 { return l.timestamp }
+func (l stubLogView) GetStatus() string            { return l.status }
+func (l stubLogView) GetHostname() string          { return l.hostname }
+
+var _ observerdef.LogView = stubLogView{}
+
+func TestMatchesLogTagFilter(t *testing.T) {
+	filter := parseLogTagFilter("service:api env:prod -host:web-2 -team")
+
+	assert.True(t, matchesLogTagFilter(
+		[]string{"service:api", "env:prod", "host:web-1"},
+		filter,
+	))
+	assert.False(t, matchesLogTagFilter(
+		[]string{"service:api", "env:prod", "host:web-2"},
+		filter,
+	))
+	assert.False(t, matchesLogTagFilter(
+		[]string{"service:api", "env:prod", "team:infra"},
+		filter,
+	))
+	assert.False(t, matchesLogTagFilter(
+		[]string{"service:worker", "env:prod", "host:web-1"},
+		filter,
+	))
+}
+
+func TestCloneCompressedGroupsDeepCopiesMembers(t *testing.T) {
+	original := []CompressedGroup{{
+		CorrelatorName: "corr",
+		GroupID:        "group-1",
+		Title:          "group",
+		CommonTags:     map[string]string{"env": "prod"},
+		Patterns:       []MetricPattern{{Pattern: "svc.*", Matched: 1, Universe: 1, Precision: 1}},
+		MemberSources:  []string{"full|metric:avg|tag:a"},
+	}}
+
+	cloned := cloneCompressedGroups(original)
+	require.Len(t, cloned, 1)
+
+	cloned[0].CommonTags["env"] = "staging"
+	cloned[0].Patterns[0].Pattern = "other.*"
+	cloned[0].MemberSources[0] = "rewritten"
+
+	assert.Equal(t, "prod", original[0].CommonTags["env"])
+	assert.Equal(t, "svc.*", original[0].Patterns[0].Pattern)
+	assert.Equal(t, "full|metric:avg|tag:a", original[0].MemberSources[0])
+}
+
+func TestMatchesLogsQueryKind(t *testing.T) {
+	rawLog := stubLogView{status: "info", timestamp: 1000, tags: []string{"service:api"}}
+	telemetryLog := stubLogView{status: "info", timestamp: 1000, tags: []string{"service:api", "telemetry:true"}}
+
+	assert.True(t, matchesLogsQuery(rawLog, logsQuery{kind: "all"}))
+	assert.True(t, matchesLogsQuery(telemetryLog, logsQuery{kind: "all"}))
+	assert.True(t, matchesLogsQuery(rawLog, logsQuery{kind: "raw"}))
+	assert.False(t, matchesLogsQuery(telemetryLog, logsQuery{kind: "raw"}))
+	assert.False(t, matchesLogsQuery(rawLog, logsQuery{kind: "telemetry"}))
+	assert.True(t, matchesLogsQuery(telemetryLog, logsQuery{kind: "telemetry"}))
+}
+
+func TestHandleNumericSeriesDataRejectsUnknownAggregation(t *testing.T) {
+	tb, err := NewTestBench(TestBenchConfig{ScenariosDir: t.TempDir()})
+	require.NoError(t, err)
+
+	tb.engine.Storage().Add("test", "metric", 1, 100, nil)
+	api := NewTestBenchAPI(tb)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/series/id/0:bogus", nil)
+	rec := httptest.NewRecorder()
+
+	api.handleSeriesDataByID(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, "invalid aggregation suffix", body["error"])
+}


### PR DESCRIPTION
## Summary
- Add server-sent events (SSE) for streaming scenario results to the UI instead of polling
- Implement paginated data APIs (limit/offset) so the frontend can handle large parquet files without transferring everything at once
- Rework frontend data fetching (hooks, API client, LogView) to use the new streaming and paginated endpoints

## Test plan
- [x] Verified testbench builds and runs with large scenario parquet files
- [x] Manual testing of SSE streaming and paginated log/chart rendering in the UI