### PR TITLE
feat(tasks): Pass --default flag to dda self feature

### DIFF
--- a/tasks/libs/common/feature_flags.py
+++ b/tasks/libs/common/feature_flags.py
@@ -8,14 +8,15 @@ from invoke.context import Context
 from tasks.libs.common.color import Color, color_message
 
 
-def is_enabled(ctx: Context, feature: str, verbose: bool = False, default: bool = False) -> bool:  # noqa
+def is_enabled(ctx: Context, feature: str, verbose: bool = False, default: bool = False) -> bool:
     """
     Performs a dda feature flag check and returns whether a feature is enabled or not.
     """
     verbose = verbose or bool(os.getenv("VERBOSE_FEATURE_FLAGS"))
 
+    default_flag = str(default).lower()
     try:
-        res = ctx.run(f'dda self feature {feature}', hide=True)
+        res = ctx.run(f'dda self feature {feature} --default {default_flag}', hide=True)
         enabled = res.stdout.strip() == 'True'
     except Exception:
         if verbose:


### PR DESCRIPTION
## Summary

Update the `is_enabled` feature flag helper to pass the `--default` flag to `dda self feature` command. This allows the default value to be handled by dda directly instead of relying solely on exception handling in Python.

The try/except block is retained to handle cases where dda fails entirely (e.g., not installed, network issues).

## Test plan

- [x] Linter passes (`dda inv linter.python`)
- [x] Manual testing with `dda self feature` command

🤖 Generated with [Claude Code](https://claude.com/claude-code)