### PR TITLE
fix(tasks): Skip gitlab_ci linter when running in workspaces

### DIFF
--- a/tasks/libs/common/utils.py
+++ b/tasks/libs/common/utils.py
@@ -97,6 +97,10 @@ def running_in_pre_commit():
     return os.environ.get("PRE_COMMIT") == "1"
 
 
+def running_in_workspace():
+    return os.environ.get("WORKSPACE_NAME") is not None
+
+
 def bin_name(name):
     """
     Generate platform dependent names for binaries

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -29,7 +29,7 @@ from tasks.libs.common.git import (
     get_file_modifications,
     get_staged_files,
 )
-from tasks.libs.common.utils import gitlab_section, is_pr_context, running_in_ci
+from tasks.libs.common.utils import gitlab_section, is_pr_context, running_in_ci, running_in_workspace
 from tasks.libs.linter.gitlab import (
     ALL_GITLABCI_SUBLINTERS,
     PREPUSH_GITLABCI_SUBLINTERS,
@@ -454,6 +454,12 @@ def gitlab_ci(
         test: The context preset to test the gitlab ci file with containing environment variables.
         custom_context: A custom context to test the gitlab ci file with.
     """
+    if running_in_workspace():
+        print(
+            f"[{color_message('INFO', Color.BLUE)}] Running in a workspace (WORKSPACE_NAME is set), skipping gitlab_ci linter"
+        )
+        return
+
     # If we have to generate a gitlabci config object, use a minimally-resolved one
     # We do not need the fully-resolved one here, and this is much faster
     configs = load_or_generate_gitlab_ci_configs(

--- a/tasks/linter.py
+++ b/tasks/linter.py
@@ -456,7 +456,8 @@ def gitlab_ci(
     """
     if running_in_workspace():
         print(
-            f"[{color_message('INFO', Color.BLUE)}] Running in a workspace (WORKSPACE_NAME is set), skipping gitlab_ci linter"
+            f"[{color_message('INFO', Color.BLUE)}] Running in a workspace (WORKSPACE_NAME is set), skipping gitlab_ci linter. "
+            f"Reason: ddtool authentication is not yet fully working in workspaces."
         )
         return
 


### PR DESCRIPTION
## Summary
- Skip the `gitlab_ci` linter when the `WORKSPACE_NAME` environment variable is set
- The gitlab_ci linter does not work properly in workspace environments due to authentication/environment issues

## Test plan
- [x] Verified Python syntax is correct
- [x] Verified linter passes (`dda inv linter.python`)
- [ ] Manual testing in workspace environment to confirm linter is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)