### PR TITLE
Reduce verbosity of debug logs during mount resolver cache synchronization.

### DIFF
--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -90,7 +90,7 @@ func (mr *Resolver) syncCacheFromListMount() error {
 	if err != nil {
 		return fmt.Errorf("error synchronizing cache from listmount: %v", err)
 	}
-	seclog.Infof("listmount sync cache found %d entries", nrMounts)
+	seclog.Debugf("listmount sync cache found %d entries", nrMounts)
 	return nil
 }
 
@@ -105,7 +105,7 @@ func (mr *Resolver) syncCacheFromProcfs() error {
 	if err != nil {
 		return fmt.Errorf("error synchronizing from procfs: %v", err)
 	}
-	seclog.Infof("procfs sync cache found %d entries", nrMounts)
+	seclog.Debugf("procfs sync cache found %d entries", nrMounts)
 	return nil
 }
 


### PR DESCRIPTION
### What does this PR do?

As stated in the PR title.

### Motivation

These logs (well, the `procfs` one specifically) are _massively_ noisy. If they're truly more important than debug level, they should probably be actual metrics instead.

### Describe how you validated your changes

### Additional Notes
