### PR TITLE
chore(rust): move rust-toolchain.toml to repo root and remove version pin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@
 /generate_tools.go                      @DataDog/agent-devx
 /service.datadog.yaml                   @DataDog/agent-delivery @DataDog/agent-devx
 /static-analysis.datadog.yml            @DataDog/agent-devx
+/rust-toolchain.toml			@DataDog/agent-build
 /Cargo.toml                             @DataDog/agent-build
 /Cargo.lock                             @DataDog/agent-build
 

--- a/pkg/discovery/module/rust/rust-toolchain.toml
+++ b/pkg/discovery/module/rust/rust-toolchain.toml
@@ -1,9 +1,0 @@
-toolchain.channel = "1.91"
-toolchain.components = [
-  "rust-analyzer",
-  "cargo",
-  "rustfmt",
-  "clippy",
-  "rustc",
-  "rust-src"
-]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,3 @@
-toolchain.channel = "1.91"
 toolchain.components = [
   "rust-analyzer",
   "cargo",


### PR DESCRIPTION
### What does this PR do?

Moves `rust-toolchain.toml` from `pkg/discovery/module/rust/` to the repository root and removes the duplicate in `pkg/procmgr/rust/`. The `toolchain.channel` version pin is removed — the file now only declares components (cargo, rustfmt, clippy, rust-analyzer, rust-src).

### Motivation

We use **Bazel** (`rules_rust`) for all Rust builds, and the actual Rust toolchain version is pinned in [`MODULE.bazel`](/MODULE.bazel). The `rust-toolchain.toml` file is **not used by Bazel at all** — it only affects local `cargo` and `rustup` invocations.

We still need the file for two reasons:

1. **`Cargo.lock` management** — `cargo generate-lockfile` is required by our Bazel crate management setup (see [Rust guidelines](/docs/public/guidelines/languages/RUST.md)), and `rustup` uses `rust-toolchain.toml` to auto-install the needed toolchain.
2. **Developer tooling** — components like `rust-analyzer` and `rust-src` are essential for IDE support (code navigation, completion, diagnostics), and things like `rustfmt` are useful for local iteration even though Bazel runs them in CI.

The `channel` version pin is removed because:
- `MODULE.bazel` is the source of truth for the Rust version used in builds. A stale `channel` in `rust-toolchain.toml` is misleading — `rules_rust` [does not read it](https://github.com/bazelbuild/rules_rust/issues/2753).
- Without a `channel`, `rustup` will install whatever version is already configured on the developer's machine, which is fine since it's only used for `cargo` lockfile management and local tooling, not builds.

### Describe how you validated your changes

`rustup component remove clippy && cargo clippy`