### PR TITLE
Fix data races on configErrors and executedRequests maps

### DIFF
--- a/comp/core/autodiscovery/providers/kube_endpoints.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints.go
@@ -45,6 +45,7 @@ type kubeEndpointsConfigProvider struct {
 	upToDate           bool
 	monitoredEndpoints map[string]bool
 	configErrors       map[string]types.ErrorMsgSet
+	configErrorsMu     sync.RWMutex
 	telemetryStore     *telemetry.Store
 }
 
@@ -284,6 +285,7 @@ func (k *kubeEndpointsConfigProvider) parseServiceAnnotationsForEndpoints(servic
 			log.Errorf("Cannot parse endpoint template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 		}
 
+		k.configErrorsMu.Lock()
 		if len(errors) > 0 {
 			errMsgSet := make(types.ErrorMsgSet)
 			for _, err := range errors {
@@ -294,6 +296,7 @@ func (k *kubeEndpointsConfigProvider) parseServiceAnnotationsForEndpoints(servic
 		} else {
 			delete(k.configErrors, endpointsID)
 		}
+		k.configErrorsMu.Unlock()
 
 		var resolveMode endpointResolveMode
 		if value, found := svc.Annotations[kubeEndpointAnnotationPrefix+kubeEndpointResolvePath]; found {
@@ -315,11 +318,12 @@ func (k *kubeEndpointsConfigProvider) parseServiceAnnotationsForEndpoints(servic
 		}
 	}
 
+	k.configErrorsMu.Lock()
 	k.cleanErrorsOfDeletedEndpoints(setEndpointIDs)
-
 	if k.telemetryStore != nil {
 		k.telemetryStore.Errors.Set(float64(len(k.configErrors)), names.KubeEndpoints)
 	}
+	k.configErrorsMu.Unlock()
 
 	return configsInfo
 }
@@ -394,5 +398,7 @@ func (k *kubeEndpointsConfigProvider) cleanErrorsOfDeletedEndpoints(setCurrentEn
 
 // GetConfigErrors returns a map of configuration errors for each Kubernetes endpoint
 func (k *kubeEndpointsConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	k.configErrorsMu.RLock()
+	defer k.configErrorsMu.RUnlock()
 	return k.configErrors
 }

--- a/pkg/fleet/daemon/remote_config.go
+++ b/pkg/fleet/daemon/remote_config.go
@@ -301,6 +301,7 @@ type installPackageTaskParams struct {
 type handleRemoteAPIRequest func(request remoteAPIRequest) error
 
 func handleUpdaterTaskUpdate(h handleRemoteAPIRequest) func(map[string]state.RawConfig, func(cfgPath string, status state.ApplyStatus)) {
+	var mu sync.Mutex
 	var executedRequests = make(map[string]struct{})
 	return func(requestConfigs map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
 		requests := map[string]remoteAPIRequest{}
@@ -315,11 +316,16 @@ func handleUpdaterTaskUpdate(h handleRemoteAPIRequest) func(map[string]state.Raw
 			requests[id] = request
 		}
 		for configID, request := range requests {
-			if _, ok := executedRequests[request.ID]; ok {
+			mu.Lock()
+			_, ok := executedRequests[request.ID]
+			if !ok {
+				executedRequests[request.ID] = struct{}{}
+			}
+			mu.Unlock()
+			if ok {
 				log.Debugf("request %s already executed", request.ID)
 				continue
 			}
-			executedRequests[request.ID] = struct{}{}
 			err := h(request)
 			if err != nil {
 				log.Errorf("could not execute request: %s", err)


### PR DESCRIPTION
### What does this PR do?

Fixes two data races:

- **M-22** (`pkg/fleet/daemon/remote_config.go`): `executedRequests` map in `handleUpdaterTaskUpdate` was read and written concurrently across invocations of the returned closure without any synchronization. Added a `sync.Mutex` in the closure to protect all accesses.

- **M-23** (`comp/core/autodiscovery/providers/kube_endpoints.go`): `configErrors` map in `kubeEndpointsConfigProvider` was written in `parseServiceAnnotationsForEndpoints` and read in `GetConfigErrors` without holding a lock. Added a dedicated `configErrorsMu sync.RWMutex` field to guard all accesses to `configErrors`.

### Motivation

Both races can corrupt map state at runtime, leading to crashes or incorrect behavior. These bugs were found by Claude Code.

### Describe how you validated your changes

Relies on CI (`go vet`, race detector tests) and local code inspection. The fix is minimal: one mutex per site, wrapping only the map accesses.

### Additional Notes

These are the same class of bug as H-16 (already fixed), which added a lock to the kube services provider's `configErrors` map.