### PR TITLE
Fix TUF integrity bypass when hashes map is empty

### DIFF
--- a/pkg/remoteconfig/state/repository.go
+++ b/pkg/remoteconfig/state/repository.go
@@ -460,6 +460,9 @@ func cachedFileFromMetadata(path string, m Metadata) CachedFile {
 // hashesEqual checks if the hash values in the TUF metadata file match the stored
 // hash values for a given config
 func hashesEqual(tufHashes data.Hashes, storedHashes map[string][]byte) bool {
+	if len(tufHashes) == 0 {
+		return false
+	}
 	for algorithm, value := range tufHashes {
 		v, ok := storedHashes[algorithm]
 		if !ok {


### PR DESCRIPTION
### What does this PR do?

`hashesEqual` in `pkg/remoteconfig/state/repository.go` returned `true` when the `tufHashes` map was empty, because an empty `range` loop falls through to `return true`. This allowed a config file with no TUF hash entries to pass the integrity check unconditionally.

The fix adds an early return of `false` when `tufHashes` is empty.

### Motivation

An empty TUF hash map means the metadata carries no integrity information. Treating it as "equal" bypasses the integrity check and could allow tampered or injected configs to be accepted.

### Describe how you validated your changes

Relies on CI and local code inspection. The fix is a single guard at the top of the function.

### Additional Notes

This bug was found by Claude Code.