### PR TITLE
[WP] Add flush of msg sender to avoid any fail

### DIFF
--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -1759,6 +1759,10 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 	defer test.Close()
 
 	t.Run("not-triggered-sent-at-startup", func(t *testing.T) {
+		// Allow any in-flight remediation_status from the previous subtest to be delivered, then clear again.
+		time.Sleep(500 * time.Millisecond)
+		test.msgSender.flush()
+
 		newRuleDefs := []*rules.RuleDefinition{remediationNotTriggeredRule}
 		if err := setTestPolicy(commonCfgDir, nil, newRuleDefs); err != nil {
 			t.Fatalf("failed to set new policy: %v", err)
@@ -1808,7 +1812,6 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("not-triggered-no-event", func(t *testing.T) {
-		test.msgSender.flush()
 		// Allow any in-flight remediation_status from the previous subtest to be delivered, then clear again.
 		time.Sleep(500 * time.Millisecond)
 		test.msgSender.flush()


### PR DESCRIPTION
### What does this PR do?
Add flush of msg sender to avoid any fail
### Motivation
Fix a test that was failing on some distros due to a msg from another test.
