### PR TITLE
Fix data race on executedRequests map in remote config handler

### DIFF
--- a/pkg/fleet/daemon/remote_config.go
+++ b/pkg/fleet/daemon/remote_config.go
@@ -301,6 +301,7 @@ type installPackageTaskParams struct {
 type handleRemoteAPIRequest func(request remoteAPIRequest) error
 
 func handleUpdaterTaskUpdate(h handleRemoteAPIRequest) func(map[string]state.RawConfig, func(cfgPath string, status state.ApplyStatus)) {
+	var mu sync.Mutex
 	var executedRequests = make(map[string]struct{})
 	return func(requestConfigs map[string]state.RawConfig, applyStateCallback func(string, state.ApplyStatus)) {
 		requests := map[string]remoteAPIRequest{}
@@ -315,11 +316,16 @@ func handleUpdaterTaskUpdate(h handleRemoteAPIRequest) func(map[string]state.Raw
 			requests[id] = request
 		}
 		for configID, request := range requests {
-			if _, ok := executedRequests[request.ID]; ok {
+			mu.Lock()
+			_, ok := executedRequests[request.ID]
+			if !ok {
+				executedRequests[request.ID] = struct{}{}
+			}
+			mu.Unlock()
+			if ok {
 				log.Debugf("request %s already executed", request.ID)
 				continue
 			}
-			executedRequests[request.ID] = struct{}{}
 			err := h(request)
 			if err != nil {
 				log.Errorf("could not execute request: %s", err)


### PR DESCRIPTION
### What does this PR do?

`handleUpdaterTaskUpdate` returns a closure that reads and writes the `executedRequests` map. When remote config pushes multiple task configs, each invocation of the closure can run concurrently, causing a data race on the map.

The fix adds a `sync.Mutex` in the closure to protect all accesses to `executedRequests`.

### Motivation

Concurrent map access in Go causes a fatal runtime panic. The race can trigger whenever the remote config client receives multiple task updates in rapid succession.

### Describe how you validated your changes

Relies on CI (race detector) and local code inspection. The change is minimal: one mutex wrapping the map reads and writes.

### Additional Notes

This bug was found by Claude Code.