### PR TITLE
Fix data race on configErrors map in kube endpoints provider

### DIFF
--- a/comp/core/autodiscovery/providers/kube_endpoints.go
+++ b/comp/core/autodiscovery/providers/kube_endpoints.go
@@ -45,6 +45,7 @@ type kubeEndpointsConfigProvider struct {
 	upToDate           bool
 	monitoredEndpoints map[string]bool
 	configErrors       map[string]types.ErrorMsgSet
+	configErrorsMu     sync.RWMutex
 	telemetryStore     *telemetry.Store
 }
 
@@ -284,6 +285,7 @@ func (k *kubeEndpointsConfigProvider) parseServiceAnnotationsForEndpoints(servic
 			log.Errorf("Cannot parse endpoint template for service %s/%s: %s", svc.Namespace, svc.Name, err)
 		}
 
+		k.configErrorsMu.Lock()
 		if len(errors) > 0 {
 			errMsgSet := make(types.ErrorMsgSet)
 			for _, err := range errors {
@@ -294,6 +296,7 @@ func (k *kubeEndpointsConfigProvider) parseServiceAnnotationsForEndpoints(servic
 		} else {
 			delete(k.configErrors, endpointsID)
 		}
+		k.configErrorsMu.Unlock()
 
 		var resolveMode endpointResolveMode
 		if value, found := svc.Annotations[kubeEndpointAnnotationPrefix+kubeEndpointResolvePath]; found {
@@ -315,11 +318,12 @@ func (k *kubeEndpointsConfigProvider) parseServiceAnnotationsForEndpoints(servic
 		}
 	}
 
+	k.configErrorsMu.Lock()
 	k.cleanErrorsOfDeletedEndpoints(setEndpointIDs)
-
 	if k.telemetryStore != nil {
 		k.telemetryStore.Errors.Set(float64(len(k.configErrors)), names.KubeEndpoints)
 	}
+	k.configErrorsMu.Unlock()
 
 	return configsInfo
 }
@@ -394,5 +398,7 @@ func (k *kubeEndpointsConfigProvider) cleanErrorsOfDeletedEndpoints(setCurrentEn
 
 // GetConfigErrors returns a map of configuration errors for each Kubernetes endpoint
 func (k *kubeEndpointsConfigProvider) GetConfigErrors() map[string]types.ErrorMsgSet {
+	k.configErrorsMu.RLock()
+	defer k.configErrorsMu.RUnlock()
 	return k.configErrors
 }


### PR DESCRIPTION
### What does this PR do?

`kubeEndpointsConfigProvider` has a `configErrors` map that is written in `parseServiceAnnotationsForEndpoints` (called from `Collect`) and read in `GetConfigErrors` with no synchronization between them.

The fix adds a dedicated `configErrorsMu sync.RWMutex` field to the struct and uses it to protect all accesses to `configErrors`.

### Motivation

Concurrent map access in Go causes a fatal runtime panic. `Collect` and `GetConfigErrors` can be called from different goroutines, triggering the race.

### Describe how you validated your changes

Relies on CI (race detector) and local code inspection. The change is minimal: one RWMutex guarding all reads and writes to `configErrors`.

### Additional Notes

This bug was found by Claude Code.