### PR TITLE
Close bbolt DB handle when context is cancelled during open

### DIFF
--- a/pkg/fleet/installer/db/db.go
+++ b/pkg/fleet/installer/db/db.go
@@ -76,6 +76,12 @@ func New(ctx context.Context, dbPath string, opts ...Option) (*PackagesDB, error
 
 	select {
 	case <-ctx.Done():
+		// The goroutine is still running; drain the channel and close the DB once it finishes.
+		go func() {
+			if r := <-ch; r.db != nil {
+				r.db.Close()
+			}
+		}()
 		return nil, ctx.Err()
 	case r := <-ch:
 		if r.err != nil {


### PR DESCRIPTION
### What does this PR do?

`New` in `pkg/fleet/installer/db/db.go` opens the bbolt database in a background goroutine and waits on a `select` for either the result or context cancellation. When the context is cancelled, the function returns immediately, but the goroutine continues running. When `bbolt.Open` eventually completes, the resulting `*bbolt.DB` handle is sent to a buffered channel and is never received — leaking an open file descriptor and the file lock.

The fix adds a background goroutine in the `ctx.Done()` case that drains the channel and closes the handle once the open completes.

### Motivation

The leaked handle holds a file lock on the bbolt database file. Any subsequent attempt to open the same database will block or fail until the process exits.

### Describe how you validated your changes

Relies on CI and local code inspection. The change adds a single goroutine in the already-exceptional cancellation path.

### Additional Notes

This bug was found by Claude Code.