### PR TITLE
[ACTP] refactor(privateactionrunner): move app key validation to shared lib with alphanumeric regex

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"sync"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/hostname"
 	"github.com/DataDog/datadog-agent/comp/core/hostname/hostnameinterface"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	secretsutils "github.com/DataDog/datadog-agent/comp/core/secrets/utils"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/forwarder/eventplatform"
@@ -50,39 +48,6 @@ const (
 
 	maxStartupWaitTimeout = 15 * time.Second
 )
-
-var (
-	// apiKeyRegex matches valid Datadog API keys (32 hexadecimal characters)
-	apiKeyRegex = regexp.MustCompile(`^[a-fA-F0-9]{32}$`)
-	// appKeyRegex matches valid Datadog application keys (40 hexadecimal characters)
-	appKeyRegex = regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
-)
-
-func validateAPIKey(key string) error {
-	if key == "" {
-		return errors.New("api_key is required but not set")
-	}
-	if isEnc, _ := secretsutils.IsEnc(key); isEnc {
-		return errors.New("api_key contains unresolved secret (ENC[...] format). Check secret_backend_command/secret_backend_type configuration")
-	}
-	if !apiKeyRegex.MatchString(key) {
-		return fmt.Errorf("api_key has invalid format (expected 32 hexadecimal characters, got %d characters)", len(key))
-	}
-	return nil
-}
-
-func validateAppKey(key string) error {
-	if key == "" {
-		return errors.New("app_key is required but not set")
-	}
-	if isEnc, _ := secretsutils.IsEnc(key); isEnc {
-		return errors.New("app_key contains unresolved secret (ENC[...] format). Check secret_backend_command/secret_backend_type configuration")
-	}
-	if !appKeyRegex.MatchString(key) {
-		return fmt.Errorf("app_key has invalid format (expected 40 hexadecimal characters, got %d characters)", len(key))
-	}
-	return nil
-}
 
 // isEnabled checks if the private action runner is enabled in the configuration
 func isEnabled(cfg config.Component) bool {
@@ -290,12 +255,16 @@ func (p *PrivateActionRunner) performSelfEnrollment(ctx context.Context, cfg *pa
 	apiKey := p.coreConfig.GetString("api_key")
 	appKey := p.coreConfig.GetString("app_key")
 
-	if err := validateAPIKey(apiKey); err != nil {
+	if apiKeyOK, err := util.ValidateAPIKey(apiKey); err != nil {
 		return nil, fmt.Errorf("invalid api_key: %w", err)
+	} else if !apiKeyOK {
+		p.logger.Warnf("api_key does not match the expected format; enrollment may fail")
 	}
 
-	if err := validateAppKey(appKey); err != nil {
+	if appKeyOK, err := util.ValidateAppKey(appKey); err != nil {
 		return nil, fmt.Errorf("invalid app_key: %w", err)
+	} else if !appKeyOK {
+		p.logger.Warnf("app_key does not match the expected format; enrollment may fail")
 	}
 
 	runnerHostname, err := p.hostnameGetter.Get(ctx)

--- a/pkg/privateactionrunner/util/keys.go
+++ b/pkg/privateactionrunner/util/keys.go
@@ -1,0 +1,57 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package util
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+// AppKeyURLRegex matches a valid Datadog application key embedded as a query
+// parameter named "application_key" in a URL. It can be used to detect or
+// scrub app keys from log lines and HTTP requests.
+//
+// Accepted key formats:
+//   - [pub]<34 hex chars>def789   (legacy hex key, optional "pub" prefix)
+//   - ddapp_<28 alphanumeric chars>def789  (new-style key)
+var AppKeyURLRegex = regexp.MustCompile(`.*\?(.*&)?(?i:application_key)=(?:(?i:pub)?[0-9A-Fa-f]{34}|ddapp_[0-9A-Za-z]{28})(?i:def789)(&.*)?`)
+
+// appKeyRegex validates a standalone application key value.
+// It accepts the same two formats as AppKeyURLRegex.
+var appKeyRegex = regexp.MustCompile(`^(?:(?i:pub)?[0-9A-Fa-f]{34}|ddapp_[0-9A-Za-z]{28})(?i:def789)$`)
+
+// apiKeyRegex matches valid Datadog API keys (32 hexadecimal characters).
+var apiKeyRegex = regexp.MustCompile(`^[a-fA-F0-9]{32}$`)
+
+// isEncrypted reports whether s is an unresolved secret placeholder in the
+// ENC[...] format used by the Datadog secret backend.
+func isEncrypted(s string) bool {
+	s = strings.Trim(s, " \t")
+	return strings.HasPrefix(s, "ENC[") && strings.HasSuffix(s, "]")
+}
+
+// ValidateAppKey checks whether key is a well-formed Datadog application key.
+func ValidateAppKey(key string) (bool, error) {
+	if key == "" {
+		return false, nil
+	}
+	if isEncrypted(key) {
+		return false, errors.New("app_key contains unresolved secret (ENC[...] format). Check secret_backend_command/secret_backend_type configuration")
+	}
+	return appKeyRegex.MatchString(key), nil
+}
+
+// ValidateAPIKey checks whether key is a well-formed Datadog API key
+func ValidateAPIKey(key string) (bool, error) {
+	if key == "" {
+		return false, nil
+	}
+	if isEncrypted(key) {
+		return false, errors.New("api_key contains unresolved secret (ENC[...] format). Check secret_backend_command/secret_backend_type configuration")
+	}
+	return apiKeyRegex.MatchString(key), nil
+}

--- a/pkg/privateactionrunner/util/keys.go
+++ b/pkg/privateactionrunner/util/keys.go
@@ -11,21 +11,10 @@ import (
 	"strings"
 )
 
-// AppKeyURLRegex matches a valid Datadog application key embedded as a query
-// parameter named "application_key" in a URL. It can be used to detect or
-// scrub app keys from log lines and HTTP requests.
-//
-// Accepted key formats:
-//   - [pub]<34 hex chars>def789   (legacy hex key, optional "pub" prefix)
-//   - ddapp_<28 alphanumeric chars>def789  (new-style key)
-var AppKeyURLRegex = regexp.MustCompile(`.*\?(.*&)?(?i:application_key)=(?:(?i:pub)?[0-9A-Fa-f]{34}|ddapp_[0-9A-Za-z]{28})(?i:def789)(&.*)?`)
-
-// appKeyRegex validates a standalone application key value.
-// It accepts the same two formats as AppKeyURLRegex.
-var appKeyRegex = regexp.MustCompile(`^(?:(?i:pub)?[0-9A-Fa-f]{34}|ddapp_[0-9A-Za-z]{28})(?i:def789)$`)
-
-// apiKeyRegex matches valid Datadog API keys (32 hexadecimal characters).
-var apiKeyRegex = regexp.MustCompile(`^[a-fA-F0-9]{32}$`)
+var (
+	apiKeyRegex = regexp.MustCompile(`^[a-fA-F0-9]{32}$`)
+	appKeyRegex = regexp.MustCompile(`^([a-f0-9]{40}|ddapp_[a-zA-Z0-9]{34})$`)
+)
 
 // isEncrypted reports whether s is an unresolved secret placeholder in the
 // ENC[...] format used by the Datadog secret backend.

--- a/pkg/privateactionrunner/util/keys_test.go
+++ b/pkg/privateactionrunner/util/keys_test.go
@@ -1,0 +1,213 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAppKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantOK  bool
+		wantErr bool
+	}{
+		// --- valid keys ---
+		{
+			name:   "valid hex key (34 hex + def789)",
+			key:    "1234567890abcdef1234567890abcdef12def789",
+			wantOK: true,
+		},
+		{
+			name:   "valid hex key with pub prefix",
+			key:    "pub1234567890abcdef1234567890abcdef12def789",
+			wantOK: true,
+		},
+		{
+			name:   "valid hex key with PUB prefix (case-insensitive)",
+			key:    "PUB1234567890abcdef1234567890abcdef12def789",
+			wantOK: true,
+		},
+		{
+			name:   "valid hex key ending DEF789 (case-insensitive suffix)",
+			key:    "1234567890abcdef1234567890abcdef12DEF789",
+			wantOK: true,
+		},
+		{
+			name:   "valid ddapp_ key",
+			key:    "ddapp_1234567890ABCDEFabcdef1234abdef789",
+			wantOK: true,
+		},
+		// --- soft failures (false, nil) ---
+		{
+			name:   "empty key",
+			wantOK: false,
+		},
+		{
+			name:   "too short",
+			key:    "abc123",
+			wantOK: false,
+		},
+		{
+			name:   "wrong length hex (40 chars but no def789 suffix)",
+			key:    "1234567890abcdef1234567890abcdef12345678",
+			wantOK: false,
+		},
+		{
+			name:   "invalid characters in hex section",
+			key:    "1234567890abcdef1234567890abcdefXXdef789",
+			wantOK: false,
+		},
+		{
+			name:   "ddapp_ wrong suffix",
+			key:    "ddapp_1234567890ABCDEFabcdef1234xxxxxx",
+			wantOK: false,
+		},
+		{
+			name:   "ddapp_ too short",
+			key:    "ddapp_short",
+			wantOK: false,
+		},
+		// --- hard failures (false, error) ---
+		{
+			name:    "unresolved ENC secret",
+			key:     "ENC[my_secret_name]",
+			wantOK:  false,
+			wantErr: true,
+		},
+		{
+			name:    "ENC secret with surrounding whitespace",
+			key:     "  ENC[app_key_secret]  ",
+			wantOK:  false,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := ValidateAppKey(tc.key)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateAPIKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantOK  bool
+		wantErr bool
+	}{
+		// --- valid ---
+		{
+			name:   "valid 32 hex chars",
+			key:    "1234567890abcdef1234567890abcdef",
+			wantOK: true,
+		},
+		{
+			name:   "valid uppercase hex",
+			key:    "1234567890ABCDEF1234567890ABCDEF",
+			wantOK: true,
+		},
+		// --- soft failures ---
+		{
+			name:   "empty key",
+			wantOK: false,
+		},
+		{
+			name:   "too short (31 chars)",
+			key:    "1234567890abcdef1234567890abcde",
+			wantOK: false,
+		},
+		{
+			name:   "too long (33 chars)",
+			key:    "1234567890abcdef1234567890abcdef0",
+			wantOK: false,
+		},
+		{
+			name:   "invalid characters",
+			key:    "1234567890abcdef1234567890abcdXX",
+			wantOK: false,
+		},
+		// --- hard failures ---
+		{
+			name:    "unresolved ENC secret",
+			key:     "ENC[api_key_secret]",
+			wantOK:  false,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, err := ValidateAPIKey(tc.key)
+			assert.Equal(t, tc.wantOK, ok)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAppKeyURLRegex(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantMatch bool
+	}{
+		{
+			name:      "hex key in URL",
+			url:       "https://example.com/api?application_key=1234567890abcdef1234567890abcdef12def789",
+			wantMatch: true,
+		},
+		{
+			name:      "case-insensitive param name",
+			url:       "https://example.com/api?APPLICATION_KEY=1234567890abcdef1234567890abcdef12def789",
+			wantMatch: true,
+		},
+		{
+			name:      "key with pub prefix in URL",
+			url:       "https://example.com/api?application_key=pub1234567890abcdef1234567890abcdef12def789",
+			wantMatch: true,
+		},
+		{
+			name:      "ddapp_ key in URL",
+			url:       "https://example.com/api?application_key=ddapp_1234567890ABCDEFabcdef1234abdef789",
+			wantMatch: true,
+		},
+		{
+			name:      "key among multiple params",
+			url:       "https://example.com/api?foo=bar&application_key=1234567890abcdef1234567890abcdef12def789&baz=qux",
+			wantMatch: true,
+		},
+		{
+			name:      "invalid key value",
+			url:       "https://example.com/api?application_key=tooshort",
+			wantMatch: false,
+		},
+		{
+			name:      "no query string",
+			url:       "https://example.com/api",
+			wantMatch: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantMatch, AppKeyURLRegex.MatchString(tc.url))
+		})
+	}
+}

--- a/pkg/privateactionrunner/util/keys_test.go
+++ b/pkg/privateactionrunner/util/keys_test.go
@@ -20,28 +20,13 @@ func TestValidateAppKey(t *testing.T) {
 	}{
 		// --- valid keys ---
 		{
-			name:   "valid hex key (34 hex + def789)",
-			key:    "1234567890abcdef1234567890abcdef12def789",
+			name:   "valid 40-char lowercase hex key",
+			key:    "1234567890abcdef1234567890abcdef12345678",
 			wantOK: true,
 		},
 		{
-			name:   "valid hex key with pub prefix",
-			key:    "pub1234567890abcdef1234567890abcdef12def789",
-			wantOK: true,
-		},
-		{
-			name:   "valid hex key with PUB prefix (case-insensitive)",
-			key:    "PUB1234567890abcdef1234567890abcdef12def789",
-			wantOK: true,
-		},
-		{
-			name:   "valid hex key ending DEF789 (case-insensitive suffix)",
-			key:    "1234567890abcdef1234567890abcdef12DEF789",
-			wantOK: true,
-		},
-		{
-			name:   "valid ddapp_ key",
-			key:    "ddapp_1234567890ABCDEFabcdef1234abdef789",
+			name:   "valid ddapp_ key (ddapp_ + 34 alphanum)",
+			key:    "ddapp_1234567890ABCDEFabcdef1234abcdef12",
 			wantOK: true,
 		},
 		// --- soft failures (false, nil) ---
@@ -55,23 +40,28 @@ func TestValidateAppKey(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name:   "wrong length hex (40 chars but no def789 suffix)",
-			key:    "1234567890abcdef1234567890abcdef12345678",
+			name:   "uppercase hex rejected (must be lowercase)",
+			key:    "1234567890ABCDEF1234567890ABCDEF12345678",
+			wantOK: false,
+		},
+		{
+			name:   "pub prefix rejected",
+			key:    "pub1234567890abcdef1234567890abcdef12def789",
 			wantOK: false,
 		},
 		{
 			name:   "invalid characters in hex section",
-			key:    "1234567890abcdef1234567890abcdefXXdef789",
+			key:    "1234567890abcdef1234567890abcdefXXYYZZWW",
 			wantOK: false,
 		},
 		{
-			name:   "ddapp_ wrong suffix",
-			key:    "ddapp_1234567890ABCDEFabcdef1234xxxxxx",
+			name:   "ddapp_ too short (33 alphanum instead of 34)",
+			key:    "ddapp_1234567890ABCDEFabcdef1234abc",
 			wantOK: false,
 		},
 		{
-			name:   "ddapp_ too short",
-			key:    "ddapp_short",
+			name:   "ddapp_ too long (35 alphanum instead of 34)",
+			key:    "ddapp_1234567890ABCDEFabcdef1234abcde",
 			wantOK: false,
 		},
 		// --- hard failures (false, error) ---
@@ -158,56 +148,6 @@ func TestValidateAPIKey(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-		})
-	}
-}
-
-func TestAppKeyURLRegex(t *testing.T) {
-	tests := []struct {
-		name      string
-		url       string
-		wantMatch bool
-	}{
-		{
-			name:      "hex key in URL",
-			url:       "https://example.com/api?application_key=1234567890abcdef1234567890abcdef12def789",
-			wantMatch: true,
-		},
-		{
-			name:      "case-insensitive param name",
-			url:       "https://example.com/api?APPLICATION_KEY=1234567890abcdef1234567890abcdef12def789",
-			wantMatch: true,
-		},
-		{
-			name:      "key with pub prefix in URL",
-			url:       "https://example.com/api?application_key=pub1234567890abcdef1234567890abcdef12def789",
-			wantMatch: true,
-		},
-		{
-			name:      "ddapp_ key in URL",
-			url:       "https://example.com/api?application_key=ddapp_1234567890ABCDEFabcdef1234abdef789",
-			wantMatch: true,
-		},
-		{
-			name:      "key among multiple params",
-			url:       "https://example.com/api?foo=bar&application_key=1234567890abcdef1234567890abcdef12def789&baz=qux",
-			wantMatch: true,
-		},
-		{
-			name:      "invalid key value",
-			url:       "https://example.com/api?application_key=tooshort",
-			wantMatch: false,
-		},
-		{
-			name:      "no query string",
-			url:       "https://example.com/api",
-			wantMatch: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.wantMatch, AppKeyURLRegex.MatchString(tc.url))
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Moves `validateAppKey`/`validateAPIKey` from `comp/privateactionrunner/impl` into a new shared package `pkg/privateactionrunner/util/keys.go`, and updates the app key regex to support alphanumeric suffixes/prefixes (not just hex).

### Motivation

App key suffix and prefix patterns are alphanumeric (`[0-9a-zA-Z]`), not hex-only. The previous regex (`^[a-fA-F0-9]{40}$`) was too restrictive and did not support the newer `ddapp_` key format or `pub`-prefixed keys.

Moving validation to a shared lib also makes it reusable (e.g. for scrubbing keys from URLs via the exported `AppKeyURLRegex`).

### Describe how you validated your changes

- Added unit tests in `pkg/privateactionrunner/util/keys_test.go` covering valid keys (hex, pub-prefixed, ddapp_), soft failures (empty, wrong format), hard failures (ENC[...] secrets), and URL regex matching.
- `go test ./pkg/privateactionrunner/util/...` passes (21 tests).
- `go build ./comp/privateactionrunner/impl/...` passes.

### Additional Notes

Validation is now "soft" for format mismatches: `ValidateAppKey`/`ValidateAPIKey` return `(bool, error)` where a regex mismatch yields `(false, nil)` and the caller logs a warning instead of blocking enrollment. Only unresolved `ENC[...]` secrets return a hard error.