### PR TITLE
fix: add guards for serverless otlp agent

### DIFF
--- a/cmd/serverless-init/main.go
+++ b/cmd/serverless-init/main.go
@@ -242,6 +242,12 @@ func setupOtlpAgent(metricAgent *metrics.ServerlessMetricAgent, tagger tagger.Co
 		log.Debugf("otlp endpoint disabled")
 		return
 	}
+
+	if metricAgent == nil || metricAgent.Demux == nil {
+		log.Warn("metric agent or demux not ready, skipping OTLP agent setup")
+		return
+	}
+
 	otlpAgent := otlp.NewServerlessOTLPAgent(metricAgent.Demux.Serializer(), tagger)
 	otlpAgent.Start()
 }

--- a/cmd/serverless-init/main_test.go
+++ b/cmd/serverless-init/main_test.go
@@ -23,6 +23,7 @@ import (
 
 	compressionmock "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx-mock"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -90,4 +91,23 @@ func TestFlushTimeout(t *testing.T) {
 	lastFlush(100*time.Millisecond, metricAgent, traceAgent, mockLogsAgent)
 	assert.Equal(t, false, metricAgent.hasBeenCalled)
 	assert.Equal(t, false, mockLogsAgent.DidFlush())
+}
+
+// TestSetupOtlpAgentNoPanic ensures setupOtlpAgent does not panic when OTLP is enabled.
+func TestSetupOtlpAgentNoPanic(t *testing.T) {
+	t.Setenv("DD_OTLP_CONFIG_LOGS_ENABLED", "true")
+	t.Setenv("DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT", "0.0.0.0:4317")
+
+	configmock.New(t)
+	_ = pkgconfigsetup.LoadDatadog(pkgconfigsetup.Datadog(), secretsmock.New(t), delegatedauthmock.New(t), nil)
+	fakeTagger := taggerfxmock.SetupFakeTagger(t)
+	metricAgent := setupMetricAgent(map[string]string{}, fakeTagger, false)
+	defer metricAgent.Stop()
+
+	assert.NotPanics(t, func() { setupOtlpAgent(metricAgent, fakeTagger) })
+
+	// Timeout to allow the goroutine in ServerlessOTLPAgent.Start() to run.
+	// If it panics the process crashes. Without this the test can pass flakily when the goroutine hasn't run yet.
+	const panicWindow = 500 * time.Millisecond
+	<-time.After(panicWindow)
 }

--- a/pkg/serverless/otlp/otlp.go
+++ b/pkg/serverless/otlp/otlp.go
@@ -44,6 +44,10 @@ func NewServerlessOTLPAgent(serializer serializer.MetricSerializer, tagger tagge
 
 // Start starts the OTLP agent listening for traces and metrics
 func (o *ServerlessOTLPAgent) Start() {
+	if o == nil || o.pipeline == nil {
+		log.Warn("OTLP agent is not initialized, skipping start")
+		return
+	}
 	go func() {
 		if err := o.pipeline.Run(context.Background()); err != nil {
 			log.Errorf("Error running the OTLP pipeline: %s", err)
@@ -53,7 +57,8 @@ func (o *ServerlessOTLPAgent) Start() {
 
 // Stop stops the OTLP agent.
 func (o *ServerlessOTLPAgent) Stop() {
-	if o == nil {
+	if o == nil || o.pipeline == nil {
+		log.Warn("OTLP agent is not initialized, skipping stop")
 		return
 	}
 	o.pipeline.Stop()


### PR DESCRIPTION
### What does this PR do?

Adds nil checks to guard against panics for serverless otlp agent when otlp logs are attempted to be enabled.

### Motivation

Panic when OTLP Logs are enabled. This feature is not supported with Serverless Init but it should not cause a panic.

```
DD_OTLP_CONFIG_LOGS_ENABLED=true
DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317
```

<img width="588" height="204" alt="Screenshot 2026-03-13 at 10 30 29 AM" src="https://github.com/user-attachments/assets/c753a5fe-f82c-40e7-9763-415177d9c11d" />

https://datadoghq.atlassian.net/browse/SVLS-8703

### Describe how you validated your changes

- Added a unit test which replicates the configuration that leads to the panic.
- Deployed to Azure Container App with OTLP environment variables configured and confirmed no panic.

<img width="594" height="49" alt="Screenshot 2026-03-13 at 10 29 56 AM" src="https://github.com/user-attachments/assets/c5effd61-e027-4c02-9087-63d03e5fbf62" />

### Additional Notes
