### PR TITLE
add CI Identity id_tokens to Windows choco build job

### DIFF
--- a/.gitlab/windows/deploy/choco_build/windows.yml
+++ b/.gitlab/windows/deploy/choco_build/windows.yml
@@ -10,6 +10,9 @@
   extends: .windows_docker_default
   variables:
     ARCH: "x64"
+  id_tokens:
+    CI_IDENTITIES_GITLAB_ID_TOKEN:
+      aud: ci-identities
   script:
     - $ErrorActionPreference = "Stop"
     - if (Test-Path build-out) { remove-item -recurse -force build-out }


### PR DESCRIPTION
### What does this PR do?
Added`id_tokens: CI_IDENTITIES_GITLAB_ID_TOKEN` to the `windows_choco_7_x64` job, following the pattern already used by other Windows runner jobs

### Motivation
The `windows_choco_7_x64` job was failing with `AccessDenied` on S3 `PutObject` because it was assuming an untrusted-jobs IAM role, which lacks write access to `dd-release-artifacts`

### Describe how you validated your changes
run a deploy build pipeline and verify a `/choco` folder exists in `dd-release-artifacts` for that pipeline id

### Additional Notes
