### PR TITLE
[Backport 7.77.x]  [ACTP-1300] Pass agent metadata in PAR enrollment request

### DIFF
--- a/pkg/privateactionrunner/enrollment/enrollment.go
+++ b/pkg/privateactionrunner/enrollment/enrollment.go
@@ -15,6 +15,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/regions"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/opms"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/util"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const defaultIdentityFileName = "privateactionrunner_private_identity.json"
@@ -35,6 +38,12 @@ type PersistedIdentity struct {
 
 // SelfEnroll performs self-registration of a private action runner using API credentials
 func SelfEnroll(ctx context.Context, ddSite, runnerHostname, apiKey, appKey string) (*Result, error) {
+	orchClusterID, err := clustername.GetClusterID()
+	if err != nil {
+		pkglog.Warnf("Failed to get orchestrator cluster ID: %v", err)
+	}
+	agentFlavor := flavor.GetFlavor()
+
 	now := time.Now().UTC()
 	formattedTime := now.Format("20060102150405")
 	runnerName := runnerHostname + "-" + formattedTime
@@ -56,6 +65,9 @@ func SelfEnroll(ctx context.Context, ddSite, runnerHostname, apiKey, appKey stri
 		runnerName,
 		runnerModes,
 		publicJwk,
+		runnerHostname,
+		orchClusterID,
+		agentFlavor,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("enrollment API call failed: %w", err)

--- a/pkg/privateactionrunner/libs/par/opms_api.go
+++ b/pkg/privateactionrunner/libs/par/opms_api.go
@@ -11,17 +11,23 @@ import (
 
 // CreateRunnerRequest represents the request to create a runner with API key auth
 type CreateRunnerRequest struct {
-	ID           string       `jsonapi:"primary,createRunnerRequest"`
-	RunnerName   string       `json:"runner_name" jsonapi:"attribute" validate:"required"`
-	RunnerModes  []modes.Mode `json:"runner_modes" jsonapi:"attribute" validate:"gt=0,max=2,dive"`
-	RunnerHost   string       `json:"runner_host" jsonapi:"attribute" validate:"omitempty,hostname"`
-	PublicKeyPEM string       `json:"public_key_pem" jsonapi:"attribute" validate:"required"`
+	ID            string       `jsonapi:"primary,createRunnerRequest"`
+	RunnerName    string       `json:"runner_name" jsonapi:"attribute" validate:"required"`
+	RunnerModes   []modes.Mode `json:"runner_modes" jsonapi:"attribute" validate:"gt=0,max=2,dive"`
+	RunnerHost    string       `json:"runner_host" jsonapi:"attribute" validate:"omitempty,hostname"`
+	PublicKeyPEM  string       `json:"public_key_pem" jsonapi:"attribute" validate:"required"`
+	AgentHostname string       `json:"agent_hostname,omitempty" jsonapi:"attribute" validate:"omitempty"`
+	OrchClusterID string       `json:"orch_cluster_id,omitempty" jsonapi:"attribute" validate:"omitempty"`
+	AgentFlavor   string       `json:"agent_flavor,omitempty" jsonapi:"attribute" validate:"omitempty"`
 }
 
 // CreateRunnerResponse represents the response for runner creation
 type CreateRunnerResponse struct {
-	ID          string   `jsonapi:"primary,createRunnerResponse"`
-	RunnerID    string   `json:"runner_id" jsonapi:"attribute"`
-	OrgID       int64    `json:"org_id" jsonapi:"attribute"`
-	RunnerModes []string `json:"runner_modes" jsonapi:"attribute"`
+	ID            string   `jsonapi:"primary,createRunnerResponse"`
+	RunnerID      string   `json:"runner_id" jsonapi:"attribute"`
+	OrgID         int64    `json:"org_id" jsonapi:"attribute"`
+	RunnerModes   []string `json:"runner_modes" jsonapi:"attribute"`
+	AgentHostname string   `json:"agent_hostname,omitempty" jsonapi:"attribute"`
+	OrchClusterID string   `json:"orch_cluster_id,omitempty" jsonapi:"attribute"`
+	AgentFlavor   string   `json:"agent_flavor,omitempty" jsonapi:"attribute"`
 }

--- a/pkg/privateactionrunner/opms/public_opms.go
+++ b/pkg/privateactionrunner/opms/public_opms.go
@@ -37,6 +37,9 @@ type PublicClient interface {
 		runnerName string,
 		runnerModes []modes.Mode,
 		publicJwk *jose.JSONWebKey,
+		agentHostname string,
+		orchClusterID string,
+		agentFlavor string,
 	) (*par.CreateRunnerResponse, error)
 }
 
@@ -62,6 +65,9 @@ func (p *publicClient) EnrollWithApiKey(
 	runnerName string,
 	runnerModes []modes.Mode,
 	publicJwk *jose.JSONWebKey,
+	agentHostname string,
+	orchClusterID string,
+	agentFlavor string,
 ) (*par.CreateRunnerResponse, error) {
 	publicKeyPEM, err := util.JWKToPEM(publicJwk)
 	if err != nil {
@@ -75,9 +81,12 @@ func (p *publicClient) EnrollWithApiKey(
 	}
 
 	request := par.CreateRunnerRequest{
-		RunnerName:   runnerName,
-		RunnerModes:  runnerModes,
-		PublicKeyPEM: publicKeyPEM,
+		RunnerName:    runnerName,
+		RunnerModes:   runnerModes,
+		PublicKeyPEM:  publicKeyPEM,
+		AgentHostname: agentHostname,
+		OrchClusterID: orchClusterID,
+		AgentFlavor:   agentFlavor,
 	}
 
 	requestBodyJSON, err := jsonapi.Marshal(request, jsonapi.MarshalClientMode())


### PR DESCRIPTION
Backport #47395

### What does this PR do?

Pass agent metadata (`AgentHostname`, `OrchClusterID`, `AgentFlavor`) in the PAR enrollment request so the backend can associate runner identity with the agent that enrolled it.

### Motivation

We need to save this field to be able to link a PAR to a Datadog Agent.

### Describe how you validated your changes

Install a new Datadog Agent to enroll a new Private Action Runner and verify that this PAR sends the new fields to the Action Platform backend during enrollment.