### PR TITLE
Set -O2 by default on cc toolchains

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,6 +38,9 @@ common:macos --features=-macos_default_link_flags # https://github.com/bazelbuil
 common:macos --macos_minimum_os=11.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 common:macos --strategy=sandboxed
 common:macos --remote_local_fallback_strategy=sandboxed
+# We don't have a toolchain set up for macos, in the meantime, we set cflags via config instead
+# TODO(alopezz): remove once we do have a toolchain and we set the flag there
+common:macos --copt=-O2
 
 # Windows config -------------------------------------------------------------------------------------------------------
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -185,6 +185,7 @@ git_override(
         "//bazel/patches:gcc-toolchain/0003-add-nostdinc-to-asmflags.patch",
         "//bazel/patches:gcc-toolchain/0004-fix-re-fetching.patch",  # https://github.com/f0rmiga/gcc-toolchain/pull/207
         "//bazel/patches:gcc-toolchain/0005-fix-bazel-9-compat.patch",
+        "//bazel/patches:gcc-toolchain/0006-add-default-optimization-feature.patch",
     ],
     remote = "https://github.com/f0rmiga/gcc-toolchain.git",
 )

--- a/bazel/patches/gcc-toolchain/0006-add-default-optimization-feature.patch
+++ b/bazel/patches/gcc-toolchain/0006-add-default-optimization-feature.patch
@@ -1,0 +1,45 @@
+From: Alex Lopez <alex.lopez@datadoghq.com>
+Date: Mon, 13 Mar 2026 00:00:00 +0000
+Subject: add default_optimization feature
+
+Adds a standalone, independently-disableable `default_optimization`
+feature that applies -O2 to C and C++ compilation. This mirrors the
+approach used in the MinGW toolchain and allows individual rules to
+opt out via `features = ["-default_optimization"]` without losing the
+hermetic toolchain setup that lives in `extra_cflags`.
+
+---
+ toolchain/cc_toolchain_config.bzl | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/toolchain/cc_toolchain_config.bzl b/toolchain/cc_toolchain_config.bzl
+--- a/toolchain/cc_toolchain_config.bzl
++++ b/toolchain/cc_toolchain_config.bzl
+@@ -371,6 +371,20 @@ def _impl(ctx):
+         ] if len(extra_cflags) > 0 else [],
+     )
+
++    default_optimization_feature = feature(
++        name = "default_optimization",
++        enabled = True,
++        flag_sets = [
++            flag_set(
++                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
++                flag_groups = [
++                    flag_group(flags = ["-O2"]),
++                ],
++            ),
++        ],
++    )
++
+     extra_cxxflags_feature = feature(
+         name = "extra_cxxflags",
+         enabled = True,
+@@ -455,6 +469,7 @@ def _impl(ctx):
+         unfiltered_compile_flags_feature,
+         redacted_dates_feature,
+         extra_cflags_feature,
++        default_optimization_feature,
+         extra_cxxflags_feature,
+         extra_ldflags_feature,
+         extra_asmflags_feature,

--- a/bazel/toolchains/mingw/toolchain.bzl
+++ b/bazel/toolchains/mingw/toolchain.bzl
@@ -86,6 +86,19 @@ def _impl(ctx):
         ],
     )
 
+    optimization_feature = feature(
+        name = "default_optimization",
+        enabled = True,
+        flag_sets = [
+            flag_set(
+                actions = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile],
+                flag_groups = [
+                    flag_group(flags = ["-O2"]),
+                ],
+            ),
+        ],
+    )
+
     # Feature for archiver flags (ar)
     archiver_flags_feature = feature(
         name = "archiver_flags",
@@ -117,7 +130,7 @@ def _impl(ctx):
     return [
         cc_common.create_cc_toolchain_config_info(
             ctx = ctx,
-            features = [default_feature, archiver_flags_feature],
+            features = [default_feature, archiver_flags_feature, optimization_feature],
             toolchain_identifier = "mingw-toolchain",
             host_system_name = "nothing",
             target_system_name = "nothing",

--- a/deps/gcrypt/gcrypt.BUILD.bazel
+++ b/deps/gcrypt/gcrypt.BUILD.bazel
@@ -319,6 +319,10 @@ cc_library(
         # `The rndjent module needs to be compiled without optimization.``
         "-O0",
     ],
+    features = [
+        # Disable the toolchain's default optimization so that -O0 above takes effect.
+        "-default_optimization",
+    ],
     implementation_deps = [
         ":config_h",
     ],


### PR DESCRIPTION
### What does this PR do?

It adds the optimization flag `-O2` at the toolchain level, matching the flags that we use on omnibus ([ref](https://github.com/DataDog/omnibus-ruby/blob/b29eb2add13a9631afb433945b1b2b00c3d5e7e3/lib/omnibus/software.rb#L712)).

It also removes manual reference to `-O2` all around, to benefit from this more widely scoped change which where it belongs if we want to mirror the omnibus setup.

### Motivation

We have been adding this flag manually for every cc rule. This is not very sustainable – since we have accepted that we do want to set this flag for everything yet it could be easy to forget adding it for any new target.

### Describe how you validated your changes

I confirmed locally that this adds the `-O2` flag correctly for rtloader as built with bazel, despite not having set the flag explicitly.

### Additional Notes

On macos we don't have a toolchain set up. To achieve a comparable effect, this PR adds the flag via [copt](https://bazel.build/docs/user-manual#copt) to .bazelrc. We'll set it up on the toolchain once we set it up.