### PR TITLE
fix(ebpf): Restore write permissions on copied eBPF object files

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1336,7 +1336,7 @@ def bazel_build_ebpf(ctx: Context, arch: Arch, build_dir: str, strip: bool = Tru
             ctx.run(f'{llvm_strip} -w -N "LBB*" {f}')
 
     for f in copied_files:
-        os.chmod(f, 0o444)
+        os.chmod(f, 0o644)
 
     print(f"Copied eBPF objects to {build_dir}")
 
@@ -1463,7 +1463,7 @@ def build_cws_object_files(
             src = os.path.join(bazel_bin, label_path, f"{name}.o")
             dst = os.path.join(str(build_dir), dest_name)
             shutil.copy2(src, dst)
-            os.chmod(dst, 0o444)
+            os.chmod(dst, 0o644)
 
 
 def clean_object_files(ctx):


### PR DESCRIPTION
### What does this PR do?

Changes the permissions set on copied eBPF object files from `0o444` (read-only) to `0o644` (owner read-write) in both `bazel_build_ebpf` and `build_cws_object_files` in `tasks/system_probe.py`.

### Motivation

#47400 (Use bazel to build ebpf parts) changed the permissions of the copied eBPF `.o` files to `0o444` (read-only). This causes `PermissionError` when running system-probe tests a second time, since `shutil.copy2` cannot overwrite the read-only destination files:

```
PermissionError: [Errno 13] Permission denied: 'pkg/ebpf/bytecode/build/arm64/dns.o'
```

The workaround is to `rm` the `.o` files before each test run, but this shouldn't be necessary. The files were installed with `0o644` before the Bazel migration (see the [File Inventory check](https://github.com/DataDog/datadog-agent/pull/47400#issuecomment-4006200796) on that PR), so this PR restores that behavior. If there's a reason to restrict permissions further, that can be done in a separate PR that also addresses the testability issues.

### Describe how you validated your changes

Ran `dda inv -e system-probe.test -p ./pkg/discovery/module -r TestIgnoreComm` twice in a row without needing to manually remove `.o` files between runs.

### Additional Notes

Reverts only the permission portion of #47400.