### PR TITLE
[ACTP] Register Private Action Runner module in node agent

### DIFF
--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -37,6 +37,7 @@ import (
 	logondurationfx "github.com/DataDog/datadog-agent/comp/logonduration/fx"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
 	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
+	privateactionrunnerfx "github.com/DataDog/datadog-agent/comp/privateactionrunner/fx"
 	ssistatusfx "github.com/DataDog/datadog-agent/comp/updater/ssistatus/fx"
 	workloadselectionfx "github.com/DataDog/datadog-agent/comp/workloadselection/fx"
 
@@ -564,6 +565,7 @@ func getSharedFxOption() fx.Option {
 		logondurationfx.Module(),
 		healthplatformfx.Module(),
 		tracetelemetryfx.Module(),
+		privateactionrunnerfx.Module(),
 	)
 }
 

--- a/comp/privateactionrunner/fx/fx.go
+++ b/comp/privateactionrunner/fx/fx.go
@@ -10,6 +10,7 @@ import (
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
 	privateactionrunnerimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/impl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"go.uber.org/fx"
 )
 
@@ -20,7 +21,8 @@ func Module() fxutil.Module {
 			privateactionrunnerimpl.NewComponent,
 		),
 		fxutil.ProvideOptional[privateactionrunner.Component](),
-		// Force instantiation since no other component depends on privateactionrunner
-		fx.Invoke(func(_ privateactionrunner.Component) {}),
+		// Force instantiation since no other component depends on privateactionrunner.
+		// Uses option.Option so that a nil Component (PAR disabled) does not cause an error.
+		fx.Invoke(func(_ option.Option[privateactionrunner.Component]) {}),
 	)
 }

--- a/comp/privateactionrunner/fx/fx.go
+++ b/comp/privateactionrunner/fx/fx.go
@@ -10,7 +10,6 @@ import (
 	privateactionrunner "github.com/DataDog/datadog-agent/comp/privateactionrunner/def"
 	privateactionrunnerimpl "github.com/DataDog/datadog-agent/comp/privateactionrunner/impl"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"go.uber.org/fx"
 )
 
@@ -21,8 +20,7 @@ func Module() fxutil.Module {
 			privateactionrunnerimpl.NewComponent,
 		),
 		fxutil.ProvideOptional[privateactionrunner.Component](),
-		// Force instantiation since no other component depends on privateactionrunner.
-		// Uses option.Option so that a nil Component (PAR disabled) does not cause an error.
-		fx.Invoke(func(_ option.Option[privateactionrunner.Component]) {}),
+		// Force instantiation since no other component depends on privateactionrunner
+		fx.Invoke(func(_ privateactionrunner.Component) {}),
 	)
 }

--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -95,7 +95,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 	if !isEnabled(reqs.Config) {
 		reqs.Log.Info("private-action-runner is not enabled. Set private_action_runner.enabled: true in your datadog.yaml file or set the environment variable DD_PRIVATE_ACTION_RUNNER_ENABLED=true.")
 		reqs.Log.Flush()
-		return Provides{}, privateactionrunner.ErrNotEnabled
+		return Provides{}, nil
 	}
 
 	runner, err := NewPrivateActionRunner(ctx, reqs.Config, reqs.Hostname, pkgrcclient.NewAdapter(reqs.RcClient), reqs.Log, reqs.Tagger, reqs.Traceroute, reqs.EventPlatform)


### PR DESCRIPTION
### Description
- Register `privateactionrunnerfx.Module()` in the node agent's shared FX options, enabling PAR to run inside the DaemonSet agent binary
- Modify `NewComponent` to return `nil` instead of `ErrNotEnabled` when PAR is disabled, so the FX dependency graph resolves without error (the `fx.Invoke` in the module forces instantiation, and a constructor error would crash the agent)

This is the agent-side counterpart to the helm chart PR: https://github.com/DataDog/helm-charts/pull/2478

### Test
- `TestCommand` and `TestCommandPidfile` pass
- Verified end-to-end on Docker Desktop Kubernetes: node agent successfully self-enrolls PAR and starts workflow/common runners