### PR TITLE
omnibus: target macOS 12.0

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -227,7 +227,7 @@ build do
                                  live_stream: Omnibus.logger.live_stream(:info),
                                  env: {
                                    ARCH: arm_target? ? "arm64" : "x86_64",
-                                   MIN_ACCEPTABLE_VERSION: "11.0",
+                                   MIN_ACCEPTABLE_VERSION: "12.0",
                                    INSTALL_DIR: install_dir,
                                    ALLOW_PATTERN: "(#{allow_list.join('|')})",
                                  }

--- a/tasks/omnibus.py
+++ b/tasks/omnibus.py
@@ -124,7 +124,7 @@ def get_omnibus_env(
             env[key] = sha1
 
     if sys.platform == 'darwin':
-        env['MACOSX_DEPLOYMENT_TARGET'] = '11.0'  # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
+        env['MACOSX_DEPLOYMENT_TARGET'] = '12.0'  # https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 
         if not skip_sign:
             env['SIGN_MAC'] = 'true'


### PR DESCRIPTION
### What does this PR do?

Increase the minimally supported macOS version to 12.0

### Motivation

Since we are using golang 1.25 or later, we can't support macOS version lower than 12.
This PR makes it explicit

### Describe how you validated your changes

### Additional Notes

Related to [#incident-51010](https://dd.enterprise.slack.com/archives/C0ALJC5G5N0) 
This PR doesn't change the current state, it only makes things explicit. As such, I didn't include a changelog, but existing release notes for the golang update didn't mention this, so feel free to request a release note