### PR TITLE
Enable all correlators by default, add config toggles

### DIFF
--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -11,7 +11,7 @@ import observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 type componentKind int
 
 const (
-	componentDetector   componentKind = iota
+	componentDetector componentKind = iota
 	componentCorrelator
 )
 
@@ -92,7 +92,7 @@ func defaultCatalog() *componentCatalog {
 						WindowSeconds:    120,
 					})
 				},
-				defaultEnabled: false,
+				defaultEnabled: true,
 			},
 			{
 				name:        "lead_lag",
@@ -106,7 +106,7 @@ func defaultCatalog() *componentCatalog {
 						WindowSeconds:       120,
 					})
 				},
-				defaultEnabled: false,
+				defaultEnabled: true,
 			},
 			{
 				name:        "surprise",
@@ -119,7 +119,7 @@ func defaultCatalog() *componentCatalog {
 						MinSupport:        2,
 					})
 				},
-				defaultEnabled: false,
+				defaultEnabled: true,
 			},
 		},
 	}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -19,7 +19,7 @@ import (
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
+
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 )
@@ -178,7 +178,26 @@ func (l *logObs) GetTimestampUnixMilli() int64 {
 // NewComponent creates an observer.Component.
 func NewComponent(deps Requires) Provides {
 	catalog := defaultCatalog()
-	detectors, correlators, _ := catalog.Instantiate(nil)
+
+	// Build correlator overrides from config keys (observer.correlators.<name>.enabled).
+	cfg := deps.Config
+	var correlatorOverrides map[string]bool
+	if cfg != nil {
+		for _, entry := range catalog.Entries() {
+			if entry.kind != componentCorrelator {
+				continue
+			}
+			key := "observer.correlators." + entry.name + ".enabled"
+			if deps.Config.IsKnown(key) {
+				if correlatorOverrides == nil {
+					correlatorOverrides = make(map[string]bool)
+				}
+				correlatorOverrides[entry.name] = deps.Config.GetBool(key)
+			}
+		}
+	}
+
+	detectors, correlators, _ := catalog.Instantiate(correlatorOverrides)
 
 	extractors := []observerdef.LogMetricsExtractor{
 		&LogMetricsExtractor{
@@ -220,12 +239,10 @@ func NewComponent(deps Requires) Provides {
 		obsCh:  make(chan observation, 1000),
 	}
 
-	cfg := pkgconfigsetup.Datadog()
-
 	// Set up handle function based on recording and analysis configuration.
 	// Recording (observer.recording.enabled) enables parquet writers and the fetcher.
 	// Analysis (observer.analysis.enabled) enables the anomaly detection pipeline.
-	analysisEnabled := cfg.GetBool("observer.analysis.enabled")
+	analysisEnabled := cfg != nil && cfg.GetBool("observer.analysis.enabled")
 
 	obs.handleFunc = obs.noopHandle
 	if analysisEnabled {

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -365,6 +365,12 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.metrics.high_frequency_interval", 0*time.Second) // 0 = disabled
 	config.BindEnvAndSetDefault("observer.event_reporter.sending_enabled", false)
 
+	// Observer correlator toggles (override catalog defaults)
+	config.BindEnvAndSetDefault("observer.correlators.cross_signal.enabled", true)
+	config.BindEnvAndSetDefault("observer.correlators.time_cluster.enabled", true)
+	config.BindEnvAndSetDefault("observer.correlators.lead_lag.enabled", true)
+	config.BindEnvAndSetDefault("observer.correlators.surprise.enabled", true)
+
 	// Auto exit configuration
 	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)
 	config.BindEnvAndSetDefault("auto_exit.noprocess.enabled", false)


### PR DESCRIPTION
## Summary

Enable all four correlators (cross_signal, time_cluster, lead_lag, surprise) by default in the observer's live agent path. Previously only cross_signal was enabled, which requires specific eBPF metric names (`network.retransmits:avg`, `ebpf.lock_contention_ns:avg`, `connection.errors:count`) and never fires outside kernel-level scenarios.

The general-purpose correlators (time_cluster, lead_lag, surprise) work with any metric source and successfully detected correlated anomalies during a live gensim episode evaluation (213_PagerDuty cassandra-repair-degradation).

## Changes

- **component_catalog.go**: Set `defaultEnabled: true` for time_cluster, lead_lag, and surprise correlators
- **config.go**: Register `observer.correlators.<name>.enabled` config keys for all four correlators, allowing runtime toggling via `datadog.yaml` or `DD_OBSERVER_CORRELATORS_*_ENABLED` env vars
- **observer.go**: Read correlator config overrides from `deps.Config` and pass to `catalog.Instantiate()`. Also normalized config access from `pkgconfigsetup.Datadog()` global to injected `deps.Config` component.

## Validation

Tested end-to-end on a live EKS cluster running the 213_PagerDuty episode:
- 20 Datadog events successfully delivered via the event reporter
- TimeCluster detected temporal co-occurrence of BOCPD anomalies across trace agent metrics
- Surprise detected statistically unusual metric co-occurrences (lift scores 2.0-24.0)
- Known issue: Surprise correlator pattern names can exceed the 200-char Events API tag limit (follow-up fix needed)

## Test plan

- [x] Live episode run with all correlators enabled
- [x] Verified events land in Datadog Events explorer (`source:agent-q-branch-observer`)
- [ ] Unit tests for correlator config override wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)