### PR TITLE
release notes: mention that macOS 12 isn't supported anymore

### DIFF
--- a/releasenotes/notes/macos-12-e5d13b7224a1073c.yaml
+++ b/releasenotes/notes/macos-12-e5d13b7224a1073c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+deprecations:
+  - |
+    macOS 11 is not support anymore, 12.0 is now the minimally supported version.


### PR DESCRIPTION
### What does this PR do?

Add a release note mentioning that we don't support macOS 11 anymore

### Motivation

Letting our users know

### Describe how you validated your changes

### Additional Notes
