### PR TITLE
fix(config): add systemd to integration.basic.allowed checks

### DIFF
--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -1455,6 +1455,7 @@ func agent(config pkgconfigmodel.Setup) {
 		"versa",
 		"cisco_aci",
 		"system",
+		"systemd",
 		"system_core",
 		"system_swap",
 		"telemetry",


### PR DESCRIPTION
### What does this PR do?
Backport of #47684 to 7.77.x.

Adds `systemd` to the list of `integration.basic.allowed` checks.

### Motivation
Backport fix to the 7.77.x release branch.

### Describe how you validated your changes
Validated in the original PR #47684.

### Additional Notes
Cherry-picked from 6682dd5135e43751b730fd111e7351f4b37fb69a.