### PR TITLE
[WP] Fix send network isolation status

### DIFF
--- a/pkg/security/probe/remediations_linux.go
+++ b/pkg/security/probe/remediations_linux.go
@@ -50,6 +50,7 @@ type Remediation struct {
 	policy             string
 	isolationReApplied bool
 	isolationNew       bool
+	isolationPerformed bool
 	ruleTags           RuleTags
 }
 
@@ -221,7 +222,7 @@ func (p *EBPFProbe) HandleRemediationStatus(rs *rules.RuleSet) {
 		}
 	}
 
-	// When a new ruleset is loaded, reset all flags
+	// When a new ruleset is loaded, reset all flags except the performed flag
 	for _, state := range p.activeRemediations {
 		state.triggered = false
 		state.isolationReApplied = false
@@ -333,9 +334,17 @@ func (p *EBPFProbe) HandleNetworkRemediation(rule *rules.Rule, ev *model.Event, 
 		return
 	}
 	remediation.triggered = true
-	if remediation.isolationReApplied {
-		// We already re-applied the isolation, no need to send the event
+
+	// if the isolation is from the same rule and was already performed, don't send an event
+	if remediation.isolationReApplied && remediation.isolationPerformed {
 		return
+	}
+
+	// if the status is performed, update the isolationPerformed field
+	if report.Status == RawPacketActionStatusPerformed {
+		remediation.isolationPerformed = true
+	} else {
+		remediation.isolationPerformed = false
 	}
 
 	remediation.processContext.PID = ev.ProcessContext.Process.Pid

--- a/pkg/security/probe/remediations_linux.go
+++ b/pkg/security/probe/remediations_linux.go
@@ -119,14 +119,14 @@ func generateKillActionKey(ruleID string, scope string, signal string) string {
 	return KillKeyPrefix + ruleID + scope + signal
 }
 
-func generateNetworkIsolationActionKey(ruleID string, filter string) string {
-	// prefix + ruleID + sha256(filter)
+func generateNetworkIsolationActionKey(ruleID string, scope string, filter string) string {
+	// prefix + ruleID + scope + sha256(filter)
 	hash := sha256.Sum256([]byte(filter))
-	return NetworkIsolationKeyPrefix + ruleID + hex.EncodeToString(hash[:])
+	return NetworkIsolationKeyPrefix + ruleID + scope + hex.EncodeToString(hash[:])
 
 }
 func generateRemediationActionKey(key string) string {
-	// prefix + agent_event_id
+	// prefix + key
 	return RemediationKeyPrefix + key
 }
 
@@ -140,7 +140,7 @@ func getRemediationKeyFromAction(rule *rules.Rule, action *rules.Action) string 
 		key = generateKillActionKey(rule.ID, action.Def.Kill.Scope, action.Def.Kill.Signal)
 	} else if action.Def.NetworkFilter != nil {
 		// ruleID + bpffilter
-		key = generateNetworkIsolationActionKey(rule.ID, action.Def.NetworkFilter.BPFFilter)
+		key = generateNetworkIsolationActionKey(rule.ID, action.Def.NetworkFilter.Scope, action.Def.NetworkFilter.BPFFilter)
 	}
 
 	if getRemediationTagBool(rule) {
@@ -378,6 +378,8 @@ func (p *EBPFProbe) HandleRemediationNotTriggered() {
 		var remediationStr string
 		if !remediation.triggered {
 			if remediation.actionType == RemediationTypeNetworkIsolation {
+				// If the isolation was not triggered, set isolationPerformed to false since the ressource might have been killed
+				remediation.isolationPerformed = false
 				remediationStr = RemediationTypeNetworkIsolationStr
 			} else if remediation.actionType == RemediationTypeKill {
 				remediationStr = RemediationTypeKillStr

--- a/pkg/security/tests/action_test.go
+++ b/pkg/security/tests/action_test.go
@@ -1760,7 +1760,7 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 
 	t.Run("not-triggered-sent-at-startup", func(t *testing.T) {
 		// Allow any in-flight remediation_status from the previous subtest to be delivered, then clear again.
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		test.msgSender.flush()
 
 		newRuleDefs := []*rules.RuleDefinition{remediationNotTriggeredRule}
@@ -1813,7 +1813,7 @@ func TestRemediationCustomEventNotTriggered(t *testing.T) {
 	})
 	t.Run("not-triggered-no-event", func(t *testing.T) {
 		// Allow any in-flight remediation_status from the previous subtest to be delivered, then clear again.
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(2000 * time.Millisecond)
 		test.msgSender.flush()
 		newRuleDefs := []*rules.RuleDefinition{noEventRule}
 		if err := setTestPolicy(commonCfgDir, nil, newRuleDefs); err != nil {


### PR DESCRIPTION
### What does this PR do?
- Add a flag `isolationPerformed` to properly send remediation status update.
- Add the scope in the key for network_isolation
### Motivation
- Previously, we did not send an event to update the status after a reload because we considered the rule applied on the first ruleset (even if it did not triggered for instance).
- If we changed the scope between 2 reloads (without changing the rule ID or the filter itself), the status was incorrect because it was not taken into the key. 