### PR TITLE
[observer] Add ForEachPoint API and SeriesHandle-based storage lookups

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -423,8 +423,12 @@ type SeriesFilter struct {
 	TagMatchers map[string]string // required tag key=value pairs
 }
 
-// SeriesKey identifies a specific series.
-type SeriesKey struct {
+type SeriesHandle int
+
+// SeriesMeta describes a series discovered via ListSeries.
+// The Handle field is a stable numeric identifier for use in hot-path methods.
+type SeriesMeta struct {
+	Handle    SeriesHandle
 	Namespace string
 	Name      string
 	Tags      []string
@@ -443,33 +447,59 @@ const (
 
 // StorageReader provides read access to time series data.
 // Detectors use this to pull whatever data they need.
+//
+// Use ListSeries to discover series and obtain their numeric handles.
+// All hot-path methods take a SeriesHandle for O(1) lookups.
+//
+// Reading points: ForEachPoint and GetSeriesRange both read the same data;
+// they differ in allocation cost and ownership model.
+//
+//   - ForEachPoint reuses a pooled buffer internally — effectively zero
+//     allocation at steady state. The callback sees each point exactly once
+//     and must not retain the *Series pointer. Prefer this for streaming or
+//     incremental callers that process points one at a time.
+//
+//   - GetSeriesRange allocates a fresh []Point each call. The caller owns the
+//     returned data and may slice, index, or store it freely. Prefer this when
+//     the detector needs random access to the full window (e.g. baseline
+//     estimation, cross-series alignment).
+//
+// Use PointCountUpTo and WriteGeneration to cheaply detect new data before
+// reading points.
 type StorageReader interface {
-	// ListSeries returns keys of all series matching the filter.
-	ListSeries(filter SeriesFilter) []SeriesKey
+	// ListSeries returns metadata for all series matching the filter.
+	ListSeries(filter SeriesFilter) []SeriesMeta
 
 	// GetSeriesRange returns points within a time range (start, end].
 	// Start is exclusive, end is inclusive. Use start=0 to read from the beginning.
-	GetSeriesRange(key SeriesKey, start, end int64, agg Aggregate) *Series
+	// Allocates a new []Point slice — see interface doc for when to prefer ForEachPoint.
+	GetSeriesRange(handle SeriesHandle, start, end int64, agg Aggregate) *Series
+
+	// ForEachPoint calls fn for every point in the time range (start, end].
+	// The Series pointer and its contents are valid only for the duration of
+	// the callback. Uses a pooled buffer internally so steady-state calls
+	// do not allocate. Returns false if the series was not found.
+	ForEachPoint(handle SeriesHandle, start, end int64, agg Aggregate, fn func(*Series, Point)) bool
 
 	// PointCount returns the number of raw data points for a series without
 	// loading or converting them. Returns 0 if the series is not found.
-	PointCount(key SeriesKey) int
+	PointCount(handle SeriesHandle) int
 
 	// PointCountUpTo returns the number of raw data points with timestamp <= endTime.
 	// Uses binary search for efficiency. Returns 0 if the series is not found.
-	PointCountUpTo(key SeriesKey, endTime int64) int
+	PointCountUpTo(handle SeriesHandle, endTime int64) int
 
 	// WriteGeneration returns a per-series counter that increments on every
 	// write to that series, including same-bucket merges. Use this to detect
 	// updates to an existing series even when its point count does not change.
 	// Returns 0 if the series is not found.
-	WriteGeneration(key SeriesKey) int64
+	WriteGeneration(handle SeriesHandle) int64
 
 	// SeriesGeneration returns a global counter that increments only when the
 	// set of known series changes. Use this to cache ListSeries results and
 	// refresh them only when new series keys appear.
 	SeriesGeneration() uint64
- }
+}
 
 // Detector is the flexible detection interface where detectors pull data from storage.
 // This supports multivariate detection across multiple series.

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -12,10 +12,14 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
+// bocpdStateKey uniquely identifies a (series, aggregation) pair for BOCPD state.
+type bocpdStateKey struct {
+	seriesHandle observer.SeriesHandle
+	agg          observer.Aggregate
+}
+
 // bocpdSeriesState holds per-series streaming BOCPD state.
 type bocpdSeriesState struct {
-	key observer.SeriesKey
-	agg observer.Aggregate
 
 	// Cursor: how many points we've processed so far (count-based for safety).
 	lastProcessedTime  int64
@@ -97,13 +101,13 @@ type BOCPDDetector struct {
 	// Aggregations to run detection on. Default: [Average, Count]
 	Aggregations []observer.Aggregate
 
-	// per-series state keyed by "namespace|name|tags|agg"
-	series map[string]*bocpdSeriesState
+	// per-(series, aggregation) state.
+	series map[bocpdStateKey]*bocpdSeriesState
 
 	// Cache the discovered series list across Detect calls. Refresh when storage
 	// reports that new series were added.
-	cachedKeys []observer.SeriesKey
-	cachedGen  uint64
+	cachedSeries []observer.SeriesMeta
+	cachedGen    uint64
 }
 
 // NewBOCPDDetector creates a streaming BOCPD detector with sensible defaults.
@@ -122,7 +126,7 @@ func NewBOCPDDetector() *BOCPDDetector {
 			observer.AggregateAverage,
 			observer.AggregateCount,
 		},
-		series: make(map[string]*bocpdSeriesState),
+		series: make(map[bocpdStateKey]*bocpdSeriesState),
 	}
 }
 
@@ -139,141 +143,92 @@ func (b *BOCPDDetector) Name() string {
 // visible point counts rather than raw slice positions.
 func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
 	b.ensureDefaults()
+
 	gen := storage.SeriesGeneration()
-	if b.cachedKeys == nil || gen != b.cachedGen {
-		b.cachedKeys = storage.ListSeries(observer.SeriesFilter{})
+	if b.cachedSeries == nil || gen != b.cachedGen {
+		b.cachedSeries = storage.ListSeries(observer.SeriesFilter{})
 		b.cachedGen = gen
 	}
-	seriesKeys := b.cachedKeys
 
 	var allAnomalies []observer.Anomaly
-	var allTelemetry []observer.ObserverTelemetry
 
-	for _, key := range seriesKeys {
+	for _, meta := range b.cachedSeries {
 		for _, agg := range b.Aggregations {
-			stateKey := b.stateKey(key, agg)
+			sk := bocpdStateKey{seriesHandle: meta.Handle, agg: agg}
 
-			// Get or create per-series state.
-			state, exists := b.series[stateKey]
+			state, exists := b.series[sk]
 			if !exists {
-				state = b.newSeriesState(key, agg)
-				b.series[stateKey] = state
+				state = &bocpdSeriesState{}
+				b.series[sk] = state
 			}
 
-			// Check if there are new points or merged values.
-			visibleCount := storage.PointCountUpTo(key, dataTime)
-			currentGen := storage.WriteGeneration(key)
+			visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
+			currentGen := storage.WriteGeneration(meta.Handle)
 			mergeOccurred := visibleCount == state.lastProcessedCount && currentGen != state.lastWriteGen
 			if visibleCount <= state.lastProcessedCount && !mergeOccurred {
 				continue
 			}
 
+			startTime := state.lastProcessedTime
 			if mergeOccurred {
-				// A same-bucket merge changed values we already processed.
-				// Re-read from the start of the last processed timestamp
-				// (inclusive) by using lastProcessedTime-1 as start.
-				startTime := state.lastProcessedTime - 1
+				startTime = state.lastProcessedTime - 1
 				if startTime < 0 {
 					startTime = 0
 				}
-				series := storage.GetSeriesRange(key, startTime, dataTime, agg)
-				if series == nil || len(series.Points) == 0 {
-					state.lastWriteGen = currentGen
-					continue
-				}
-				// Re-process points from the merged timestamp onward.
-				for _, p := range series.Points {
-					anomaly, telemetry := b.processPoint(state, p, series)
-					if anomaly != nil {
-						allAnomalies = append(allAnomalies, *anomaly)
-					}
-					allTelemetry = append(allTelemetry, telemetry...)
-				}
-				state.lastProcessedTime = series.Points[len(series.Points)-1].Timestamp
-				state.lastProcessedCount = visibleCount
-				state.lastWriteGen = currentGen
-				continue
 			}
 
-			// Read only new points since last processed time.
-			series := storage.GetSeriesRange(key, state.lastProcessedTime, dataTime, agg)
-			if series == nil || len(series.Points) == 0 {
-				continue
-			}
-
-			// Process each new point incrementally.
-			for _, p := range series.Points {
-				anomaly, telemetry := b.processPoint(state, p, series)
+			pointsSeen := false
+			storage.ForEachPoint(meta.Handle, startTime, dataTime, agg, func(series *observer.Series, p observer.Point) {
+				pointsSeen = true
+				anomaly := b.processPoint(state, p, series, agg)
 				if anomaly != nil {
 					allAnomalies = append(allAnomalies, *anomaly)
 				}
-				allTelemetry = append(allTelemetry, telemetry...)
-			}
+				state.lastProcessedTime = p.Timestamp
+			})
 
-			// Update cursor.
-			state.lastProcessedTime = series.Points[len(series.Points)-1].Timestamp
-			state.lastProcessedCount = visibleCount
-			state.lastWriteGen = currentGen
+			if !pointsSeen && mergeOccurred {
+				state.lastWriteGen = currentGen
+				continue
+			}
+			if pointsSeen {
+				state.lastProcessedCount = visibleCount
+				state.lastWriteGen = currentGen
+			}
 		}
 	}
 
-	return observer.DetectionResult{Anomalies: allAnomalies, Telemetry: allTelemetry}
+	return observer.DetectionResult{Anomalies: allAnomalies}
 }
 
 // Reset clears all per-series state for replay/reanalysis.
 func (b *BOCPDDetector) Reset() {
-	b.series = make(map[string]*bocpdSeriesState)
-	b.cachedKeys = nil
+	b.series = make(map[bocpdStateKey]*bocpdSeriesState)
+	b.cachedSeries = nil
 	b.cachedGen = 0
 }
 
 // processPoint handles a single new observation for a series.
-// Returns an anomaly (if new alert onset) and telemetry for observability.
-func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, series *observer.Series) (*observer.Anomaly, []observer.ObserverTelemetry) {
+// Returns an anomaly pointer if this point triggers a new alert onset.
+func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate) *observer.Anomaly {
 	x := p.Value
 
-	// Phase 1: Warmup — accumulate baseline statistics.
 	if !state.initialized {
-		return b.warmupPoint(state, x), nil
+		return b.warmupPoint(state, x)
 	}
 
-	// Phase 2: Online BOCPD posterior update.
 	triggered, cpProb, shortRunMass := b.updatePosterior(state, x)
 
-	// Emit telemetry for cpProb and shortRunMass at each initialized point.
-	telemetry := []observer.ObserverTelemetry{
-		{
-			DetectorName: b.Name(),
-			Metric: &metricObs{
-				name:      "cp_prob",
-				value:     cpProb,
-				timestamp: p.Timestamp,
-			},
-		},
-		{
-			DetectorName: b.Name(),
-			Metric: &metricObs{
-				name:      "short_run_mass",
-				value:     shortRunMass,
-				timestamp: p.Timestamp,
-			},
-		},
-	}
-
-	// Phase 3: Alert lifecycle.
 	if triggered {
 		state.recoveryCount = 0
 		if !state.inAlert {
-			// New alert onset — emit anomaly.
 			state.inAlert = true
 			state.alertStart = p.Timestamp
-			return b.makeAnomaly(state, p, series, cpProb, shortRunMass), telemetry
+			return b.makeAnomaly(state, p, series, agg, cpProb, shortRunMass)
 		}
-		// Already in alert — suppress repeated emission.
-		return nil, telemetry
+		return nil
 	}
 
-	// Not triggered on this point.
 	if state.inAlert {
 		state.recoveryCount++
 		if state.recoveryCount >= b.RecoveryPoints {
@@ -281,7 +236,7 @@ func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, 
 			state.recoveryCount = 0
 		}
 	}
-	return nil, telemetry
+	return nil
 }
 
 // warmupPoint accumulates a point during the warmup phase using Welford's algorithm.
@@ -395,8 +350,8 @@ func (b *BOCPDDetector) updatePosterior(state *bocpdSeriesState, x float64) (boo
 }
 
 // makeAnomaly constructs an Anomaly for a new alert onset.
-func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, cpProb, shortRunMass float64) *observer.Anomaly {
-	seriesName := series.Name + ":" + aggSuffix(state.agg)
+func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, cpProb, shortRunMass float64) *observer.Anomaly {
+	seriesName := series.Name + ":" + aggSuffix(agg)
 	deviation := (p.Value - state.baselineMean) / state.baselineStddev
 
 	triggerType := "short-run posterior mass"
@@ -425,19 +380,6 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 			CurrentValue:   p.Value,
 			DeviationSigma: deviation,
 		},
-	}
-}
-
-// stateKey returns a unique key for per-series state tracking.
-func (b *BOCPDDetector) stateKey(key observer.SeriesKey, agg observer.Aggregate) string {
-	return seriesKey(key.Namespace, key.Name, key.Tags) + "|" + aggSuffix(agg)
-}
-
-// newSeriesState creates a fresh per-series state entry.
-func (b *BOCPDDetector) newSeriesState(key observer.SeriesKey, agg observer.Aggregate) *bocpdSeriesState {
-	return &bocpdSeriesState{
-		key: key,
-		agg: agg,
 	}
 }
 
@@ -471,7 +413,7 @@ func (b *BOCPDDetector) ensureDefaults() {
 		b.RecoveryPoints = 10
 	}
 	if b.series == nil {
-		b.series = make(map[string]*bocpdSeriesState)
+		b.series = make(map[bocpdStateKey]*bocpdSeriesState)
 	}
 	if len(b.Aggregations) == 0 {
 		b.Aggregations = []observer.Aggregate{

--- a/comp/observer/impl/metrics_detector_bocpd_test.go
+++ b/comp/observer/impl/metrics_detector_bocpd_test.go
@@ -283,7 +283,7 @@ func TestFindingH3_CPProbUsesOnlyPriorPredictiveNotSumOverRunLengths(t *testing.
 		MinVariance:        1.0,
 		RecoveryPoints:     10,
 		Aggregations:       []observer.Aggregate{observer.AggregateAverage},
-		series:             make(map[string]*bocpdSeriesState),
+		series:             make(map[bocpdStateKey]*bocpdSeriesState),
 	}
 
 	storage := newTimeSeriesStorage()
@@ -384,8 +384,7 @@ func TestFindingM6_BOCPDSkipsSameBucketValueMerges(t *testing.T) {
 	storage.Add("ns", "metric", 200.0, 5, nil)
 
 	// Verify storage actually merged: average should be 150, not 100.
-	key := observer.SeriesKey{Namespace: "ns", Name: "metric"}
-	series := storage.GetSeriesRange(key, 4, 5, observer.AggregateAverage)
+	series := storage.GetSeriesRange(observer.SeriesHandle(0), 4, 5, observer.AggregateAverage)
 	require.NotNil(t, series)
 	require.Len(t, series.Points, 1)
 	assert.Equal(t, 150.0, series.Points[0].Value,
@@ -418,9 +417,9 @@ func TestFindingM6_BOCPDSkipsSameBucketValueMerges(t *testing.T) {
 	}
 	genAfter := stateAfter.lastWriteGen
 
-	pointCount := storage.PointCountUpTo(key, 5)
+	pointCount := storage.PointCountUpTo(observer.SeriesHandle(0), 5)
 	t.Logf("genBefore=%d, genAfter=%d, PointCountUpTo=%d, writeGen=%d",
-		genBefore, genAfter, pointCount, storage.WriteGeneration(key))
+		genBefore, genAfter, pointCount, storage.WriteGeneration(observer.SeriesHandle(0)))
 
 	// The detector should notice the merge via writeGeneration even though
 	// PointCountUpTo didn't change. If it re-processed, genAfter > genBefore.

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -23,22 +23,22 @@ type RRCFScoredPoint struct {
 
 // RRCFScoreStats contains distribution statistics and full score history for threshold analysis.
 type RRCFScoreStats struct {
-	Enabled        bool              `json:"enabled"`
-	SampleCount    int               `json:"sampleCount"`
-	AlignedPoints  int               `json:"alignedPoints"`
-	ShinglesBuilt  int               `json:"shinglesBuilt"`
-	MinScore       float64           `json:"minScore"`
-	MaxScore       float64           `json:"maxScore"`
-	MeanScore      float64           `json:"meanScore"`
-	StddevScore    float64           `json:"stddevScore"`
-	P50            float64           `json:"p50"`
-	P75            float64           `json:"p75"`
-	P90            float64           `json:"p90"`
-	P95            float64           `json:"p95"`
-	P99            float64           `json:"p99"`
-	Config         RRCFConfigSummary `json:"config"`
-	Metrics        []string          `json:"metrics"`
-	Scores         []RRCFScoredPoint `json:"scores"`
+	Enabled       bool              `json:"enabled"`
+	SampleCount   int               `json:"sampleCount"`
+	AlignedPoints int               `json:"alignedPoints"`
+	ShinglesBuilt int               `json:"shinglesBuilt"`
+	MinScore      float64           `json:"minScore"`
+	MaxScore      float64           `json:"maxScore"`
+	MeanScore     float64           `json:"meanScore"`
+	StddevScore   float64           `json:"stddevScore"`
+	P50           float64           `json:"p50"`
+	P75           float64           `json:"p75"`
+	P90           float64           `json:"p90"`
+	P95           float64           `json:"p95"`
+	P99           float64           `json:"p99"`
+	Config        RRCFConfigSummary `json:"config"`
+	Metrics       []string          `json:"metrics"`
+	Scores        []RRCFScoredPoint `json:"scores"`
 }
 
 // RRCFConfigSummary is a JSON-friendly summary of RRCF configuration.
@@ -124,9 +124,9 @@ type RRCFDetector struct {
 	// Each metric becomes a dimension in the feature vector.
 	metrics []RRCFMetricDef
 
-	// resolvedKeys caches the actual SeriesKey (with tags) for each metric.
+	// resolvedKeys caches the numeric series ID for each metric.
 	// Populated lazily on first Detect call via ListSeries discovery.
-	resolvedKeys map[string]observer.SeriesKey
+	resolvedKeys map[string]observer.SeriesHandle
 
 	// cursors tracks read position per metric for incremental reads.
 	cursors map[string]int64
@@ -164,13 +164,13 @@ func NewRRCFDetector(config RRCFConfig) *RRCFDetector {
 	forest := newRCForest(config.NumTrees, config.TreeSize, shingleDim, 42)
 
 	return &RRCFDetector{
-		config:        config,
-		metrics:       metrics,
-		resolvedKeys:  make(map[string]observer.SeriesKey),
-		cursors:       make(map[string]int64),
-		forest:        forest,
-		recentScores:  make([]float64, 0, 100),
-		allScores:     make([]RRCFScoredPoint, 0, 1024),
+		config:       config,
+		metrics:      metrics,
+		resolvedKeys: make(map[string]observer.SeriesHandle),
+		cursors:      make(map[string]int64),
+		forest:       forest,
+		recentScores: make([]float64, 0, 100),
+		allScores:    make([]RRCFScoredPoint, 0, 1024),
 	}
 }
 
@@ -213,12 +213,12 @@ func (r *RRCFDetector) Detect(storage observer.StorageReader, dataTime int64) ob
 	return r.scoreAndDetect(shingles, dataTime)
 }
 
-// resolveKey returns the cached SeriesKey for a metric definition.
+// resolveKey returns the cached numeric series ID for a metric definition.
 // Keys are populated by resolveAllKeys on the first Detect call.
-func (r *RRCFDetector) resolveKey(m RRCFMetricDef) (observer.SeriesKey, bool) {
+func (r *RRCFDetector) resolveKey(m RRCFMetricDef) (observer.SeriesHandle, bool) {
 	cursorKey := m.Namespace + "|" + m.Name
-	key, ok := r.resolvedKeys[cursorKey]
-	return key, ok
+	id, ok := r.resolvedKeys[cursorKey]
+	return id, ok
 }
 
 // resolveAllKeys discovers series keys for all metrics at once, ensuring they share
@@ -231,22 +231,21 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 	}
 
 	// For each metric, collect all matching series grouped by tag string
-	// Collect all series per metric
-	seriesByMetric := make(map[string][]observer.SeriesKey) // cursorKey -> all matching keys
+	seriesByMetric := make(map[string][]observer.SeriesMeta) // cursorKey -> all matching series
 	for _, m := range r.metrics {
 		cursorKey := m.Namespace + "|" + m.Name
 		matches := storage.ListSeries(observer.SeriesFilter{
 			Namespace:   m.Namespace,
 			NamePattern: m.Name,
 		})
-		for _, key := range matches {
-			if key.Name == m.Name {
-				seriesByMetric[cursorKey] = append(seriesByMetric[cursorKey], key)
+		for _, meta := range matches {
+			if meta.Name == m.Name {
+				seriesByMetric[cursorKey] = append(seriesByMetric[cursorKey], meta)
 			}
 		}
 	}
 
-	// Build a tag signature for each series key
+	// Build a tag signature for each series
 	tagSig := func(tags []string) string {
 		sorted := make([]string, len(tags))
 		copy(sorted, tags)
@@ -255,14 +254,14 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 	}
 
 	// Group series by tag signature and find a tag set that has ALL metrics
-	tagSetMetrics := make(map[string]map[string]observer.SeriesKey) // tagSig -> cursorKey -> SeriesKey
-	for cursorKey, keys := range seriesByMetric {
-		for _, key := range keys {
-			sig := tagSig(key.Tags)
+	tagSetMetrics := make(map[string]map[string]observer.SeriesMeta) // tagSig -> cursorKey -> SeriesMeta
+	for cursorKey, metas := range seriesByMetric {
+		for _, meta := range metas {
+			sig := tagSig(meta.Tags)
 			if tagSetMetrics[sig] == nil {
-				tagSetMetrics[sig] = make(map[string]observer.SeriesKey)
+				tagSetMetrics[sig] = make(map[string]observer.SeriesMeta)
 			}
-			tagSetMetrics[sig][cursorKey] = key
+			tagSetMetrics[sig][cursorKey] = meta
 		}
 	}
 
@@ -278,8 +277,8 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 		}
 		// Count total points across all metrics for this tag set
 		pc := 0
-		for _, key := range metricsMap {
-			pc += storage.PointCount(key)
+		for _, meta := range metricsMap {
+			pc += storage.PointCount(meta.Handle)
 		}
 		if mc > bestMetricCount || (mc == bestMetricCount && pc > bestPointCount) {
 			bestMetricCount = mc
@@ -298,8 +297,8 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 	log.Printf("  RRCF: resolved %d metrics to tag set with %d total points\n", bestMetricCount, bestPointCount)
 
 	// Resolve all metrics to this tag set
-	for cursorKey, key := range tagSetMetrics[bestSig] {
-		r.resolvedKeys[cursorKey] = key
+	for cursorKey, meta := range tagSetMetrics[bestSig] {
+		r.resolvedKeys[cursorKey] = meta.Handle
 	}
 
 	return true
@@ -310,7 +309,7 @@ func (r *RRCFDetector) readNewPoints(storage observer.StorageReader, dataTime in
 	result := make(map[string][]observer.Point)
 
 	for _, m := range r.metrics {
-		key, found := r.resolveKey(m)
+		id, found := r.resolveKey(m)
 		if !found {
 			continue
 		}
@@ -318,7 +317,7 @@ func (r *RRCFDetector) readNewPoints(storage observer.StorageReader, dataTime in
 		cursorKey := m.Namespace + "|" + m.Name
 		cursor := r.cursors[cursorKey]
 
-		series := storage.GetSeriesRange(key, cursor, dataTime, m.Agg)
+		series := storage.GetSeriesRange(id, cursor, dataTime, m.Agg)
 		if series == nil || len(series.Points) == 0 {
 			continue
 		}
@@ -491,8 +490,8 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 				Source:       "score",
 				DetectorName: r.Name(),
 				Title:        "RRCF multivariate anomaly",
-				Description:    fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),
-				Timestamp:      s.endTimestamp,
+				Description:  fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),
+				Timestamp:    s.endTimestamp,
 				DebugInfo: &observer.AnomalyDebugInfo{
 					CurrentValue:   score,
 					Threshold:      threshold,
@@ -552,7 +551,7 @@ func (r *RRCFDetector) scoreShingle(s shingle) float64 {
 
 // Reset clears all state, useful for testing or after major regime changes.
 func (r *RRCFDetector) Reset() {
-	r.resolvedKeys = make(map[string]observer.SeriesKey)
+	r.resolvedKeys = make(map[string]observer.SeriesHandle)
 	r.cursors = make(map[string]int64)
 	r.recentScores = r.recentScores[:0]
 	r.allScores = r.allScores[:0]

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -472,26 +472,25 @@ func (a *seriesDetectorAdapter) Reset() {
 }
 
 func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
-	seriesKeys := storage.ListSeries(observerdef.SeriesFilter{})
+	allSeries := storage.ListSeries(observerdef.SeriesFilter{})
 
 	var allAnomalies []observerdef.Anomaly
 	var allTelemetry []observerdef.ObserverTelemetry
 
-	for _, key := range seriesKeys {
-		keyStr := seriesKey(key.Namespace, key.Name, key.Tags)
-		visibleCount := storage.PointCountUpTo(key, dataTime)
+	for _, meta := range allSeries {
+		keyStr := seriesKey(meta.Namespace, meta.Name, meta.Tags)
+		visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
 		if prev, ok := a.lastVisibleCount[keyStr]; ok && prev == visibleCount {
 			continue
 		}
 		a.lastVisibleCount[keyStr] = visibleCount
 
-		// Series has new data — run detector on each aggregation.
 		for _, agg := range a.aggregations {
 			start := int64(0)
 			if a.windowSec > 0 {
 				start = dataTime - a.windowSec
 			}
-			series := storage.GetSeriesRange(key, start, dataTime, agg)
+			series := storage.GetSeriesRange(meta.Handle, start, dataTime, agg)
 			if series == nil || len(series.Points) == 0 {
 				continue
 			}
@@ -511,10 +510,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 		}
 	}
 
-	return observerdef.DetectionResult{
-		Anomalies: allAnomalies,
-		Telemetry: allTelemetry,
-	}
+	return observerdef.DetectionResult{Anomalies: allAnomalies, Telemetry: allTelemetry}
 }
 
 // aggSuffix returns a short suffix for the given aggregation type.

--- a/comp/observer/impl/profile_test.go
+++ b/comp/observer/impl/profile_test.go
@@ -104,11 +104,33 @@ func BenchmarkGetSeriesRange(b *testing.B) {
 	for sec := int64(0); sec < 576; sec++ {
 		storage.Add("ns", "metric_0", 100.0+rand.Float64()*10, sec, nil)
 	}
-	key := observerdef.SeriesKey{Namespace: "ns", Name: "metric_0"}
-
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		storage.GetSeriesRange(key, 0, 576, observerdef.AggregateAverage)
+		storage.GetSeriesRange(observerdef.SeriesHandle(0), 0, 576, observerdef.AggregateAverage)
+	}
+}
+
+// BenchmarkForEachPoint isolates the ForEachPoint read path.
+func BenchmarkForEachPoint(b *testing.B) {
+	storage := newTimeSeriesStorage()
+	for sec := int64(0); sec < 576; sec++ {
+		storage.Add("ns", "metric_0", 100.0+rand.Float64()*10, sec, nil)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		storage.ForEachPoint(observerdef.SeriesHandle(0), 0, 576, observerdef.AggregateAverage, func(_ *observerdef.Series, _ observerdef.Point) {})
+	}
+}
+
+// BenchmarkForEachPoint_Small exercises ForEachPoint for a typical incremental read (5 points).
+func BenchmarkForEachPoint_Small(b *testing.B) {
+	storage := newTimeSeriesStorage()
+	for sec := int64(0); sec < 576; sec++ {
+		storage.Add("ns", "metric_0", 100.0+rand.Float64()*10, sec, nil)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		storage.ForEachPoint(observerdef.SeriesHandle(0), 570, 576, observerdef.AggregateAverage, func(_ *observerdef.Series, _ observerdef.Point) {})
 	}
 }
 
@@ -118,10 +140,8 @@ func BenchmarkPointCountUpTo(b *testing.B) {
 	for sec := int64(0); sec < 576; sec++ {
 		storage.Add("ns", "metric_0", 100.0+rand.Float64()*10, sec, nil)
 	}
-	key := observerdef.SeriesKey{Namespace: "ns", Name: "metric_0"}
-
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		storage.PointCountUpTo(key, 300)
+		storage.PointCountUpTo(observerdef.SeriesHandle(0), 300)
 	}
 }

--- a/comp/observer/impl/stateview.go
+++ b/comp/observer/impl/stateview.go
@@ -23,14 +23,14 @@ func (e *engine) StateView() *stateView {
 
 // --- Storage access ---
 
-// ListSeries returns keys of all series matching the filter.
-func (sv *stateView) ListSeries(filter observerdef.SeriesFilter) []observerdef.SeriesKey {
+// ListSeries returns metadata for all series matching the filter.
+func (sv *stateView) ListSeries(filter observerdef.SeriesFilter) []observerdef.SeriesMeta {
 	return sv.engine.storage.ListSeries(filter)
 }
 
 // GetSeriesRange returns points within a time range for a series.
-func (sv *stateView) GetSeriesRange(key observerdef.SeriesKey, start, end int64, agg observerdef.Aggregate) *observerdef.Series {
-	return sv.engine.storage.GetSeriesRange(key, start, end, agg)
+func (sv *stateView) GetSeriesRange(handle observerdef.SeriesHandle, start, end int64, agg observerdef.Aggregate) *observerdef.Series {
+	return sv.engine.storage.GetSeriesRange(handle, start, end, agg)
 }
 
 // ScenarioBounds returns the time bounds of stored data.

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -28,8 +28,14 @@ func TestStateView_StorageAccess(t *testing.T) {
 		t.Fatalf("expected 2 series, got %d", len(keys))
 	}
 
-	// GetSeriesRange
-	series := sv.GetSeriesRange(observerdef.SeriesKey{Namespace: "ns", Name: "cpu"}, 0, 200, observerdef.AggregateAverage)
+	// GetSeriesRange — find the "cpu" series ID from ListSeries
+	cpuHandle := observerdef.SeriesHandle(-1)
+	for _, m := range keys {
+		if m.Name == "cpu" {
+			cpuHandle = m.Handle
+		}
+	}
+	series := sv.GetSeriesRange(cpuHandle, 0, 200, observerdef.AggregateAverage)
 	if series == nil {
 		t.Fatal("expected series data, got nil")
 	}

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -27,9 +27,10 @@ type timeSeriesStorage struct {
 	// even if no metric series was written for that timestamp.
 	observationTimestamps map[int64]struct{}
 
-	// Compact numeric IDs for API responses; unrelated to generation tracking.
-	seriesIDs    map[string]int // internal key → numeric ID
-	seriesIDKeys []string       // numeric ID → internal key (index = ID)
+	// Compact numeric IDs for O(1) lookups and API responses.
+	seriesIDs     map[string]observer.SeriesHandle // internal key → numeric handle
+	seriesIDKeys  []string                         // numeric ID → internal key (index = ID)
+	seriesIDStats []*seriesStats                   // numeric ID → *seriesStats (index = ID)
 
 	// Global generation for the series catalog; increments only when a new
 	// series key is created, not on every write to an existing series.
@@ -46,9 +47,10 @@ type timeSeriesStorage struct {
 // Data is stored in columnar layout: parallel arrays indexed by point position.
 // Timestamps are stored in sorted order, enabling binary search for range queries.
 type seriesStats struct {
-	Namespace string
-	Name      string
-	Tags      []string
+	Namespace   string
+	Name        string
+	Tags        []string
+	internalKey string // cached map key to avoid recomputation
 
 	// writeGeneration is per-series and increments on every Add, including
 	// same-bucket merges into an existing point.
@@ -191,7 +193,7 @@ func newTimeSeriesStorage() *timeSeriesStorage {
 	return &timeSeriesStorage{
 		series:                make(map[string]*seriesStats),
 		observationTimestamps: make(map[int64]struct{}),
-		seriesIDs:             make(map[string]int),
+		seriesIDs:             make(map[string]observer.SeriesHandle),
 		droppedByMetric:       make(map[string]int64),
 		sampledDrops:          make(map[string]int),
 	}
@@ -220,15 +222,17 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	stats, exists := s.series[key]
 	if !exists {
 		stats = &seriesStats{
-			Namespace: namespace,
-			Name:      name,
-			Tags:      canonicalizeTags(tags),
+			Namespace:   namespace,
+			Name:        name,
+			Tags:        canonicalizeTags(tags),
+			internalKey: key,
 		}
 		s.series[key] = stats
-		// Assign a compact numeric ID for API responses.
-		id := len(s.seriesIDKeys)
+		// Assign a compact numeric ID.
+		id := observer.SeriesHandle(len(s.seriesIDKeys))
 		s.seriesIDs[key] = id
 		s.seriesIDKeys = append(s.seriesIDKeys, key)
+		s.seriesIDStats = append(s.seriesIDStats, stats)
 		s.seriesGen++
 	}
 	stats.writeGeneration++
@@ -520,10 +524,19 @@ func joinTags(tags []string) string {
 	}
 }
 
+// resolveByID returns the seriesStats for a numeric series ID.
+// Returns nil for out-of-range IDs. Caller must hold s.mu (read or write).
+func (s *timeSeriesStorage) resolveByID(handle observer.SeriesHandle) *seriesStats {
+	if handle < 0 || int(handle) >= len(s.seriesIDStats) {
+		return nil
+	}
+	return s.seriesIDStats[handle]
+}
+
 // seriesMeta is lightweight series metadata including point count,
 // used for API listing without materializing point data.
 type seriesMeta struct {
-	ID         int // compact numeric ID
+	Handle     observer.SeriesHandle // compact numeric handle
 	Namespace  string
 	Name       string
 	Tags       []string
@@ -540,7 +553,7 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 	for key, stats := range s.series {
 		if stats.Namespace == namespace {
 			result = append(result, seriesMeta{
-				ID:         s.seriesIDs[key],
+				Handle:     s.seriesIDs[key],
 				Namespace:  stats.Namespace,
 				Name:       stats.Name,
 				Tags:       copyTags(stats.Tags),
@@ -549,8 +562,8 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 		}
 	}
 	sort.Slice(result, func(i, j int) bool {
-		if result[i].ID != result[j].ID {
-			return result[i].ID < result[j].ID
+		if result[i].Handle != result[j].Handle {
+			return result[i].Handle < result[j].Handle
 		}
 		if result[i].Name != result[j].Name {
 			return result[i].Name < result[j].Name
@@ -562,14 +575,14 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 
 // GetSeriesByNumericID looks up a series by its compact numeric ID and returns
 // the data using the specified aggregation.
-func (s *timeSeriesStorage) GetSeriesByNumericID(id int, agg Aggregate) *observer.Series {
+func (s *timeSeriesStorage) GetSeriesByNumericID(handle observer.SeriesHandle, agg Aggregate) *observer.Series {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if id < 0 || id >= len(s.seriesIDKeys) {
+	if handle < 0 || int(handle) >= len(s.seriesIDKeys) {
 		return nil
 	}
-	key := s.seriesIDKeys[id]
+	key := s.seriesIDKeys[handle]
 	stats := s.series[key]
 	if stats == nil {
 		return nil
@@ -708,38 +721,36 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 }
 
 // FullKeyForNumericID returns the internal storage key for a compact numeric ID.
-func (s *timeSeriesStorage) FullKeyForNumericID(id int) (string, bool) {
+func (s *timeSeriesStorage) FullKeyForNumericID(handle observer.SeriesHandle) (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if id < 0 || id >= len(s.seriesIDKeys) {
+	if handle < 0 || int(handle) >= len(s.seriesIDKeys) {
 		return "", false
 	}
-	return s.seriesIDKeys[id], true
+	return s.seriesIDKeys[handle], true
 }
 
 // StorageReader interface implementation
 
-// ListSeries returns keys of all series matching the filter.
-func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.SeriesKey {
+// ListSeries returns metadata for all series matching the filter.
+func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.SeriesMeta {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var result []observer.SeriesKey
-	for _, stats := range s.series {
-		// Check namespace filter
+	var result []observer.SeriesMeta
+	for key, stats := range s.series {
 		if filter.Namespace != "" && stats.Namespace != filter.Namespace {
 			continue
 		}
-		// Check name pattern filter (prefix match)
 		if filter.NamePattern != "" && !strings.HasPrefix(stats.Name, filter.NamePattern) {
 			continue
 		}
-		// Check tag matchers
 		if !matchTags(stats.Tags, filter.TagMatchers) {
 			continue
 		}
-		result = append(result, observer.SeriesKey{
+		result = append(result, observer.SeriesMeta{
+			Handle:    s.seriesIDs[key],
 			Namespace: stats.Namespace,
 			Name:      stats.Name,
 			Tags:      stats.Tags,
@@ -749,12 +760,11 @@ func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.
 }
 
 // PointCount returns the number of raw data points for a series.
-func (s *timeSeriesStorage) PointCount(key observer.SeriesKey) int {
+func (s *timeSeriesStorage) PointCount(handle observer.SeriesHandle) int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	k := seriesKey(key.Namespace, key.Name, key.Tags)
-	if stats, ok := s.series[k]; ok {
+	if stats := s.resolveByID(handle); stats != nil {
 		return stats.pointCount()
 	}
 	return 0
@@ -762,17 +772,14 @@ func (s *timeSeriesStorage) PointCount(key observer.SeriesKey) int {
 
 // PointCountUpTo returns the number of raw data points with timestamp <= endTime.
 // Uses binary search since timestamps are sorted.
-func (s *timeSeriesStorage) PointCountUpTo(key observer.SeriesKey, endTime int64) int {
+func (s *timeSeriesStorage) PointCountUpTo(handle observer.SeriesHandle, endTime int64) int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	k := seriesKey(key.Namespace, key.Name, key.Tags)
-	stats, ok := s.series[k]
-	if !ok || stats.pointCount() == 0 {
+	stats := s.resolveByID(handle)
+	if stats == nil || stats.pointCount() == 0 {
 		return 0
 	}
-
-	// Binary search for the first timestamp > endTime.
 	return searchAfter(stats.timestamps, endTime)
 }
 
@@ -788,12 +795,11 @@ func (s *timeSeriesStorage) RecordObservationTime(timestamp int64) {
 // WriteGeneration returns a counter that increments on every Add call
 // (including same-bucket merges). Detectors use this to detect value
 // changes that don't create new buckets.
-func (s *timeSeriesStorage) WriteGeneration(key observer.SeriesKey) int64 {
+func (s *timeSeriesStorage) WriteGeneration(handle observer.SeriesHandle) int64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	k := seriesKey(key.Namespace, key.Name, key.Tags)
-	if stats, ok := s.series[k]; ok {
+	if stats := s.resolveByID(handle); stats != nil {
 		return stats.writeGeneration
 	}
 	return 0
@@ -821,12 +827,11 @@ func matchTags(tags []string, matchers map[string]string) bool {
 // GetSeriesRange returns points within a time range (start, end].
 // Start is exclusive, end is inclusive. Use start=0 to read from the beginning.
 // Uses binary search on the timestamps column for O(log N) range lookup.
-func (s *timeSeriesStorage) GetSeriesRange(key observer.SeriesKey, start, end int64, agg Aggregate) *observer.Series {
+func (s *timeSeriesStorage) GetSeriesRange(handle observer.SeriesHandle, start, end int64, agg Aggregate) *observer.Series {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	internalKey := seriesKey(key.Namespace, key.Name, key.Tags)
-	stats := s.series[internalKey]
+	stats := s.resolveByID(handle)
 	if stats == nil {
 		return nil
 	}
@@ -885,4 +890,78 @@ func (s *timeSeriesStorage) GetSeriesRange(key observer.SeriesKey, start, end in
 		Tags:      stats.Tags,
 		Points:    points,
 	}
+}
+
+// pointBufPool reuses point buffers across ForEachPoint calls to avoid
+// per-call allocation. Each buffer grows to its high-water mark and stays.
+var pointBufPool = sync.Pool{
+	New: func() any { return &[]observer.Point{} },
+}
+
+// ForEachPoint calls fn for every point in the time range (start, end].
+// The Series pointer is valid only for the duration of the callback.
+// Returns false if the series was not found.
+//
+// Points are copied under the read lock into a pooled buffer; the callback
+// runs outside the lock so callers cannot block writers.
+func (s *timeSeriesStorage) ForEachPoint(
+	handle observer.SeriesHandle, start, end int64, agg Aggregate,
+	fn func(*observer.Series, observer.Point),
+) bool {
+	bufp := pointBufPool.Get().(*[]observer.Point)
+	buf := *bufp
+
+	series, buf, ok := s.snapshotRange(handle, start, end, agg, buf)
+	if !ok {
+		*bufp = buf
+		pointBufPool.Put(bufp)
+		return false
+	}
+
+	for _, p := range buf {
+		fn(&series, p)
+	}
+
+	*bufp = buf
+	pointBufPool.Put(bufp)
+	return true
+}
+
+// snapshotRange copies points for a time range into buf under the read lock.
+// Returns the series metadata, the (potentially grown) buffer, and whether the
+// series was found.
+func (s *timeSeriesStorage) snapshotRange(
+	handle observer.SeriesHandle, start, end int64, agg Aggregate,
+	buf []observer.Point,
+) (observer.Series, []observer.Point, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	stats := s.resolveByID(handle)
+	if stats == nil {
+		return observer.Series{}, buf, false
+	}
+
+	lo := searchAfter(stats.timestamps, start)
+	hi := searchAfter(stats.timestamps, end)
+	n := hi - lo
+
+	if cap(buf) >= n {
+		buf = buf[:n]
+	} else {
+		buf = make([]observer.Point, n)
+	}
+
+	for i := 0; i < n; i++ {
+		buf[i] = observer.Point{
+			Timestamp: stats.timestamps[lo+i],
+			Value:     stats.aggregateAt(lo+i, agg),
+		}
+	}
+
+	return observer.Series{
+		Namespace: stats.Namespace,
+		Name:      stats.Name,
+		Tags:      stats.Tags,
+	}, buf, true
 }

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -259,11 +259,12 @@ func makeRangeStorage() *timeSeriesStorage {
 	return s
 }
 
-var rangeKey = observer.SeriesKey{Namespace: "ns", Name: "m"}
+// rangeID is the numeric ID for the first (and only) series added by makeRangeStorage.
+const rangeID = observer.SeriesHandle(0)
 
 func TestGetSeriesRange_EmptySeries(t *testing.T) {
 	s := newTimeSeriesStorage()
-	result := s.GetSeriesRange(observer.SeriesKey{Namespace: "ns", Name: "m"}, 0, 100, AggregateSum)
+	result := s.GetSeriesRange(observer.SeriesHandle(-1), 0, 100, AggregateSum)
 	assert.Nil(t, result)
 }
 
@@ -271,22 +272,23 @@ func TestGetSeriesRange_SinglePoint(t *testing.T) {
 	s := newTimeSeriesStorage()
 	s.Add("ns", "m", 42.0, 100, nil)
 
-	key := observer.SeriesKey{Namespace: "ns", Name: "m"}
+	// First series added gets ID 0
+	id := observer.SeriesHandle(0)
 
 	// Range that includes the point: (0, 100]
-	result := s.GetSeriesRange(key, 0, 100, AggregateSum)
+	result := s.GetSeriesRange(id, 0, 100, AggregateSum)
 	require.NotNil(t, result)
 	require.Len(t, result.Points, 1)
 	assert.Equal(t, int64(100), result.Points[0].Timestamp)
 	assert.Equal(t, 42.0, result.Points[0].Value)
 
 	// Range that excludes the point: start == point timestamp (exclusive)
-	result = s.GetSeriesRange(key, 100, 200, AggregateSum)
+	result = s.GetSeriesRange(id, 100, 200, AggregateSum)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Points)
 
 	// Range before the point
-	result = s.GetSeriesRange(key, 0, 99, AggregateSum)
+	result = s.GetSeriesRange(id, 0, 99, AggregateSum)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Points)
 }
@@ -295,7 +297,7 @@ func TestGetSeriesRange_StartExclusiveEndInclusive(t *testing.T) {
 	s := makeRangeStorage()
 
 	// (20, 40] should include 30, 40 but not 20
-	result := s.GetSeriesRange(rangeKey, 20, 40, AggregateSum)
+	result := s.GetSeriesRange(rangeID, 20, 40, AggregateSum)
 	require.NotNil(t, result)
 	require.Len(t, result.Points, 2)
 	assert.Equal(t, int64(30), result.Points[0].Timestamp)
@@ -306,14 +308,14 @@ func TestGetSeriesRange_ExactBoundaryHits(t *testing.T) {
 	s := makeRangeStorage()
 
 	// (10, 50] should include 20, 30, 40, 50 but not 10
-	result := s.GetSeriesRange(rangeKey, 10, 50, AggregateSum)
+	result := s.GetSeriesRange(rangeID, 10, 50, AggregateSum)
 	require.NotNil(t, result)
 	require.Len(t, result.Points, 4)
 	assert.Equal(t, int64(20), result.Points[0].Timestamp)
 	assert.Equal(t, int64(50), result.Points[3].Timestamp)
 
 	// (0, 10] should include only 10
-	result = s.GetSeriesRange(rangeKey, 0, 10, AggregateSum)
+	result = s.GetSeriesRange(rangeID, 0, 10, AggregateSum)
 	require.NotNil(t, result)
 	require.Len(t, result.Points, 1)
 	assert.Equal(t, int64(10), result.Points[0].Timestamp)
@@ -323,7 +325,7 @@ func TestGetSeriesRange_StartZeroReadsAll(t *testing.T) {
 	s := makeRangeStorage()
 
 	// (0, 999] with start=0 should include all 5 points
-	result := s.GetSeriesRange(rangeKey, 0, 999, AggregateSum)
+	result := s.GetSeriesRange(rangeID, 0, 999, AggregateSum)
 	require.NotNil(t, result)
 	assert.Len(t, result.Points, 5)
 }
@@ -332,12 +334,12 @@ func TestGetSeriesRange_NoOverlap(t *testing.T) {
 	s := makeRangeStorage()
 
 	// Range entirely before data
-	result := s.GetSeriesRange(rangeKey, 0, 5, AggregateSum)
+	result := s.GetSeriesRange(rangeID, 0, 5, AggregateSum)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Points)
 
 	// Range entirely after data
-	result = s.GetSeriesRange(rangeKey, 50, 100, AggregateSum)
+	result = s.GetSeriesRange(rangeID, 50, 100, AggregateSum)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Points)
 }
@@ -348,7 +350,7 @@ func TestGetSeriesRange_AllAggregates(t *testing.T) {
 	s.Add("ns", "m", 10.0, 100, nil)
 	s.Add("ns", "m", 20.0, 100, nil)
 
-	key := observer.SeriesKey{Namespace: "ns", Name: "m"}
+	id := observer.SeriesHandle(0)
 
 	for _, tc := range []struct {
 		agg      Aggregate
@@ -360,7 +362,7 @@ func TestGetSeriesRange_AllAggregates(t *testing.T) {
 		{AggregateMax, 20.0},
 		{AggregateAverage, 15.0},
 	} {
-		result := s.GetSeriesRange(key, 0, 200, tc.agg)
+		result := s.GetSeriesRange(id, 0, 200, tc.agg)
 		require.NotNil(t, result)
 		require.Len(t, result.Points, 1)
 		assert.Equal(t, tc.expected, result.Points[0].Value, "agg=%d", tc.agg)
@@ -371,23 +373,23 @@ func TestPointCountUpTo_BinarySearch(t *testing.T) {
 	s := makeRangeStorage()
 
 	// All points <= 50
-	assert.Equal(t, 5, s.PointCountUpTo(rangeKey, 50))
+	assert.Equal(t, 5, s.PointCountUpTo(rangeID, 50))
 	// Points <= 30: timestamps 10, 20, 30
-	assert.Equal(t, 3, s.PointCountUpTo(rangeKey, 30))
+	assert.Equal(t, 3, s.PointCountUpTo(rangeID, 30))
 	// Points <= 25: timestamps 10, 20
-	assert.Equal(t, 2, s.PointCountUpTo(rangeKey, 25))
+	assert.Equal(t, 2, s.PointCountUpTo(rangeID, 25))
 	// Points <= 9: none
-	assert.Equal(t, 0, s.PointCountUpTo(rangeKey, 9))
+	assert.Equal(t, 0, s.PointCountUpTo(rangeID, 9))
 	// Points <= 10: just one
-	assert.Equal(t, 1, s.PointCountUpTo(rangeKey, 10))
+	assert.Equal(t, 1, s.PointCountUpTo(rangeID, 10))
 	// Non-existent series
-	assert.Equal(t, 0, s.PointCountUpTo(observer.SeriesKey{Namespace: "x", Name: "y"}, 100))
+	assert.Equal(t, 0, s.PointCountUpTo(observer.SeriesHandle(999), 100)) // non-existent ID
 }
 
 func TestPointCount_ColumnarLayout(t *testing.T) {
 	s := makeRangeStorage()
-	assert.Equal(t, 5, s.PointCount(rangeKey))
-	assert.Equal(t, 0, s.PointCount(observer.SeriesKey{Namespace: "x", Name: "y"}))
+	assert.Equal(t, 5, s.PointCount(rangeID))
+	assert.Equal(t, 0, s.PointCount(observer.SeriesHandle(999))) // non-existent ID
 }
 
 func TestGetSeriesRange_OutOfOrderInsert(t *testing.T) {
@@ -397,8 +399,7 @@ func TestGetSeriesRange_OutOfOrderInsert(t *testing.T) {
 	s.Add("ns", "m", 10.0, 10, nil)
 	s.Add("ns", "m", 20.0, 20, nil)
 
-	key := observer.SeriesKey{Namespace: "ns", Name: "m"}
-	result := s.GetSeriesRange(key, 0, 100, AggregateSum)
+	result := s.GetSeriesRange(observer.SeriesHandle(0), 0, 100, AggregateSum)
 	require.NotNil(t, result)
 	require.Len(t, result.Points, 3)
 	assert.Equal(t, int64(10), result.Points[0].Timestamp)

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -413,7 +413,7 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, r *http.Request
 		for _, m := range metas {
 			for _, agg := range []Aggregate{AggregateAverage, AggregateCount} {
 				nameWithAgg := m.Name + ":" + aggSuffix(agg)
-				compactID := strconv.Itoa(m.ID) + ":" + aggSuffix(agg)
+				compactID := strconv.Itoa(int(m.Handle)) + ":" + aggSuffix(agg)
 				allSeries = append(allSeries, seriesInfo{
 					ID:         compactID,
 					Namespace:  m.Namespace,
@@ -447,7 +447,7 @@ func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Req
 		prefix := seriesID[:colonIdx]
 		if numericID, parseErr := strconv.Atoi(prefix); parseErr == nil {
 			aggStr := seriesID[colonIdx+1:]
-			api.handleNumericSeriesData(w, numericID, aggStr, seriesID)
+			api.handleNumericSeriesData(w, observerdef.SeriesHandle(numericID), aggStr, seriesID)
 			return
 		}
 	}
@@ -462,7 +462,7 @@ func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Req
 }
 
 // handleNumericSeriesData resolves a compact numeric ID to series data.
-func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID int, aggStr string, originalID string) {
+func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID observerdef.SeriesHandle, aggStr string, originalID string) {
 	var agg Aggregate
 	switch aggStr {
 	case "avg":


### PR DESCRIPTION
Add ForEachPoint to StorageReader for zero-allocation point iteration. It snapshots points into a pooled buffer under the read lock, then invokes the callback outside the lock so detector work doesn't extend the critical section.

Migrate StorageReader from SeriesKey (string-based map lookup) to SeriesHandle (numeric O(1) index). ListSeries now returns SeriesMeta with a stable Handle for use in all hot-path methods.

Update BOCPD to use ForEachPoint, removing its manual buffer management and collapsing the merge/normal read paths into one.