### PR TITLE
Mount SSI volumes as read-only

### DIFF
--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/init_container.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/libraryinjection/init_container.go
@@ -66,6 +66,7 @@ func (p *InitContainerProvider) InjectInjector(pod *corev1.Pod, cfg InjectorConf
 		Name:      InstrumentationVolumeName,
 		MountPath: asAbsPath(injectPackageDir),
 		SubPath:   injectPackageDir,
+		ReadOnly:  true,
 	})
 
 	// Timestamp file path for tracking init container completion
@@ -166,6 +167,7 @@ func (p *InitContainerProvider) InjectLibrary(pod *corev1.Pod, cfg LibraryConfig
 		Name:      InstrumentationVolumeName,
 		MountPath: asAbsPath(libraryPackagesDir),
 		SubPath:   libraryPackagesDir,
+		ReadOnly:  true,
 	})
 
 	return MutationResult{

--- a/pkg/ssi/testutils/pod_init_container.go
+++ b/pkg/ssi/testutils/pod_init_container.go
@@ -41,6 +41,7 @@ func initContainerVolumeMounts() []corev1.VolumeMount {
 			Name:      "datadog-auto-instrumentation",
 			MountPath: "/opt/datadog-packages/datadog-apm-inject",
 			SubPath:   "opt/datadog-packages/datadog-apm-inject",
+			ReadOnly:  true,
 		},
 		{
 			Name:      "datadog-auto-instrumentation-etc",
@@ -52,6 +53,7 @@ func initContainerVolumeMounts() []corev1.VolumeMount {
 			Name:      "datadog-auto-instrumentation",
 			MountPath: "/opt/datadog/apm/library",
 			SubPath:   "opt/datadog/apm/library",
+			ReadOnly:  true,
 		},
 	}
 }

--- a/releasenotes-dca/notes/ssi-readonly-mounts-aa64f0f252e8194c.yaml
+++ b/releasenotes-dca/notes/ssi-readonly-mounts-aa64f0f252e8194c.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Single Step Instrumentation volumes are now mounted as read-only to prevent accidental writes to SSI artifacts.


### PR DESCRIPTION
### What does this PR do?

This PR mounts SSI volumes as read-only (`readOnly: true`) for the init_container injection method, like it's done for other methods.

### Motivation

Improve security and prevent accidental modification of mounted SSI artifacts in init containers.

### Describe how you validated your changes

- Validated by unit and e2e tests
- Tested locally with injector-dev. Before, the mounted directories were writable, now they aren't.

### Additional Notes

The volume is in read-only only in the application containers, not in the init containers.