### PR TITLE
[AMCC-177][metric filterlist] Fix various bugs in filterlist component

### DIFF
--- a/comp/filterlist/def/component.go
+++ b/comp/filterlist/def/component.go
@@ -13,6 +13,7 @@ package filterlist
 
 import utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 
+// Component is the component type
 type Component interface {
 	OnUpdateMetricFilterList(func(utilstrings.Matcher, utilstrings.Matcher))
 	OnUpdateTagFilterList(func(TagMatcher))

--- a/comp/filterlist/def/component.go
+++ b/comp/filterlist/def/component.go
@@ -17,5 +17,6 @@ type Component interface {
 	OnUpdateMetricFilterList(func(utilstrings.Matcher, utilstrings.Matcher))
 	OnUpdateTagFilterList(func(TagMatcher))
 	GetMetricFilterList() utilstrings.Matcher
+	GetHistoFilterList() utilstrings.Matcher
 	GetTagFilterList() TagMatcher
 }

--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -167,7 +167,9 @@ func loadTagFilterList(entries []MetricTagListEntry, log log.Component) tagMatch
 
 // GetTagFilterList returns the current tag filterlist.
 func (fl *FilterList) GetTagFilterList() filterlist.TagMatcher {
-	return &fl.tagFilterList
+	fl.updateTagMtx.RLock()
+	defer fl.updateTagMtx.RUnlock()
+	return fl.tagFilterList
 }
 
 // GetMetricFilterList returns the current metric filterlist.
@@ -255,7 +257,7 @@ func (fl *FilterList) setTagFilterList(metricTags tagMatcher) {
 	defer fl.updateTagMtx.RUnlock()
 
 	for _, update := range fl.tagFilterListUpdate {
-		update(&fl.tagFilterList)
+		update(fl.tagFilterList)
 	}
 }
 
@@ -336,7 +338,7 @@ func (fl *FilterList) OnUpdateTagFilterList(onUpdate func(filterlist.TagMatcher)
 	fl.updateTagMtx.RLock()
 	defer fl.updateTagMtx.RUnlock()
 
-	onUpdate(&fl.tagFilterList)
+	onUpdate(fl.tagFilterList)
 }
 
 func NewFilterListReq(req Requires) Provides {

--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -321,11 +321,6 @@ func (fl *FilterList) OnUpdateMetricFilterList(onUpdate func(utilstrings.Matcher
 	fl.updateMetricMtx.Lock()
 	fl.metricFilterListUpdate = append(fl.metricFilterListUpdate, onUpdate)
 	fl.updateMetricMtx.Unlock()
-
-	fl.updateMetricMtx.RLock()
-	defer fl.updateMetricMtx.RUnlock()
-
-	onUpdate(fl.filterList, fl.histoFilterList)
 }
 
 // OnUpdateTagFilterList is called to register a callback to be called when the
@@ -334,11 +329,6 @@ func (fl *FilterList) OnUpdateTagFilterList(onUpdate func(filterlist.TagMatcher)
 	fl.updateTagMtx.Lock()
 	fl.tagFilterListUpdate = append(fl.tagFilterListUpdate, onUpdate)
 	fl.updateTagMtx.Unlock()
-
-	fl.updateTagMtx.RLock()
-	defer fl.updateTagMtx.RUnlock()
-
-	onUpdate(fl.tagFilterList)
 }
 
 func NewFilterListReq(req Requires) Provides {

--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -177,6 +177,17 @@ func (fl *FilterList) GetMetricFilterList() utilstrings.Matcher {
 	return fl.filterList
 }
 
+// GetHistoFilterList returns the current histogram-specific metric filterlist.
+// This is a subset of the full metric filterlist containing only entries that
+// match histogram aggregate suffixes. It is used by DogStatsD workers which
+// pre-filter regular metrics in listeners; only histogram-derived names need
+// post-aggregation filtering.
+func (fl *FilterList) GetHistoFilterList() utilstrings.Matcher {
+	fl.updateMetricMtx.RLock()
+	defer fl.updateMetricMtx.RUnlock()
+	return fl.histoFilterList
+}
+
 // create a list based on all `metricNames` but only containing metric names
 // with histogram aggregates suffixes.
 func (fl *FilterList) createHistogramsFilterList(metricNames []string) []string {

--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -14,7 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry"
-	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
+	filterlistdef "github.com/DataDog/datadog-agent/comp/filterlist/def"
 	rctypes "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/types"
 	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -31,7 +31,7 @@ type Requires struct {
 
 // Provides contains the RC component
 type Provides struct {
-	Comp       filterlist.Component
+	Comp       filterlistdef.Component
 	RCListener rctypes.ListenerProvider
 }
 
@@ -46,7 +46,7 @@ type FilterList struct {
 
 	log           log.Component
 	config        config.Component
-	telemetrycomp telemetry.Component
+	telemetryComp telemetry.Component
 
 	updateMetricMtx        sync.RWMutex
 	metricFilterListUpdate []func(utilstrings.Matcher, utilstrings.Matcher)
@@ -54,7 +54,7 @@ type FilterList struct {
 	histoFilterList        utilstrings.Matcher
 
 	updateTagMtx        sync.RWMutex
-	tagFilterListUpdate []func(filterlist.TagMatcher)
+	tagFilterListUpdate []func(filterlistdef.TagMatcher)
 	tagFilterList       tagMatcher
 
 	tlmMetricFilterListUpdates telemetry.SimpleCounter
@@ -64,8 +64,11 @@ type FilterList struct {
 	tlmTagFilterListSize    telemetry.SimpleGauge
 }
 
-// Load the config, registers with RC
-func NewFilterList(log log.Component, config config.Component, telemetrycomp telemetry.Component) *FilterList {
+// NewFilterList loads the local config.
+// Note that registering with RC happens via separate methods
+// (OnUpdateMetricFilterList, OnUpdateTagFilterList) called from
+// the packages that use FilterList.
+func NewFilterList(log log.Component, config config.Component, telemetryComp telemetry.Component) *FilterList {
 	// init the metric names filterlist
 	filterlist := config.GetStringSlice("metric_filterlist")
 	filterlistPrefix := config.GetBool("metric_filterlist_match_prefix")
@@ -88,16 +91,16 @@ func NewFilterList(log log.Component, config config.Component, telemetrycomp tel
 		tagFilterList: tagFilterListEntries,
 	}
 
-	tlmMetricFilterListUpdates := telemetrycomp.NewSimpleCounter("filterlist", "updates",
+	tlmMetricFilterListUpdates := telemetryComp.NewSimpleCounter("filterlist", "updates",
 		"Incremented when a reconfiguration of the metric filterlist happened",
 	)
-	tlmMetricFilterListSize := telemetrycomp.NewSimpleGauge("filterlist", "size",
+	tlmMetricFilterListSize := telemetryComp.NewSimpleGauge("filterlist", "size",
 		"Metric filter list size",
 	)
-	tlmTagFilterListUpdates := telemetrycomp.NewSimpleCounter("tag_filterlist", "updates",
+	tlmTagFilterListUpdates := telemetryComp.NewSimpleCounter("tag_filterlist", "updates",
 		"Incremented when a reconfiguration of the tag filterlist happened",
 	)
-	tlmTagFilterListSize := telemetrycomp.NewSimpleGauge("tag_filterlist", "size",
+	tlmTagFilterListSize := telemetryComp.NewSimpleGauge("tag_filterlist", "size",
 		"Tag filter list size",
 	)
 
@@ -105,7 +108,7 @@ func NewFilterList(log log.Component, config config.Component, telemetrycomp tel
 		localFilterListConfig:      localFilterListConfig,
 		config:                     config,
 		log:                        log,
-		telemetrycomp:              telemetrycomp,
+		telemetryComp:              telemetryComp,
 		tlmMetricFilterListUpdates: tlmMetricFilterListUpdates,
 		tlmMetricFilterListSize:    tlmMetricFilterListSize,
 		tlmTagFilterListUpdates:    tlmTagFilterListUpdates,
@@ -162,24 +165,24 @@ func loadTagFilterList(entries []MetricTagListEntry, log log.Component) tagMatch
 		}
 	}
 
-	return newTagMatcher(tagFilterList)
+	return newTagMatcher(tagFilterList, log)
 }
 
-// GetTagFilterList returns the current tag filterlist.
-func (fl *FilterList) GetTagFilterList() filterlist.TagMatcher {
+// GetTagFilterList returns the current tag filterlistdef.
+func (fl *FilterList) GetTagFilterList() filterlistdef.TagMatcher {
 	fl.updateTagMtx.RLock()
 	defer fl.updateTagMtx.RUnlock()
 	return fl.tagFilterList
 }
 
-// GetMetricFilterList returns the current metric filterlist.
+// GetMetricFilterList returns the current metric filterlistdef.
 func (fl *FilterList) GetMetricFilterList() utilstrings.Matcher {
 	fl.updateMetricMtx.RLock()
 	defer fl.updateMetricMtx.RUnlock()
 	return fl.filterList
 }
 
-// GetHistoFilterList returns the current histogram-specific metric filterlist.
+// GetHistoFilterList returns the current histogram-specific metric filterlistdef.
 // This is a subset of the full metric filterlist containing only entries that
 // match histogram aggregate suffixes. It is used by DogStatsD workers which
 // pre-filter regular metrics in listeners; only histogram-derived names need
@@ -201,7 +204,7 @@ func (fl *FilterList) createHistogramsFilterList(metricNames []string) []string 
 		percentileAggrs[i] = fmt.Sprintf("%dpercentile", percentile)
 	}
 
-	histoMetricNames := []string{}
+	var histoMetricNames []string
 	for _, metricName := range metricNames {
 		// metric names ending with a histogram aggregates
 		for _, aggr := range aggrs {
@@ -217,7 +220,7 @@ func (fl *FilterList) createHistogramsFilterList(metricNames []string) []string 
 		}
 	}
 
-	fl.log.Debugf("SetMetricFilterList created a histograms subsets of %d metric names", len(histoMetricNames))
+	fl.log.Debugf("SetMetricFilterList created a histograms subset of %d metric names", len(histoMetricNames))
 	return histoMetricNames
 }
 
@@ -230,9 +233,9 @@ func (fl *FilterList) SetTagFilterList(metricTags map[string]MetricTagList) {
 
 		var action action
 		if tags.Action == "exclude" {
-			action = Exclude
+			action = exclude
 		} else {
-			action = Include
+			action = include
 		}
 
 		hashedTags[name] = hashedMetricTagList{
@@ -325,7 +328,7 @@ func (fl *FilterList) OnUpdateMetricFilterList(onUpdate func(utilstrings.Matcher
 
 // OnUpdateTagFilterList is called to register a callback to be called when the
 // metric tag list is updated.
-func (fl *FilterList) OnUpdateTagFilterList(onUpdate func(filterlist.TagMatcher)) {
+func (fl *FilterList) OnUpdateTagFilterList(onUpdate func(filterlistdef.TagMatcher)) {
 	fl.updateTagMtx.Lock()
 	fl.tagFilterListUpdate = append(fl.tagFilterListUpdate, onUpdate)
 	fl.updateTagMtx.Unlock()

--- a/comp/filterlist/impl/filterlist.go
+++ b/comp/filterlist/impl/filterlist.go
@@ -175,7 +175,7 @@ func (fl *FilterList) GetTagFilterList() filterlistdef.TagMatcher {
 	return fl.tagFilterList
 }
 
-// GetMetricFilterList returns the current metric filterlistdef.
+// GetMetricFilterList returns the current metric filterlist.
 func (fl *FilterList) GetMetricFilterList() utilstrings.Matcher {
 	fl.updateMetricMtx.RLock()
 	defer fl.updateMetricMtx.RUnlock()

--- a/comp/filterlist/impl/noop_filterlist.go
+++ b/comp/filterlist/impl/noop_filterlist.go
@@ -30,8 +30,13 @@ func (*noopFilterList) GetTagFilterList() filterlist.TagMatcher {
 	return NewNoopTagMatcher()
 }
 
-// GetTagFilterList does nothing.
+// GetMetricFilterList does nothing.
 func (*noopFilterList) GetMetricFilterList() utilstrings.Matcher {
+	return utilstrings.NewMatcher([]string{}, false)
+}
+
+// GetHistoFilterList does nothing.
+func (*noopFilterList) GetHistoFilterList() utilstrings.Matcher {
 	return utilstrings.NewMatcher([]string{}, false)
 }
 

--- a/comp/filterlist/impl/noop_filterlist.go
+++ b/comp/filterlist/impl/noop_filterlist.go
@@ -10,7 +10,7 @@ import (
 	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
-// NoopFilterList is a Noop FilterList to be used for tests.
+// noopFilterList is a Noop FilterList to be used for tests.
 type noopFilterList struct{}
 
 func NewNoopFilterList() filterlist.Component {

--- a/comp/filterlist/impl/noop_filterlist.go
+++ b/comp/filterlist/impl/noop_filterlist.go
@@ -20,10 +20,8 @@ func NewNoopFilterList() filterlist.Component {
 // OnUpdateMetricFilterList does nothing.
 func (*noopFilterList) OnUpdateMetricFilterList(_ func(utilstrings.Matcher, utilstrings.Matcher)) {}
 
-// OnUpdateTagFilterList calls the callback with a noop tag matcher.
-func (*noopFilterList) OnUpdateTagFilterList(onUpdate func(filterlist.TagMatcher)) {
-	onUpdate(NewNoopTagMatcher())
-}
+// OnUpdateTagFilterList does nothing.
+func (*noopFilterList) OnUpdateTagFilterList(_ func(filterlist.TagMatcher)) {}
 
 // GetTagFilterList does nothing.
 func (*noopFilterList) GetTagFilterList() filterlist.TagMatcher {

--- a/comp/filterlist/impl/rc.go
+++ b/comp/filterlist/impl/rc.go
@@ -187,9 +187,9 @@ func (fl *FilterList) buildTagFilterListConfig(tagFilterListUpdates []filteredTa
 				hashedTags := hashTags(metric.Tags)
 				var rcAction action
 				if metric.ExcludeTag {
-					rcAction = Exclude
+					rcAction = exclude
 				} else {
-					rcAction = Include
+					rcAction = include
 				}
 				tags[metric.Name] = hashedMetricTagList{
 					action: rcAction,
@@ -217,21 +217,20 @@ func (fl *FilterList) buildTagFilterListConfig(tagFilterListUpdates []filteredTa
 // mergeMetricTagListEntry merges the given metric entry with the current entry.
 // It needs to merge with both the hashed and unhashed variants.
 func (fl *FilterList) mergeMetricTagListEntry(metric tagEntry, currentHashed hashedMetricTagList, currentEntry MetricTagListEntry) (hashedMetricTagList, MetricTagListEntry) {
-
-	if (currentHashed.action == Exclude) == metric.ExcludeTag {
+	if (currentHashed.action == exclude) == metric.ExcludeTag {
 		// Both metrics define the same action so we can just merge the list.
 		currentHashed.tags = append(currentHashed.tags, hashTags(metric.Tags)...)
 
 		// Merge unhashed tags too
 		currentEntry.Tags = append(currentEntry.Tags, metric.Tags...)
 		return currentHashed, currentEntry
-	} else if currentHashed.action == Include {
+	} else if currentHashed.action == include {
 		// We always prefer the exclude tag, overwrite the existing config with this one.
 		hashedTags := hashTags(metric.Tags)
 
 		// Overwrite unhashed entry with exclude
 		hashed := hashedMetricTagList{
-			action: Exclude,
+			action: exclude,
 			tags:   hashedTags,
 		}
 

--- a/comp/filterlist/impl/rc_test.go
+++ b/comp/filterlist/impl/rc_test.go
@@ -691,15 +691,15 @@ func TestFilterListUpdateMultipleMetrics(t *testing.T) {
 	)
 }
 
-// TestMergeMetricTagListEntry_SameActionInclude tests merging tags when both entries have Include action
+// TestMergeMetricTagListEntry_SameActionInclude tests merging tags when both entries have include action
 func TestMergeMetricTagListEntry_SameActionInclude(t *testing.T) {
 	require := require.New(t)
 
 	filterList, _ := newFilterList(t)
 
-	// Setup: current entry with Include action
+	// Setup: current entry with include action
 	currentHashed := hashedMetricTagList{
-		action: Include,
+		action: include,
 		tags:   hashTags([]string{"env", "host"}),
 	}
 	currentEntry := MetricTagListEntry{
@@ -708,7 +708,7 @@ func TestMergeMetricTagListEntry_SameActionInclude(t *testing.T) {
 		Tags:       []string{"env", "host"},
 	}
 
-	// New entry also with Include action
+	// New entry also with include action
 	newMetric := tagEntry{
 		Name:       "test.metric",
 		ExcludeTag: false,
@@ -719,7 +719,7 @@ func TestMergeMetricTagListEntry_SameActionInclude(t *testing.T) {
 	hashedResult, entryResult := filterList.mergeMetricTagListEntry(newMetric, currentHashed, currentEntry)
 
 	require.Equal(hashedResult, hashedMetricTagList{
-		action: Include,
+		action: include,
 		tags:   hashTags([]string{"env", "host", "pod", "cluster"}),
 	})
 
@@ -730,15 +730,15 @@ func TestMergeMetricTagListEntry_SameActionInclude(t *testing.T) {
 	})
 }
 
-// TestMergeMetricTagListEntry_SameActionExclude tests merging tags when both entries have Exclude action
+// TestMergeMetricTagListEntry_SameActionExclude tests merging tags when both entries have exclude action
 func TestMergeMetricTagListEntry_SameActionExclude(t *testing.T) {
 	require := require.New(t)
 
 	filterList, _ := newFilterList(t)
 
-	// Setup: current entry with Exclude action
+	// Setup: current entry with exclude action
 	currentHashed := hashedMetricTagList{
-		action: Exclude,
+		action: exclude,
 		tags:   hashTags([]string{"env", "host"}),
 	}
 	currentEntry := MetricTagListEntry{
@@ -747,7 +747,7 @@ func TestMergeMetricTagListEntry_SameActionExclude(t *testing.T) {
 		Tags:       []string{"env", "host"},
 	}
 
-	// New entry also with Exclude action
+	// New entry also with exclude action
 	newMetric := tagEntry{
 		Name:       "test.metric",
 		ExcludeTag: true,
@@ -758,7 +758,7 @@ func TestMergeMetricTagListEntry_SameActionExclude(t *testing.T) {
 	hashedResult, entryResult := filterList.mergeMetricTagListEntry(newMetric, currentHashed, currentEntry)
 
 	require.Equal(hashedResult, hashedMetricTagList{
-		action: Exclude,
+		action: exclude,
 		tags:   hashTags([]string{"env", "host", "pod", "cluster"}),
 	})
 
@@ -769,15 +769,15 @@ func TestMergeMetricTagListEntry_SameActionExclude(t *testing.T) {
 	})
 }
 
-// TestMergeMetricTagListEntry_IncludeOverriddenByExclude tests that Exclude overwrites Include
+// TestMergeMetricTagListEntry_IncludeOverriddenByExclude tests that exclude overwrites include
 func TestMergeMetricTagListEntry_IncludeOverriddenByExclude(t *testing.T) {
 	require := require.New(t)
 
 	filterList, _ := newFilterList(t)
 
-	// Setup: current entry with Include action
+	// Setup: current entry with include action
 	currentHashed := hashedMetricTagList{
-		action: Include,
+		action: include,
 		tags:   hashTags([]string{"env", "host"}),
 	}
 	currentEntry := MetricTagListEntry{
@@ -786,7 +786,7 @@ func TestMergeMetricTagListEntry_IncludeOverriddenByExclude(t *testing.T) {
 		Tags:       []string{"env", "host"},
 	}
 
-	// New entry with Exclude action (should overwrite)
+	// New entry with exclude action (should overwrite)
 	newMetric := tagEntry{
 		Name:       "test.metric",
 		ExcludeTag: true,
@@ -797,7 +797,7 @@ func TestMergeMetricTagListEntry_IncludeOverriddenByExclude(t *testing.T) {
 	hashedResult, entryResult := filterList.mergeMetricTagListEntry(newMetric, currentHashed, currentEntry)
 
 	require.Equal(hashedResult, hashedMetricTagList{
-		action: Exclude,
+		action: exclude,
 		tags:   hashTags([]string{"pod"}),
 	})
 
@@ -808,15 +808,15 @@ func TestMergeMetricTagListEntry_IncludeOverriddenByExclude(t *testing.T) {
 	})
 }
 
-// TestMergeMetricTagListEntry_ExcludeIgnoresInclude tests that Exclude entry ignores Include updates
+// TestMergeMetricTagListEntry_ExcludeIgnoresInclude tests that exclude entry ignores include updates
 func TestMergeMetricTagListEntry_ExcludeIgnoresInclude(t *testing.T) {
 	require := require.New(t)
 
 	filterList, _ := newFilterList(t)
 
-	// Setup: current entry with Exclude action
+	// Setup: current entry with exclude action
 	currentHashed := hashedMetricTagList{
-		action: Exclude,
+		action: exclude,
 		tags:   hashTags([]string{"env", "host"}),
 	}
 	currentEntry := MetricTagListEntry{
@@ -825,7 +825,7 @@ func TestMergeMetricTagListEntry_ExcludeIgnoresInclude(t *testing.T) {
 		Tags:       []string{"env", "host"},
 	}
 
-	// New entry with Include action (should be ignored)
+	// New entry with include action (should be ignored)
 	newMetric := tagEntry{
 		Name:       "test.metric",
 		ExcludeTag: false,
@@ -837,7 +837,7 @@ func TestMergeMetricTagListEntry_ExcludeIgnoresInclude(t *testing.T) {
 
 	// Results should be the original exclude
 	require.Equal(hashedResult, hashedMetricTagList{
-		action: Exclude,
+		action: exclude,
 		tags:   hashTags([]string{"env", "host"}),
 	})
 

--- a/comp/filterlist/impl/tagfilterlist.go
+++ b/comp/filterlist/impl/tagfilterlist.go
@@ -78,7 +78,7 @@ func newTagMatcher(metrics map[string]MetricTagList) tagMatcher {
 		case "":
 			action = Exclude
 		default:
-			log.Warnf("`metric_tag_filterlist.%s.action` configuration should be either `include` or `exclude`. Defaulting to `exclude`.", v.Action)
+			log.Warnf("`metric_tag_filterlist.%s.action` configuration value %q should be either `include` or `exclude`. Defaulting to `exclude`.", k, v.Action)
 			action = Exclude
 		}
 		hashed[k] = hashedMetricTagList{

--- a/comp/filterlist/impl/tagfilterlist.go
+++ b/comp/filterlist/impl/tagfilterlist.go
@@ -46,15 +46,13 @@ type hashedMetricTagList struct {
 }
 
 func NewEmptyTagMatcher() filterlist.TagMatcher {
-	matcher := tagMatcher{
+	return tagMatcher{
 		MetricTags: map[string]hashedMetricTagList{},
 	}
-	return &matcher
 }
 
 func NewTagMatcher(metrics map[string]MetricTagList) filterlist.TagMatcher {
-	matcher := newTagMatcher(metrics)
-	return &matcher
+	return newTagMatcher(metrics)
 }
 
 // NewTagMatcher creates a new instance of TagMatcher. The function takes
@@ -107,7 +105,7 @@ func tagName(tag string) string {
 // ShouldStripTags returns true if it has been configured to strip tags
 // from the given metric name. The returned tag list will be used to query
 // the tag.
-func (m *tagMatcher) ShouldStripTags(metricName string) (func(tag string) bool, bool) {
+func (m tagMatcher) ShouldStripTags(metricName string) (func(tag string) bool, bool) {
 	tm, ok := m.MetricTags[metricName]
 	if !ok {
 		return nil, false

--- a/comp/filterlist/impl/tagfilterlist.go
+++ b/comp/filterlist/impl/tagfilterlist.go
@@ -9,8 +9,8 @@ import (
 	"slices"
 	"strings"
 
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	filterlist "github.com/DataDog/datadog-agent/comp/filterlist/def"
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/twmb/murmur3"
 )
 
@@ -35,11 +35,11 @@ type MetricTagListEntry struct {
 type action bool
 
 const (
-	Exclude action = true
-	Include action = false
+	exclude action = true
+	include action = false
 )
 
-// HashedMetricTagList contains the list of tags hashed using murmur3.
+// hashedMetricTagList contains the list of tags hashed using murmur3.
 type hashedMetricTagList struct {
 	tags   []uint64
 	action action
@@ -51,15 +51,15 @@ func NewEmptyTagMatcher() filterlist.TagMatcher {
 	}
 }
 
-func NewTagMatcher(metrics map[string]MetricTagList) filterlist.TagMatcher {
-	return newTagMatcher(metrics)
+func NewTagMatcher(metrics map[string]MetricTagList, log log.Component) filterlist.TagMatcher {
+	return newTagMatcher(metrics, log)
 }
 
 // NewTagMatcher creates a new instance of TagMatcher. The function takes
 // a list of metric names and tags. Those tags are hashed using murmur3.
 // The hashed value is then used to query whether a tag should be removed
 // from a given metric.
-func newTagMatcher(metrics map[string]MetricTagList) tagMatcher {
+func newTagMatcher(metrics map[string]MetricTagList, log log.Component) tagMatcher {
 	// Store a hashed version of the tag list since that will take up
 	// less space and be faster to query.
 	hashed := make(map[string]hashedMetricTagList, len(metrics))
@@ -69,21 +69,21 @@ func newTagMatcher(metrics map[string]MetricTagList) tagMatcher {
 			tags = append(tags, murmur3.StringSum64(tag))
 		}
 
-		var action action
+		var act action
 		switch v.Action {
 		case "include":
-			action = Include
+			act = include
 		case "exclude":
-			action = Exclude
+			act = exclude
 		case "":
-			action = Exclude
+			act = exclude
 		default:
 			log.Warnf("`metric_tag_filterlist.%s.action` configuration value %q should be either `include` or `exclude`. Defaulting to `exclude`.", k, v.Action)
-			action = Exclude
+			act = exclude
 		}
 		hashed[k] = hashedMetricTagList{
 			tags:   tags,
-			action: action,
+			action: act,
 		}
 	}
 

--- a/comp/filterlist/impl/tagfilterlist_test.go
+++ b/comp/filterlist/impl/tagfilterlist_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
+
 package filterlistimpl
 
 import (
@@ -10,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/twmb/murmur3"
+
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 )
 
 func TestNewTagMatcher(t *testing.T) {
@@ -26,22 +30,22 @@ func TestNewTagMatcher(t *testing.T) {
 			Tags:   []string{"pod"},
 			Action: "invalid",
 		},
-	})
+	}, logmock.New(t))
 
 	assert.NotNil(t, matcher)
 	assert.Equal(t, matcher.MetricTags["metric1"], hashedMetricTagList{
 		tags:   []uint64{murmur3.StringSum64("env"), murmur3.StringSum64("host")},
-		action: Exclude,
+		action: exclude,
 	})
 
 	assert.Equal(t, matcher.MetricTags["metric2"], hashedMetricTagList{
 		tags:   []uint64{},
-		action: Include,
+		action: include,
 	})
 
 	assert.Equal(t, matcher.MetricTags["metric3"], hashedMetricTagList{
 		tags:   []uint64{murmur3.StringSum64("pod")},
-		action: Exclude,
+		action: exclude,
 	})
 }
 
@@ -90,7 +94,7 @@ func TestTagMatcher(t *testing.T) {
 		},
 	}
 
-	matcher := newTagMatcher(metrics)
+	matcher := newTagMatcher(metrics, logmock.New(t))
 
 	// Test metric1 tags are excluded
 	keepTagFunc, shouldStrip := matcher.ShouldStripTags("metric1")

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -297,7 +297,7 @@ func NewFlushAndSerializeInParallel(config model.Config) FlushAndSerializeInPara
 }
 
 // NewBufferedAggregator instantiates a BufferedAggregator
-func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder eventplatform.Component, haAgent haagent.Component, tagger tagger.Component, hostname string, flushInterval time.Duration) *BufferedAggregator {
+func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder eventplatform.Component, haAgent haagent.Component, tagger tagger.Component, hostname string, flushInterval time.Duration, flushFilterList utilstrings.Matcher, tagFilterList filterlist.TagMatcher) *BufferedAggregator {
 	bufferSize := pkgconfigsetup.Datadog().GetInt("aggregator_buffer_size")
 
 	agentName := flavor.GetFlavor()
@@ -359,7 +359,9 @@ func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder
 		flushAndSerializeInParallel: NewFlushAndSerializeInParallel(pkgconfigsetup.Datadog()),
 
 		filterListChan:    make(chan utilstrings.Matcher),
+		flushFilterList:   flushFilterList,
 		tagfilterListChan: make(chan filterlist.TagMatcher),
+		tagFilterList:     tagFilterList,
 	}
 
 	return aggregator

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -278,7 +278,7 @@ type BufferedAggregator struct {
 	filterListChan  chan utilstrings.Matcher
 	flushFilterList utilstrings.Matcher
 
-	tagfilterListChan chan filterlist.TagMatcher
+	tagFilterListChan chan filterlist.TagMatcher
 	tagFilterList     filterlist.TagMatcher
 }
 
@@ -297,7 +297,7 @@ func NewFlushAndSerializeInParallel(config model.Config) FlushAndSerializeInPara
 }
 
 // NewBufferedAggregator instantiates a BufferedAggregator
-func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder eventplatform.Component, haAgent haagent.Component, tagger tagger.Component, hostname string, flushInterval time.Duration, flushFilterList utilstrings.Matcher, tagFilterList filterlist.TagMatcher) *BufferedAggregator {
+func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder eventplatform.Component, haAgent haagent.Component, tagger tagger.Component, hostname string, flushInterval time.Duration, filterList filterlist.Component) *BufferedAggregator {
 	bufferSize := pkgconfigsetup.Datadog().GetInt("aggregator_buffer_size")
 
 	agentName := flavor.GetFlavor()
@@ -359,9 +359,9 @@ func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder
 		flushAndSerializeInParallel: NewFlushAndSerializeInParallel(pkgconfigsetup.Datadog()),
 
 		filterListChan:    make(chan utilstrings.Matcher),
-		flushFilterList:   flushFilterList,
-		tagfilterListChan: make(chan filterlist.TagMatcher),
-		tagFilterList:     tagFilterList,
+		flushFilterList:   filterList.GetMetricFilterList(),
+		tagFilterListChan: make(chan filterlist.TagMatcher),
+		tagFilterList:     filterList.GetTagFilterList(),
 	}
 
 	return aggregator
@@ -804,7 +804,7 @@ func (agg *BufferedAggregator) run() {
 
 		case matcher := <-agg.filterListChan:
 			agg.flushFilterList = matcher
-		case matcher := <-agg.tagfilterListChan:
+		case matcher := <-agg.tagFilterListChan:
 			agg.tagFilterList = matcher
 		case <-agg.health.C:
 		case checkItem := <-agg.checkItems:

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -167,7 +168,7 @@ func TestAddServiceCheckDefaultValues(t *testing.T) {
 	s := &MockSerializerIterableSerie{}
 	taggerComponent := taggerfxmock.SetupFakeTagger(t)
 
-	agg := NewBufferedAggregator(s, nil, nil, taggerComponent, "resolved-hostname", DefaultFlushInterval)
+	agg := NewBufferedAggregator(s, nil, nil, taggerComponent, "resolved-hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
 
 	agg.addServiceCheck(servicecheck.ServiceCheck{
 		// leave Host and Ts fields blank
@@ -200,7 +201,7 @@ func TestAddEventDefaultValues(t *testing.T) {
 
 	s := &MockSerializerIterableSerie{}
 	taggerComponent := taggerfxmock.SetupFakeTagger(t)
-	agg := NewBufferedAggregator(s, nil, nil, taggerComponent, "resolved-hostname", DefaultFlushInterval)
+	agg := NewBufferedAggregator(s, nil, nil, taggerComponent, "resolved-hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
 
 	agg.addEvent(event.Event{
 		// only populate required fields
@@ -250,7 +251,7 @@ func TestDefaultData(t *testing.T) {
 
 	s := &MockSerializerIterableSerie{}
 	taggerComponent := taggerfxmock.SetupFakeTagger(t)
-	agg := NewBufferedAggregator(s, nil, haagentmock.NewMockHaAgent(), taggerComponent, "hostname", DefaultFlushInterval)
+	agg := NewBufferedAggregator(s, nil, haagentmock.NewMockHaAgent(), taggerComponent, "hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
 
 	start := time.Now()
 
@@ -296,7 +297,7 @@ func TestDefaultSeries(t *testing.T) {
 	mockHaAgent.SetEnabled(true)
 	mockHaAgent.SetState(haagent.Active)
 
-	agg := NewBufferedAggregator(s, nil, mockHaAgent, taggerComponent, "hostname", DefaultFlushInterval)
+	agg := NewBufferedAggregator(s, nil, mockHaAgent, taggerComponent, "hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
 
 	start := time.Now()
 
@@ -651,7 +652,7 @@ func TestTags(t *testing.T) {
 			mockHaAgent := haagentmock.NewMockHaAgent().(haagentmock.Component)
 			mockHaAgent.SetEnabled(tt.haAgentEnabled)
 
-			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, tt.hostname, time.Second)
+			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, tt.hostname, time.Second, utilstrings.Matcher{}, nil)
 			agg.agentTags = tt.agentTags
 			agg.globalTags = tt.globalTags
 			assert.ElementsMatch(t, tt.want, agg.tags(tt.withVersion))
@@ -683,7 +684,7 @@ func TestConfigIDTags(t *testing.T) {
 			taggerComponent := taggerfxmock.SetupFakeTagger(t)
 			mockHaAgent := haagentmock.NewMockHaAgent().(haagentmock.Component)
 
-			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, "my-hostname", time.Second)
+			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, "my-hostname", time.Second, utilstrings.Matcher{}, nil)
 			assert.ElementsMatch(t, tt.want, agg.configIDTags())
 		})
 	}
@@ -715,7 +716,7 @@ func TestAddDJMRecurrentSeries(t *testing.T) {
 	s := &MockSerializerIterableSerie{}
 	// NewBufferedAggregator with DJM enable will create a new recurrentSeries
 	taggerComponent := taggerfxmock.SetupFakeTagger(t)
-	NewBufferedAggregator(s, nil, nil, taggerComponent, "hostname", DefaultFlushInterval)
+	NewBufferedAggregator(s, nil, nil, taggerComponent, "hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
 
 	expectedRecurrentSeries := metrics.Series{&metrics.Serie{
 		Name:   "datadog.djm.agent_host",

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagset"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
@@ -168,7 +167,7 @@ func TestAddServiceCheckDefaultValues(t *testing.T) {
 	s := &MockSerializerIterableSerie{}
 	taggerComponent := taggerfxmock.SetupFakeTagger(t)
 
-	agg := NewBufferedAggregator(s, nil, nil, taggerComponent, "resolved-hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
+	agg := NewBufferedAggregator(s, nil, nil, taggerComponent, "resolved-hostname", DefaultFlushInterval, filterlistmock.NewMockFilterList())
 
 	agg.addServiceCheck(servicecheck.ServiceCheck{
 		// leave Host and Ts fields blank
@@ -201,7 +200,7 @@ func TestAddEventDefaultValues(t *testing.T) {
 
 	s := &MockSerializerIterableSerie{}
 	taggerComponent := taggerfxmock.SetupFakeTagger(t)
-	agg := NewBufferedAggregator(s, nil, nil, taggerComponent, "resolved-hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
+	agg := NewBufferedAggregator(s, nil, nil, taggerComponent, "resolved-hostname", DefaultFlushInterval, filterlistmock.NewMockFilterList())
 
 	agg.addEvent(event.Event{
 		// only populate required fields
@@ -251,7 +250,7 @@ func TestDefaultData(t *testing.T) {
 
 	s := &MockSerializerIterableSerie{}
 	taggerComponent := taggerfxmock.SetupFakeTagger(t)
-	agg := NewBufferedAggregator(s, nil, haagentmock.NewMockHaAgent(), taggerComponent, "hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
+	agg := NewBufferedAggregator(s, nil, haagentmock.NewMockHaAgent(), taggerComponent, "hostname", DefaultFlushInterval, filterlistmock.NewMockFilterList())
 
 	start := time.Now()
 
@@ -297,7 +296,7 @@ func TestDefaultSeries(t *testing.T) {
 	mockHaAgent.SetEnabled(true)
 	mockHaAgent.SetState(haagent.Active)
 
-	agg := NewBufferedAggregator(s, nil, mockHaAgent, taggerComponent, "hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
+	agg := NewBufferedAggregator(s, nil, mockHaAgent, taggerComponent, "hostname", DefaultFlushInterval, filterlistmock.NewMockFilterList())
 
 	start := time.Now()
 
@@ -652,7 +651,7 @@ func TestTags(t *testing.T) {
 			mockHaAgent := haagentmock.NewMockHaAgent().(haagentmock.Component)
 			mockHaAgent.SetEnabled(tt.haAgentEnabled)
 
-			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, tt.hostname, time.Second, utilstrings.Matcher{}, nil)
+			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, tt.hostname, time.Second, filterlistmock.NewMockFilterList())
 			agg.agentTags = tt.agentTags
 			agg.globalTags = tt.globalTags
 			assert.ElementsMatch(t, tt.want, agg.tags(tt.withVersion))
@@ -684,7 +683,7 @@ func TestConfigIDTags(t *testing.T) {
 			taggerComponent := taggerfxmock.SetupFakeTagger(t)
 			mockHaAgent := haagentmock.NewMockHaAgent().(haagentmock.Component)
 
-			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, "my-hostname", time.Second, utilstrings.Matcher{}, nil)
+			agg := NewBufferedAggregator(nil, nil, mockHaAgent, taggerComponent, "my-hostname", time.Second, filterlistmock.NewMockFilterList())
 			assert.ElementsMatch(t, tt.want, agg.configIDTags())
 		})
 	}
@@ -716,7 +715,7 @@ func TestAddDJMRecurrentSeries(t *testing.T) {
 	s := &MockSerializerIterableSerie{}
 	// NewBufferedAggregator with DJM enable will create a new recurrentSeries
 	taggerComponent := taggerfxmock.SetupFakeTagger(t)
-	NewBufferedAggregator(s, nil, nil, taggerComponent, "hostname", DefaultFlushInterval, utilstrings.Matcher{}, nil)
+	NewBufferedAggregator(s, nil, nil, taggerComponent, "hostname", DefaultFlushInterval, filterlistmock.NewMockFilterList())
 
 	expectedRecurrentSeries := metrics.Series{&metrics.Serie{
 		Name:   "datadog.djm.agent_host",

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -93,7 +93,7 @@ func (cs *CheckSampler) newSketchSeries(ck ckey.ContextKey, points []metrics.Ske
 	return ss
 }
 
-func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket, filterList filterlist.TagMatcher) {
+func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket, tagFilterList filterlist.TagMatcher) {
 	if bucket.Value < 0 {
 		if !cs.logThrottling.ShouldThrottle() {
 			log.Warnf("Negative bucket value %d for metric %s discarding", bucket.Value, bucket.Name)
@@ -116,7 +116,7 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket, filterList fi
 		return
 	}
 
-	contextKey := cs.contextResolver.trackContext(bucket, filterList)
+	contextKey := cs.contextResolver.trackContext(bucket, tagFilterList)
 
 	// if the bucket is monotonic and we have already seen the bucket we only send the delta
 	if bucket.Monotonic {

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -107,7 +107,7 @@ func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSample
 	defer cr.taggerBuffer.Reset()
 	defer cr.metricBuffer.Reset()
 
-	if metricSampleContext.GetMetricType() == metrics.DistributionType {
+	if filterList != nil && metricSampleContext.GetMetricType() == metrics.DistributionType {
 		if tagMatcher, strip := filterList.ShouldStripTags(metricSampleContext.GetName()); strip {
 			// Currently only distributions are supported, strip out tags if it is configured to remove tags for this given
 			// metric.

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
@@ -324,7 +325,7 @@ func testTrackContextStrippingOriginTags(t *testing.T, store *tags.Store) {
 			Tags:   []string{"env", "pod_name"},
 			Action: "exclude",
 		},
-	})
+	}, logmock.New(t))
 
 	fakeTagger := setupTagger(t)
 
@@ -372,7 +373,7 @@ func testTrackContextStrippingOriginTagsDiffers(t *testing.T, store *tags.Store)
 			Tags:   []string{"env"},
 			Action: "exclude",
 		},
-	})
+	}, logmock.New(t))
 
 	fakeTagger := setupTagger(t)
 
@@ -415,7 +416,7 @@ func testTrackContextStrippingMetricTags(t *testing.T, store *tags.Store) {
 			Tags:   []string{"env", "pod_name", "thing"},
 			Action: "exclude",
 		},
-	})
+	}, logmock.New(t))
 
 	fakeTagger := setupTagger(t)
 
@@ -462,7 +463,7 @@ func testTrackContextStrippingMetricTagsDiffers(t *testing.T, store *tags.Store)
 			Tags:   []string{"env", "pod_name"},
 			Action: "exclude",
 		},
-	})
+	}, logmock.New(t))
 
 	fakeTagger := setupTagger(t)
 
@@ -505,7 +506,7 @@ func testTrackContextGaugesTagsUnstripped(t *testing.T, store *tags.Store) {
 			Tags:   []string{"env", "pod_name"},
 			Action: "exclude",
 		},
-	})
+	}, logmock.New(t))
 
 	fakeTagger := setupTagger(t)
 

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -189,7 +189,7 @@ func initAgentDemultiplexer(log log.Component,
 
 		statsdWorkers[i] = newTimeSamplerWorker(statsdSampler, options.FlushInterval,
 			bufferSize, metricSamplePool, agg.flushAndSerializeInParallel, tagsStore,
-			filterList.GetMetricFilterList(), filterList.GetTagFilterList())
+			filterList.GetHistoFilterList(), filterList.GetTagFilterList())
 	}
 
 	var noAggWorker *noAggregationStreamWorker

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -167,8 +167,7 @@ func initAgentDemultiplexer(log log.Component,
 	// prepare the embedded aggregator
 	// --
 
-	agg := NewBufferedAggregator(sharedSerializer, eventPlatformForwarder, haAgent, tagger, hostname, options.FlushInterval,
-		filterList.GetMetricFilterList(), filterList.GetTagFilterList())
+	agg := NewBufferedAggregator(sharedSerializer, eventPlatformForwarder, haAgent, tagger, hostname, options.FlushInterval, filterList)
 
 	// statsd samplers
 	// ---------------
@@ -516,7 +515,7 @@ func (d *AgentDemultiplexer) GetEventPlatformForwarder() (eventplatform.Forwarde
 	return d.aggregator.GetEventPlatformForwarder()
 }
 
-func (d *AgentDemultiplexer) SetAggregatorTagFilterList(tagmatcher filterlist.TagMatcher) {
+func (d *AgentDemultiplexer) SetAggregatorTagFilterList(tagMatcher filterlist.TagMatcher) {
 	d.m.RLock()
 	defer d.m.RUnlock()
 
@@ -526,10 +525,10 @@ func (d *AgentDemultiplexer) SetAggregatorTagFilterList(tagmatcher filterlist.Ta
 		return
 	}
 
-	d.aggregator.tagfilterListChan <- tagmatcher
+	d.aggregator.tagFilterListChan <- tagMatcher
 
 	for _, worker := range d.statsd.workers {
-		worker.tagFilterListChan <- tagmatcher
+		worker.tagFilterListChan <- tagMatcher
 	}
 }
 

--- a/pkg/aggregator/demultiplexer_agent.go
+++ b/pkg/aggregator/demultiplexer_agent.go
@@ -167,7 +167,8 @@ func initAgentDemultiplexer(log log.Component,
 	// prepare the embedded aggregator
 	// --
 
-	agg := NewBufferedAggregator(sharedSerializer, eventPlatformForwarder, haAgent, tagger, hostname, options.FlushInterval)
+	agg := NewBufferedAggregator(sharedSerializer, eventPlatformForwarder, haAgent, tagger, hostname, options.FlushInterval,
+		filterList.GetMetricFilterList(), filterList.GetTagFilterList())
 
 	// statsd samplers
 	// ---------------
@@ -298,9 +299,8 @@ func (d *AgentDemultiplexer) run() {
 		go d.noAggStreamWorker.run()
 	}
 
-	// It is important to set this up after the statsd workers have been started
-	// to make sure they are running to receive the initial filter list and any
-	// updates
+	// It is important to register callbacks after the statsd workers have been started
+	// to make sure they are running to receive any filter list updates
 	d.filterList.OnUpdateMetricFilterList(d.SetSamplersFilterList)
 	d.filterList.OnUpdateTagFilterList(d.SetAggregatorTagFilterList)
 

--- a/pkg/aggregator/demultiplexer_agent_test.go
+++ b/pkg/aggregator/demultiplexer_agent_test.go
@@ -234,7 +234,7 @@ func TestUpdateTagFilterList(t *testing.T) {
 	// After initial setup, we have filterlist from the configuration file.
 	// It may take a little time as it has to be sent to a separate routine.
 	require.Eventually(func() bool {
-		return len(demux.aggregator.tagfilterListChan) == 0
+		return len(demux.aggregator.tagFilterListChan) == 0
 	}, time.Second, time.Millisecond, "aggregator should consume the tagfilterList update")
 
 	// Tag 1 and 2 are excluded
@@ -251,7 +251,7 @@ func TestUpdateTagFilterList(t *testing.T) {
 
 	// Ensure the new filter list has been sent.
 	require.Eventually(func() bool {
-		return len(demux.aggregator.tagfilterListChan) == 0
+		return len(demux.aggregator.tagFilterListChan) == 0
 	}, time.Second, time.Millisecond, "aggregator should consume the tagfilterList update")
 
 	testCountBlocked([]string{"tag1:one", "tag2:two", "tag3:three"}, 62.0)

--- a/pkg/collector/corechecks/snmp/integration_profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/integration_profile_metadata_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
@@ -41,7 +42,7 @@ func TestProfileMetadata_f5(t *testing.T) {
 	setupHostname(t)
 	cfg := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	cfg.SetWithoutSource("confd_path", invalidPath)
 

--- a/pkg/collector/corechecks/snmp/integration_profile_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/integration_profile_metadata_test.go
@@ -19,11 +19,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
+	filterlistimpl "github.com/DataDog/datadog-agent/comp/filterlist/impl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
@@ -42,7 +42,7 @@ func TestProfileMetadata_f5(t *testing.T) {
 	setupHostname(t)
 	cfg := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	cfg.SetWithoutSource("confd_path", invalidPath)
 

--- a/pkg/collector/corechecks/snmp/integration_topology_test.go
+++ b/pkg/collector/corechecks/snmp/integration_topology_test.go
@@ -19,10 +19,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
+	filterlistimpl "github.com/DataDog/datadog-agent/comp/filterlist/impl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
@@ -35,7 +35,7 @@ func TestTopologyPayload_LLDP(t *testing.T) {
 	setupHostname(t)
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	mockConfig.SetWithoutSource("confd_path", invalidPath)
 
@@ -806,7 +806,7 @@ profiles:
 func TestTopologyPayload_CDP(t *testing.T) {
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	mockConfig.SetWithoutSource("confd_path", invalidPath)
 
@@ -1567,7 +1567,7 @@ profiles:
 func TestTopologyPayload_CDPSecondaryIP(t *testing.T) {
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	mockConfig.SetWithoutSource("confd_path", invalidPath)
 
@@ -2329,7 +2329,7 @@ profiles:
 func TestTopologyPayload_LLDP_CDP(t *testing.T) {
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	mockConfig.SetWithoutSource("confd_path", invalidPath)
 

--- a/pkg/collector/corechecks/snmp/integration_topology_test.go
+++ b/pkg/collector/corechecks/snmp/integration_topology_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/checkconfig"
@@ -34,7 +35,7 @@ func TestTopologyPayload_LLDP(t *testing.T) {
 	setupHostname(t)
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	mockConfig.SetWithoutSource("confd_path", invalidPath)
 
@@ -805,7 +806,7 @@ profiles:
 func TestTopologyPayload_CDP(t *testing.T) {
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	mockConfig.SetWithoutSource("confd_path", invalidPath)
 
@@ -1566,7 +1567,7 @@ profiles:
 func TestTopologyPayload_CDPSecondaryIP(t *testing.T) {
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	mockConfig.SetWithoutSource("confd_path", invalidPath)
 
@@ -2328,7 +2329,7 @@ profiles:
 func TestTopologyPayload_LLDP_CDP(t *testing.T) {
 	mockConfig := configmock.New(t)
 	timeNow = common.MockTimeNow
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
 	invalidPath, _ := filepath.Abs(filepath.Join("internal", "test", "metadata.d"))
 	mockConfig.SetWithoutSource("confd_path", invalidPath)
 

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
+	filterlistimpl "github.com/DataDog/datadog-agent/comp/filterlist/impl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/internal/profile"
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
@@ -27,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 func setupHostname(t *testing.T) {
@@ -40,7 +40,7 @@ func TestConfigurations(t *testing.T) {
 	setupHostname(t)
 
 	profile.SetConfdPathAndCleanProfiles()
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -352,7 +352,7 @@ profiles:
 func TestInlineProfileConfiguration(t *testing.T) {
 	setupHostname(t)
 	profile.SetConfdPathAndCleanProfiles()
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 
 	// language=yaml
 	rawInstanceConfig := []byte(`

--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 func setupHostname(t *testing.T) {
@@ -39,7 +40,7 @@ func TestConfigurations(t *testing.T) {
 	setupHostname(t)
 
 	profile.SetConfdPathAndCleanProfiles()
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -351,7 +352,7 @@ profiles:
 func TestInlineProfileConfiguration(t *testing.T) {
 	setupHostname(t)
 	profile.SetConfdPathAndCleanProfiles()
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
 
 	// language=yaml
 	rawInstanceConfig := []byte(`

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
+	filterlistimpl "github.com/DataDog/datadog-agent/comp/filterlist/impl"
 	"github.com/DataDog/datadog-agent/comp/metadata/inventorychecks/inventorychecksimpl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
@@ -31,7 +32,6 @@ import (
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 const systemdVersion = "241"
@@ -1226,7 +1226,7 @@ unit_names:
 func TestCheckID(t *testing.T) {
 	check1 := newCheck()
 	check2 := newCheck()
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 
 	// language=yaml
 	rawInstanceConfig1 := []byte(`

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -31,6 +31,7 @@ import (
 	checkid "github.com/DataDog/datadog-agent/pkg/collector/check/id"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/metrics/servicecheck"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 const systemdVersion = "241"
@@ -1225,7 +1226,7 @@ unit_names:
 func TestCheckID(t *testing.T) {
 	check1 := newCheck()
 	check2 := newCheck()
-	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, nooptagger.NewComponent(), "", 1*time.Hour, utilstrings.Matcher{}, nil)
 
 	// language=yaml
 	rawInstanceConfig1 := []byte(`

--- a/test/benchmarks/kubernetes_state/main.go
+++ b/test/benchmarks/kubernetes_state/main.go
@@ -25,10 +25,10 @@ import (
 	"k8s.io/kube-state-metrics/v2/pkg/options"
 
 	nooptagger "github.com/DataDog/datadog-agent/comp/core/tagger/impl-noop"
+	filterlistimpl "github.com/DataDog/datadog-agent/comp/filterlist/impl"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	cluster "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm"
 	kubestatemetrics "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder"
-	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 const (
@@ -212,7 +212,7 @@ func main() {
 	 * As it has a `nil` serializer, it will panic if it tries to flush the metrics.
 	 * That’s why we need a big enough flush interval
 	 */
-	aggregator.NewBufferedAggregator(nil, nil, nil, taggerComponent, "", 1*time.Hour, utilstrings.Matcher{}, nil)
+	aggregator.NewBufferedAggregator(nil, nil, nil, taggerComponent, "", 1*time.Hour, filterlistimpl.NewNoopFilterList())
 
 	/*
 	 * Wait for informers to get populated

--- a/test/benchmarks/kubernetes_state/main.go
+++ b/test/benchmarks/kubernetes_state/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	cluster "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm"
 	kubestatemetrics "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder"
+	utilstrings "github.com/DataDog/datadog-agent/pkg/util/strings"
 )
 
 const (
@@ -211,7 +212,7 @@ func main() {
 	 * As it has a `nil` serializer, it will panic if it tries to flush the metrics.
 	 * That’s why we need a big enough flush interval
 	 */
-	aggregator.NewBufferedAggregator(nil, nil, nil, taggerComponent, "", 1*time.Hour)
+	aggregator.NewBufferedAggregator(nil, nil, nil, taggerComponent, "", 1*time.Hour, utilstrings.Matcher{}, nil)
 
 	/*
 	 * Wait for informers to get populated

--- a/test/new-e2e/tests/agent-metric-pipelines/metric-filterlist/docs.go
+++ b/test/new-e2e/tests/agent-metric-pipelines/metric-filterlist/docs.go
@@ -1,0 +1,7 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package metricfilterlist contains e2e tests for the metric_filterlist feature.
+package metricfilterlist

--- a/test/new-e2e/tests/agent-metric-pipelines/metric-filterlist/metric_filterlist_nix_test.go
+++ b/test/new-e2e/tests/agent-metric-pipelines/metric-filterlist/metric_filterlist_nix_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package metricfilterlist contains e2e tests for the metric_filterlist feature.
+package metricfilterlist
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+const (
+	allowedMetric = "e2e.metric.filterlist.allowed"
+	blockedMetric = "e2e.metric.filterlist.blocked"
+)
+
+type metricFilterListSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+// TestMetricFilterList runs the metric_filterlist e2e test on Linux.
+func TestMetricFilterList(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &metricFilterListSuite{}, e2e.WithProvisioner(
+		awshost.Provisioner(
+			awshost.WithRunOptions(
+				scenec2.WithAgentOptions(
+					agentparams.WithAgentConfig(fmt.Sprintf(`
+metric_filterlist:
+  - "%s"
+`, blockedMetric)),
+				),
+			),
+		),
+	))
+}
+
+// sendStatsdGauge sends a DogStatsD gauge metric to the agent via UDP on the remote host.
+func (s *metricFilterListSuite) sendStatsdGauge(name string, value int) {
+	cmd := fmt.Sprintf(`bash -c 'echo -n "%s:%d|g" > /dev/udp/127.0.0.1/8125'`, name, value)
+	s.Env().RemoteHost.MustExecute(cmd)
+}
+
+// TestMetricFilterListBlocksMetric verifies that:
+//   - a metric listed in metric_filterlist is NOT forwarded to the intake
+//   - a metric NOT in metric_filterlist IS forwarded normally
+func (s *metricFilterListSuite) TestMetricFilterListBlocksMetric() {
+	// Send both metrics on each retry so metrics keep flowing until the pipeline confirms a flush.
+	require.EventuallyWithT(s.T(), func(c *assert.CollectT) {
+		s.sendStatsdGauge(allowedMetric, 1)
+		s.sendStatsdGauge(blockedMetric, 1)
+
+		metrics, err := s.Env().FakeIntake.Client().FilterMetrics(allowedMetric)
+		assert.NoError(c, err)
+		assert.NotEmpty(c, metrics, "allowed metric should be forwarded to fakeintake")
+	}, 2*time.Minute, 5*time.Second, "timed out waiting for allowed metric to reach fakeintake")
+
+	// At this point the aggregation pipeline has flushed at least once.
+	// Verify the blocked metric never reached fakeintake.
+	metrics, err := s.Env().FakeIntake.Client().FilterMetrics(blockedMetric)
+	require.NoError(s.T(), err)
+	assert.Empty(s.T(), metrics, "filtered metric should not have been forwarded to fakeintake")
+}


### PR DESCRIPTION
## What does this PR do?

This PR fixes several bugs in the `comp/filterlist` component that handles metric and tag filter lists (used by the `metric_filterlist` feature), and adds an e2e test for metric filtering (in order to prevent any re-occurence of the regression fixed in #47604)

### Reviewer tips
* the PR has been split into small commits that can be reviewed separately
* Leaving aside test files, only agent-metric-pipelines-owned files are actually modified

### Fixes

- **(mid/high impact) Data race in `GetTagFilterList` and tag filter callbacks**: `GetTagFilterList` previously returned `&fl.tagFilterList` without holding a lock; callbacks passed the same pointer to long-running workers, causing a race when `setTagFilterList` overwrote the value concurrently. Fixed by making `GetTagFilterList` return under `RLock`. For idiomatic and to be future proof, also changed `GetTagFilterList` to return the value rather than a pointer (and changed the `ShouldStripTags` method accordingly to use a value receiver)

- **(low impact) Incorrect filter list used during DogStatsD worker initialization**: Workers were initialized with `GetMetricFilterList()` (the full filter list) but subsequently updated via `SetSamplersFilterList` with the histogram-specific subset. This caused over-filtering between startup and the first `OnUpdateMetricFilterList` callback. Fixed by adding `GetHistoFilterList()` to the interface and using it at worker initialization. Low impact because in practice this "over-filtering" should never actually impact which metrics are actually filtered or not (it only impacts performance slightly because a larger filter list is unnecessarily used).

- **(low impact) Immediate callback invocation on registration (`OnUpdate*`)**: Registration callbacks now only register; callers initialize via `Get*()` methods directly. Initial filter list values are passed to `NewBufferedAggregator` at construction time, eliminating the post-constructor assignment pattern. Added nil-guard for `TagMatcher` in `trackContext`.

- **(low impact) Wrong logger used in `tagfilterlist.go`**: The file imported the trace agent logger instead of the correct one.

- **(low impact) Warning log format in `tagfilterlist`**: Fixed format string.

### E2E Test

Added a new E2E test suite under `test/new-e2e/tests/agent-metric-pipelines/metric-filterlist/` that verifies:
- Metrics listed in `metric_filterlist` are **not** forwarded to the intake.
- Unlisted metrics **are** forwarded normally.

Uses the `awshost` provisioner with DogStatsD UDP delivery and `fakeintake` for assertions.

## Describe how you validated your changes

All changes should be covered by unit tests. No additional manual testing was performed.

## Additional Notes
