### PR TITLE
libdd_discovery: build as a static library

### DIFF
--- a/pkg/discovery/module/rust/.gitignore
+++ b/pkg/discovery/module/rust/.gitignore
@@ -1,2 +1,3 @@
 target
 system-probe-lite
+*.a

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
-load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_shared_library", "rust_test")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_static_library", "rust_test")
 
 # ============================================================================
 # Library Targets (rlib + cdylib)
@@ -50,8 +50,8 @@ rust_library(
     ],
 )
 
-# Shared library (cdylib) for FFI/cgo integration
-rust_shared_library(
+# Static library (staticlib) for FFI integration
+rust_static_library(
     name = "libdd_discovery",
     srcs = glob(
         ["src/**/*.rs"],

--- a/pkg/discovery/module/rust/Cargo.toml
+++ b/pkg/discovery/module/rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 
 [lib]
 name = "dd_discovery"
-crate-type = ["rlib", "cdylib"]
+crate-type = ["rlib", "staticlib"]
 
 [[bin]]
 name = "system-probe-lite"

--- a/pkg/discovery/module/rust/README.md
+++ b/pkg/discovery/module/rust/README.md
@@ -12,16 +12,16 @@ cargo build --release --bin system-probe-lite
 
 The binary will be located at `target/release/system-probe-lite`.
 
-### Build the Shared Library
+### Build the Static Library
 
-The `dd-discovery` shared library (`libdd_discovery.so`) contains the service
+The `dd-discovery` static library (`libdd_discovery.a`) contains the service
 discovery logic and exposes a C FFI for use from other languages (e.g., Go via cgo):
 
 ```bash
 cargo build --release --lib
 ```
 
-The shared library will be located at `target/release/libdd_discovery.so`.
+The static library will be located at `target/release/libdd_discovery.a`.
 
 #### FFI Interface
 
@@ -39,7 +39,7 @@ from the Rust FFI types using [cbindgen](https://github.com/mozilla/cbindgen).
 cargo build --release
 ```
 
-This builds both the binary and the shared library.
+This builds both the binary and the static library.
 
 ## Development
 


### PR DESCRIPTION
### What does this PR do?

This PR changes `libdd_discovery` to be built as a static library instead of a shared library.

### Motivation

The shared library was not bringing anything except needing to set `LD_LIBRARY_PATH` to run system-probe.

### Describe how you validated your changes

### Additional Notes
