### PR TITLE
Fix observer scorer: first post-onset match, drop greedy matching

### DIFF
--- a/cmd/observer-scorer/main.go
+++ b/cmd/observer-scorer/main.go
@@ -54,8 +54,8 @@ func main() {
 	fmt.Printf("Gaussian F1 Score\n")
 	fmt.Printf("  Input:       %s\n", *outputPath)
 	fmt.Printf("  Sigma:       %.1fs\n", *sigma)
-	fmt.Printf("  Predictions: %d scored, %d warmup filtered, %d cascading filtered\n",
-		result.NumPredictions, result.NumFilteredWarmup, result.NumFilteredCascading)
+	fmt.Printf("  Predictions: %d scored, %d warmup filtered\n",
+		result.NumPredictions, result.NumFilteredWarmup)
 	fmt.Println()
 	fmt.Printf("  F1:        %.4f\n", result.F1)
 	fmt.Printf("  Precision: %.4f\n", result.Precision)

--- a/cmd/observer-scorer/main.go
+++ b/cmd/observer-scorer/main.go
@@ -54,8 +54,8 @@ func main() {
 	fmt.Printf("Gaussian F1 Score\n")
 	fmt.Printf("  Input:       %s\n", *outputPath)
 	fmt.Printf("  Sigma:       %.1fs\n", *sigma)
-	fmt.Printf("  Predictions: %d scored, %d warmup filtered\n",
-		result.NumPredictions, result.NumFilteredWarmup)
+	fmt.Printf("  Predictions: %d scored, %d warmup filtered, %d post-onset ignored\n",
+		result.NumPredictions, result.NumFilteredWarmup, result.NumFilteredCascading)
 	fmt.Println()
 	fmt.Printf("  F1:        %.4f\n", result.F1)
 	fmt.Printf("  Precision: %.4f\n", result.Precision)

--- a/comp/observer/impl/score.go
+++ b/comp/observer/impl/score.go
@@ -12,7 +12,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"sort"
 	"time"
 )
 
@@ -40,8 +39,11 @@ type ScoreResult struct {
 }
 
 // ComputeGaussianF1 scores predicted anomaly events against ground truth events
-// using Gaussian overlap. Predictions are symmetric Gaussians; ground truth events
-// are asymmetric half-Gaussians (zero mass before onset, normal decay after).
+// using Gaussian overlap with right-sided half-Gaussians.
+//
+// For each ground truth event, the prediction with the highest overlap is selected
+// as the match. Predictions before the ground truth onset get zero overlap and
+// cannot match. All other predictions are false positives.
 func ComputeGaussianF1(input ScoreInput) ScoreResult {
 	result := ScoreResult{
 		NumPredictions:  len(input.PredictionTimestamps),
@@ -66,58 +68,40 @@ func ComputeGaussianF1(input ScoreInput) ScoreResult {
 		return result
 	}
 
-	// Greedy nearest-match: each prediction matches to nearest unmatched ground truth.
-	type match struct {
-		predIdx int
-		gtIdx   int
-		dist    float64
-	}
-
-	// Build all pairwise distances
-	var candidates []match
-	for i, p := range input.PredictionTimestamps {
-		for j, g := range input.GroundTruthTimestamps {
-			dist := math.Abs(float64(p - g))
-			candidates = append(candidates, match{predIdx: i, gtIdx: j, dist: dist})
-		}
-	}
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].dist < candidates[j].dist
-	})
-
+	// For each GT, find the prediction with the best overlap.
+	// Predictions before GT onset get zero overlap (no credit for early alarms).
 	matchedPred := make(map[int]bool)
-	matchedGT := make(map[int]bool)
-
 	var tp, fp, fn float64
 
-	for _, c := range candidates {
-		if matchedPred[c.predIdx] || matchedGT[c.gtIdx] {
-			continue
-		}
-		matchedPred[c.predIdx] = true
-		matchedGT[c.gtIdx] = true
+	for _, gt := range input.GroundTruthTimestamps {
+		bestOverlap := 0.0
+		bestIdx := -1
 
-		overlap := halfGaussianOverlap(
-			input.PredictionTimestamps[c.predIdx],
-			input.GroundTruthTimestamps[c.gtIdx],
-			input.Sigma,
-		)
-		tp += overlap
-		fp += 1.0 - overlap // prediction area not overlapping ground truth
-		fn += 1.0 - overlap // ground truth area not overlapping prediction
+		for i, p := range input.PredictionTimestamps {
+			if matchedPred[i] || p < gt {
+				continue
+			}
+			overlap := halfGaussianOverlap(p, gt, input.Sigma)
+			if overlap > bestOverlap {
+				bestOverlap = overlap
+				bestIdx = i
+			}
+		}
+
+		if bestIdx >= 0 {
+			matchedPred[bestIdx] = true
+			tp += bestOverlap
+			fp += 1.0 - bestOverlap
+			fn += 1.0 - bestOverlap
+		} else {
+			fn += 1.0
+		}
 	}
 
 	// Unmatched predictions → full FP
 	for i := range input.PredictionTimestamps {
 		if !matchedPred[i] {
 			fp += 1.0
-		}
-	}
-
-	// Unmatched ground truths → full FN
-	for j := range input.GroundTruthTimestamps {
-		if !matchedGT[j] {
-			fn += 1.0
 		}
 	}
 

--- a/comp/observer/impl/score.go
+++ b/comp/observer/impl/score.go
@@ -32,18 +32,18 @@ type ScoreResult struct {
 	FN                   float64 `json:"fn"`
 	NumPredictions       int     `json:"num_predictions"`
 	NumGroundTruths      int     `json:"num_ground_truths"`
-	NumFilteredWarmup    int     `json:"num_filtered_warmup"`
-	NumFilteredCascading int     `json:"num_filtered_cascading"`
-	NumBaselineFPs       int     `json:"num_baseline_fps"`
+	NumFilteredWarmup int `json:"num_filtered_warmup"`
+	NumBaselineFPs    int `json:"num_baseline_fps"`
 	Sigma                float64 `json:"sigma"`
 }
 
 // ComputeGaussianF1 scores predicted anomaly events against ground truth events
 // using Gaussian overlap with right-sided half-Gaussians.
 //
-// For each ground truth event, the prediction with the highest overlap is selected
-// as the match. Predictions before the ground truth onset get zero overlap and
-// cannot match. All other predictions are false positives.
+// For each ground truth event, the first (earliest) post-onset prediction is
+// matched and scored via halfGaussianOverlap. Predictions before any GT onset
+// are counted as FP (baseline noise). Other post-onset predictions that aren't
+// the first match are ignored entirely (expected during an active incident).
 func ComputeGaussianF1(input ScoreInput) ScoreResult {
 	result := ScoreResult{
 		NumPredictions:  len(input.PredictionTimestamps),
@@ -68,41 +68,53 @@ func ComputeGaussianF1(input ScoreInput) ScoreResult {
 		return result
 	}
 
-	// For each GT, find the prediction with the best overlap.
-	// Predictions before GT onset get zero overlap (no credit for early alarms).
+	// Find the minimum GT onset — predictions before this are baseline FP.
+	minGT := input.GroundTruthTimestamps[0]
+	for _, gt := range input.GroundTruthTimestamps[1:] {
+		if gt < minGT {
+			minGT = gt
+		}
+	}
+
+	// For each GT, find the first (earliest timestamp) post-onset prediction.
 	matchedPred := make(map[int]bool)
-	var tp, fp, fn float64
+	var tp, fn float64
 
 	for _, gt := range input.GroundTruthTimestamps {
-		bestOverlap := 0.0
-		bestIdx := -1
+		firstIdx := -1
+		var firstTS int64
 
 		for i, p := range input.PredictionTimestamps {
 			if matchedPred[i] || p < gt {
 				continue
 			}
-			overlap := halfGaussianOverlap(p, gt, input.Sigma)
-			if overlap > bestOverlap {
-				bestOverlap = overlap
-				bestIdx = i
+			if firstIdx == -1 || p < firstTS {
+				firstIdx = i
+				firstTS = p
 			}
 		}
 
-		if bestIdx >= 0 {
-			matchedPred[bestIdx] = true
-			tp += bestOverlap
-			fp += 1.0 - bestOverlap
-			fn += 1.0 - bestOverlap
+		if firstIdx >= 0 {
+			matchedPred[firstIdx] = true
+			overlap := halfGaussianOverlap(firstTS, gt, input.Sigma)
+			tp += overlap
+			fn += 1.0 - overlap
 		} else {
 			fn += 1.0
 		}
 	}
 
-	// Unmatched predictions → full FP
-	for i := range input.PredictionTimestamps {
-		if !matchedPred[i] {
+	// FP = predictions before any GT onset (baseline noise).
+	// Post-onset predictions that aren't the first match are ignored.
+	var fp float64
+	for i, p := range input.PredictionTimestamps {
+		if matchedPred[i] {
+			continue
+		}
+		if p < minGT {
 			fp += 1.0
 		}
+		// else: post-onset, unmatched → ignored (expected during incident)
 	}
 
 	result.TP = tp
@@ -286,25 +298,13 @@ func ScoreOutputFile(outputPath string, groundTruthTimestamps []int64, scenarios
 		return nil, errors.New("no ground truth: provide --ground-truth-ts or --scenarios-dir with metadata.json")
 	}
 
-	// Compute prediction window: filter warmup (before baseline.start) and
-	// cascading effects (beyond max(groundTruth) + 2*sigma).
-	maxGT := groundTruthTimestamps[0]
-	for _, gt := range groundTruthTimestamps[1:] {
-		if gt > maxGT {
-			maxGT = gt
-		}
-	}
-	cutoff := float64(maxGT) + 2*sigma
-
+	// Filter warmup predictions (before baseline.start).
+	// Post-onset non-matched predictions are handled by ComputeGaussianF1 (ignored).
 	var predictions []int64
-	var numFilteredWarmup, numFilteredCascading int
+	var numFilteredWarmup int
 	for _, period := range output.AnomalyPeriods {
 		if baselineStart > 0 && period.PeriodStart < baselineStart {
 			numFilteredWarmup++
-			continue
-		}
-		if float64(period.PeriodStart) > cutoff {
-			numFilteredCascading++
 			continue
 		}
 		predictions = append(predictions, period.PeriodStart)
@@ -330,7 +330,6 @@ func ScoreOutputFile(outputPath string, groundTruthTimestamps []int64, scenarios
 		Sigma:                 sigma,
 	})
 	result.NumFilteredWarmup = numFilteredWarmup
-	result.NumFilteredCascading = numFilteredCascading
 	result.NumBaselineFPs = numBaselineFPs
 
 	return &result, nil

--- a/comp/observer/impl/score.go
+++ b/comp/observer/impl/score.go
@@ -32,8 +32,9 @@ type ScoreResult struct {
 	FN                   float64 `json:"fn"`
 	NumPredictions       int     `json:"num_predictions"`
 	NumGroundTruths      int     `json:"num_ground_truths"`
-	NumFilteredWarmup int `json:"num_filtered_warmup"`
-	NumBaselineFPs    int `json:"num_baseline_fps"`
+	NumFilteredWarmup    int     `json:"num_filtered_warmup"`
+	NumFilteredCascading int     `json:"num_filtered_cascading"`
+	NumBaselineFPs       int     `json:"num_baseline_fps"`
 	Sigma                float64 `json:"sigma"`
 }
 
@@ -310,17 +311,25 @@ func ScoreOutputFile(outputPath string, groundTruthTimestamps []int64, scenarios
 		predictions = append(predictions, period.PeriodStart)
 	}
 
-	// Count baseline FPs: scored predictions that fire before disruption onset.
+	// Count baseline FPs and post-onset predictions for reporting.
 	minGT := groundTruthTimestamps[0]
+	maxGT := groundTruthTimestamps[0]
 	for _, gt := range groundTruthTimestamps[1:] {
 		if gt < minGT {
 			minGT = gt
 		}
+		if gt > maxGT {
+			maxGT = gt
+		}
 	}
-	var numBaselineFPs int
+	cascadingCutoff := float64(maxGT) + 2*sigma
+	var numBaselineFPs, numCascading int
 	for _, p := range predictions {
 		if p < minGT {
 			numBaselineFPs++
+		}
+		if float64(p) > cascadingCutoff {
+			numCascading++
 		}
 	}
 
@@ -330,6 +339,7 @@ func ScoreOutputFile(outputPath string, groundTruthTimestamps []int64, scenarios
 		Sigma:                 sigma,
 	})
 	result.NumFilteredWarmup = numFilteredWarmup
+	result.NumFilteredCascading = numCascading
 	result.NumBaselineFPs = numBaselineFPs
 
 	return &result, nil

--- a/comp/observer/impl/score.go
+++ b/comp/observer/impl/score.go
@@ -108,19 +108,22 @@ func ComputeGaussianF1(input ScoreInput) ScoreResult {
 	// FP = predictions before any GT onset (baseline noise).
 	// Post-onset predictions that aren't the first match are ignored.
 	var fp float64
+	var numIgnored int
 	for i, p := range input.PredictionTimestamps {
 		if matchedPred[i] {
 			continue
 		}
 		if p < minGT {
 			fp += 1.0
+		} else {
+			numIgnored++
 		}
-		// else: post-onset, unmatched → ignored (expected during incident)
 	}
 
 	result.TP = tp
 	result.FP = fp
 	result.FN = fn
+	result.NumFilteredCascading = numIgnored
 
 	if tp+fp > 0 {
 		result.Precision = tp / (tp + fp)
@@ -311,25 +314,17 @@ func ScoreOutputFile(outputPath string, groundTruthTimestamps []int64, scenarios
 		predictions = append(predictions, period.PeriodStart)
 	}
 
-	// Count baseline FPs and post-onset predictions for reporting.
+	// Count baseline FPs: scored predictions that fire before disruption onset.
 	minGT := groundTruthTimestamps[0]
-	maxGT := groundTruthTimestamps[0]
 	for _, gt := range groundTruthTimestamps[1:] {
 		if gt < minGT {
 			minGT = gt
 		}
-		if gt > maxGT {
-			maxGT = gt
-		}
 	}
-	cascadingCutoff := float64(maxGT) + 2*sigma
-	var numBaselineFPs, numCascading int
+	var numBaselineFPs int
 	for _, p := range predictions {
 		if p < minGT {
 			numBaselineFPs++
-		}
-		if float64(p) > cascadingCutoff {
-			numCascading++
 		}
 	}
 
@@ -339,7 +334,6 @@ func ScoreOutputFile(outputPath string, groundTruthTimestamps []int64, scenarios
 		Sigma:                 sigma,
 	})
 	result.NumFilteredWarmup = numFilteredWarmup
-	result.NumFilteredCascading = numCascading
 	result.NumBaselineFPs = numBaselineFPs
 
 	return &result, nil

--- a/comp/observer/impl/score_test.go
+++ b/comp/observer/impl/score_test.go
@@ -124,35 +124,34 @@ func TestGaussianF1_MultipleGroundTruths(t *testing.T) {
 	assert.Equal(t, 2, result.NumGroundTruths)
 }
 
-func TestGaussianF1_HalfGaussianSymmetry(t *testing.T) {
-	// With both prediction and ground truth as right-sided half-Gaussians,
-	// equal distances before and after produce the same overlap — both
-	// distributions extend rightward, so the geometry is symmetric around d=0.
+func TestGaussianF1_BeforeOnsetIsZero(t *testing.T) {
+	// Predictions before ground truth onset get zero overlap — no credit for early alarms.
 	before := ComputeGaussianF1(ScoreInput{
 		PredictionTimestamps:  []int64{92}, // 8s before
 		GroundTruthTimestamps: []int64{100},
 		Sigma:                 testSigma,
 	})
+	assert.Equal(t, 0.0, before.F1, "prediction before onset should score 0")
+	assert.Equal(t, 1.0, before.FP, "prediction before onset is a full FP")
+	assert.Equal(t, 1.0, before.FN, "ground truth is unmatched → full FN")
 
 	after := ComputeGaussianF1(ScoreInput{
 		PredictionTimestamps:  []int64{108}, // 8s after
 		GroundTruthTimestamps: []int64{100},
 		Sigma:                 testSigma,
 	})
+	assert.Greater(t, after.F1, 0.3, "prediction after onset should score well")
+}
 
-	assert.InDelta(t, before.F1, after.F1, 0.01,
-		"equal distances should produce similar scores (before=%.3f, after=%.3f)",
-		before.F1, after.F1)
-
-	// But a prediction far before onset should score much less than one close after
-	farBefore := ComputeGaussianF1(ScoreInput{
-		PredictionTimestamps:  []int64{60}, // 40s before (4σ)
+func TestGaussianF1_BeforeOnsetDoesNotStealMatch(t *testing.T) {
+	// A baseline FP 1s before GT must not steal the match from a real detection after GT.
+	result := ComputeGaussianF1(ScoreInput{
+		PredictionTimestamps:  []int64{99, 102}, // 99 is closer by distance but before GT
 		GroundTruthTimestamps: []int64{100},
 		Sigma:                 testSigma,
 	})
-	assert.Less(t, farBefore.F1, after.F1,
-		"far before onset (%.3f) should score less than close after (%.3f)",
-		farBefore.F1, after.F1)
+	assert.Greater(t, result.F1, 0.0, "post-onset prediction should match, not the closer pre-onset one")
+	assert.Greater(t, result.TP, 0.0, "should have nonzero TP from the post-onset match")
 }
 
 func TestScoreOutputFile(t *testing.T) {

--- a/comp/observer/impl/score_test.go
+++ b/comp/observer/impl/score_test.go
@@ -54,13 +54,15 @@ func TestGaussianF1_LateDetection(t *testing.T) {
 }
 
 func TestGaussianF1_NoisyButCorrect(t *testing.T) {
+	// 5 false alarms during baseline + 1 good detection after onset.
+	// Post-onset unmatched predictions are ignored, so only the 5 pre-onset
+	// predictions count as FP.
 	result := ComputeGaussianF1(ScoreInput{
 		PredictionTimestamps:  []int64{20, 30, 40, 50, 60, 102},
 		GroundTruthTimestamps: []int64{100},
 		Sigma:                 testSigma,
 	})
 
-	// 5 false alarms during baseline + 1 good detection
 	assert.Less(t, result.F1, 0.5, "noisy detector should be penalized")
 	assert.Greater(t, result.F1, 0.0, "correct detection should keep score above zero")
 	assert.Less(t, result.Precision, 0.3, "many FPs should hurt precision")
@@ -86,8 +88,10 @@ func TestGaussianF1_FalseAlarmOnly(t *testing.T) {
 		Sigma:                 testSigma,
 	})
 
-	// Prediction 80s away (8σ) — virtually no overlap
-	assert.Less(t, result.F1, 0.05, "distant false alarm should score near zero")
+	// Prediction 80s before onset → FP, GT unmatched → FN
+	assert.Equal(t, 0.0, result.F1, "distant false alarm should score zero")
+	assert.Equal(t, 1.0, result.FP)
+	assert.Equal(t, 1.0, result.FN)
 }
 
 func TestGaussianF1_NoPredictionsNoGroundTruth(t *testing.T) {
@@ -144,14 +148,44 @@ func TestGaussianF1_BeforeOnsetIsZero(t *testing.T) {
 }
 
 func TestGaussianF1_BeforeOnsetDoesNotStealMatch(t *testing.T) {
-	// A baseline FP 1s before GT must not steal the match from a real detection after GT.
+	// Prediction at 99 (before GT=100) is FP.
+	// Prediction at 102 (first post-onset) matches.
 	result := ComputeGaussianF1(ScoreInput{
-		PredictionTimestamps:  []int64{99, 102}, // 99 is closer by distance but before GT
+		PredictionTimestamps:  []int64{99, 102},
 		GroundTruthTimestamps: []int64{100},
 		Sigma:                 testSigma,
 	})
 	assert.Greater(t, result.F1, 0.0, "post-onset prediction should match, not the closer pre-onset one")
 	assert.Greater(t, result.TP, 0.0, "should have nonzero TP from the post-onset match")
+	assert.Equal(t, 1.0, result.FP, "pre-onset prediction at 99 should be FP")
+}
+
+func TestGaussianF1_MultipleFiresDuringDisruption(t *testing.T) {
+	// Detector fires 3 times during disruption, 0 baseline FPs.
+	// First post-onset prediction (102) matches GT. The other two (110, 120)
+	// are post-onset unmatched → ignored. Should score near-perfect.
+	result := ComputeGaussianF1(ScoreInput{
+		PredictionTimestamps:  []int64{102, 110, 120},
+		GroundTruthTimestamps: []int64{100},
+		Sigma:                 testSigma,
+	})
+	assert.InDelta(t, 1.0, result.F1, 0.1, "3 fires during disruption with 0 baseline FPs should score near-perfect")
+	assert.Equal(t, 0.0, result.FP, "no FPs — extra post-onset predictions are ignored")
+}
+
+func TestGaussianF1_OneFireDuringDisruptionPlusBaselineFPs(t *testing.T) {
+	// Detector fires once during disruption + 5 baseline FPs.
+	// Good recall (detection matches) but precision penalized by 5 FPs.
+	result := ComputeGaussianF1(ScoreInput{
+		PredictionTimestamps:  []int64{10, 20, 30, 40, 50, 102},
+		GroundTruthTimestamps: []int64{100},
+		Sigma:                 testSigma,
+	})
+	assert.Greater(t, result.Recall, 0.8, "should have good recall from the match")
+	assert.Less(t, result.Precision, 0.5, "5 FPs should penalize precision")
+	assert.Greater(t, result.F1, 0.0, "F1 should be nonzero — there is a match")
+	assert.Less(t, result.F1, 0.6, "F1 should be penalized by the 5 baseline FPs")
+	assert.Equal(t, 5.0, result.FP, "5 pre-onset predictions are FP")
 }
 
 func TestScoreOutputFile(t *testing.T) {
@@ -179,13 +213,13 @@ func TestScoreOutputFile(t *testing.T) {
 	assert.Equal(t, 2, result.NumPredictions)
 	assert.Equal(t, 1, result.NumGroundTruths)
 	assert.Equal(t, 0, result.NumFilteredWarmup)
-	assert.Equal(t, 0, result.NumFilteredCascading)
 	assert.Greater(t, result.F1, 0.0)
 }
 
-func TestScoreOutputFile_PredictionWindowFiltering(t *testing.T) {
-	// Ground truth at 100, sigma=10 → cutoff = 100 + 2*10 = 120
-	// Predictions at 50 (baseline FP), 102 (good), 130 (cascading, filtered), 200 (cascading, filtered)
+func TestScoreOutputFile_PostOnsetIgnored(t *testing.T) {
+	// Ground truth at 100, sigma=10.
+	// Predictions at 50 (baseline FP), 102 (match), 130 (post-onset ignored), 200 (post-onset ignored).
+	// No cascading filter — post-onset unmatched are just ignored by the scorer.
 	output := ObserverOutput{
 		Metadata: ObserverMetadata{
 			Scenario:      "test",
@@ -195,8 +229,8 @@ func TestScoreOutputFile_PredictionWindowFiltering(t *testing.T) {
 		AnomalyPeriods: []ObserverCorrelation{
 			{Pattern: "baseline_fp", PeriodStart: 50},
 			{Pattern: "good_detect", PeriodStart: 102},
-			{Pattern: "cascade_1", PeriodStart: 130},
-			{Pattern: "cascade_2", PeriodStart: 200},
+			{Pattern: "post_onset_1", PeriodStart: 130},
+			{Pattern: "post_onset_2", PeriodStart: 200},
 		},
 	}
 
@@ -209,25 +243,13 @@ func TestScoreOutputFile_PredictionWindowFiltering(t *testing.T) {
 	result, err := ScoreOutputFile(path, []int64{100}, "", testSigma)
 	require.NoError(t, err)
 
-	// 2 predictions scored (50, 102), 2 cascading filtered (130, 200)
-	assert.Equal(t, 2, result.NumPredictions, "only predictions within window should be scored")
+	// All 4 predictions pass to scorer (no cascading filter).
+	assert.Equal(t, 4, result.NumPredictions, "all predictions should be passed to scorer")
 	assert.Equal(t, 0, result.NumFilteredWarmup)
-	assert.Equal(t, 2, result.NumFilteredCascading, "predictions beyond cutoff should be filtered")
 	assert.Equal(t, 1, result.NumGroundTruths)
-
-	// Prediction at exactly the cutoff (120) should be included
-	output.AnomalyPeriods = append(output.AnomalyPeriods, ObserverCorrelation{
-		Pattern: "at_cutoff", PeriodStart: 120,
-	})
-	data, err = json.MarshalIndent(output, "", "  ")
-	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(path, data, 0644))
-
-	result, err = ScoreOutputFile(path, []int64{100}, "", testSigma)
-	require.NoError(t, err)
-
-	assert.Equal(t, 3, result.NumPredictions, "prediction at cutoff should be included")
-	assert.Equal(t, 2, result.NumFilteredCascading)
+	assert.Equal(t, 1, result.NumBaselineFPs, "prediction at 50 is a baseline FP")
+	// FP = 1 (the prediction at 50, before onset). Post-onset 130 and 200 are ignored.
+	assert.Equal(t, 1.0, result.FP, "only pre-onset predictions count as FP")
 }
 
 func TestScoreOutputFile_MetadataInference(t *testing.T) {
@@ -294,7 +316,6 @@ func TestScoreOutputFile_ExplicitOverridesMetadata(t *testing.T) {
 
 func TestScoreOutputFile_WarmupFiltering(t *testing.T) {
 	// baseline.start at T=100 (warmup ends), disruption.start at T=200
-	// sigma=10 → cascading cutoff = 200 + 20 = 220
 	scenariosDir := t.TempDir()
 	scenarioDir := filepath.Join(scenariosDir, "test_scenario")
 	require.NoError(t, os.MkdirAll(scenarioDir, 0755))
@@ -305,11 +326,11 @@ func TestScoreOutputFile_WarmupFiltering(t *testing.T) {
 	output := ObserverOutput{
 		Metadata: ObserverMetadata{Scenario: "test_scenario"},
 		AnomalyPeriods: []ObserverCorrelation{
-			{Pattern: "warmup_noise_1", PeriodStart: 50}, // warmup → filtered
-			{Pattern: "warmup_noise_2", PeriodStart: 90}, // warmup → filtered
-			{Pattern: "baseline_fp", PeriodStart: 120},   // baseline FP → scored
-			{Pattern: "good_detect", PeriodStart: 202},   // near onset → scored
-			{Pattern: "cascade", PeriodStart: 250},       // cascading → filtered
+			{Pattern: "warmup_noise_1", PeriodStart: 50},  // warmup → filtered
+			{Pattern: "warmup_noise_2", PeriodStart: 90},  // warmup → filtered
+			{Pattern: "baseline_fp", PeriodStart: 120},    // baseline FP → scored
+			{Pattern: "good_detect", PeriodStart: 202},    // near onset → scored
+			{Pattern: "post_onset", PeriodStart: 250},     // post-onset unmatched → scored but ignored by F1
 		},
 	}
 	data, err := json.MarshalIndent(output, "", "  ")
@@ -322,6 +343,5 @@ func TestScoreOutputFile_WarmupFiltering(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, result.NumFilteredWarmup, "predictions before baseline.start should be filtered")
-	assert.Equal(t, 1, result.NumFilteredCascading, "predictions beyond 2σ should be filtered")
-	assert.Equal(t, 2, result.NumPredictions, "only baseline FP and good detect should be scored")
+	assert.Equal(t, 3, result.NumPredictions, "baseline FP, good detect, and post-onset should all be scored")
 }

--- a/comp/observer/impl/score_test.go
+++ b/comp/observer/impl/score_test.go
@@ -246,6 +246,7 @@ func TestScoreOutputFile_PostOnsetIgnored(t *testing.T) {
 	// All 4 predictions pass to scorer (no cascading filter).
 	assert.Equal(t, 4, result.NumPredictions, "all predictions should be passed to scorer")
 	assert.Equal(t, 0, result.NumFilteredWarmup)
+	assert.Equal(t, 2, result.NumFilteredCascading, "predictions at 130 and 200 are beyond GT+2σ")
 	assert.Equal(t, 1, result.NumGroundTruths)
 	assert.Equal(t, 1, result.NumBaselineFPs, "prediction at 50 is a baseline FP")
 	// FP = 1 (the prediction at 50, before onset). Post-onset 130 and 200 are ignored.
@@ -326,11 +327,11 @@ func TestScoreOutputFile_WarmupFiltering(t *testing.T) {
 	output := ObserverOutput{
 		Metadata: ObserverMetadata{Scenario: "test_scenario"},
 		AnomalyPeriods: []ObserverCorrelation{
-			{Pattern: "warmup_noise_1", PeriodStart: 50},  // warmup → filtered
-			{Pattern: "warmup_noise_2", PeriodStart: 90},  // warmup → filtered
-			{Pattern: "baseline_fp", PeriodStart: 120},    // baseline FP → scored
-			{Pattern: "good_detect", PeriodStart: 202},    // near onset → scored
-			{Pattern: "post_onset", PeriodStart: 250},     // post-onset unmatched → scored but ignored by F1
+			{Pattern: "warmup_noise_1", PeriodStart: 50}, // warmup → filtered
+			{Pattern: "warmup_noise_2", PeriodStart: 90}, // warmup → filtered
+			{Pattern: "baseline_fp", PeriodStart: 120},   // baseline FP → scored
+			{Pattern: "good_detect", PeriodStart: 202},   // near onset → scored
+			{Pattern: "post_onset", PeriodStart: 250},    // post-onset unmatched → scored but ignored by F1
 		},
 	}
 	data, err := json.MarshalIndent(output, "", "  ")
@@ -343,5 +344,6 @@ func TestScoreOutputFile_WarmupFiltering(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 2, result.NumFilteredWarmup, "predictions before baseline.start should be filtered")
+	assert.Equal(t, 1, result.NumFilteredCascading, "prediction at 250 is beyond GT+2σ")
 	assert.Equal(t, 3, result.NumPredictions, "baseline FP, good detect, and post-onset should all be scored")
 }

--- a/comp/observer/impl/score_test.go
+++ b/comp/observer/impl/score_test.go
@@ -171,6 +171,7 @@ func TestGaussianF1_MultipleFiresDuringDisruption(t *testing.T) {
 	})
 	assert.InDelta(t, 1.0, result.F1, 0.1, "3 fires during disruption with 0 baseline FPs should score near-perfect")
 	assert.Equal(t, 0.0, result.FP, "no FPs — extra post-onset predictions are ignored")
+	assert.Equal(t, 2, result.NumFilteredCascading, "2 post-onset predictions ignored")
 }
 
 func TestGaussianF1_OneFireDuringDisruptionPlusBaselineFPs(t *testing.T) {


### PR DESCRIPTION
tl;dr: The greedy match approach for scoring could give near-full credit to a pre-onset prediction a few seconds before disruption, and penalized some valid post-disruption detections as false positives. This PR fixes that.  

- **Fixed match-stealing bug** : greedy distance based matcher could assign a baseline anomaly to the ground truth (GT) if it is closer to GT than the first post-disruption anomaly. baseline anomalies should never match to GT and should be full false positives (count as 0).
- **only score first onset anomaly**: explicitly only score first anomaly post disruption for credit (via gaussian overlap of GT and prediction). everything else after that first anomaly is ignored and does not negatively or positively impact score. 

## Test plan

- [x] All 18 scoring tests pass (TestGaussianF1, TestScoreOutputFile)
- [x] New tests: MultipleFiresDuringDisruption (3 fires in disruption time, 0 baseline → F1 near 1.0), OneFireDuringDisruptionPlusBaselineFPs (1 fire + 5 FPs → penalized precision, good recall)
- [x] observer-scorer CLI builds clean
- [x] q.eval-scenarios end-to-end
