### PR TITLE
ci(chainguard): Add dd-octo-sts policy for slapr workflow

### DIFF
--- a/.github/chainguard/self.slapr.read-members.sts.yaml
+++ b/.github/chainguard/self.slapr.read-members.sts.yaml
@@ -1,0 +1,14 @@
+---
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/datadog-agent:pull_request
+
+claim_pattern:
+  event_name: (pull_request|pull_request_review)
+  ref: refs/(pull/\d+/merge|heads/main)
+  job_workflow_ref: DataDog/datadog-agent/\.github/workflows/slapr\.yml@refs/(pull/\d+/merge|heads/main)
+
+permissions:
+  contents: read
+  pull_requests: read
+  members: read


### PR DESCRIPTION
### What does this PR do?

Adds a new dd-octo-sts trust policy at `.github/chainguard/self.slapr.read-members.sts.yaml` to grant the `slapr.yml` workflow short-lived GitHub tokens with `contents:read`, `pull_requests:read`, and `members:read` permissions.

### Motivation

The slapr workflow needs to read organization members to function properly. This policy allows it to obtain scoped tokens via dd-octo-sts instead of relying on broader credentials.

### Describe how you validated your changes

Policy file follows the established dd-octo-sts pattern used by other policies in `.github/chainguard/`. The claim patterns match `pull_request` and `pull_request_review` events on PR merge refs and `main`.

### Additional Notes

The policy scopes to:
- **Subject**: `repo:DataDog/datadog-agent:pull_request`
- **Events**: `pull_request` and `pull_request_review`
- **Refs**: PR merge refs and `main`
- **Workflow**: `slapr.yml` only