### PR TITLE
ci(actions): Add slapr workflow for Slack emoji PR updates

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         review-map: tasks/libs/pipeline/github_slack_map.yaml
         github-token: ${{ steps.octo-sts.outputs.token }}
-        slack-api-token: ${{ secrets.SLAPR_SLACK_API_TOKEN }}
-        slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
-        bot-user-id: ${{ vars.SLAPR_BOT_USER_ID }}
+        slack-api-token: ${{ secrets.SLACK_SLAPR_BOT_TOKEN }}
+        slack-channel-id: ${{ vars.DEFAULT_CHANNEL_ID }}
+        bot-user-id: ${{ vars.SLAPR_BOT_ID }}
         emoji-approved: done

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -21,7 +21,9 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         token: ${{ steps.octo-sts.outputs.token }}
-    - uses: DataDog/slapr@b67da6553b2d723f7a01ce07e7b3764e12112b6c
+        sparse-checkout: tasks/libs/pipeline/github_slack_map.yaml
+        sparse-checkout-cone-mode: false
+    - uses: DataDog/slapr@3c19d2a0971acfc3f5a3524b508ed233f8ce0e23
       with:
         review-map: tasks/libs/pipeline/github_slack_map.yaml
         github-token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -1,0 +1,31 @@
+---
+name: Slack emoji PR updates
+on:
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [closed]
+
+jobs:
+  run_slapr:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
+      id: octo-sts
+      with:
+        scope: DataDog/datadog-agent
+        policy: self.slapr.read-members
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        token: ${{ steps.octo-sts.outputs.token }}
+    - uses: DataDog/slapr@099b695b7d2a10263c6918c58b022c3ccbdef4d5
+      with:
+        review-map: tasks/libs/pipeline/github_slack_map.yaml
+      env:
+        GITHUB_TOKEN: "${{ steps.octo-sts.outputs.token }}"
+        SLACK_CHANNEL_ID: "${{ vars.SLACK_CHANNEL_ID }}"
+        SLACK_API_TOKEN: "${{ secrets.SLAPR_SLACK_API_TOKEN }}"
+        SLAPR_BOT_USER_ID: "${{ vars.SLAPR_BOT_USER_ID }}"
+        SLAPR_EMOJI_APPROVED: done

--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   run_slapr:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -20,12 +21,11 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         token: ${{ steps.octo-sts.outputs.token }}
-    - uses: DataDog/slapr@099b695b7d2a10263c6918c58b022c3ccbdef4d5
+    - uses: DataDog/slapr@b67da6553b2d723f7a01ce07e7b3764e12112b6c
       with:
         review-map: tasks/libs/pipeline/github_slack_map.yaml
-      env:
-        GITHUB_TOKEN: "${{ steps.octo-sts.outputs.token }}"
-        SLACK_CHANNEL_ID: "${{ vars.SLACK_CHANNEL_ID }}"
-        SLACK_API_TOKEN: "${{ secrets.SLAPR_SLACK_API_TOKEN }}"
-        SLAPR_BOT_USER_ID: "${{ vars.SLAPR_BOT_USER_ID }}"
-        SLAPR_EMOJI_APPROVED: done
+        github-token: ${{ steps.octo-sts.outputs.token }}
+        slack-api-token: ${{ secrets.SLAPR_SLACK_API_TOKEN }}
+        slack-channel-id: ${{ vars.SLACK_CHANNEL_ID }}
+        bot-user-id: ${{ vars.SLAPR_BOT_USER_ID }}
+        emoji-approved: done


### PR DESCRIPTION
### What does this PR do?

Adds a new GitHub Actions workflow (`.github/workflows/slapr.yml`) that integrates [slapr](https://github.com/DataDog/slapr) to post Slack emoji updates on PRs based on review status.

The workflow:
- Triggers on `pull_request_review` (submitted) and `pull_request` (closed) events
- Uses `dd-octo-sts` to obtain a scoped GitHub token with `contents:read`, `pull_requests:read`, and `members:read` permissions
- Runs slapr with the `github_slack_map.yaml` review map to resolve team-to-channel mappings

### Motivation

Automate Slack notifications for PR review activity, giving teams visibility into review progress directly in their Slack channels.

### Describe how you validated your changes

- Verified the dd-octo-sts policy (`self.slapr.read-members`) is set up in a companion PR: https://github.com/DataDog/datadog-agent/pull/47838
- Execution of the workflow of this PR
  - ok with [full repo checkout](https://github.com/DataDog/datadog-agent/actions/runs/23289117966?pr=47839)
  - ok with [sparse checkout](https://github.com/DataDog/datadog-agent/actions/runs/23289286793?pr=47839)

### Additional Notes

- **Dependency**: Requires the dd-octo-sts policy from #47838 and the YAML format change from #47782
- **Secrets/vars needed**: `SLAPR_SLACK_API_TOKEN` secret, `SLACK_CHANNEL_ID` and `SLAPR_BOT_USER_ID` repository variables
- The slapr action ref is pinned to a commit sha on the slapr workflow. Still some little adjustment to do on this side to pin to a release version, which will be tracked by renovate