### PR TITLE
pkg/trace: fix missing base service tag

### DIFF
--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -60,6 +60,7 @@ type PayloadAggregationKey struct {
 	ImageTag        string
 	Lang            string
 	ProcessTagsHash uint64
+	BaseService     string
 }
 
 func getStatusCode(meta map[string]string, metrics map[string]float64) uint32 {

--- a/pkg/trace/stats/client_stats_aggregator.go
+++ b/pkg/trace/stats/client_stats_aggregator.go
@@ -175,7 +175,7 @@ func (a *ClientStatsAggregator) add(now time.Time, p *pb.ClientStatsPayload) {
 	a.setVersionDataFromContainerTags(p)
 	p.ProcessTagsHash = processTagsHash(p.ProcessTags)
 	// compute the PayloadAggregationKey, common for all buckets within the payload
-	payloadAggKey := newPayloadAggregationKey(p.Env, p.Hostname, p.Version, p.ContainerID, p.GitCommitSha, p.ImageTag, p.Lang, p.ProcessTagsHash)
+	payloadAggKey := newPayloadAggregationKey(p.Env, p.Hostname, p.Version, p.ContainerID, p.GitCommitSha, p.ImageTag, p.Lang, p.ProcessTagsHash, p.Service)
 
 	// acquire lock over shared data
 	a.mu.Lock()
@@ -348,6 +348,7 @@ func (b *bucket) aggregationToPayloads() []*pb.ClientStatsPayload {
 			Lang:            payloadKey.Lang,
 			GitCommitSha:    payloadKey.GitCommitSha,
 			ContainerID:     payloadKey.ContainerID,
+			Service:         payloadKey.BaseService,
 			Stats:           clientBuckets,
 			ProcessTagsHash: payloadKey.ProcessTagsHash,
 			ProcessTags:     b.processTags[payloadKey.ProcessTagsHash],
@@ -401,7 +402,7 @@ func exporGroupedStats(aggrKey BucketsAggregationKey, stats *aggregatedStats) (*
 	}, nil
 }
 
-func newPayloadAggregationKey(env, hostname, version, cid, gitCommitSha, imageTag, lang string, processTagsHash uint64) PayloadAggregationKey {
+func newPayloadAggregationKey(env, hostname, version, cid, gitCommitSha, imageTag, lang string, processTagsHash uint64, baseService string) PayloadAggregationKey {
 	return PayloadAggregationKey{
 		Env:             env,
 		Hostname:        hostname,
@@ -411,6 +412,7 @@ func newPayloadAggregationKey(env, hostname, version, cid, gitCommitSha, imageTa
 		ImageTag:        imageTag,
 		Lang:            lang,
 		ProcessTagsHash: processTagsHash,
+		BaseService:     baseService,
 	}
 }
 

--- a/pkg/trace/stats/client_stats_aggregator_test.go
+++ b/pkg/trace/stats/client_stats_aggregator_test.go
@@ -829,6 +829,74 @@ func TestLangAggregation(t *testing.T) {
 	})
 }
 
+func TestBaseServiceAggregation(t *testing.T) {
+	t.Run("service_preserved_through_aggregation", func(t *testing.T) {
+		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.writer = msw
+		testTime := time.Unix(time.Now().Unix(), 0)
+
+		bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
+		c1 := payloadWithCounts(testTime, bak, "", "test-version", "", "", "", 11, 7, 100)
+		c1.Service = "my-base-service"
+		c2 := payloadWithCounts(testTime, bak, "", "test-version", "", "", "", 27, 2, 300)
+		c2.Service = "my-base-service"
+
+		a.add(testTime, deepCopy(c1))
+		a.add(testTime, deepCopy(c2))
+		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+
+		require.Len(t, msw.payloads, 1)
+		require.Len(t, msw.payloads[0].Stats, 1)
+		assert.Equal(t, "my-base-service", msw.payloads[0].Stats[0].Service)
+	})
+
+	t.Run("different_service_separate_payloads", func(t *testing.T) {
+		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.writer = msw
+		testTime := time.Unix(time.Now().Unix(), 0)
+
+		bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
+		c1 := payloadWithCounts(testTime, bak, "", "test-version", "", "", "", 11, 7, 100)
+		c1.Service = "service-a"
+		c2 := payloadWithCounts(testTime, bak, "", "test-version", "", "", "", 27, 2, 300)
+		c2.Service = "service-b"
+
+		a.add(testTime, deepCopy(c1))
+		a.add(testTime, deepCopy(c2))
+		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+
+		require.Len(t, msw.payloads, 1)
+		require.Len(t, msw.payloads[0].Stats, 2)
+
+		services := make(map[string]bool)
+		for _, stat := range msw.payloads[0].Stats {
+			services[stat.Service] = true
+		}
+		assert.True(t, services["service-a"])
+		assert.True(t, services["service-b"])
+	})
+
+	t.Run("empty_service_preserved", func(t *testing.T) {
+		a := newTestAggregator()
+		msw := &mockStatsWriter{}
+		a.writer = msw
+		testTime := time.Unix(time.Now().Unix(), 0)
+
+		bak := BucketsAggregationKey{Service: "s", Name: "test.op"}
+		c1 := payloadWithCounts(testTime, bak, "", "test-version", "", "", "", 11, 7, 100)
+		c1.Service = ""
+
+		a.add(testTime, deepCopy(c1))
+		a.flushOnTime(testTime.Add(oldestBucketStart + time.Nanosecond))
+
+		require.Len(t, msw.payloads, 1)
+		require.Len(t, msw.payloads[0].Stats, 1)
+		assert.Equal(t, "", msw.payloads[0].Stats[0].Service)
+	})
+}
+
 func TestNewBucketAggregationKeyPeerTags(t *testing.T) {
 	// The hash of "peer.service:remote-service".
 	peerTagsHash := uint64(3430395298086625290)

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -205,6 +205,7 @@ func (c *Concentrator) addNow(pt *traceutil.ProcessedTrace, tags infraTags) {
 		ImageTag:        pt.ImageTag,
 		Lang:            pt.Lang,
 		ProcessTagsHash: tags.processTagsHash,
+		BaseService:     pt.Root.Meta[tagBaseService],
 	}
 	for _, s := range pt.TraceChunk.Spans {
 		statSpan, ok := c.spanConcentrator.NewStatSpanFromPB(s, c.peerTagKeys, c.spanDerivedPrimaryTagKeys)
@@ -231,6 +232,7 @@ func (c *Concentrator) addNowV1(pt *traceutil.ProcessedTraceV1, tags infraTags) 
 		env = c.agentEnv
 	}
 	weight := weightV1(pt.Root)
+	baseService, _ := pt.Root.GetAttributeAsString(tagBaseService)
 	aggKey := PayloadAggregationKey{
 		Env:             env,
 		Hostname:        hostname,
@@ -239,6 +241,7 @@ func (c *Concentrator) addNowV1(pt *traceutil.ProcessedTraceV1, tags infraTags) 
 		GitCommitSha:    pt.GitCommitSha,
 		ImageTag:        pt.ImageTag,
 		ProcessTagsHash: tags.processTagsHash,
+		BaseService:     baseService,
 	}
 	for _, s := range pt.TraceChunk.Spans {
 		statSpan, ok := c.spanConcentrator.NewStatSpanFromV1(s, c.peerTagKeys, c.spanDerivedPrimaryTagKeys)

--- a/pkg/trace/stats/concentrator_test.go
+++ b/pkg/trace/stats/concentrator_test.go
@@ -1009,6 +1009,92 @@ func TestLangInStats(t *testing.T) {
 	})
 }
 
+func TestBaseServiceInStats(t *testing.T) {
+	t.Run("base_service_propagated", func(t *testing.T) {
+		now := time.Now()
+		spans := []*pb.Span{testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, map[string]string{
+			"_dd.base_service": "base-svc",
+		})}
+		traceutil.ComputeTopLevel(spans)
+
+		testTrace := toProcessedTrace(spans, "none", "", "", "", "", "")
+		c := NewTestConcentrator(now)
+		c.addNow(testTrace, infraTags{})
+
+		stats := c.flushNow(now.UnixNano()+int64(c.spanConcentrator.bufferLen)*testBucketInterval, false)
+		require.Len(t, stats.Stats, 1)
+		assert.Equal(t, "base-svc", stats.Stats[0].Service)
+	})
+
+	t.Run("empty_base_service", func(t *testing.T) {
+		now := time.Now()
+		spans := []*pb.Span{testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, nil)}
+		traceutil.ComputeTopLevel(spans)
+
+		testTrace := toProcessedTrace(spans, "none", "", "", "", "", "")
+		c := NewTestConcentrator(now)
+		c.addNow(testTrace, infraTags{})
+
+		stats := c.flushNow(now.UnixNano()+int64(c.spanConcentrator.bufferLen)*testBucketInterval, false)
+		require.Len(t, stats.Stats, 1)
+		assert.Equal(t, "", stats.Stats[0].Service)
+	})
+
+	t.Run("different_base_service_separate_payloads", func(t *testing.T) {
+		now := time.Now()
+		c := NewTestConcentrator(now)
+
+		spans1 := []*pb.Span{testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, map[string]string{
+			"_dd.base_service": "base-svc-1",
+		})}
+		traceutil.ComputeTopLevel(spans1)
+		testTrace1 := toProcessedTrace(spans1, "none", "", "", "", "", "")
+
+		spans2 := []*pb.Span{testSpan(now, 2, 0, 60, 5, "A1", "resource1", 0, map[string]string{
+			"_dd.base_service": "base-svc-2",
+		})}
+		traceutil.ComputeTopLevel(spans2)
+		testTrace2 := toProcessedTrace(spans2, "none", "", "", "", "", "")
+
+		c.addNow(testTrace1, infraTags{})
+		c.addNow(testTrace2, infraTags{})
+
+		stats := c.flushNow(now.UnixNano()+int64(c.spanConcentrator.bufferLen)*testBucketInterval, false)
+		require.Len(t, stats.Stats, 2)
+
+		services := make(map[string]bool)
+		for _, stat := range stats.Stats {
+			services[stat.Service] = true
+		}
+		assert.True(t, services["base-svc-1"])
+		assert.True(t, services["base-svc-2"])
+	})
+
+	t.Run("same_base_service_same_payload", func(t *testing.T) {
+		now := time.Now()
+		c := NewTestConcentrator(now)
+
+		spans1 := []*pb.Span{testSpan(now, 1, 0, 50, 5, "A1", "resource1", 0, map[string]string{
+			"_dd.base_service": "base-svc",
+		})}
+		traceutil.ComputeTopLevel(spans1)
+		testTrace1 := toProcessedTrace(spans1, "none", "", "", "", "", "")
+
+		spans2 := []*pb.Span{testSpan(now, 2, 0, 60, 5, "A1", "resource1", 0, map[string]string{
+			"_dd.base_service": "base-svc",
+		})}
+		traceutil.ComputeTopLevel(spans2)
+		testTrace2 := toProcessedTrace(spans2, "none", "", "", "", "", "")
+
+		c.addNow(testTrace1, infraTags{})
+		c.addNow(testTrace2, infraTags{})
+
+		stats := c.flushNow(now.UnixNano()+int64(c.spanConcentrator.bufferLen)*testBucketInterval, false)
+		require.Len(t, stats.Stats, 1)
+		assert.Equal(t, "base-svc", stats.Stats[0].Service)
+	})
+}
+
 func TestServiceSourceInStats(t *testing.T) {
 	now := time.Now()
 	c := NewTestConcentrator(now)

--- a/pkg/trace/stats/span_concentrator.go
+++ b/pkg/trace/stats/span_concentrator.go
@@ -406,6 +406,7 @@ func (sc *SpanConcentrator) Flush(now int64, force bool) []*pb.ClientStatsPayloa
 			GitCommitSha:    k.GitCommitSha,
 			ImageTag:        k.ImageTag,
 			Lang:            k.Lang,
+			Service:         k.BaseService,
 			Stats:           s,
 			Tags:            containerTagsByID[k.ContainerID],
 			ProcessTags:     processTagsByHash[k.ProcessTagsHash],

--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -150,6 +150,7 @@ func (sb *RawBucket) Export() map[PayloadAggregationKey]*pb.ClientStatsBucket {
 			ImageTag:        k.ImageTag,
 			Lang:            k.Lang,
 			ProcessTagsHash: k.ProcessTagsHash,
+			BaseService:     k.BaseService,
 		}
 		s, ok := m[key]
 		if !ok {

--- a/releasenotes/notes/fix-keep-base-service-on-apm-server-stats-cafcb381b064de00.yaml
+++ b/releasenotes/notes/fix-keep-base-service-on-apm-server-stats-cafcb381b064de00.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix base_service tag being missed on a subset of APM stats
+    matching span.kind=server.


### PR DESCRIPTION
### What does this PR do?

This PR ensures that ClientStatsPayload.Service is always filled with the client base_service


For agent based stats computation, the ClientStatsPayload.Service field was never filled. Base service was set only in peer tags for a subset of span kinds. In particular it is [missed for span.Kind = "server"](https://github.com/DataDog/datadog-agent/blob/7.76.1/pkg/trace/stats/span_concentrator.go#L80-L97)

On agent 7.57 by mistake the support of the[ Service field was removed on ClientStatsPayload](https://github.com/DataDog/datadog-agent/pull/28129), in particular for dd-trace-java the field is ignored from [agent 7.57, agent 7.77]

### Motivation

### Describe how you validated your changes

### Additional Notes
