### PR TITLE
Drop gstatus from non-linux

### DIFF
--- a/deps/gstatus/BUILD.bazel
+++ b/deps/gstatus/BUILD.bazel
@@ -25,10 +25,7 @@ genrule(
     srcs = ["@gstatus_binary//file"],
     outs = ["gstatus"],
     cmd = "sed -e '1s@.*@#!/opt/datadog-agent/embedded/bin/python@' $(location @gstatus_binary//file:file) >$@",
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 pkg_files(

--- a/deps/gstatus/BUILD.bazel
+++ b/deps/gstatus/BUILD.bazel
@@ -25,6 +25,10 @@ genrule(
     srcs = ["@gstatus_binary//file"],
     outs = ["gstatus"],
     cmd = "sed -e '1s@.*@#!/opt/datadog-agent/embedded/bin/python@' $(location @gstatus_binary//file:file) >$@",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 pkg_files(

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -9,8 +9,8 @@ pkg_filegroup(
     srcs = [
         "//packages/install_dir/embedded:all_files",
     ] + select({
-        "@platforms//os:windows": [],
-        "//conditions:default": ["//deps/gstatus:all_files"],
+        "@platforms//os:linux": ["//deps/gstatus:all_files"],
+        "//conditions:default": [],
     }),
 )
 

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -7,11 +7,11 @@ package(default_visibility = ["//packages:__subpackages__"])
 pkg_filegroup(
     name = "embedded",
     srcs = [
-        "//deps/gstatus:bin_files",
-        # have to include this explicitly because it is not hooked up with package_metadata
-        "//deps/gstatus:license_file",
         "//packages/install_dir/embedded:all_files",
-    ],
+    ] + select({
+        "@platforms//os:windows": [],
+        "//conditions:default": ["//deps/gstatus:all_files"],
+    }),
 )
 
 # This is a placeholder for an eventual group containg (the future) top level binaries


### PR DESCRIPTION
### What does this PR do?

It removes the gstatus binary from systems other than linux.

### Motivation

This was accidentally added in https://github.com/DataDog/datadog-agent/pull/43788 while moving some of the layout code from omnibus to Bazel (adding 7+ MiB to the msi on-disk size). `gstatus` is only meant to be linux-compatible:
- datadog-glusterfs is the only user of it in the Agent, and is only shipped on linux: https://github.com/DataDog/integrations-core/blob/178172224a9c7de4f015b31a4d0b3bbf3f587549/requirements-agent-release.txt#L87
- gstatus depends on glustercli [which is only linux](https://github.com/gluster/glustercli-python/blob/920ddcec3d774de28a7f8cf04e033f0d0fa40c13/setup.py#L30). 

### Describe how you validated your changes

- Checking that non-linux packages drop gstatus and linux packages kept it.
- Green CI.

### Additional Notes

I added `target_compatible_with` to the gstatus "binary" target as an extra measure to fail fast and ensure it doesn't get shipped other than in Linux.