### PR TITLE
Add USM team as CODEOWNERS for /test/new-e2e/tests/usm

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -848,6 +848,7 @@
 # windows-products primary owner for windows tests so we get failure notifications
 /test/new-e2e/tests/installer/windows         @DataDog/windows-products @DataDog/fleet
 /test/new-e2e/tests/gpu                       @DataDog/ebpf-platform
+/test/new-e2e/tests/usm                       @DataDog/universal-service-monitoring
 /test/new-e2e/examples/ecs_test.go           @DataDog/ecs-experiences
 /test/otel/                                   @DataDog/opentelemetry-agent
 /test/static/                                 @DataDog/agent-build


### PR DESCRIPTION
### What does this PR do?
Set USM team as the code owners of `/test/new-e2e/tests/usm`.

### Motivation
Ensure the universal-service-monitoring team is notified and required as reviewers for changes to USM e2e tests.

### Describe how you validated your changes
Verified the CODEOWNERS entry follows the existing format and is placed with the other `/test/new-e2e/tests/` entries.

### Additional Notes
