### PR TITLE
pkg/clusteragent/admission: remove unused wmeta field from admission webhook structs

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -122,7 +122,7 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 	}
 
 	// Setup config webhook.
-	configWebhook, err := generateConfigWebhook(wmeta, datadogConfig)
+	configWebhook, err := generateConfigWebhook(datadogConfig)
 	if err != nil {
 		log.Errorf("failed to register config webhook: %v", err)
 	} else {
@@ -130,7 +130,7 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 	}
 
 	// Setup tags from labels webhook.
-	tagsWebhook, err := generateTagsFromLabelsWebhook(wmeta, datadogConfig)
+	tagsWebhook, err := generateTagsFromLabelsWebhook(datadogConfig)
 	if err != nil {
 		log.Errorf("failed to register tags from labels webhook: %v", err)
 	} else {
@@ -180,23 +180,23 @@ func (c *controllerBase) generateWebhooks(wmeta workloadmeta.Component, pa workl
 	return webhooks
 }
 
-func generateConfigWebhook(wmeta workloadmeta.Component, datadogConfig config.Component) (*configWebhook.Webhook, error) {
+func generateConfigWebhook(datadogConfig config.Component) (*configWebhook.Webhook, error) {
 	filter, err := configWebhook.NewFilter(datadogConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create config filter: %v", err)
 	}
 	mutatorCfg := configWebhook.NewMutatorConfig(datadogConfig)
 	mutator := configWebhook.NewMutator(mutatorCfg, filter)
-	return configWebhook.NewWebhook(wmeta, datadogConfig, mutator), nil
+	return configWebhook.NewWebhook(datadogConfig, mutator), nil
 }
 
-func generateTagsFromLabelsWebhook(wmeta workloadmeta.Component, datadogConfig config.Component) (*tagsfromlabels.Webhook, error) {
+func generateTagsFromLabelsWebhook(datadogConfig config.Component) (*tagsfromlabels.Webhook, error) {
 	filter, err := tagsfromlabels.NewFilter(datadogConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tags from labels filter: %v", err)
 	}
 	mutator := tagsfromlabels.NewMutator(tagsfromlabels.NewMutatorConfig(datadogConfig), filter)
-	return tagsfromlabels.NewWebhook(wmeta, datadogConfig, mutator), nil
+	return tagsfromlabels.NewWebhook(datadogConfig, mutator), nil
 }
 
 // controllerBase acts as a base class for ControllerV1 and ControllerV1beta1.

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go
@@ -47,6 +47,6 @@ func NewAutoInstrumentation(datadogConfig config.Component, wmeta workloadmeta.C
 		apm,
 	)
 	labelSelectors := NewLabelSelectors(NewLabelSelectorsConfig(datadogConfig))
-	return NewWebhook(config.Webhook, wmeta, mutator, labelSelectors)
+	return NewWebhook(config.Webhook, mutator, labelSelectors)
 
 }

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -60,14 +59,13 @@ type Webhook struct {
 	resources       map[string][]string
 	operations      []admissionregistrationv1.OperationType
 	matchConditions []admissionregistrationv1.MatchCondition
-	wmeta           workloadmeta.Component
 	mutator         mutatecommon.Mutator
 	config          *WebhookConfig
 	labelSelectors  *LabelSelectors
 }
 
 // NewWebhook returns a new Webhook dependent on the injection filter.
-func NewWebhook(config *WebhookConfig, wmeta workloadmeta.Component, mutator mutatecommon.Mutator, labelSelectors *LabelSelectors) (*Webhook, error) {
+func NewWebhook(config *WebhookConfig, mutator mutatecommon.Mutator, labelSelectors *LabelSelectors) (*Webhook, error) {
 	log.Debug("Successfully created SSI webhook")
 	return &Webhook{
 		name:            WebhookName,
@@ -75,7 +73,6 @@ func NewWebhook(config *WebhookConfig, wmeta workloadmeta.Component, mutator mut
 		operations:      WebhookOperations,
 		matchConditions: WebhookMatchConditions,
 		mutator:         mutator,
-		wmeta:           wmeta,
 		config:          config,
 		labelSelectors:  labelSelectors,
 	}, nil

--- a/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook_test.go
+++ b/pkg/clusteragent/admission/mutate/autoinstrumentation/webhook_test.go
@@ -81,11 +81,10 @@ func TestWebhookIsEnabled(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			mockMeta := common.FakeStore(t)
 			mockMutator := common.FakeMutator(t, false)
 			mockLabelSelectors := NewFakeLabelSelector()
 
-			webhook, err := autoinstrumentation.NewWebhook(test.config, mockMeta, mockMutator, mockLabelSelectors)
+			webhook, err := autoinstrumentation.NewWebhook(test.config, mockMutator, mockLabelSelectors)
 			require.NoError(t, err)
 
 			require.Equal(t, test.expected, webhook.IsEnabled())
@@ -108,11 +107,10 @@ func TestWebhookEndpoint(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			mockMeta := common.FakeStore(t)
 			mockMutator := common.FakeMutator(t, false)
 			mockLabelSelectors := NewFakeLabelSelector()
 
-			webhook, err := autoinstrumentation.NewWebhook(test.config, mockMeta, mockMutator, mockLabelSelectors)
+			webhook, err := autoinstrumentation.NewWebhook(test.config, mockMutator, mockLabelSelectors)
 			require.NoError(t, err)
 
 			require.Equal(t, test.expected, webhook.Endpoint())
@@ -165,12 +163,11 @@ func TestWebhookLabelSelectors(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			mockConfig := common.FakeConfigWithValues(t, test.config)
-			mockMeta := common.FakeStore(t)
 			mockMutator := common.FakeMutator(t, false)
 
 			labelSelectors := autoinstrumentation.NewLabelSelectors(autoinstrumentation.NewLabelSelectorsConfig(mockConfig))
 			config := autoinstrumentation.NewWebhookConfig(mockConfig)
-			webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator, labelSelectors)
+			webhook, err := autoinstrumentation.NewWebhook(config, mockMutator, labelSelectors)
 			require.NoError(t, err)
 
 			namespaceSelector, selector := webhook.LabelSelectors(test.useNamespaceSelector)
@@ -182,12 +179,11 @@ func TestWebhookLabelSelectors(t *testing.T) {
 
 func TestWebhookResources(t *testing.T) {
 	mockConfig := common.FakeConfig(t)
-	mockMeta := common.FakeStore(t)
 	mockMutator := common.FakeMutator(t, false)
 	mockLabelSelectors := NewFakeLabelSelector()
 
 	config := autoinstrumentation.NewWebhookConfig(mockConfig)
-	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator, mockLabelSelectors)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMutator, mockLabelSelectors)
 	require.NoError(t, err)
 
 	require.Equal(t, autoinstrumentation.WebhookResources, webhook.Resources())
@@ -195,12 +191,11 @@ func TestWebhookResources(t *testing.T) {
 
 func TestWebhookTimeout(t *testing.T) {
 	mockConfig := common.FakeConfig(t)
-	mockMeta := common.FakeStore(t)
 	mockMutator := common.FakeMutator(t, false)
 	mockLabelSelectors := NewFakeLabelSelector()
 
 	config := autoinstrumentation.NewWebhookConfig(mockConfig)
-	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator, mockLabelSelectors)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMutator, mockLabelSelectors)
 	require.NoError(t, err)
 
 	require.Equal(t, int32(0), webhook.Timeout())
@@ -208,12 +203,11 @@ func TestWebhookTimeout(t *testing.T) {
 
 func TestWebhookOperations(t *testing.T) {
 	mockConfig := common.FakeConfig(t)
-	mockMeta := common.FakeStore(t)
 	mockMutator := common.FakeMutator(t, false)
 	mockLabelSelectors := NewFakeLabelSelector()
 
 	config := autoinstrumentation.NewWebhookConfig(mockConfig)
-	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator, mockLabelSelectors)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMutator, mockLabelSelectors)
 	require.NoError(t, err)
 
 	require.Equal(t, autoinstrumentation.WebhookOperations, webhook.Operations())
@@ -221,12 +215,11 @@ func TestWebhookOperations(t *testing.T) {
 
 func TestWebhookMatchConditions(t *testing.T) {
 	mockConfig := common.FakeConfig(t)
-	mockMeta := common.FakeStore(t)
 	mockMutator := common.FakeMutator(t, false)
 	mockLabelSelectors := NewFakeLabelSelector()
 
 	config := autoinstrumentation.NewWebhookConfig(mockConfig)
-	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator, mockLabelSelectors)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMutator, mockLabelSelectors)
 	require.NoError(t, err)
 
 	require.Equal(t, autoinstrumentation.WebhookMatchConditions, webhook.MatchConditions())
@@ -234,12 +227,11 @@ func TestWebhookMatchConditions(t *testing.T) {
 
 func TestWebhookName(t *testing.T) {
 	mockConfig := common.FakeConfig(t)
-	mockMeta := common.FakeStore(t)
 	mockMutator := common.FakeMutator(t, false)
 	mockLabelSelectors := NewFakeLabelSelector()
 
 	config := autoinstrumentation.NewWebhookConfig(mockConfig)
-	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator, mockLabelSelectors)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMutator, mockLabelSelectors)
 	require.NoError(t, err)
 
 	require.Equal(t, autoinstrumentation.WebhookName, webhook.Name())
@@ -247,12 +239,11 @@ func TestWebhookName(t *testing.T) {
 
 func TestWebhookType(t *testing.T) {
 	mockConfig := common.FakeConfig(t)
-	mockMeta := common.FakeStore(t)
 	mockMutator := common.FakeMutator(t, false)
 	mockLabelSelectors := NewFakeLabelSelector()
 
 	config := autoinstrumentation.NewWebhookConfig(mockConfig)
-	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator, mockLabelSelectors)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMutator, mockLabelSelectors)
 	require.NoError(t, err)
 
 	require.Equal(t, admissioncommon.MutatingWebhook, webhook.WebhookType().String())
@@ -260,12 +251,11 @@ func TestWebhookType(t *testing.T) {
 
 func TestWebhookFunc(t *testing.T) {
 	mockConfig := common.FakeConfig(t)
-	mockMeta := common.FakeStore(t)
 	mockMutator := common.FakeMutator(t, false)
 	mockLabelSelectors := NewFakeLabelSelector()
 
 	config := autoinstrumentation.NewWebhookConfig(mockConfig)
-	webhook, err := autoinstrumentation.NewWebhook(config, mockMeta, mockMutator, mockLabelSelectors)
+	webhook, err := autoinstrumentation.NewWebhook(config, mockMutator, mockLabelSelectors)
 	require.NoError(t, err)
 
 	pod := common.FakePod("foo")

--- a/pkg/clusteragent/admission/mutate/config/config.go
+++ b/pkg/clusteragent/admission/mutate/config/config.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 )
@@ -77,12 +76,11 @@ type Webhook struct {
 	resources       map[string][]string
 	operations      []admissionregistrationv1.OperationType
 	matchConditions []admissionregistrationv1.MatchCondition
-	wmeta           workloadmeta.Component
 	mutator         mutatecommon.Mutator
 }
 
 // NewWebhook returns a new Webhook
-func NewWebhook(wmeta workloadmeta.Component, datadogConfig config.Component, mutator mutatecommon.Mutator) *Webhook {
+func NewWebhook(datadogConfig config.Component, mutator mutatecommon.Mutator) *Webhook {
 	return &Webhook{
 		name:            webhookName,
 		isEnabled:       datadogConfig.GetBool("admission_controller.inject_config.enabled"),
@@ -90,7 +88,6 @@ func NewWebhook(wmeta workloadmeta.Component, datadogConfig config.Component, mu
 		resources:       map[string][]string{"": {"pods"}},
 		operations:      []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 		matchConditions: []admissionregistrationv1.MatchCondition{},
-		wmeta:           wmeta,
 		mutator:         mutator,
 	}
 }

--- a/pkg/clusteragent/admission/mutate/config/config_test.go
+++ b/pkg/clusteragent/admission/mutate/config/config_test.go
@@ -22,13 +22,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
-	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	admCommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common/namespace"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
@@ -90,12 +86,11 @@ func Test_injectionMode(t *testing.T) {
 func TestInjectHostIP(t *testing.T) {
 	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true"})
-	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	datadogConfig := config.NewMock(t)
 	filter, err := NewFilter(datadogConfig)
 	require.NoError(t, err)
 	mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-	webhook := NewWebhook(wmeta, datadogConfig, mutator)
+	webhook := NewWebhook(datadogConfig, mutator)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -105,12 +100,11 @@ func TestInjectHostIP(t *testing.T) {
 func TestInjectService(t *testing.T) {
 	pod := mutatecommon.FakePodWithContainer("foo-pod", corev1.Container{})
 	pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": "service"})
-	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	datadogConfig := config.NewMock(t)
 	filter, err := NewFilter(datadogConfig)
 	require.NoError(t, err)
 	mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-	webhook := NewWebhook(wmeta, datadogConfig, mutator)
+	webhook := NewWebhook(datadogConfig, mutator)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.Nil(t, err)
 	assert.True(t, injected)
@@ -134,15 +128,10 @@ func TestInjectEntityID(t *testing.T) {
 			})
 			pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true"})
 			datadogConfig := config.NewMockWithOverrides(t, tt.configOverrides)
-			wmeta := fxutil.Test[workloadmeta.Component](
-				t,
-				core.MockBundle(),
-				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-			)
 			filter, err := NewFilter(datadogConfig)
 			require.NoError(t, err)
 			mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-			webhook := NewWebhook(wmeta, datadogConfig, mutator)
+			webhook := NewWebhook(datadogConfig, mutator)
 			injected, err := webhook.inject(pod, "", nil)
 			assert.Nil(t, err)
 			assert.True(t, injected)
@@ -472,7 +461,6 @@ func TestInjectSocket(t *testing.T) {
 			}
 
 			pod = mutatecommon.WithLabels(pod, map[string]string{"admission.datadoghq.com/enabled": "true", "admission.datadoghq.com/config.mode": mode})
-			wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 
 			datadogConfig := config.NewMockWithOverrides(t, map[string]interface{}{
 				"csi.enabled":                  test.withCSIDriver,
@@ -485,7 +473,7 @@ func TestInjectSocket(t *testing.T) {
 			filter, err := NewFilter(datadogConfig)
 			require.NoError(t, err)
 			mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-			webhook := NewWebhook(wmeta, datadogConfig, mutator)
+			webhook := NewWebhook(datadogConfig, mutator)
 			injected, err := webhook.inject(pod, "", nil)
 			assert.Nil(t, err)
 			assert.True(t, injected)
@@ -691,15 +679,10 @@ func TestInjectSocket_VolumeTypeSocket(t *testing.T) {
 				"apm_config.receiver_socket":                             test.apmSocketFilePath,
 				"dogstatsd_socket":                                       test.dsdSocketFilePath,
 			})
-			wmeta := fxutil.Test[workloadmeta.Component](
-				t,
-				core.MockBundle(),
-				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-			)
 			filter, err := NewFilter(datadogConfig)
 			require.NoError(t, err)
 			mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-			webhook := NewWebhook(wmeta, datadogConfig, mutator)
+			webhook := NewWebhook(datadogConfig, mutator)
 			injected, err := webhook.inject(pod, "", nil)
 			assert.Nil(t, err)
 			assert.True(t, injected)
@@ -763,12 +746,11 @@ func TestInjectSocketWithConflictingVolumeAndInitContainer(t *testing.T) {
 		},
 	}
 
-	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	datadogConfig := config.NewMock(t)
 	filter, err := NewFilter(datadogConfig)
 	require.NoError(t, err)
 	mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-	webhook := NewWebhook(wmeta, datadogConfig, mutator)
+	webhook := NewWebhook(datadogConfig, mutator)
 	injected, err := webhook.inject(pod, "", nil)
 	assert.True(t, injected)
 	assert.Nil(t, err)
@@ -803,14 +785,10 @@ func TestJSONPatchCorrectness(t *testing.T) {
 			podJSON, err := json.Marshal(pod)
 			assert.NoError(t, err)
 			datadogConfig := config.NewMockWithOverrides(t, tt.overrides)
-			wmeta := fxutil.Test[workloadmeta.Component](t,
-				core.MockBundle(),
-				workloadmetafxmock.MockModule(workloadmeta.NewParams()),
-			)
 			filter, err := NewFilter(datadogConfig)
 			require.NoError(t, err)
 			mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-			webhook := NewWebhook(wmeta, datadogConfig, mutator)
+			webhook := NewWebhook(datadogConfig, mutator)
 			request := admission.Request{
 				Object:    podJSON,
 				Namespace: "bar",
@@ -839,12 +817,11 @@ func BenchmarkJSONPatch(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	wmeta := fxutil.Test[workloadmeta.Component](b, core.MockBundle())
 	datadogConfig := config.NewMock(b)
 	filter, err := NewFilter(datadogConfig)
 	require.NoError(b, err)
 	mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-	webhook := NewWebhook(wmeta, datadogConfig, mutator)
+	webhook := NewWebhook(datadogConfig, mutator)
 	podJSON := obj.(*admiv1.AdmissionReview).Request.Object.Raw
 
 	b.ResetTimer()

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/cluster-agent/admission"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/common"
 	mutatecommon "github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
 )
@@ -33,12 +32,11 @@ type Webhook struct {
 	resources       map[string][]string
 	operations      []admissionregistrationv1.OperationType
 	matchConditions []admissionregistrationv1.MatchCondition
-	wmeta           workloadmeta.Component
 	mutator         mutatecommon.Mutator
 }
 
 // NewWebhook returns a new Webhook
-func NewWebhook(wmeta workloadmeta.Component, datadogConfig config.Component, mutator mutatecommon.Mutator) *Webhook {
+func NewWebhook(datadogConfig config.Component, mutator mutatecommon.Mutator) *Webhook {
 	return &Webhook{
 		name:            webhookName,
 		isEnabled:       datadogConfig.GetBool("admission_controller.inject_tags.enabled"),
@@ -46,7 +44,6 @@ func NewWebhook(wmeta workloadmeta.Component, datadogConfig config.Component, mu
 		resources:       map[string][]string{"": {"pods"}},
 		operations:      []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 		matchConditions: []admissionregistrationv1.MatchCondition{},
-		wmeta:           wmeta,
 		mutator:         mutator,
 	}
 }

--- a/pkg/clusteragent/admission/mutate/tagsfromlabels/tags_test.go
+++ b/pkg/clusteragent/admission/mutate/tagsfromlabels/tags_test.go
@@ -14,12 +14,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 
-	"github.com/DataDog/datadog-agent/comp/core"
 	"github.com/DataDog/datadog-agent/comp/core/config"
-	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/admission/mutate/common"
-	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
 var scheme = kscheme.Scheme
@@ -163,14 +159,13 @@ func Test_injectTags(t *testing.T) {
 			},
 		},
 	}
-	wmeta := fxutil.Test[workloadmeta.Component](t, core.MockBundle(), workloadmetafxmock.MockModule(workloadmeta.NewParams()))
 	datadogConfig := config.NewMock(t)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			filter, err := NewFilter(datadogConfig)
 			assert.NoError(t, err)
 			mutator := NewMutator(NewMutatorConfig(datadogConfig), filter)
-			webhook := NewWebhook(wmeta, datadogConfig, mutator)
+			webhook := NewWebhook(datadogConfig, mutator)
 			_, err = webhook.inject(tt.pod, "ns", nil)
 			assert.NoError(t, err)
 			assert.Len(t, tt.pod.Spec.Containers, 1)


### PR DESCRIPTION
### What does this PR do?

The wmeta (workloadmeta.Component) field was stored in the Webhook struct for config, tagsfromlabels, and autoinstrumentation webhooks but never read. All mutation logic is delegated to the mutator field. Remove the field and the corresponding NewWebhook parameter, updating all call sites and tests.

### Motivation

Reduce component dependencies.

### Describe how you validated your changes

### Additional Notes
