### PR TITLE
Dockerfiles: include `apt update` to all `apt install` commands

### DIFF
--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -26,16 +26,15 @@ RUN if [ "$CI" = "true" ]; then \
   fi
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update
 
 FROM baseimage AS nosys-seccomp
-RUN apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
+RUN apt update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
 COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c  -lseccomp
 
 FROM baseimage AS extract-base
-RUN apt install --no-install-recommends -y curl ca-certificates maven xz-utils
+RUN apt update && apt install --no-install-recommends -y curl ca-certificates maven xz-utils
 
 ############################################################
 #  Preparation stage: retrieval of 3rd party dependencies  #
@@ -81,7 +80,8 @@ ENV DOCKER_DD_AGENT=true \
     S6_READ_ONLY_ROOT=1
 
 # make sure we have recent dependencies -- CVE-fixing time!
-RUN apt full-upgrade -y \
+RUN apt update && \
+  apt full-upgrade -y \
   # Install iproute2 package for the ss utility that is used by the network check.
   # When the network check will have switched from using ss to directly parsing /proc/net/tcp,
   # this can be removed

--- a/Dockerfiles/agent/Dockerfile
+++ b/Dockerfiles/agent/Dockerfile
@@ -80,8 +80,8 @@ ENV DOCKER_DD_AGENT=true \
     S6_READ_ONLY_ROOT=1
 
 # make sure we have recent dependencies -- CVE-fixing time!
-RUN apt update && \
-  apt full-upgrade -y \
+RUN apt update \
+  && apt full-upgrade -y \
   # Install iproute2 package for the ss utility that is used by the network check.
   # When the network check will have switched from using ss to directly parsing /proc/net/tcp,
   # this can be removed

--- a/Dockerfiles/base-image/Dockerfile
+++ b/Dockerfiles/base-image/Dockerfile
@@ -26,10 +26,9 @@ RUN if [ "$CI" = "true" ]; then \
   fi
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update
 
 FROM baseimage AS nosys-seccomp
-RUN apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
+RUN apt update && apt install --no-install-recommends -y gcc libc6-dev libseccomp-dev
 COPY nosys-seccomp/nosys.c   /tmp/nosys.c
 COPY nosys-seccomp/nosys.sym /tmp/nosys.sym
 RUN gcc -pipe -Wall -Wextra -O2 -shared -fPIC -Wl,--version-script=/tmp/nosys.sym -o /tmp/nosys.so /tmp/nosys.c  -lseccomp
@@ -44,7 +43,8 @@ LABEL maintainer="Datadog <package@datadoghq.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 # make sure we have recent dependencies -- CVE-fixing time!
-RUN apt full-upgrade -y && \
+RUN apt update && \
+    apt full-upgrade -y && \
     apt install -y tzdata ca-certificates adduser && \
     apt clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### What does this PR do?

Ensure we refresh the packages lists before attempting to install a package

### Motivation

In some conditions, we might use a cached layer for the `apt update` command, but still attempt to run the `apt install` command.
When that happens, if a new package version was pushed upstream, we will fail to download the old package and the image will fail to build

### Describe how you validated your changes

### Additional Notes

[#incident-51085](https://dd.enterprise.slack.com/archives/C0ALTHS133L)
