### PR TITLE
[ACTP] Fix private action runner doc URL in config template

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4607,7 +4607,7 @@ api_key:
 #   # @param actions_allowlist - list of strings - optional
 #   # @env DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST - comma separated list of strings - optional
 #   # List of actions that the Private Action Runner is allowed to execute.
-#   # See http://docs.datadoghq.com/fr/actions/private_actions/use_private_actions#change-the-allowlist-of-a-runner
+#   # See http://docs.datadoghq.com/actions/private_actions/use_private_actions#change-the-allowlist-of-a-runner
 #   # for the list of available actions.
 #
 #   actions_allowlist:


### PR DESCRIPTION
### Description

Remove `/fr/` locale prefix from the private action runner documentation link in `config_template.yaml` so it points to the default English page instead of the French one.

### Test

No test needed — documentation link change only.