### PR TITLE
[NDM] Stop sending device tags directly on SNMP metrics when resource enrichment is enabled

### DIFF
--- a/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/internal/checkconfig/config.go
@@ -85,47 +85,49 @@ type DeviceDigest string
 
 // InitConfig is used to deserialize integration init config
 type InitConfig struct {
-	Profiles              profile.ProfileConfigMap          `yaml:"profiles"`
-	UseRCProfiles         Boolean                           `yaml:"use_remote_config_profiles"`
-	GlobalMetrics         []profiledefinition.MetricsConfig `yaml:"global_metrics"`
-	OidBatchSize          Number                            `yaml:"oid_batch_size"`
-	BulkMaxRepetitions    Number                            `yaml:"bulk_max_repetitions"`
-	CollectDeviceMetadata Boolean                           `yaml:"collect_device_metadata"`
-	CollectTopology       Boolean                           `yaml:"collect_topology"`
-	CollectVPN            Boolean                           `yaml:"collect_vpn"`
-	UseDeviceIDAsHostname Boolean                           `yaml:"use_device_id_as_hostname"`
-	MinCollectionInterval int                               `yaml:"min_collection_interval"`
-	Namespace             string                            `yaml:"namespace"`
-	PingConfig            snmpintegration.PackedPingConfig  `yaml:"ping"`
-	Loader                string                            `yaml:"loader"`
+	Profiles                     profile.ProfileConfigMap          `yaml:"profiles"`
+	UseRCProfiles                Boolean                           `yaml:"use_remote_config_profiles"`
+	GlobalMetrics                []profiledefinition.MetricsConfig `yaml:"global_metrics"`
+	OidBatchSize                 Number                            `yaml:"oid_batch_size"`
+	BulkMaxRepetitions           Number                            `yaml:"bulk_max_repetitions"`
+	CollectDeviceMetadata        Boolean                           `yaml:"collect_device_metadata"`
+	CollectTopology              Boolean                           `yaml:"collect_topology"`
+	CollectVPN                   Boolean                           `yaml:"collect_vpn"`
+	UseDeviceIDAsHostname        Boolean                           `yaml:"use_device_id_as_hostname"`
+	MinCollectionInterval        int                               `yaml:"min_collection_interval"`
+	Namespace                    string                            `yaml:"namespace"`
+	PingConfig                   snmpintegration.PackedPingConfig  `yaml:"ping"`
+	Loader                       string                            `yaml:"loader"`
+	EnrichDeviceTagsFromResource Boolean                           `yaml:"enrich_device_tags_from_resource"`
 }
 
 // InstanceConfig is used to deserialize integration instance config
 type InstanceConfig struct {
-	Name                  string                              `yaml:"name"`
-	IPAddress             string                              `yaml:"ip_address"`
-	Port                  Number                              `yaml:"port"`
-	CommunityString       string                              `yaml:"community_string"`
-	SnmpVersion           string                              `yaml:"snmp_version"`
-	Timeout               Number                              `yaml:"timeout"`
-	Retries               Number                              `yaml:"retries"`
-	User                  string                              `yaml:"user"`
-	AuthProtocol          string                              `yaml:"authProtocol"`
-	AuthKey               string                              `yaml:"authKey"`
-	PrivProtocol          string                              `yaml:"privProtocol"`
-	PrivKey               string                              `yaml:"privKey"`
-	ContextName           string                              `yaml:"context_name"`
-	Metrics               []profiledefinition.MetricsConfig   `yaml:"metrics"`     // SNMP metrics definition
-	MetricTags            []profiledefinition.MetricTagConfig `yaml:"metric_tags"` // SNMP metric tags definition
-	Profile               string                              `yaml:"profile"`
-	UseGlobalMetrics      bool                                `yaml:"use_global_metrics"`
-	CollectDeviceMetadata *Boolean                            `yaml:"collect_device_metadata"`
-	CollectTopology       *Boolean                            `yaml:"collect_topology"`
-	CollectVPN            *Boolean                            `yaml:"collect_vpn"`
-	UseDeviceIDAsHostname *Boolean                            `yaml:"use_device_id_as_hostname"`
-	PingConfig            snmpintegration.PackedPingConfig    `yaml:"ping"`
-	Loader                string                              `yaml:"loader"`
-	UseRCProfiles         *Boolean                            `yaml:"use_remote_config_profiles"`
+	Name                         string                              `yaml:"name"`
+	IPAddress                    string                              `yaml:"ip_address"`
+	Port                         Number                              `yaml:"port"`
+	CommunityString              string                              `yaml:"community_string"`
+	SnmpVersion                  string                              `yaml:"snmp_version"`
+	Timeout                      Number                              `yaml:"timeout"`
+	Retries                      Number                              `yaml:"retries"`
+	User                         string                              `yaml:"user"`
+	AuthProtocol                 string                              `yaml:"authProtocol"`
+	AuthKey                      string                              `yaml:"authKey"`
+	PrivProtocol                 string                              `yaml:"privProtocol"`
+	PrivKey                      string                              `yaml:"privKey"`
+	ContextName                  string                              `yaml:"context_name"`
+	Metrics                      []profiledefinition.MetricsConfig   `yaml:"metrics"`     // SNMP metrics definition
+	MetricTags                   []profiledefinition.MetricTagConfig `yaml:"metric_tags"` // SNMP metric tags definition
+	Profile                      string                              `yaml:"profile"`
+	UseGlobalMetrics             bool                                `yaml:"use_global_metrics"`
+	CollectDeviceMetadata        *Boolean                            `yaml:"collect_device_metadata"`
+	CollectTopology              *Boolean                            `yaml:"collect_topology"`
+	CollectVPN                   *Boolean                            `yaml:"collect_vpn"`
+	UseDeviceIDAsHostname        *Boolean                            `yaml:"use_device_id_as_hostname"`
+	PingConfig                   snmpintegration.PackedPingConfig    `yaml:"ping"`
+	Loader                       string                              `yaml:"loader"`
+	UseRCProfiles                *Boolean                            `yaml:"use_remote_config_profiles"`
+	EnrichDeviceTagsFromResource *Boolean                            `yaml:"enrich_device_tags_from_resource"`
 
 	// ExtraTags is a workaround to pass tags from snmp listener to snmp integration via AD template
 	// (see cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml) that only works with strings.
@@ -208,6 +210,8 @@ type CheckConfig struct {
 	PingConfig  pinger.Config
 
 	UseUnconnectedUDPSocket bool
+
+	EnrichDeviceTagsFromResource bool
 }
 
 // UpdateDeviceIDAndTags updates DeviceID and DeviceIDTags
@@ -285,6 +289,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	instance.UseGlobalMetrics = true
 	initConfig.CollectDeviceMetadata = true
 	initConfig.CollectTopology = true
+	initConfig.EnrichDeviceTagsFromResource = true
 
 	err := yaml.Unmarshal(rawInitConfig, &initConfig)
 	if err != nil {
@@ -340,6 +345,12 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		c.UseDeviceIDAsHostname = bool(*instance.UseDeviceIDAsHostname)
 	} else {
 		c.UseDeviceIDAsHostname = bool(initConfig.UseDeviceIDAsHostname)
+	}
+
+	if instance.EnrichDeviceTagsFromResource != nil {
+		c.EnrichDeviceTagsFromResource = bool(*instance.EnrichDeviceTagsFromResource)
+	} else {
+		c.EnrichDeviceTagsFromResource = bool(initConfig.EnrichDeviceTagsFromResource)
 	}
 
 	if instance.ExtraTags != "" {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck.go
@@ -285,7 +285,12 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 		d.sender.ServiceCheck(serviceCheckName, servicecheck.ServiceCheckOK, tags, "")
 	}
 
-	metricTags := append(tags, "dd.internal.resource:ndm_device:"+d.GetDeviceID())
+	var metricTags []string
+	if d.config.EnrichDeviceTagsFromResource {
+		metricTags = []string{"dd.internal.resource:ndm_device:" + d.GetDeviceID()}
+	} else {
+		metricTags = tags
+	}
 	d.sender.Gauge(deviceReachableMetric, utils.BoolToFloat64(deviceReachable), metricTags)
 	d.sender.Gauge(deviceUnreachableMetric, utils.BoolToFloat64(!deviceReachable), metricTags)
 	if values != nil {

--- a/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/internal/devicecheck/devicecheck_test.go
@@ -47,6 +47,7 @@ collect_topology: false
 `)
 	// language=yaml
 	rawInitConfig := []byte(`
+enrich_device_tags_from_resource: false
 profiles:
  f5-big-ip:
    definition_file: f5-big-ip.yaml
@@ -194,6 +195,7 @@ use_global_metrics: true
 `)
 	// language=yaml
 	rawInitConfig := []byte(`
+enrich_device_tags_from_resource: false
 profiles:
  f5-big-ip:
    definition_file: f5-big-ip.yaml
@@ -349,6 +351,7 @@ collect_topology: false
 `)
 	// language=yaml
 	rawInitConfig := []byte(`
+enrich_device_tags_from_resource: false
 profiles:
  f5-big-ip:
    definition_file: f5-big-ip.yaml
@@ -645,6 +648,114 @@ profiles:
 	sender.AssertNotCalled(t, "Gauge", "datadog.snmp.requests", mock.Anything, mock.Anything, mock.Anything)
 }
 
+func TestEnrichDeviceTagsFromResource(t *testing.T) {
+	profile.SetConfdPathAndCleanProfiles()
+	sess := session.CreateMockSession()
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: public
+collect_device_metadata: false
+metrics:
+- symbol:
+    OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
+    name: myMetric
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+enrich_device_tags_from_resource: false
+profiles:
+ f5-big-ip:
+   definition_file: f5-big-ip.yaml
+`)
+
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig, nil)
+	assert.Nil(t, err)
+	config.EnrichDeviceTagsFromResource = true
+
+	connMgr := NewConnectionManager(config, sessionFactory)
+	deviceCk, err := NewDeviceCheck(config, connMgr, agentconfig.NewMock(t))
+	assert.Nil(t, err)
+
+	sender := mocksender.NewMockSender("123")
+	sender.SetupAcceptAll()
+	deviceCk.SetSender(report.NewMetricSender(sender, "", nil, report.MakeInterfaceBandwidthState()))
+
+	sysObjectIDPacket := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+
+	packets := []gosnmp.SnmpPacket{
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.1.1.0",
+					Type:  gosnmp.OctetString,
+					Value: []byte("my_desc"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.1.2.0",
+					Type:  gosnmp.ObjectIdentifier,
+					Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+				},
+				{
+					Name:  "1.3.6.1.2.1.1.3.0",
+					Type:  gosnmp.TimeTicks,
+					Value: 20,
+				},
+				{
+					Name:  "1.3.6.1.2.1.1.5.0",
+					Type:  gosnmp.OctetString,
+					Value: []byte("foo_sys_name"),
+				},
+			},
+		},
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
+					Type:  gosnmp.Integer,
+					Value: 30,
+				},
+			},
+		},
+	}
+
+	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
+	sess.On("Get", mock.MatchedBy(func(oids []string) bool {
+		return len(oids) > 1 // scalar fetch
+	})).Return(&packets[0], nil)
+	sess.On("Get", mock.MatchedBy(func(oids []string) bool {
+		return len(oids) == 1
+	})).Return(&packets[1], nil)
+
+	err = deviceCk.Run(time.Now())
+	assert.Nil(t, err)
+
+	resourceTag := "dd.internal.resource:ndm_device:default:1.2.3.4"
+
+	// Metrics should have the resource tag
+	sender.AssertMetricTaggedWith(t, "Gauge", deviceReachableMetric, []string{resourceTag})
+
+	// Metrics should NOT have device-level tags (those come from backend enrichment)
+	sender.AssertMetricNotTaggedWith(t, "Gauge", deviceReachableMetric, []string{"snmp_device:1.2.3.4"})
+	sender.AssertMetricNotTaggedWith(t, "Gauge", deviceReachableMetric, []string{"device_namespace:default"})
+
+	// Service checks should still have device tags (they are not resource-enriched)
+	sender.AssertServiceCheck(t, "snmp.can_check", servicecheck.ServiceCheckOK, "", []string{"snmp_device:1.2.3.4"}, "")
+}
+
 func TestRun_sessionCloseError(t *testing.T) {
 	profile.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
@@ -665,6 +776,7 @@ metrics:
 `)
 	// language=yaml
 	rawInitConfig := []byte(`
+enrich_device_tags_from_resource: false
 profiles:
  f5-big-ip:
    definition_file: f5-big-ip.yaml
@@ -711,6 +823,7 @@ ping:
 `)
 	// language=yaml
 	rawInitConfig := []byte(`
+enrich_device_tags_from_resource: false
 profiles:
  f5-big-ip:
    definition_file: f5-big-ip.yaml
@@ -873,6 +986,7 @@ ping:
 `)
 	// language=yaml
 	rawInitConfig := []byte(`
+enrich_device_tags_from_resource: false
 profiles:
  f5-big-ip:
    definition_file: f5-big-ip.yaml

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -110,7 +110,7 @@ tags:
   - "mytag:foo"
 `)
 
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
@@ -424,7 +424,7 @@ metrics:
     tag: interface
 `)
 
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 	chk.singleDeviceCk.SetInterfaceBandwidthState(report.MockInterfaceRateMap("1", 50_000_000, 40_000_000, 20, 10, int64(946684785000000000)))
 
@@ -544,7 +544,7 @@ metrics:
     name: SomeCounter64Metric
 `)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
@@ -624,6 +624,7 @@ tags:
 `)
 	// language=yaml
 	rawInitConfig := []byte(`
+enrich_device_tags_from_resource: false
 profiles:
   f5-big-ip:
     definition_file: f5-big-ip.yaml
@@ -1013,7 +1014,7 @@ ip_address: 1.2.3.4
 community_string: public
 `)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
@@ -1266,7 +1267,7 @@ namespace: '%s'
 			deps := createDeps(t)
 			senderManager := deps.Demultiplexer
 
-			err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+			err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 			assert.Nil(t, err)
 
 			sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
@@ -1321,7 +1322,7 @@ metrics:
     name: myMetric
 `)
 	senderManager := mocksender.CreateDefaultDemultiplexer()
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
@@ -1373,7 +1374,7 @@ tags:
   - "autodiscovery_subnet:127.0.0.0/30"
 `)
 	// language=yaml
-	rawInitConfig := []byte(``)
+	rawInitConfig := []byte(`enrich_device_tags_from_resource: false`)
 
 	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
@@ -1707,7 +1708,7 @@ tags:
   - "autodiscovery_subnet:127.0.0.0/30"
 `)
 	// language=yaml
-	rawInitConfig := []byte(``)
+	rawInitConfig := []byte(`enrich_device_tags_from_resource: false`)
 
 	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
@@ -1852,7 +1853,7 @@ metric_tags:
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	_, err = waitForDiscoveredDevices(chk.discovery, 4, 2*time.Second)
@@ -2209,7 +2210,7 @@ metric_tags:
 	sess.On("GetNext", []string{"1.0"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	_, err = waitForDiscoveredDevices(chk.discovery, 4, 2*time.Second)
@@ -2275,7 +2276,7 @@ metrics:
 use_device_id_as_hostname: true
 `)
 
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSenderWithSenderManager(chk.ID(), senderManager)
@@ -2494,7 +2495,7 @@ metrics:
 	}
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
 
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	_, err = waitForDiscoveredDevices(chk.discovery, 4, 2*time.Second)
@@ -2686,7 +2687,7 @@ ip_address: 1.2.3.4
 community_string: public
 `)
 
-	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	err := chk.Configure(senderManager, integration.FakeConfigHash, rawInstanceConfig, []byte(`enrich_device_tags_from_resource: false`), "test")
 	assert.Nil(t, err)
 
 	// check Cancel does not panic when called with single check

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -551,6 +551,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.timeout", 5)
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.retries", 3)
 
+	config.BindEnvAndSetDefault("network_devices.snmp.enrich_device_tags_from_resource", false)
+
 	config.BindEnvAndSetDefault("network_devices.default_scan.enabled", false)
 
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.snmp_traps.forwarder.")


### PR DESCRIPTION
### What does this PR do?
When `enrich_device_tags_from_resource` is enabled, SNMP metrics only carry the `dd.internal.resource:ndm_device:<id>` tag instead of all device-level tags. The backend enriches metrics with device tags from the NDM metadata resource, making it the single source of truth, similar to how SetExternalTags works for host tags.

This fixes a bug where changing device tags (e.g. site, profile) causes metrics to temporarily carry both old and new tag values: the agent sends metrics with new tags, but the backend also enriches with old cached resource tags until metadata is reprocessed.

The flag defaults to on, and can be disabled per-instance or in init_config with `enrich_device_tags_from_resource: false`.

### Motivation

### Describe how you validated your changes

### Additional Notes
