### PR TITLE
[Backport 7.77.x][CWS] handle runc CLONE_INTO_CGROUP to fix cgroup ID propagation (#47796)

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -36,11 +36,6 @@ void __attribute__((always_inline)) copy_proc_entry(struct process_entry_t *src,
     bpf_probe_read(dst->comm, TASK_COMM_LEN, src->comm);
 }
 
-void __attribute__((always_inline)) copy_proc_cache(struct proc_cache_t *src, struct proc_cache_t *dst) {
-    dst->cgroup = src->cgroup;
-    copy_proc_entry(&src->entry, &dst->entry);
-}
-
 void __attribute__((always_inline)) copy_pid_cache_except_exit_ts(struct pid_cache_t *src, struct pid_cache_t *dst) {
     dst->cookie = src->cookie;
     dst->user_session_id = src->user_session_id;

--- a/pkg/security/ebpf/c/include/hooks/cgroup.h
+++ b/pkg/security/ebpf/c/include/hooks/cgroup.h
@@ -60,8 +60,8 @@ static __attribute__((always_inline)) int trace__cgroup_write(ctx_t *ctx) {
         // Select the old cache entry
         old_entry = get_proc_from_cookie(cookie);
         if (old_entry) {
-            // copy cache data
-            copy_proc_cache(old_entry, &new_entry);
+            new_entry.cgroup = old_entry->cgroup;
+            copy_proc_entry(&old_entry->entry, &new_entry.entry);
         }
     } else {
         new_cookie = 1;

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -114,6 +114,7 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
     u64 input;
     LOAD_CONSTANT("do_fork_input", input);
 
+    u64 flags = 0;
     if (input == DO_FORK_STRUCT_INPUT) {
         u64 exit_signal_offset;
         LOAD_CONSTANT("kernel_clone_args_exit_signal_offset", exit_signal_offset);
@@ -125,12 +126,16 @@ int __attribute__((always_inline)) handle_do_fork(ctx_t *ctx) {
         if (exit_signal == SIGCHLD) {
             syscall.fork.is_thread = 0;
         }
+
+        bpf_probe_read(&flags, sizeof(flags), (void *)args);
     } else {
-        u64 flags = (u64)CTX_PARM1(ctx);
+        flags = (u64)CTX_PARM1(ctx);
         if ((flags & SIGCHLD) == SIGCHLD) {
             syscall.fork.is_thread = 0;
         }
     }
+
+    syscall.fork.flags = flags;
 
     cache_syscall(&syscall);
 
@@ -188,6 +193,8 @@ int __attribute__((always_inline)) sched_process_fork_common(void *ctx, u32 pid,
         bpf_map_update_elem(&netns_cache, &pid, &child_netns_entry, BPF_ANY);
     }
 
+    // TODO should inherit the nmtns
+
     // if this is a thread, leave
     if (syscall->fork.is_thread) {
         pop_syscall(EVENT_FORK);
@@ -221,6 +228,8 @@ int __attribute__((always_inline)) sched_process_fork_common(void *ctx, u32 pid,
     // sched::sched_process_fork is triggered from the parent process, update the pid / tid to the child value
     event->process.pid = pid;
     event->process.tid = pid;
+
+    event->pid_entry.fork_flags = syscall->fork.flags;
 
     u32 *inum = bpf_map_lookup_elem(&mntns_cache, &ppid);
     if (inum) {
@@ -775,7 +784,9 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
             parent_inode = parent_pc->entry.executable.path_key.ino;
 
             // inherit the parent cgroup context
-            fill_cgroup_context(parent_pc, &pc.cgroup);
+            if ((fork_entry->fork_flags & (CLONE_INTO_CGROUP | CLONE_NEWCGROUP)) == 0) {
+                fill_cgroup_context(parent_pc, &pc.cgroup);
+            }
         }
     }
 

--- a/pkg/security/ebpf/c/include/structs/process.h
+++ b/pkg/security/ebpf/c/include/structs/process.h
@@ -38,6 +38,7 @@ struct pid_cache_t {
     u64 fork_timestamp;
     u64 exit_timestamp;
     u64 user_session_id;
+    u64 fork_flags;
     struct credentials_t credentials;
 };
 

--- a/pkg/security/ebpf/c/include/structs/syscalls.h
+++ b/pkg/security/ebpf/c/include/structs/syscalls.h
@@ -152,8 +152,9 @@ struct syscall_cache_t {
         } exec;
 
         struct {
-            u32 is_thread;
-            u32 is_kthread;
+            u64 flags;
+            u32 is_thread: 1;
+            u32 is_kthread : 1;
             u32 parent_pid;
         } fork;
 

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -1340,7 +1340,7 @@ func (p *EBPFResolver) syncKernelMaps(entry *model.ProcessCacheEntry) {
 			seclog.Errorf("couldn't push proc_cache entry to kernel space: %s", err)
 		}
 	}
-	pidCacheEntryB := make([]byte, 88)
+	pidCacheEntryB := make([]byte, model.PidCacheEntrySize)
 	_, err = entry.Process.MarshalPidCache(pidCacheEntryB, bootTime)
 	if err != nil {
 		seclog.Errorf("couldn't marshal pid_cache entry: %s", err)

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -239,6 +239,7 @@ func deepCopyProcessPtr(fieldToCopy *Process) *Process {
 	copied.ExecTime = fieldToCopy.ExecTime
 	copied.ExitTime = fieldToCopy.ExitTime
 	copied.FileEvent = deepCopyFileEvent(fieldToCopy.FileEvent)
+	copied.ForkFlags = fieldToCopy.ForkFlags
 	copied.ForkTime = fieldToCopy.ForkTime
 	copied.IsExec = fieldToCopy.IsExec
 	copied.IsExecExec = fieldToCopy.IsExecExec
@@ -465,6 +466,7 @@ func deepCopyProcess(fieldToCopy Process) Process {
 	copied.ExecTime = fieldToCopy.ExecTime
 	copied.ExitTime = fieldToCopy.ExitTime
 	copied.FileEvent = deepCopyFileEvent(fieldToCopy.FileEvent)
+	copied.ForkFlags = fieldToCopy.ForkFlags
 	copied.ForkTime = fieldToCopy.ForkTime
 	copied.IsExec = fieldToCopy.IsExec
 	copied.IsExecExec = fieldToCopy.IsExecExec

--- a/pkg/security/secl/model/marshallers_linux.go
+++ b/pkg/security/secl/model/marshallers_linux.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+const (
+	// PidCacheEntrySize is the size of the pid_cache_t
+	PidCacheEntrySize = 96
+)
+
 // BinaryMarshaler interface implemented by every event type
 type BinaryMarshaler interface {
 	MarshalBinary(data []byte) (int, error)
@@ -133,7 +138,7 @@ func (e *Credentials) MarshalBinary(data []byte) (int, error) {
 // MarshalPidCache marshals a binary representation of itself
 func (e *Process) MarshalPidCache(data []byte, bootTime time.Time) (int, error) {
 	// Marshal pid_cache_t
-	if len(data) < 88 {
+	if len(data) < PidCacheEntrySize {
 		return 0, ErrNotEnoughSpace
 	}
 	binary.NativeEndian.PutUint64(data[0:8], e.Cookie)
@@ -144,7 +149,8 @@ func (e *Process) MarshalPidCache(data []byte, bootTime time.Time) (int, error) 
 	marshalTime(data[16:24], e.ForkTime.Sub(bootTime))
 	marshalTime(data[24:32], e.ExitTime.Sub(bootTime))
 	binary.NativeEndian.PutUint64(data[32:40], e.UserSession.K8SSessionID)
-	written := 40
+	binary.NativeEndian.PutUint64(data[40:48], e.ForkFlags)
+	written := 48
 
 	n, err := MarshalBinary(data[written:], &e.Credentials)
 	if err != nil {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -374,6 +374,8 @@ type Process struct {
 	ExitTime time.Time `field:"exit_time,opts:getters_only"`
 	ExecTime time.Time `field:"exec_time,opts:getters_only"`
 
+	ForkFlags uint64 `field:"-"`
+
 	// TODO: merge with ExecTime
 	CreatedAt uint64 `field:"created_at,handler:ResolveProcessCreatedAt"` // SECLDoc[created_at] Definition:`Timestamp of the creation of the process`
 

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -211,7 +211,7 @@ func (e *Process) UnmarshalProcEntryBinary(data []byte) (int, error) {
 
 // UnmarshalPidCacheBinary unmarshalls Unmarshal pid_cache_t
 func (e *Process) UnmarshalPidCacheBinary(data []byte) (int, error) {
-	const size = 88
+	const size = PidCacheEntrySize
 	if len(data) < size {
 		return 0, ErrNotEnoughData
 	}
@@ -231,19 +231,21 @@ func (e *Process) UnmarshalPidCacheBinary(data []byte) (int, error) {
 	e.ExitTime = unmarshalTime(data[24:32])
 	e.UserSession.K8SSessionID = binary.NativeEndian.Uint64(data[32:40])
 
+	e.ForkFlags = binary.NativeEndian.Uint64(data[40:48])
+
 	// Unmarshal the credentials contained in pid_cache_t
-	read, err := e.Credentials.UnmarshalBinary(data[40:])
+	read, err := e.Credentials.UnmarshalBinary(data[48:])
 	if err != nil {
 		return 0, err
 	}
-	read += 40
+	read += 48
 
 	return validateReadSize(size, read)
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *Process) UnmarshalBinary(data []byte) (int, error) {
-	const size = 292 // size of struct exec_event_t starting from process_entry_t, inclusive
+	const size = 300 // size of struct exec_event_t starting from process_entry_t, inclusive
 	if len(data) < size {
 		return 0, ErrNotEnoughData
 	}


### PR DESCRIPTION
Recent versions of runc use clone3(2) with CLONE_INTO_CGROUP when available, placing new container processes directly into the target cgroup at spawn time without writing the PID to cgroup.procs. This eliminates the CgroupWriteEventType event that the security agent was relying on to propagate cgroup context to newly created processes, causing incorrect cgroup ID assignment.

Remove the parent cgroup inheritance via fill_cgroup_context during exec event handling. Instead, an empty CGroupContext is passed when inserting the exec entry, which causes the cgroup resolver to fall back to procfs (/proc/<pid>/cgroup) to resolve the correct cgroup ID. Also inline copy_proc_cache into its single call site in trace__cgroup_write.

runc reference: https://github.com/opencontainers/runc/commit/5af4dd4e644519330686b4d6543b2beca59328ab


(cherry picked from commit 6e8b562220836433af30e68ead746bde1479fc64)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
