### PR TITLE
fix(fleet): Skip subprocess for getStates on Windows to fix OOM errors

### DIFF
--- a/pkg/fleet/installer/commands/command_setup_nix_test.go
+++ b/pkg/fleet/installer/commands/command_setup_nix_test.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+
+package commands
+
+func setupTestPaths() func() {
+	return func() {}
+}

--- a/pkg/fleet/installer/commands/command_setup_windows_test.go
+++ b/pkg/fleet/installer/commands/command_setup_windows_test.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+)
+
+// setupTestPaths creates a temporary directory structure that mimics the
+// installer's on-disk state, and overrides paths.PackagesPath /
+// paths.AgentConfigDir / paths.AgentConfigDirExp so the in-process
+// getStates (Windows) reads from it.
+//
+// Returns a cleanup function that restores the original paths and removes
+// the temporary directory.
+func setupTestPaths() func() {
+	origPackagesPath := paths.PackagesPath
+	origAgentConfigDir := paths.AgentConfigDir
+	origAgentConfigDirExp := paths.AgentConfigDirExp
+
+	tmpDir, err := os.MkdirTemp("", "installer-test-*")
+	if err != nil {
+		panic(err)
+	}
+
+	packagesDir := filepath.Join(tmpDir, "packages")
+	configDir := filepath.Join(tmpDir, "config")
+	configDirExp := filepath.Join(tmpDir, "config-exp")
+
+	// Create packages/datadog-agent with stable and experiment symlinks.
+	// Repository.GetState reads symlinks named "stable" and "experiment"
+	// and returns filepath.Base of the target as the version.
+	pkgDir := filepath.Join(packagesDir, "datadog-agent")
+	stableDir := filepath.Join(pkgDir, "7.31.0")
+	experimentDir := filepath.Join(pkgDir, "7.32.0")
+	for _, d := range []string{stableDir, experimentDir} {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			panic(err)
+		}
+	}
+	if err := os.Symlink(stableDir, filepath.Join(pkgDir, "stable")); err != nil {
+		panic(err)
+	}
+	if err := os.Symlink(experimentDir, filepath.Join(pkgDir, "experiment")); err != nil {
+		panic(err)
+	}
+
+	// Create config directory with .deployment-id file.
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, ".deployment-id"), []byte("abc-def-hij"), 0644); err != nil {
+		panic(err)
+	}
+
+	// Create experiment config directory (no .deployment-id = empty experiment).
+	if err := os.MkdirAll(configDirExp, 0755); err != nil {
+		panic(err)
+	}
+
+	paths.PackagesPath = packagesDir
+	paths.AgentConfigDir = configDir
+	paths.AgentConfigDirExp = configDirExp
+
+	return func() {
+		paths.PackagesPath = origPackagesPath
+		paths.AgentConfigDir = origAgentConfigDir
+		paths.AgentConfigDirExp = origAgentConfigDirExp
+		os.RemoveAll(tmpDir)
+	}
+}

--- a/pkg/fleet/installer/commands/command_test.go
+++ b/pkg/fleet/installer/commands/command_test.go
@@ -51,6 +51,8 @@ func TestMain(m *testing.M) {
 		return
 	}
 	os.Setenv(testCmdEnv, "true")
+	cleanup := setupTestPaths()
+	defer cleanup()
 	os.Exit(m.Run())
 }
 

--- a/pkg/fleet/installer/exec/installer_exec.go
+++ b/pkg/fleet/installer/exec/installer_exec.go
@@ -336,27 +336,6 @@ func (i *InstallerExec) AvailableDiskSpace() (uint64, error) {
 	return repositories.AvailableDiskSpace()
 }
 
-// getStates retrieves the state of all packages & their configuration from disk.
-func (i *InstallerExec) getStates(ctx context.Context) (repo *repository.PackageStates, err error) {
-	cmd := i.newInstallerCmd(ctx, "get-states")
-	defer func() { cmd.span.Finish(err) }()
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	err = cmd.Run()
-	if err != nil {
-		return nil, fmt.Errorf("error getting state from disk: %w\n%s", err, stderr.String())
-	}
-	var pkgStates *repository.PackageStates
-	err = json.Unmarshal(stdout.Bytes(), &pkgStates)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling state from disk: %w\n`%s`", err, stdout.String())
-	}
-
-	return pkgStates, nil
-}
-
 // State returns the state of a package.
 func (i *InstallerExec) State(ctx context.Context, pkg string) (repository.State, error) {
 	allStates, err := i.ConfigAndPackageStates(ctx)

--- a/pkg/fleet/installer/exec/installer_exec_nix.go
+++ b/pkg/fleet/installer/exec/installer_exec_nix.go
@@ -9,8 +9,14 @@
 package exec
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
 )
 
 func (i *InstallerExec) newInstallerCmdPlatform(cmd *exec.Cmd) *exec.Cmd {
@@ -21,4 +27,25 @@ func (i *InstallerExec) newInstallerCmdPlatform(cmd *exec.Cmd) *exec.Cmd {
 	}
 
 	return cmd
+}
+
+// getStates retrieves the state of all packages & their configuration from disk.
+// On Linux/macOS this spawns a subprocess for privilege escalation.
+func (i *InstallerExec) getStates(ctx context.Context) (repo *repository.PackageStates, err error) {
+	cmd := i.newInstallerCmd(ctx, "get-states")
+	defer func() { cmd.span.Finish(err) }()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	if err != nil {
+		return nil, fmt.Errorf("error getting state from disk: %w\n%s", err, stderr.String())
+	}
+	var pkgStates *repository.PackageStates
+	err = json.Unmarshal(stdout.Bytes(), &pkgStates)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling state from disk: %w\n`%s`", err, stdout.String())
+	}
+	return pkgStates, nil
 }

--- a/pkg/fleet/installer/exec/installer_exec_windows.go
+++ b/pkg/fleet/installer/exec/installer_exec_windows.go
@@ -9,8 +9,15 @@
 package exec
 
 import (
+	"context"
+	"fmt"
 	"os/exec"
 	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/config"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/repository"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/telemetry"
 )
 
 func (i *InstallerExec) newInstallerCmdPlatform(cmd *exec.Cmd) *exec.Cmd {
@@ -18,4 +25,43 @@ func (i *InstallerExec) newInstallerCmdPlatform(cmd *exec.Cmd) *exec.Cmd {
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
 	}
 	return cmd
+}
+
+// getStates retrieves the state of all packages & their configuration from disk.
+// On Windows there is no privilege boundary between the daemon and the installer
+// binary, so we read the package & config states in-process instead of spawning
+// a subprocess (which is the main source of OOM errors on Windows).
+func (i *InstallerExec) getStates(ctx context.Context) (_ *repository.PackageStates, err error) {
+	span, _ := telemetry.StartSpanFromContext(ctx, "installer.get-states")
+	defer func() { span.Finish(err) }()
+
+	repos := repository.NewRepositories(paths.PackagesPath, nil)
+	packageStates, err := repos.GetStates()
+	if err != nil {
+		return nil, fmt.Errorf("error getting package states from disk: %w", err)
+	}
+
+	configDirs := &config.Directories{
+		StablePath:     paths.AgentConfigDir,
+		ExperimentPath: paths.AgentConfigDirExp,
+	}
+	configState, err := configDirs.GetState()
+	if err != nil {
+		return nil, fmt.Errorf("error getting config state from disk: %w", err)
+	}
+	stableDeploymentID := configState.StableDeploymentID
+	if stableDeploymentID == "" {
+		stableDeploymentID = "empty"
+	}
+	configStates := map[string]repository.State{
+		"datadog-agent": {
+			Stable:     stableDeploymentID,
+			Experiment: configState.ExperimentDeploymentID,
+		},
+	}
+
+	return &repository.PackageStates{
+		States:       packageStates,
+		ConfigStates: configStates,
+	}, nil
 }

--- a/pkg/fleet/installer/exec/installer_exec_windows.go
+++ b/pkg/fleet/installer/exec/installer_exec_windows.go
@@ -10,7 +10,9 @@ package exec
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os/exec"
 	"syscall"
 
@@ -37,8 +39,11 @@ func (i *InstallerExec) getStates(ctx context.Context) (_ *repository.PackageSta
 
 	repos := repository.NewRepositories(paths.PackagesPath, nil)
 	packageStates, err := repos.GetStates()
-	if err != nil {
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return nil, fmt.Errorf("error getting package states from disk: %w", err)
+	}
+	if packageStates == nil {
+		packageStates = make(map[string]repository.State)
 	}
 
 	configDirs := &config.Directories{


### PR DESCRIPTION
### What does this PR do?

Moves `getStates` from the platform-agnostic `installer_exec.go` into platform-specific files:
- **Windows** (`installer_exec_windows.go`): Reads package and config states directly in-process using `repository.NewRepositories` and `config.Directories.GetState()`, avoiding the subprocess spawn entirely.
- **Linux/macOS** (`installer_exec_nix.go`): Keeps the existing subprocess approach unchanged (needed for privilege escalation via `RootToDatadogAgent()`/`DatadogAgentToRoot()`).

### Motivation

`getStatesFromDisk` / `getStates` is the biggest source of errors in the installer on Windows. The errors are OOM/VirtualAlloc/paging-file failures caused by spawning a subprocess to read package states.

On Windows, there's no permission reason to spawn a separate process. The state-reading logic itself is lightweight (reads symlinks and `.deployment-id` files from disk), so running it in-process eliminates the OOM-prone subprocess entirely.

### Describe how you validated your changes

- Cross-compiled for Windows: `GOOS=windows go build ./pkg/fleet/installer/exec/`
- Built for darwin: `go build ./pkg/fleet/installer/exec/`
- Ran all installer tests: `go test ./pkg/fleet/installer/...` — all pass
- Ran daemon tests: `go test ./pkg/fleet/daemon/...` — all pass

### Additional Notes

The Windows in-process implementation mirrors the logic from `installerImpl.ConfigAndPackageStates` + `installerImpl.configStates` in `installer.go`, but without opening the bbolt database or creating an OCI downloader. It still emits a telemetry span (`installer.get-states`) for observability.