### PR TITLE
[CONTP-1397] Improve admission controller probe status in agent status

### DIFF
--- a/pkg/clusteragent/admission/probe/probe.go
+++ b/pkg/clusteragent/admission/probe/probe.go
@@ -106,6 +106,11 @@ func (p *Probe) GetStatsSnapshot() StatsSnapshot {
 	}
 }
 
+// IsLeader returns whether this instance is the current leader.
+func (p *Probe) IsLeader() bool {
+	return p.isLeaderFunc()
+}
+
 // GetStatsForStatus returns probe stats formatted for the agent status output.
 func (p *Probe) GetStatsForStatus() map[string]interface{} {
 	snap := p.GetStatsSnapshot()

--- a/pkg/clusteragent/admission/probe/probe_test.go
+++ b/pkg/clusteragent/admission/probe/probe_test.go
@@ -31,9 +31,10 @@ const testNamespace = "test-probe-ns"
 
 func newTestProbe(client *fakeclientset.Clientset) *Probe {
 	return &Probe{
-		k8sClient:  client,
-		namespace:  testNamespace,
-		logLimiter: log.NewLogLimit(10, time.Minute),
+		k8sClient:    client,
+		namespace:    testNamespace,
+		isLeaderFunc: func() bool { return true },
+		logLimiter:   log.NewLogLimit(10, time.Minute),
 	}
 }
 

--- a/pkg/clusteragent/admission/status.go
+++ b/pkg/clusteragent/admission/status.go
@@ -35,12 +35,45 @@ func setProbe(p *admprobe.Probe) {
 	currentProbe.Store(p)
 }
 
-func getProbeStats() map[string]interface{} {
+// getProbeStatus builds the complete probe status map for the agent status
+// output.
+//
+// The returned map always contains "Enabled" (bool). Depending on the state,
+// it also contains exactly one of:
+//   - "Error"    (string) — runtime config error (e.g. missing RBAC)
+//   - "Detail"   (string) — informational message (follower, not yet started)
+//   - "HasStats" (bool)   — execution stats are present
+func getProbeStatus() map[string]interface{} {
+	result := map[string]interface{}{}
+
+	enabled := pkgconfigsetup.Datadog().GetBool("admission_controller.probe.enabled")
+	result["Enabled"] = enabled
+	if !enabled {
+		return result
+	}
+
 	p := currentProbe.Load()
 	if p == nil {
-		return nil
+		result["Detail"] = "Waiting for the admission controller to start..."
+		return result
 	}
-	return p.GetStatsForStatus()
+
+	if !p.IsLeader() {
+		result["Detail"] = "The probe is only active on the leader instance."
+		return result
+	}
+
+	stats := p.GetStatsForStatus()
+	if ce, ok := stats["ConfigError"]; ok {
+		result["Error"] = ce
+		return result
+	}
+
+	result["HasStats"] = true
+	for k, v := range stats {
+		result[k] = v
+	}
+	return result
 }
 
 // GetStatus returns status info for the secret and webhook controllers.
@@ -78,9 +111,7 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 		status["Secret"] = secretStatus
 	}
 
-	if probeStats := getProbeStats(); probeStats != nil {
-		status["Probe"] = probeStats
-	}
+	status["Probe"] = getProbeStatus()
 
 	return status
 }

--- a/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
+++ b/pkg/clusteragent/admission/status_templates/admissionwebhook.tmpl
@@ -53,9 +53,12 @@
 
     Connectivity Probe
     ------------------
-    {{- if .admissionWebhook.Probe.ConfigError }}
-    Configuration Error: {{ .admissionWebhook.Probe.ConfigError }}
-    {{- else }}
+    Enabled: {{ if .admissionWebhook.Probe.Enabled }}true{{ else }}false{{ end }}
+    {{- if .admissionWebhook.Probe.Error }}
+    Error: {{ .admissionWebhook.Probe.Error }}
+    {{- else if .admissionWebhook.Probe.Detail }}
+    {{ .admissionWebhook.Probe.Detail }}
+    {{- else if .admissionWebhook.Probe.HasStats }}
     Total Executions: {{ .admissionWebhook.Probe.TotalExecutions }}
     Success Rate: {{ .admissionWebhook.Probe.SuccessRate }}
     {{- if gt .admissionWebhook.Probe.TotalExecutions 0 }}


### PR DESCRIPTION
### What does this PR do?

Improves the Connectivity Probe section so that it is easier for the user to understand the status of the probe.

### Motivation

The probe is enabled/disabled globally, but only runs on the leader cluster agent replica.

Only the leader replica has active information about the connectivity probe stats. 

If the user runs `agent status` on the follower, we should show whether or not the probe is enabled, but we should also tell the user that stats can be found on the leader. 

Previously, it was less obvious; it was not showing if the probe is enabled or not, and it showed the stats as 0 (which might be misleading and make the user think the probe is not running properly)

Before: 

```
Connectivity Probe
    ------------------
    Total Executions: 0
    Success Rate: N/A
```

After 

```
    Connectivity Probe
    ------------------
    Enabled: true
    The probe is only active on the leader instance.
```