### PR TITLE
[AGENTRUN-1083] Go `network` v2 check now monitors host network namespace when in container

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -84,7 +84,6 @@ type networkInstanceConfig struct {
 	UseSudoConntrack          bool     `yaml:"use_sudo_conntrack"`
 	BlacklistConntrackMetrics []string `yaml:"blacklist_conntrack_metrics"`
 	WhitelistConntrackMetrics []string `yaml:"whitelist_conntrack_metrics"`
-	ProcfsPath                string   `yaml:"procfs_path"`
 }
 
 type networkInitConfig struct{}
@@ -951,12 +950,6 @@ func (c *NetworkCheck) Configure(senderManager sender.SenderManager, _ uint64, r
 		return err
 	}
 
-	// Apply instance-level procfs_path override
-	if c.config.instance.ProcfsPath != "" {
-		procfsPath := strings.TrimRight(c.config.instance.ProcfsPath, "/")
-		c.net = defaultNetworkStats{procPath: procfsPath}
-	}
-
 	if c.config.instance.ExcludedInterfaceRe != "" {
 		pattern, err := regexp.Compile(c.config.instance.ExcludedInterfaceRe)
 		if err != nil {
@@ -982,8 +975,8 @@ func Factory(cfg config.Component) option.Option[func() check.Check] {
 
 func newCheck(cfg config.Component) check.Check {
 	procfsPath := "/proc"
-	if cfg.IsSet("procfs_path") {
-		procfsPath = strings.TrimRight(cfg.GetString("procfs_path"), "/")
+	if v := cfg.GetString("procfs_path"); v != "" {
+		procfsPath = strings.TrimRight(v, "/")
 	}
 
 	return &NetworkCheck{

--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -84,6 +84,7 @@ type networkInstanceConfig struct {
 	UseSudoConntrack          bool     `yaml:"use_sudo_conntrack"`
 	BlacklistConntrackMetrics []string `yaml:"blacklist_conntrack_metrics"`
 	WhitelistConntrackMetrics []string `yaml:"whitelist_conntrack_metrics"`
+	ProcfsPath                string   `yaml:"procfs_path"`
 }
 
 type networkInitConfig struct{}
@@ -950,6 +951,12 @@ func (c *NetworkCheck) Configure(senderManager sender.SenderManager, _ uint64, r
 		return err
 	}
 
+	// Apply instance-level procfs_path override
+	if c.config.instance.ProcfsPath != "" {
+		procfsPath := strings.TrimRight(c.config.instance.ProcfsPath, "/")
+		c.net = defaultNetworkStats{procPath: procfsPath}
+	}
+
 	if c.config.instance.ExcludedInterfaceRe != "" {
 		pattern, err := regexp.Compile(c.config.instance.ExcludedInterfaceRe)
 		if err != nil {
@@ -975,7 +982,7 @@ func Factory(cfg config.Component) option.Option[func() check.Check] {
 
 func newCheck(cfg config.Component) check.Check {
 	procfsPath := "/proc"
-	if cfg.IsConfigured("procfs_path") {
+	if cfg.IsSet("procfs_path") {
 		procfsPath = strings.TrimRight(cfg.GetString("procfs_path"), "/")
 	}
 

--- a/pkg/collector/corechecks/net/networkv2/network_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_test.go
@@ -1318,23 +1318,6 @@ func TestGlobalProcfsPathUsedWhenInContainer(t *testing.T) {
 	assert.Equal(t, "/host/proc", check.net.GetProcPath())
 }
 
-// TestInstanceProcfsPathOverridesDefaultNamespace validates that an instance-level
-// procfs_path in the check config overrides whatever path was set at check creation
-// time. This is the per-instance escape hatch for container environments.
-func TestInstanceProcfsPathOverridesDefaultNamespace(t *testing.T) {
-	// Simulate the check created with the container's /proc (default)
-	check := createTestNetworkCheck(&defaultNetworkStats{procPath: "/proc"})
-
-	rawInstanceConfig := []byte(`
-procfs_path: "/host/proc"
-`)
-	err := check.Configure(aggregator.NewNoOpSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
-	assert.Nil(t, err)
-
-	// After Configure, the check must use the host procfs path, not the container's /proc
-	assert.Equal(t, "/host/proc", check.net.GetProcPath())
-}
-
 func TestNetworkCheck(t *testing.T) {
 	net := &fakeNetworkStats{
 		counterStats: []net.IOCountersStat{

--- a/pkg/collector/corechecks/net/networkv2/network_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
+	configmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/safchain/ethtool"
 )
@@ -1300,6 +1302,37 @@ excluded_interface_re: "eth.*"
 	assert.Equal(t, true, check.config.instance.CollectConnectionState)
 	assert.ElementsMatch(t, []string{"eth0", "lo0"}, check.config.instance.ExcludedInterfaces)
 	assert.Equal(t, "eth.*", check.config.instance.ExcludedInterfaceRe)
+}
+
+// TestGlobalProcfsPathUsedWhenInContainer validates that when procfs_path is set in the
+// global agent config (as done automatically when running in a container with the host
+// proc mounted at /host/proc), newCheck picks it up correctly. This was broken before
+// the fix because cfg.IsConfigured did not match keys set via the config system, causing
+// the check to always fall back to the container's own /proc.
+func TestGlobalProcfsPathUsedWhenInContainer(t *testing.T) {
+	cfg := configmock.New(t)
+	cfg.Set("procfs_path", "/host/proc", configmodel.SourceAgentRuntime)
+
+	check := newCheck(cfg).(*NetworkCheck)
+
+	assert.Equal(t, "/host/proc", check.net.GetProcPath())
+}
+
+// TestInstanceProcfsPathOverridesDefaultNamespace validates that an instance-level
+// procfs_path in the check config overrides whatever path was set at check creation
+// time. This is the per-instance escape hatch for container environments.
+func TestInstanceProcfsPathOverridesDefaultNamespace(t *testing.T) {
+	// Simulate the check created with the container's /proc (default)
+	check := createTestNetworkCheck(&defaultNetworkStats{procPath: "/proc"})
+
+	rawInstanceConfig := []byte(`
+procfs_path: "/host/proc"
+`)
+	err := check.Configure(aggregator.NewNoOpSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+
+	// After Configure, the check must use the host procfs path, not the container's /proc
+	assert.Equal(t, "/host/proc", check.net.GetProcPath())
 }
 
 func TestNetworkCheck(t *testing.T) {

--- a/releasenotes/notes/fix-network-check-container-0a81ab421fbcf54f.yaml
+++ b/releasenotes/notes/fix-network-check-container-0a81ab421fbcf54f.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The Go network v2 check now correctly monitors the host network namespace
+    when running in a container, similar to the Python version's behavior.


### PR DESCRIPTION
### What does this PR do?
The Go v2 network did not properly monitor the host network namespace when running in a container. Instead, it reported the container's network namespace metric.

### Motivation
This PR realigns the Go v2 network check behavior with that of the Python version.

### Describe how you validated your changes
Added unit tests to validate change + Claude analysis of the changes (see below).

### Additional Notes
Claude confirmation that these changes fix the bug:
```
1. IsConfigured → IsSet (line 980)

This looks correct. The Python check uses datadog_agent.get_config('procfs_path') which returns the value if it's set at all (including from environment variables like DD_PROCFS_PATH). IsSet is the closer equivalent — IsConfigured may have stricter semantics that would miss env-var-based config.

2. Instance-level procfs_path override (lines 88, 949-953)

This adds support for a procfs_path field in the check's instance config, allowing it to override the agent-level procfs_path. This aligns with the Python check, which reads procfs_path from datadog_agent.get_config('procfs_path') at the agent level but could also be influenced by instance config.

Verdict

Your changes look correct. The real fix is the IsConfigured → IsSet change — that's likely why the container wasn't being detected properly. If procfs_path was set via environment variable (DD_PROCFS_PATH=/host/proc), IsConfigured might have returned false, causing the Go check to fall back to /proc. With /proc as the path, GetNetProcBasePath() wouldn't append /1 even in a container, so the check would read the wrong /proc/net/* files instead of /proc/1/net/*.

The instance-level procfs_path override is a nice addition for parity with the Python check but is secondary to the core fix.
```