### PR TITLE
Revert "[CWS] use path_id for the mount resolution (#45693)"

### DIFF
--- a/pkg/security/ebpf/c/include/helpers/filesystem.h
+++ b/pkg/security/ebpf/c/include/helpers/filesystem.h
@@ -11,17 +11,12 @@
 #include "dentry_resolver.h"
 #include "discarders.h"
 
-// the bump revision value is used to increase the mount id part of the path id when the mount is updated
-// this means that two different mount id can be considered as the same if the difference is less than the bump revision value
-// see the userspace equality check in the model_unix.go file
-#define MOUNT_REVISION_BUMP_VALUE 64
-
 static __attribute__((always_inline)) void bump_high_path_id(u32 mount_id) {
     u32 key = mount_id % PATH_ID_HIGH_MAP_SIZE;
 
     u32 *id = bpf_map_lookup_elem(&path_id_high, &key);
     if (id) {
-        __sync_fetch_and_add(id, MOUNT_REVISION_BUMP_VALUE);
+        __sync_fetch_and_add(id, 1);
     }
 }
 

--- a/pkg/security/ebpf/c/include/tests/path_id_test.h
+++ b/pkg/security/ebpf/c/include/tests/path_id_test.h
@@ -20,7 +20,7 @@ int test_path_id_mount_and_invalidation() {
     bump_high_path_id(mount_id1);
 
     u32 mount_1_path_id_after_release = get_path_id(0, mount_id1, 1, PATH_ID_INVALIDATE_TYPE_NONE);
-    assert_equals(mount_1_path_id_after_release, PATH_ID(64, 1), "path id should have low and high id incremented");
+    assert_equals(mount_1_path_id_after_release, PATH_ID(1, 1), "path id should have low and high id incremented");
 
     return 1;
 }

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -130,7 +130,7 @@ func (fh *EBPFFieldHandlers) ResolveFileFilesystem(ev *model.Event, f *model.Fil
 		if f.IsFileless() {
 			f.Filesystem = model.TmpFS
 		} else {
-			fs, err := fh.resolvers.MountResolver.ResolveFilesystem(f.FileFields.PathKey, ev.PIDContext.Pid)
+			fs, err := fh.resolvers.MountResolver.ResolveFilesystem(f.FileFields.MountID, ev.PIDContext.Pid)
 			if err != nil {
 				ev.SetPathResolutionError(f, err)
 			}
@@ -180,7 +180,7 @@ func (fh *EBPFFieldHandlers) ResolveMountPointPath(ev *model.Event, e *model.Mou
 		return "/"
 	}
 	if len(e.MountPointPath) == 0 {
-		mountPointPath, _, _, err := fh.resolvers.MountResolver.ResolveMountPath(e.RootPathKey, ev.PIDContext.Pid)
+		mountPointPath, _, _, err := fh.resolvers.MountResolver.ResolveMountPath(e.MountID, ev.PIDContext.Pid)
 		if err != nil {
 			e.MountPointPathResolutionError = err
 			return ""
@@ -193,7 +193,7 @@ func (fh *EBPFFieldHandlers) ResolveMountPointPath(ev *model.Event, e *model.Mou
 // ResolveMountSourcePath resolves a mount source path
 func (fh *EBPFFieldHandlers) ResolveMountSourcePath(ev *model.Event, e *model.MountEvent) string {
 	if e.BindSrcMountID != 0 && len(e.MountSourcePath) == 0 {
-		bindSourceMountPath, _, _, err := fh.resolvers.MountResolver.ResolveMountPath(model.PathKey{MountID: e.BindSrcMountID}, ev.PIDContext.Pid)
+		bindSourceMountPath, _, _, err := fh.resolvers.MountResolver.ResolveMountPath(e.BindSrcMountID, ev.PIDContext.Pid)
 		if err != nil {
 			e.MountSourcePathResolutionError = err
 			return ""
@@ -211,7 +211,7 @@ func (fh *EBPFFieldHandlers) ResolveMountSourcePath(ev *model.Event, e *model.Mo
 // ResolveMountRootPath resolves a mount root path
 func (fh *EBPFFieldHandlers) ResolveMountRootPath(ev *model.Event, e *model.MountEvent) string {
 	if len(e.MountRootPath) == 0 {
-		mountRootPath, _, _, err := fh.resolvers.MountResolver.ResolveMountRoot(e.RootPathKey, ev.PIDContext.Pid)
+		mountRootPath, _, _, err := fh.resolvers.MountResolver.ResolveMountRoot(e.MountID, ev.PIDContext.Pid)
 		if err != nil {
 			e.MountRootPathResolutionError = err
 			return ""
@@ -532,7 +532,7 @@ func (fh *EBPFFieldHandlers) ResolveHashes(eventType model.EventType, process *m
 // ResolveCGroupVersion resolves the version of the cgroup API
 func (fh *EBPFFieldHandlers) ResolveCGroupVersion(ev *model.Event, e *model.CGroupContext) int {
 	if e.CGroupVersion == 0 {
-		if filesystem, _ := fh.resolvers.MountResolver.ResolveFilesystem(e.CGroupPathKey, ev.PIDContext.Pid); filesystem == "cgroup2" {
+		if filesystem, _ := fh.resolvers.MountResolver.ResolveFilesystem(e.CGroupPathKey.MountID, ev.PIDContext.Pid); filesystem == "cgroup2" {
 			e.CGroupVersion = 2
 		} else {
 			e.CGroupVersion = 1

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1253,7 +1253,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		// TODO: this should be moved in the resolver itself in order to handle the fallbacks
 		if event.Mount.GetFSType() == "nsfs" {
 			nsid := uint32(event.Mount.RootPathKey.Inode)
-			mountPath, _, _, err := p.Resolvers.MountResolver.ResolveMountPath(event.Mount.RootPathKey, event.PIDContext.Pid)
+			mountPath, _, _, err := p.Resolvers.MountResolver.ResolveMountPath(event.Mount.MountID, event.PIDContext.Pid)
 			if err != nil {
 				seclog.Debugf("failed to get mount path: %v", err)
 			} else {
@@ -1268,7 +1268,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		}
 
 		// we can skip this error as this is for the umount only and there is no impact on the filepath resolution
-		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(model.PathKey{MountID: event.Umount.MountID}, event.PIDContext.Pid)
+		mount, _, _, _ := p.Resolvers.MountResolver.ResolveMount(event.Umount.MountID, event.PIDContext.Pid)
 		if mount != nil && mount.GetFSType() == "nsfs" {
 			nsid := uint32(mount.RootPathKey.Inode)
 			if namespace := p.Resolvers.NamespaceResolver.ResolveNetworkNamespace(nsid); namespace != nil {

--- a/pkg/security/resolvers/mount/interface.go
+++ b/pkg/security/resolvers/mount/interface.go
@@ -17,12 +17,12 @@ type ResolverInterface interface {
 	IsMountIDValid(mountID uint32) (bool, error)
 	SyncCache() error
 	Delete(mountID uint32, mountIDUnique uint64) error
-	ResolveFilesystem(pathKey model.PathKey, pid uint32) (string, error)
+	ResolveFilesystem(mountID uint32, pid uint32) (string, error)
 	Insert(m model.Mount) error
 	InsertMoved(m model.Mount) error
-	ResolveMountRoot(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error)
-	ResolveMountPath(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error)
-	ResolveMount(pathKey model.PathKey, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error)
+	ResolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
+	ResolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error)
+	ResolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error)
 	SendStats() error
 	SetPidMntNs(pid uint32, ns uint32)
 	ToJSON() ([]byte, error)

--- a/pkg/security/resolvers/mount/mountlister.go
+++ b/pkg/security/resolvers/mount/mountlister.go
@@ -12,16 +12,15 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"golang.org/x/sys/unix"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
-
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"golang.org/x/sys/unix"
 )
 
 // Flags needed by statmount
@@ -132,10 +131,7 @@ func newMountFromStatmount(sm *Statmount) *model.Mount {
 
 	// create a Mount out of the parsed MountInfo
 	return &model.Mount{
-		MountID: sm.MntIDOld,
-		RootPathKey: model.PathKey{
-			MountID: sm.MntIDOld,
-		},
+		MountID:       sm.MntIDOld,
 		MountIDUnique: sm.MntID,
 		Device:        utils.Mkdev(sm.SbDevMajor, sm.SbDevMinor),
 		ParentPathKey: model.PathKey{

--- a/pkg/security/resolvers/mount/no_op_resolver.go
+++ b/pkg/security/resolvers/mount/no_op_resolver.go
@@ -44,7 +44,7 @@ func (mr *NoOpResolver) Delete(_ uint32, _ uint64) error {
 }
 
 // ResolveFilesystem returns the name of the filesystem
-func (mr *NoOpResolver) ResolveFilesystem(_ model.PathKey, _ uint32) (string, error) {
+func (mr *NoOpResolver) ResolveFilesystem(_ uint32, _ uint32) (string, error) {
 	return "", nil
 }
 
@@ -54,17 +54,17 @@ func (mr *NoOpResolver) Insert(_ model.Mount) error {
 }
 
 // ResolveMountRoot returns the root of a mount identified by its mount ID.
-func (mr *NoOpResolver) ResolveMountRoot(_ model.PathKey, _ uint32) (string, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMountRoot(_ uint32, _ uint32) (string, model.MountSource, model.MountOrigin, error) {
 	return "", model.MountSourceUnknown, model.MountOriginUnknown, nil
 }
 
 // ResolveMountPath returns the path of a mount identified by its mount ID.
-func (mr *NoOpResolver) ResolveMountPath(_ model.PathKey, _ uint32) (string, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMountPath(_ uint32, _ uint32) (string, model.MountSource, model.MountOrigin, error) {
 	return "", model.MountSourceUnknown, model.MountOriginUnknown, nil
 }
 
 // ResolveMount returns the mount
-func (mr *NoOpResolver) ResolveMount(_ model.PathKey, _ uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+func (mr *NoOpResolver) ResolveMount(_ uint32, _ uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
 	return nil, model.MountSourceUnknown, model.MountOriginUnknown, errors.New("not available")
 }
 

--- a/pkg/security/resolvers/mount/procfs_mountlister.go
+++ b/pkg/security/resolvers/mount/procfs_mountlister.go
@@ -9,15 +9,14 @@
 package mount
 
 import (
-	"os"
-	"path/filepath"
-	"strconv"
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/moby/sys/mountinfo"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 )
 
 // newMountFromMountInfo - Creates a new Mount from parsed MountInfo data
@@ -50,10 +49,7 @@ func newMountFromMountInfo(mnt *mountinfo.Info) *model.Mount {
 	// create a Mount out of the parsed MountInfo
 	return &model.Mount{
 		MountID: uint32(mnt.ID),
-		RootPathKey: model.PathKey{
-			MountID: uint32(mnt.ID),
-		},
-		Device: utils.Mkdev(uint32(mnt.Major), uint32(mnt.Minor)),
+		Device:  utils.Mkdev(uint32(mnt.Major), uint32(mnt.Minor)),
 		ParentPathKey: model.PathKey{
 			MountID: uint32(mnt.Parent),
 		},

--- a/pkg/security/resolvers/mount/resolver.go
+++ b/pkg/security/resolvers/mount/resolver.go
@@ -132,9 +132,16 @@ func (mr *Resolver) syncCache() error {
 
 // syncPidProcfs Snapshots the mounts of the pid namespace using procfs
 func (mr *Resolver) syncPidProcfs(pid uint32) error {
+	mounts := []*model.Mount{}
+
 	err := GetPidProcfs(kernel.ProcFSRoot(), pid, func(sm *model.Mount) {
-		mr.insert(sm)
+		mr.mounts.Remove(sm.MountID)
+		mounts = append(mounts, sm)
 	})
+
+	for _, m := range mounts {
+		mr.insert(m)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error synchronizing the pid procfs: %v", err)
@@ -144,9 +151,16 @@ func (mr *Resolver) syncPidProcfs(pid uint32) error {
 
 // syncPidListmount Snapshots the mounts of the pid namespace using the listmount api
 func (mr *Resolver) syncPidListmount(pid uint32) error {
+	mounts := []*model.Mount{}
+
 	err := GetPidListmount(kernel.ProcFSRoot(), pid, func(sm *model.Mount) {
-		mr.insert(sm)
+		mr.mounts.Remove(sm.MountID)
+		mounts = append(mounts, sm)
 	})
+
+	for _, m := range mounts {
+		mr.insert(m)
+	}
 
 	if err != nil {
 		return fmt.Errorf("error synchronizing from procfs: %v", err)
@@ -214,7 +228,7 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 	mount.MountPointStr, _ = mr.dentryResolver.Resolve(mount.ParentPathKey, false)
 
 	mr.insert(mount)
-	_, _, _, _ = mr.getMountPath(mount.RootPathKey.MountID, 0)
+	_, _, _, _ = mr.getMountPath(mount.MountID, 0)
 
 	// Find all the mounts that I'm the parent of
 	for mnt := range mr.mounts.ValuesIter() {
@@ -230,7 +244,7 @@ func (mr *Resolver) insertMoved(mount *model.Mount) {
 	// Update the mount path for all the children
 	mr.walkMountSubtree(mount, func(child *model.Mount) {
 		child.Path = ""
-		_, _, _, _ = mr.getMountPath(child.RootPathKey.MountID, 0)
+		_, _, _, _ = mr.getMountPath(child.MountID, 0)
 	})
 }
 
@@ -310,11 +324,11 @@ func (mr *Resolver) Delete(mountID uint32, mountIDUnique uint64) error {
 }
 
 // ResolveFilesystem returns the name of the filesystem
-func (mr *Resolver) ResolveFilesystem(pathKey model.PathKey, pid uint32) (string, error) {
+func (mr *Resolver) ResolveFilesystem(mountID uint32, pid uint32) (string, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	mount, _, _, err := mr.resolveMount(pathKey, pid)
+	mount, _, _, err := mr.resolveMount(mountID, pid)
 	if err != nil {
 		return model.UnknownFS, err
 	}
@@ -406,11 +420,6 @@ func (mr *Resolver) insert(m *model.Mount) {
 		}
 	}
 
-	if m.RootPathKey.IsNull() {
-		// this should never happen
-		seclog.Warnf("root path key is null for mount %d", m.MountID)
-	}
-
 	mr.mounts.Add(m.MountID, m)
 }
 
@@ -422,8 +431,8 @@ func (mr *Resolver) lookupByMountID(mountID uint32) *model.Mount {
 	return nil
 }
 
-func (mr *Resolver) lookupMount(pathKey model.PathKey) (*model.Mount, model.MountSource, model.MountOrigin) {
-	mount := mr.lookupByMountID(pathKey.MountID)
+func (mr *Resolver) lookupMount(mountID uint32) (*model.Mount, model.MountSource, model.MountOrigin) {
+	mount := mr.lookupByMountID(mountID)
 
 	if mount == nil {
 		return nil, model.MountSourceUnknown, model.MountOriginUnknown
@@ -437,7 +446,7 @@ func (mr *Resolver) _getMountPath(mountID uint32, pid uint32, depth int) (string
 		return "", model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	mount, source, origin := mr.lookupMount(model.PathKey{MountID: mountID})
+	mount, source, origin := mr.lookupMount(mountID)
 	if mount == nil {
 		return "", source, origin, &ErrMountNotFound{MountID: mountID}
 	}
@@ -492,15 +501,15 @@ func (mr *Resolver) getMountPath(mountID uint32, pid uint32) (string, model.Moun
 }
 
 // ResolveMountRoot returns the root of a mount identified by its mount ID.
-func (mr *Resolver) ResolveMountRoot(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+func (mr *Resolver) ResolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	return mr.resolveMountRoot(pathKey, pid)
+	return mr.resolveMountRoot(mountID, pid)
 }
 
-func (mr *Resolver) resolveMountRoot(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
-	mount, source, origin, err := mr.resolveMount(pathKey, pid)
+func (mr *Resolver) resolveMountRoot(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+	mount, source, origin, err := mr.resolveMount(mountID, pid)
 	if err != nil {
 		return "", source, origin, err
 	}
@@ -508,19 +517,19 @@ func (mr *Resolver) resolveMountRoot(pathKey model.PathKey, pid uint32) (string,
 }
 
 // ResolveMountPath returns the path of a mount identified by its mount ID.
-func (mr *Resolver) ResolveMountPath(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+func (mr *Resolver) ResolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	return mr.resolveMountPath(pathKey, pid)
+	return mr.resolveMountPath(mountID, pid)
 }
 
-func (mr *Resolver) resolveMountPath(pathKey model.PathKey, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
-	if _, err := mr.IsMountIDValid(pathKey.MountID); err != nil {
+func (mr *Resolver) resolveMountPath(mountID uint32, pid uint32) (string, model.MountSource, model.MountOrigin, error) {
+	if _, err := mr.IsMountIDValid(mountID); err != nil {
 		return "", model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	path, source, origin, err := mr.getMountPath(pathKey.MountID, pid)
+	path, source, origin, err := mr.getMountPath(mountID, pid)
 	if err == nil {
 		mr.cacheHitsStats.Inc()
 		return path, source, origin, nil
@@ -528,14 +537,14 @@ func (mr *Resolver) resolveMountPath(pathKey model.PathKey, pid uint32) (string,
 	mr.cacheMissStats.Inc()
 
 	if !mr.opts.UseProcFS {
-		return "", model.MountSourceUnknown, model.MountOriginUnknown, &ErrMountNotFound{MountID: pathKey.MountID}
+		return "", model.MountSourceUnknown, model.MountOriginUnknown, &ErrMountNotFound{MountID: mountID}
 	}
 
 	if err := mr.syncPidNamespace(pid); err != nil {
 		return "", model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	path, source, origin, err = mr.getMountPath(pathKey.MountID, pid)
+	path, source, origin, err = mr.getMountPath(mountID, pid)
 	if err == nil {
 		mr.procHitsStats.Inc()
 		return path, source, origin, nil
@@ -546,23 +555,20 @@ func (mr *Resolver) resolveMountPath(pathKey model.PathKey, pid uint32) (string,
 }
 
 // ResolveMount returns the mount
-func (mr *Resolver) ResolveMount(pathKey model.PathKey, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+func (mr *Resolver) ResolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	return mr.resolveMount(pathKey, pid)
+	return mr.resolveMount(mountID, pid)
 }
 
-func (mr *Resolver) resolveMount(pathKey model.PathKey, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
-	if _, err := mr.IsMountIDValid(pathKey.MountID); err != nil {
+func (mr *Resolver) resolveMount(mountID uint32, pid uint32) (*model.Mount, model.MountSource, model.MountOrigin, error) {
+	if _, err := mr.IsMountIDValid(mountID); err != nil {
 		return nil, model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	mount, source, origin := mr.lookupMount(pathKey)
-	if mount != nil && pathKey.MountEquals(mount.RootPathKey) {
-		// update the path ID to the latest one
-		mount.RootPathKey.PathID = pathKey.PathID
-
+	mount, source, origin := mr.lookupMount(mountID)
+	if mount != nil {
 		mr.cacheHitsStats.Inc()
 		return mount, source, origin, nil
 	}
@@ -572,16 +578,13 @@ func (mr *Resolver) resolveMount(pathKey model.PathKey, pid uint32) (*model.Moun
 		return nil, model.MountSourceUnknown, model.MountOriginUnknown, err
 	}
 
-	if mount, ok := mr.mounts.Get(pathKey.MountID); ok && pathKey.MountEquals(mount.RootPathKey) {
-		// update the path ID to the latest one
-		mount.RootPathKey.PathID = pathKey.PathID
-
+	if mount, ok := mr.mounts.Get(mountID); mount != nil && ok {
 		mr.procHitsStats.Inc()
 		return mount, model.MountSourceMountID, mount.Origin, nil
 	}
 	mr.procMissStats.Inc()
 
-	return nil, model.MountSourceUnknown, model.MountOriginUnknown, &ErrMountNotFound{MountID: pathKey.MountID}
+	return nil, model.MountSourceUnknown, model.MountOriginUnknown, &ErrMountNotFound{MountID: mountID}
 }
 
 // SendStats sends metrics about the current state of the mount resolver

--- a/pkg/security/resolvers/mount/resolver_test.go
+++ b/pkg/security/resolvers/mount/resolver_test.go
@@ -10,9 +10,8 @@ package mount
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )
@@ -46,10 +45,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 27,
-								RootPathKey: model.PathKey{
-									MountID: 27,
-								},
-								Device: 1,
+								Device:  1,
 								ParentPathKey: model.PathKey{
 									MountID: 1,
 								},
@@ -78,10 +74,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 127,
-								RootPathKey: model.PathKey{
-									MountID: 127,
-								},
-								Device: 52,
+								Device:  52,
 								ParentPathKey: model.PathKey{
 									MountID: 27,
 								},
@@ -142,10 +135,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 27,
-								RootPathKey: model.PathKey{
-									MountID: 27,
-								},
-								Device: 1,
+								Device:  1,
 								ParentPathKey: model.PathKey{
 									MountID: 1,
 								},
@@ -214,10 +204,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 27,
-								RootPathKey: model.PathKey{
-									MountID: 27,
-								},
-								Device: 1,
+								Device:  1,
 								ParentPathKey: model.PathKey{
 									MountID: 1,
 								},
@@ -245,10 +232,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 638,
-								RootPathKey: model.PathKey{
-									MountID: 638,
-								},
-								Device: 53,
+								Device:  53,
 								ParentPathKey: model.PathKey{
 									MountID: 635,
 								},
@@ -262,10 +246,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 639,
-								RootPathKey: model.PathKey{
-									MountID: 639,
-								},
-								Device: 54,
+								Device:  54,
 								ParentPathKey: model.PathKey{
 									MountID: 638,
 								},
@@ -294,10 +275,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 32,
-								RootPathKey: model.PathKey{
-									MountID: 32,
-								},
-								Device: 97,
+								Device:  97,
 								ParentPathKey: model.PathKey{
 									MountID: 638,
 								},
@@ -309,10 +287,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 41,
-								RootPathKey: model.PathKey{
-									MountID: 41,
-								},
-								Device: 98,
+								Device:  98,
 								ParentPathKey: model.PathKey{
 									MountID: 32,
 								},
@@ -324,10 +299,7 @@ func TestMountResolver(t *testing.T) {
 						mount: &model.MountEvent{
 							Mount: model.Mount{
 								MountID: 42,
-								RootPathKey: model.PathKey{
-									MountID: 42,
-								},
-								Device: 99,
+								Device:  99,
 								ParentPathKey: model.PathKey{
 									MountID: 41,
 								},
@@ -373,7 +345,7 @@ func TestMountResolver(t *testing.T) {
 					mr.insert(&evt.mount.Mount)
 				}
 				if evt.umount != nil {
-					mount, _, _, err := mr.ResolveMount(model.PathKey{MountID: evt.umount.MountID}, pid)
+					mount, _, _, err := mr.ResolveMount(evt.umount.MountID, pid)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -382,7 +354,7 @@ func TestMountResolver(t *testing.T) {
 			}
 
 			for _, testC := range tt.args.cases {
-				p, _, _, err := mr.ResolveMountPath(model.PathKey{MountID: testC.mountID}, pid)
+				p, _, _, err := mr.ResolveMountPath(testC.mountID, pid)
 				if err != nil {
 					if testC.expectedError != nil {
 						assert.Equal(t, testC.expectedError.Error(), err.Error())

--- a/pkg/security/resolvers/path/resolver.go
+++ b/pkg/security/resolvers/path/resolver.go
@@ -53,7 +53,7 @@ func (r *Resolver) ResolveMountAttributes(e *model.FileEvent, pidCtx *model.PIDC
 		return nil
 	}
 
-	mnt, _, _, err := r.mountResolver.ResolveMount(e.PathKey, pidCtx.Pid)
+	mnt, _, _, err := r.mountResolver.ResolveMount(e.MountID, pidCtx.Pid)
 	if err != nil {
 		return fmt.Errorf("attribute resolution error: %w", err)
 	}
@@ -77,7 +77,7 @@ func (r *Resolver) ResolveFullFilePath(e *model.FileFields, pidCtx *model.PIDCon
 		return pathStr, "", model.MountSourceMountID, model.MountOriginEvent, nil
 	}
 
-	mountPath, source, origin, err := r.mountResolver.ResolveMountPath(e.PathKey, pidCtx.Pid)
+	mountPath, source, origin, err := r.mountResolver.ResolveMountPath(e.MountID, pidCtx.Pid)
 	if err != nil {
 		if _, err := r.mountResolver.IsMountIDValid(e.MountID); errors.Is(err, mount.ErrMountKernelID) {
 			return pathStr, "", origin, source, &ErrPathResolutionNotCritical{Err: fmt.Errorf("mount ID(%d) invalid: %w", e.MountID, err)}
@@ -85,7 +85,7 @@ func (r *Resolver) ResolveFullFilePath(e *model.FileFields, pidCtx *model.PIDCon
 		return pathStr, "", source, origin, &ErrPathResolution{Err: err}
 	}
 
-	rootPath, source, origin, err := r.mountResolver.ResolveMountRoot(e.PathKey, pidCtx.Pid)
+	rootPath, source, origin, err := r.mountResolver.ResolveMountRoot(e.MountID, pidCtx.Pid)
 	if err != nil {
 		if _, err := r.mountResolver.IsMountIDValid(e.MountID); errors.Is(err, mount.ErrMountKernelID) {
 			return pathStr, "", source, origin, &ErrPathResolutionNotCritical{Err: fmt.Errorf("mount ID(%d) invalid: %w", e.MountID, err)}

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -415,7 +415,7 @@ func (p *EBPFResolver) enrichEventFromProcfs(entry *model.ProcessCacheEntry, pro
 		entry.FileEvent.MountVisible = true
 		entry.FileEvent.MountDetached = false
 		// resolve container path with the MountEBPFResolver
-		entry.FileEvent.Filesystem, err = p.mountResolver.ResolveFilesystem(entry.Process.FileEvent.PathKey, entry.Process.Pid)
+		entry.FileEvent.Filesystem, err = p.mountResolver.ResolveFilesystem(entry.Process.FileEvent.MountID, entry.Process.Pid)
 		if err != nil {
 			seclog.Debugf("snapshot failed for mount %d with pid %d : couldn't get the filesystem: %s", entry.Process.FileEvent.MountID, proc.Pid, err)
 		}
@@ -814,7 +814,7 @@ func (p *EBPFResolver) SetProcessSymlink(entry *model.ProcessCacheEntry) {
 // SetProcessFilesystem resolves process file system
 func (p *EBPFResolver) setProcessFilesystem(entry *model.ProcessCacheEntry) (string, error) {
 	if entry.FileEvent.MountID != 0 {
-		fs, err := p.mountResolver.ResolveFilesystem(entry.FileEvent.PathKey, entry.Pid)
+		fs, err := p.mountResolver.ResolveFilesystem(entry.FileEvent.MountID, entry.Pid)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -907,27 +907,6 @@ type PathKey struct {
 	PathID  uint32 `field:"-"`
 }
 
-// MountEquals returns true if the mount ID is the same as the other mount ID taking the path ID into account
-// See the increment of the path ID when the mount is updated kernel side
-func (p *PathKey) MountEquals(other PathKey) bool {
-	// PathID encodes as PATH_ID(high, low) = (high << 16) | (low & 0xFFFF).
-	// The high 16 bits are the mount revision counter (bumped by MOUNT_REVISION_BUMP_VALUE on
-	// global invalidations such as directory renames/unlinks affecting the mount namespace).
-	// The low 16 bits are a per-inode counter and are unrelated between different files,
-	// so we must compare the high bits here.
-	pathID, otherPathID := uint16(p.PathID>>16), uint16(other.PathID>>16)
-
-	diff := pathID - otherPathID // unsigned wrap-around
-	if diff > 0x8000 {
-		diff = ^diff + 1 // equivalent to 65536 - diff
-	}
-
-	// see kernel side definition of MOUNT_REVISION_BUMP_VALUE
-	const mountRevisionBumpValue = 64
-
-	return p.MountID == other.MountID && (p.PathID == 0 || other.PathID == 0 || diff < mountRevisionBumpValue)
-}
-
 // OnDemandPerArgSize is the size of each argument in Data in the on-demand event
 const OnDemandPerArgSize = 64
 

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -364,7 +364,7 @@ func testMountSnapshot(t *testing.T) {
 	checkSnapshotAndModelMatch := func(mntInfo *mountinfo.Info) {
 		dev := utils.Mkdev(uint32(mntInfo.Major), uint32(mntInfo.Minor))
 
-		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(model.PathKey{MountID: uint32(mntInfo.ID)}, pid)
+		mount, mountSource, mountOrigin, err := mountResolver.ResolveMount(uint32(mntInfo.ID), pid)
 		if err != nil {
 			t.Error(err)
 			return
@@ -377,7 +377,7 @@ func testMountSnapshot(t *testing.T) {
 		assert.Equal(t, mntInfo.FSType, mount.FSType, "snapshot and model fstype mismatch")
 		assert.Equal(t, mntInfo.Root, mount.RootStr, "snapshot and model root mismatch")
 
-		mountPointPath, mountSource, mountOrigin, err := mountResolver.ResolveMountPath(model.PathKey{MountID: mount.MountID}, pid)
+		mountPointPath, mountSource, mountOrigin, err := mountResolver.ResolveMountPath(mount.MountID, pid)
 		if err != nil {
 			t.Errorf("failed to resolve mountpoint path of mountpoint with id %d", mount.MountID)
 		}

--- a/pkg/security/tests/move_mount_test.go
+++ b/pkg/security/tests/move_mount_test.go
@@ -92,7 +92,7 @@ func TestMoveMount(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.RootPathKey, 0)
+			mountPtr, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
 			assert.Equal(t, err, nil)
 			assert.Equal(t, submountDir, mountPtr.Path, "Wrong mountpoint path")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
@@ -253,13 +253,13 @@ func TestMoveMountRecursiveNoPropagation(t *testing.T) {
 				return false
 			}
 			p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
-			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.RootPathKey, 0)
+			mount, _, _, err := p.Resolvers.MountResolver.ResolveMount(event.Mount.MountID, 0)
 			assert.Equal(t, err, nil, "Error resolving mount")
 			assert.Equal(t, 2, len(mount.Children), "Wrong number of child mounts")
 			assert.NotEqual(t, 0, event.Mount.NamespaceInode, "Namespace inode not captured")
 
 			for _, childMountID := range mount.Children {
-				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(model.PathKey{MountID: childMountID}, 0)
+				child, _, _, err := p.Resolvers.MountResolver.ResolveMount(childMountID, 0)
 				assert.Equal(t, err, nil, "Error resolving child mount")
 				assert.True(t, strings.HasPrefix(child.Path, te.submountDirDst), "Path wasn't updated")
 			}
@@ -338,7 +338,7 @@ func TestMoveMountRecursivePropagation(t *testing.T) {
 
 		p, _ := test.probe.PlatformProbe.(*sprobe.EBPFProbe)
 		for i := range allMounts {
-			path, _, _, _ := p.Resolvers.MountResolver.ResolveMountPath(model.PathKey{MountID: i}, 0)
+			path, _, _, _ := p.Resolvers.MountResolver.ResolveMountPath(i, 0)
 
 			if len(path) == 0 || !strings.Contains(path, "tmp1") && !strings.Contains(path, "tmp2") {
 				// Some paths aren't being fully resolved due to missing mounts in the chain

--- a/pkg/security/tests/umount_test.go
+++ b/pkg/security/tests/umount_test.go
@@ -9,14 +9,12 @@
 package tests
 
 import (
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 	"syscall"
 	"testing"
 	"time"
-
-	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
-	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/sys/unix"
 )
 
 func TmpMountAtLegacyAPI(dir string) error {
@@ -50,7 +48,7 @@ func TestUmount(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	mnt, _, _, err := p.Resolvers.MountResolver.ResolveMount(model.PathKey{MountID: mountID}, 0)
+	mnt, _, _, err := p.Resolvers.MountResolver.ResolveMount(mountID, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +66,7 @@ func TestUmount(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Resolve the mount after detaching, without using redemption or reloading. Should return nil
-	mnt, _, _, err = p.Resolvers.MountResolver.ResolveMount(model.PathKey{MountID: mountID}, 0)
+	mnt, _, _, err = p.Resolvers.MountResolver.ResolveMount(mountID, 0)
 	if err == nil {
 		t.Fatal("No error")
 	}


### PR DESCRIPTION
This reverts commit adf918f242636e4b89d93037faa0e3c5ca807553.

I will re-introduce it after more investigation about the impact regarding some path resolution error metrics.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
