### PR TITLE
feat(discovery): Implement /discovery/state endpoint in system-probe-lite

### DIFF
--- a/pkg/discovery/module/impl_linux.go
+++ b/pkg/discovery/module/impl_linux.go
@@ -108,10 +108,12 @@ func (s *discovery) handleStatusEndpoint(w http.ResponseWriter, _ *http.Request)
 // handleStateEndpoint is the handler for the /state endpoint.
 // Returns the internal state of the discovery module.
 func (s *discovery) handleStateEndpoint(w http.ResponseWriter, req *http.Request) {
-	s.mux.Lock()
-	defer s.mux.Unlock()
+	s.mux.RLock()
+	defer s.mux.RUnlock()
 
-	state := make(map[string]interface{})
+	state := map[string]interface{}{
+		"implementation": "system-probe",
+	}
 
 	utils.WriteAsJSON(req, w, state, utils.CompactOutput)
 }

--- a/pkg/discovery/module/impl_linux.go
+++ b/pkg/discovery/module/impl_linux.go
@@ -108,8 +108,8 @@ func (s *discovery) handleStatusEndpoint(w http.ResponseWriter, _ *http.Request)
 // handleStateEndpoint is the handler for the /state endpoint.
 // Returns the internal state of the discovery module.
 func (s *discovery) handleStateEndpoint(w http.ResponseWriter, req *http.Request) {
-	s.mux.RLock()
-	defer s.mux.RUnlock()
+	s.mux.Lock()
+	defer s.mux.Unlock()
 
 	state := map[string]interface{}{
 		"implementation": "system-probe",

--- a/pkg/discovery/module/impl_linux_test.go
+++ b/pkg/discovery/module/impl_linux_test.go
@@ -134,20 +134,40 @@ func setupRustDiscoveryModule(t *testing.T) *testDiscoveryModule {
 
 type discoveryTestSuite struct {
 	suite.Suite
-	setupModule func(t *testing.T) *testDiscoveryModule
-	discovery   *testDiscoveryModule
+	setupModule            func(t *testing.T) *testDiscoveryModule
+	discovery              *testDiscoveryModule
+	expectedImplementation string
 }
 
 func (s *discoveryTestSuite) SetupTest() {
 	s.discovery = s.setupModule(s.T())
 }
 
+func (s *discoveryTestSuite) TestState() {
+	t := s.T()
+
+	url := s.discovery.url + "/" + string(config.DiscoveryModule) + "/state"
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err)
+
+	resp, err := s.discovery.client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var state map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&state)
+	require.NoError(t, err)
+
+	require.Equal(t, s.expectedImplementation, state["implementation"])
+}
+
 func TestDiscovery(t *testing.T) {
 	t.Run("go", func(t *testing.T) {
-		suite.Run(t, &discoveryTestSuite{setupModule: setupGoDiscoveryModule})
+		suite.Run(t, &discoveryTestSuite{setupModule: setupGoDiscoveryModule, expectedImplementation: "system-probe"})
 	})
 	t.Run("rust", func(t *testing.T) {
-		suite.Run(t, &discoveryTestSuite{setupModule: setupRustDiscoveryModule})
+		suite.Run(t, &discoveryTestSuite{setupModule: setupRustDiscoveryModule, expectedImplementation: "system-probe-lite"})
 	})
 }
 

--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -162,6 +162,26 @@ async fn handle_services(
         .map_err(|e| anyhow!("Failed to build response: {}", e))
 }
 
+async fn handle_state() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
+    Response::builder()
+        .header("Content-Type", "application/json")
+        .body(
+            Full::new(
+                serde_json::to_vec(&json!({
+                    "implementation": "system-probe-lite",
+                }))
+                .unwrap_or_else(|e| {
+                    error!("Failed to serialize response: {e}");
+                    b"Internal server error".to_vec()
+                })
+                .into(),
+            )
+            .map_err(|e| match e {})
+            .boxed(),
+        )
+        .map_err(|e| anyhow!("Failed to build response: {}", e))
+}
+
 async fn handle_debug_stats() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
     Response::builder()
         .header("Content-Type", "application/json")
@@ -202,6 +222,7 @@ async fn handle_request(
             debug!("Handling /discovery/services request");
             handle_services(req).await
         }
+        (&Method::GET, "/discovery/state") => handle_state().await,
         (&Method::GET, "/debug/stats") => handle_debug_stats().await,
         _ => {
             info!(

--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -166,16 +166,9 @@ async fn handle_state() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
     Response::builder()
         .header("Content-Type", "application/json")
         .body(
-            Full::new(
-                serde_json::to_vec(&json!({
-                    "implementation": "system-probe-lite",
-                }))
-                .unwrap_or_else(|e| {
-                    error!("Failed to serialize response: {e}");
-                    b"Internal server error".to_vec()
-                })
-                .into(),
-            )
+            Full::new(Bytes::from_static(
+                b"{\"implementation\":\"system-probe-lite\"}",
+            ))
             .map_err(|e| match e {})
             .boxed(),
         )

--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -166,9 +166,16 @@ async fn handle_state() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
     Response::builder()
         .header("Content-Type", "application/json")
         .body(
-            Full::new(Bytes::from_static(
-                b"{\"implementation\":\"system-probe-lite\"}",
-            ))
+            Full::new(
+                serde_json::to_vec(&json!({
+                    "implementation": "system-probe-lite",
+                }))
+                .unwrap_or_else(|e| {
+                    error!("Failed to serialize response: {e}");
+                    b"Internal server error".to_vec()
+                })
+                .into(),
+            )
             .map_err(|e| match e {})
             .boxed(),
         )


### PR DESCRIPTION
### What does this PR do?

Implements the `GET /discovery/state` endpoint in system-probe-lite and populates the previously empty endpoint in system-probe. Both return a JSON object with an `implementation` field identifying which binary is serving:

- system-probe: `{"implementation":"system-probe"}`
- system-probe-lite: `{"implementation":"system-probe-lite"}`

This endpoint is called by the flare collector (`pkg/flare/archive_linux.go`) and written to `discovery.log` in flare archives.

### Motivation

The `/discovery/state` endpoint existed in system-probe but returned empty JSON `{}`, and was entirely missing from system-probe-lite (returning 404). This made `discovery.log` in flares useless for debugging. Adding the `implementation` field lets support and developers immediately identify whether discovery is running via system-probe or system-probe-lite.

### Describe how you validated your changes

- Added `TestState` suite method in `impl_linux_test.go` that runs against both Go and Rust implementations, asserting the correct `implementation` value for each
- `TestDiscovery/go/TestState` — PASS
- `TestDiscovery/rust/TestState` — PASS
- Rust lints pass: `bazel build --config=lint //pkg/discovery/module/rust/...`

### Additional Notes

The test leverages the existing `discoveryTestSuite` which runs all suite methods against both the Go (httptest) and Rust (actual binary on unix socket) implementations.