### PR TITLE
Add Dockerfiles/dev/Dockerfile for local dev image builds

### DIFF
--- a/.claude/skills/build-agent-dev-image/SKILL.md
+++ b/.claude/skills/build-agent-dev-image/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: build-agent-dev-image
+description: Build a local dev Docker image of the Datadog Agent using Dockerfiles/dev/Dockerfile — compiles the local source tree with the same build environment as `dda env dev run` and layers the binary on top of the official agent image.
+argument-hint: "[--name <image-name>] [--tag <tag>] [--agent-image <base-image>] [--extra-args <build-args>]"
+allowed-tools: Bash(docker *)
+disable-model-invocation: true
+---
+
+# Build Agent Dev Image
+
+Build a dev Docker image from the local source tree using `Dockerfiles/dev/Dockerfile`.
+
+The image compiles the local agent binary inside `datadog/agent-dev-env-linux` (the same
+environment as `dda env dev run -- dda inv -- agent.build`) and layers the result on top of
+the official `gcr.io/datadoghq/agent:latest` image.
+
+## Arguments: $ARGUMENTS
+
+Parse the arguments above and extract:
+- `--name <image-name>` — Docker image name (default: `datadog/agent-dev`)
+- `--tag <tag>` — Docker image tag (default: `local`)
+- `--agent-image <base-image>` — Override the base agent image (default: `gcr.io/datadoghq/agent:latest`)
+- `--extra-args <args>` — Extra flags forwarded to `dda inv agent.build` inside the build
+
+## Instructions
+
+1. **Build the image** from the repo root with the resolved values:
+   ```bash
+   docker buildx build \
+     -t <name>:<tag> \
+     -f Dockerfiles/dev/Dockerfile \
+     [--build-arg AGENT_IMAGE=<agent-image>] \
+     [--build-arg BUILD_EXTRA_ARGS=<extra-args>] \
+     .
+   ```
+   Run with `run_in_background: true` — the full build takes ~3–5 minutes.
+
+2. **Show the user** the full command before starting.
+
+## Examples
+
+```
+/build-agent-dev-image
+/build-agent-dev-image --tag my-feature
+/build-agent-dev-image --name myrepo/agent-dev --tag pr-1234
+/build-agent-dev-image --agent-image gcr.io/datadoghq/agent:7.65.0
+/build-agent-dev-image --extra-args "--bundle-ebpf"
+```

--- a/Dockerfiles/dev/Dockerfile
+++ b/Dockerfiles/dev/Dockerfile
@@ -1,0 +1,72 @@
+# syntax=docker/dockerfile:1
+#
+# Docker dev image: builds the local agent binary using the same build environment
+# as `dda env dev run -- dda inv -- agent.build`, then layers it on top of the
+# official agent image so Python, JMX, and all embedded deps remain intact.
+#
+# The source tree is bind-mounted during the build RUN (not COPY'd), so it never
+# appears as an image layer. Only the compiled artifacts are kept.
+#
+# Usage (BuildKit required):
+#   docker buildx build -t datadog/agent-dev:local -f Dockerfiles/dev/Dockerfile .
+#
+# Optional build args:
+#   --build-arg AGENT_IMAGE=gcr.io/datadoghq/agent:7.x.y  (default: latest)
+#   --build-arg BUILD_EXTRA_ARGS=""  extra flags forwarded to agent.build
+
+ARG AGENT_IMAGE=gcr.io/datadoghq/agent:latest
+
+########################################################################
+# Stage 1: Official agent image — source of embedded Python/libs
+########################################################################
+FROM ${AGENT_IMAGE} AS agent-base
+
+########################################################################
+# Stage 2: Build stage — same image used by `dda env dev run`
+########################################################################
+FROM datadog/agent-dev-env-linux AS builder
+
+ARG BUILD_EXTRA_ARGS=""
+
+# Copy the agent's embedded Python and native libs to their final install
+# path so the binary's RPATH is correct without post-build patching.
+COPY --from=agent-base /opt/datadog-agent/embedded/bin     /opt/datadog-agent/embedded/bin
+COPY --from=agent-base /opt/datadog-agent/embedded/lib     /opt/datadog-agent/embedded/lib
+COPY --from=agent-base /opt/datadog-agent/embedded/include /opt/datadog-agent/embedded/include
+
+# Ensure patchelf is available to fix RPATH after build
+RUN apt-get update -q && apt-get install -y --no-install-recommends patchelf && rm -rf /var/lib/apt/lists/*
+
+# Mount the source tree read-write (overlay — host files are never modified).
+# Build artifacts are written outside the mount to /build-output so they
+# persist after the bind mount is released.
+# The build context includes real git metadata (HEAD, refs, packed-refs) so
+# `git rev-parse` / `git describe` work without needing the full object store.
+RUN --mount=type=bind,source=.,target=/root/repos/datadog-agent,rw \
+    mkdir -p /build-output && \
+    cd /root/repos/datadog-agent && \
+    LD_LIBRARY_PATH=/opt/datadog-agent/embedded/lib \
+    dda inv agent.build \
+        --build-exclude=systemd \
+        --cmake-options="-DPython3_ROOT_DIR=/opt/datadog-agent/embedded -DPython3_FIND_STRATEGY=LOCATION" \
+        ${BUILD_EXTRA_ARGS} && \
+    cp bin/agent/agent /build-output/agent && \
+    # Patch the RPATH so the binary finds rtloader in the official agent image's lib dir.
+    # The rtloader .so files are NOT replaced — the ones already in the image are used.
+    patchelf --set-rpath /opt/datadog-agent/embedded/lib /build-output/agent
+
+########################################################################
+# Stage 3: Final image — official agent runtime + locally built binary
+########################################################################
+FROM ${AGENT_IMAGE}
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get clean && \
+    apt-get -o Acquire::Retries=4 update && \
+    apt-get install -y --no-install-recommends bash-completion less vim && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Replace only the agent binary. The rtloader .so files already in the official
+# image are kept — the binary's RPATH was patched to find them at runtime.
+COPY --from=builder /build-output/agent \
+    /opt/datadog-agent/bin/agent/agent


### PR DESCRIPTION
## Summary

- Adds `Dockerfiles/dev/Dockerfile`: a self-contained multi-stage build that compiles the local agent binary inside `datadog/agent-dev-env-linux` (the same environment as `dda env dev run`) and layers it on top of the official `gcr.io/datadoghq/agent` image
- Adds `Dockerfiles/dev/Dockerfile.dockerignore`: keeps the build context minimal
- Adds `.claude/skills/build-agent-dev-image/SKILL.md`: a Claude skill (`/build-agent-dev-image`) for invoking the build with configurable name, tag, and base image

## Usage

```bash
docker buildx build -t datadog/agent-dev:local -f Dockerfiles/dev/Dockerfile .

# With options
docker buildx build \
  -t myrepo/agent-dev:my-feature \
  --build-arg AGENT_IMAGE=gcr.io/datadoghq/agent:7.65.0 \
  -f Dockerfiles/dev/Dockerfile .
```

Or via the Claude skill:
```
/build-agent-dev-image --tag my-feature
```

## Comparison with `agent.hacky-dev-image-build`

The existing `dda inv agent.hacky-dev-image-build` task and this Dockerfile solve the same problem but with different trade-offs:

| | `hacky-dev-image-build` | `Dockerfiles/dev/Dockerfile` |
|---|---|---|
| **Build runs** | On the host machine | Inside Docker (hermetic) |
| **Toolchain required** | Yes (Go, cmake, Python…) | No — Docker only |
| **Artifacts on disk** | Writes to `bin/`, `dev/lib/` | None — bind-mounted overlay |
| **rtloader handling** | Copies locally built `.so` files + perl binary patch for embedded Python path | Uses rtloader from the official image as-is; only `patchelf`s the agent binary RPATH |
| **Incremental rebuild** | Fast if already built locally | Always recompiles (BuildKit cache helps) |
| **Debugger (Delve)** | Included by default | Not included |
| **Extra agents** | system-probe, trace-agent, security-agent, process-agent via flags | Agent binary only |
| **Source tree in image** | Yes (for Delve source mapping) | No |
| **Entry point** | `dda env dev run -- dda inv -- agent.hacky-dev-image-build` | `docker buildx build` |

**When to use this Dockerfile:**
- Building on a clean machine or in CI without a local toolchain
- Sharing a reproducible dev image with teammates
- When you don't need Delve or extra agent binaries

**When to prefer `hacky-dev-image-build`:**
- Fast iteration when you're already building locally (avoids recompile)
- You need Delve for source-level debugging
- You need system-probe, trace-agent, or other components in the same image

## Test plan

- [x] `docker buildx build -t datadog/agent-dev:local -f Dockerfiles/dev/Dockerfile .` succeeds
- [x] `docker run --rm -e DD_API_KEY=00000000000000000000000000000001 datadog/agent-dev:local agent version` prints correct version from local HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)