### PR TITLE
Add X-Datadog-Additional-Tags header to data-streams-message requests

### DIFF
--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder.go
@@ -37,6 +37,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/option"
 	"github.com/DataDog/datadog-agent/pkg/util/startstop"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 //go:generate mockgen -source=$GOFILE -package=$GOPACKAGE -destination=epforwarder_mockgen.go
@@ -494,6 +495,7 @@ func newHTTPPassthroughPipeline(
 	desc passthroughPipelineDesc,
 	destinationsContext *client.DestinationsContext,
 	pipelineID int,
+	hostname string,
 ) (p *passthroughPipeline, err error) {
 	configKeys := config.NewLogsConfigKeys(desc.endpointsConfigPrefix, coreConfig)
 	compressionOptions := config.EndpointCompressionOptions{
@@ -515,6 +517,16 @@ func newHTTPPassthroughPipeline(
 	if !endpoints.UseHTTP {
 		return nil, errors.New("endpoints must be http")
 	}
+
+	if desc.eventType == eventTypeDataStreamsMessage {
+		extraHeaders := map[string]string{
+			"X-Datadog-Additional-Tags": fmt.Sprintf("host:%s,agent_version:%s", hostname, version.AgentVersion),
+		}
+		for i := range endpoints.Endpoints {
+			endpoints.Endpoints[i].ExtraHTTPHeaders = extraHeaders
+		}
+	}
+
 	// epforwarder pipelines apply their own defaults on top of the hardcoded logs defaults
 	if endpoints.BatchMaxConcurrentSend <= 0 {
 		endpoints.BatchMaxConcurrentSend = desc.defaultBatchMaxConcurrentSend
@@ -616,12 +628,12 @@ func joinHosts(endpoints []config.Endpoint) string {
 	return strings.Join(additionalHosts, ",")
 }
 
-func newDefaultEventPlatformForwarder(config model.Reader, eventPlatformReceiver eventplatformreceiver.Component, compression logscompression.Component) *defaultEventPlatformForwarder {
+func newDefaultEventPlatformForwarder(config model.Reader, eventPlatformReceiver eventplatformreceiver.Component, compression logscompression.Component, hostname string) *defaultEventPlatformForwarder {
 	destinationsCtx := client.NewDestinationsContext()
 	destinationsCtx.Start()
 	pipelines := make(map[string]*passthroughPipeline)
 	for i, desc := range getPassthroughPipelines() {
-		p, err := newHTTPPassthroughPipeline(config, eventPlatformReceiver, compression, desc, destinationsCtx, i)
+		p, err := newHTTPPassthroughPipeline(config, eventPlatformReceiver, compression, desc, destinationsCtx, i, hostname)
 		if err != nil {
 			log.Errorf("Failed to initialize event platform forwarder pipeline. eventType=%s, error=%s", desc.eventType, err.Error())
 			continue
@@ -651,7 +663,8 @@ func newEventPlatformForwarder(deps dependencies) eventplatform.Component {
 	if deps.Params.UseNoopEventPlatformForwarder {
 		forwarder = newNoopEventPlatformForwarder(deps.Hostname, deps.Compression)
 	} else if deps.Params.UseEventPlatformForwarder {
-		forwarder = newDefaultEventPlatformForwarder(deps.Config, deps.EventPlatformReceiver, deps.Compression)
+		hostnameStr := deps.Hostname.GetSafe(context.Background())
+		forwarder = newDefaultEventPlatformForwarder(deps.Config, deps.EventPlatformReceiver, deps.Compression, hostnameStr)
 	}
 	if forwarder == nil {
 		return option.NonePtr[eventplatform.Forwarder]()
@@ -676,7 +689,8 @@ func NewNoopEventPlatformForwarder(hostname hostnameinterface.Component, compres
 }
 
 func newNoopEventPlatformForwarder(hostname hostnameinterface.Component, compression logscompression.Component) *defaultEventPlatformForwarder {
-	f := newDefaultEventPlatformForwarder(pkgconfigsetup.Datadog(), eventplatformreceiverimpl.NewReceiver(hostname).Comp, compression)
+	hostnameStr := hostname.GetSafe(context.Background())
+	f := newDefaultEventPlatformForwarder(pkgconfigsetup.Datadog(), eventplatformreceiverimpl.NewReceiver(hostname).Comp, compression, hostnameStr)
 	// remove the senders
 	for _, p := range f.pipelines {
 		p.strategy = nil

--- a/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_test.go
+++ b/comp/forwarder/eventplatform/eventplatformimpl/epforwarder_test.go
@@ -137,6 +137,7 @@ func (suite *EventPlatformForwarderTestSuite) TestNewHTTPPassthroughPipelineComp
 				desc,
 				nil,
 				0,
+				"test-hostname",
 			)
 			suite.Require().NoError(err)
 			suite.Require().NotNil(pipeline)

--- a/comp/logs/agent/config/endpoints.go
+++ b/comp/logs/agent/config/endpoints.go
@@ -87,6 +87,8 @@ type Endpoint struct {
 	TrackType IntakeTrackType
 	Protocol  IntakeProtocol
 	Origin    IntakeOrigin
+
+	ExtraHTTPHeaders map[string]string
 }
 
 // unmarshalEndpoint is used to load additional endpoints from the configuration which stored as JSON/mapstructure.

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -360,6 +360,9 @@ func (d *Destination) unconditionalSend(payload *message.Payload) (err error) {
 	req.Header.Set("dd-message-timestamp", strconv.FormatInt(getMessageTimestamp(payload.MessageMetas), 10))
 	then := time.Now()
 	req.Header.Set("dd-current-timestamp", strconv.FormatInt(then.UnixMilli(), 10))
+	for k, v := range d.endpoint.ExtraHTTPHeaders {
+		req.Header.Set(k, v)
+	}
 
 	req = req.WithContext(ctx)
 	resp, err := d.client.Do(req)

--- a/releasenotes/notes/dsm-additional-tags-header-08936df3e2c64c13.yaml
+++ b/releasenotes/notes/dsm-additional-tags-header-08936df3e2c64c13.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add ``X-Datadog-Additional-Tags`` header with hostname and agent version to data-streams-message HTTP requests.


### PR DESCRIPTION
## Summary

- Adds `ExtraHTTPHeaders` field to the `Endpoint` config struct in the logs agent
- Applies extra headers in the HTTP destination sender's `unconditionalSend` method
- Populates `X-Datadog-Additional-Tags` with `host:<hostname>,agent_version:<version>` for the `data-streams-message` pipeline, matching the format used by APM's pipeline stats proxy

## Motivation

the `data-streams-message` track does not forward agent host & version to the backend. Which is needed for us to add the right tags on different metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)