### PR TITLE
feat(e2e/installer): fix docker auth and use ECR image refs

### DIFF
--- a/test/new-e2e/tests/installer/host/fixtures.go
+++ b/test/new-e2e/tests/installer/host/fixtures.go
@@ -73,7 +73,7 @@ func (h *Host) CallExamplePythonApp(traceID string) {
 // StartExamplePythonAppInDocker starts the example Python app in Docker
 func (h *Host) StartExamplePythonAppInDocker() {
 	h.WaitForTraceAgentSocketReady()
-	h.remote.MustExecute(`sudo docker run --name python-app -d -p 8081:8080 -v /opt/fixtures/http_server.py:/usr/src/app/http_server.py public.ecr.aws/docker/library/python:3.8-slim python /usr/src/app/http_server.py`)
+	h.remote.MustExecute(`sudo docker run --name python-app -d -p 8081:8080 -v /opt/fixtures/http_server.py:/usr/src/app/http_server.py 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/python:3.8-slim python /usr/src/app/http_server.py`)
 }
 
 // StopExamplePythonAppInDocker stops the example Python app in Docker

--- a/test/new-e2e/tests/installer/host/fixtures.go
+++ b/test/new-e2e/tests/installer/host/fixtures.go
@@ -73,7 +73,8 @@ func (h *Host) CallExamplePythonApp(traceID string) {
 // StartExamplePythonAppInDocker starts the example Python app in Docker
 func (h *Host) StartExamplePythonAppInDocker() {
 	h.WaitForTraceAgentSocketReady()
-	h.remote.MustExecute(`sudo docker run --name python-app -d -p 8081:8080 -v /opt/fixtures/http_server.py:/usr/src/app/http_server.py 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/library/python:3.8-slim python /usr/src/app/http_server.py`)
+	h.remote.MustExecute(fmt.Sprintf("sudo docker run --name python-app -d -p 8081:8080 -v /opt/fixtures/http_server.py:/usr/src/app/http_server.py %s python /usr/src/app/http_server.py",
+		h.dockerImage("dockerhub/library/python:3.8-slim", "python:3.8-slim")))
 }
 
 // StopExamplePythonAppInDocker stops the example Python app in Docker

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -81,6 +81,16 @@ func (h *Host) setSystemdVersion() {
 	h.systemdVersion = version
 }
 
+// dockerImage returns the ECR pull-through URL for ecrPath when a registry is configured,
+// or publicFallback otherwise.
+func (h *Host) dockerImage(ecrPath, publicFallback string) string {
+	reg, _ := runner.GetProfile().ParamStore().GetWithDefault(parameters.ImagePullRegistry, "")
+	if reg == "" {
+		return publicFallback
+	}
+	return strings.SplitN(reg, ",", 2)[0] + "/" + ecrPath
+}
+
 // ensureDockerLogin logs the host into the ECR registry when E2E_IMAGE_PULL_* is set, so pulls work.
 // It must be called whenever Docker is available (already installed or just installed).
 func (h *Host) ensureDockerLogin() {
@@ -570,7 +580,8 @@ func (h *Host) SetUmask(mask string) (oldmask string) {
 func (h *Host) SetupProxy() {
 	// Install Docker & the Squid Proxy
 	h.InstallDocker()
-	h.remote.MustExecute("sudo docker run -d --name squid-proxy -v /opt/fixtures/squid.conf:/etc/squid/squid.conf -p 3128:3128 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/ubuntu/squid:4.10-20.04_beta")
+	h.remote.MustExecute(fmt.Sprintf("sudo docker run -d --name squid-proxy -v /opt/fixtures/squid.conf:/etc/squid/squid.conf -p 3128:3128 %s",
+		h.dockerImage("dockerhub/ubuntu/squid:4.10-20.04_beta", "public.ecr.aws/ubuntu/squid:4.10-20.04_beta")))
 
 	squidIP := strings.TrimSpace(h.remote.MustExecute("sudo docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' squid-proxy"))
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -97,6 +97,24 @@ func (h *Host) configureDockerECRCredentialHelper() {
 	h.remote.MustExecute(`sudo mkdir -p /root/.docker && printf '{"credsStore":"ecr-login"}\n' | sudo tee /root/.docker/config.json > /dev/null`)
 }
 
+// installECRCredentialHelper installs the amazon-ecr-credential-helper binary if not already present.
+func (h *Host) installECRCredentialHelper() {
+	if _, err := h.remote.Execute("command -v docker-credential-ecr-login"); err == nil {
+		return
+	}
+	switch h.pkgManager {
+	case "apt":
+		h.remote.MustExecute("sudo apt-get install -y amazon-ecr-credential-helper")
+	case "yum":
+		h.remote.MustExecute("sudo yum install -y amazon-ecr-credential-helper")
+	case "zypper":
+		// No official amazon-ecr-credential-helper package for zypper; download the binary directly.
+		h.remote.MustExecute(`ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && sudo curl -fsSL "https://github.com/awslabs/amazon-ecr-credential-helper/releases/latest/download/docker-credential-ecr-login_linux_${ARCH}" -o /usr/local/bin/docker-credential-ecr-login && sudo chmod +x /usr/local/bin/docker-credential-ecr-login`)
+	default:
+		h.t().Fatalf("unsupported package manager: %s", h.pkgManager)
+	}
+}
+
 // TODO[@agent-devx]: Probably move this to the proper docker component defined in components/docker/component.go
 // InstallDocker installs Docker on the host if it is not already installed.
 func (h *Host) InstallDocker() {
@@ -120,6 +138,7 @@ func (h *Host) InstallDocker() {
 		require.NoErrorf(h.t(), err, "failed to start Docker, logs: %s", h.remote.MustExecute("sudo journalctl -xeu docker"))
 	}()
 	if _, err := h.remote.Execute("command -v docker"); err == nil {
+		h.installECRCredentialHelper()
 		h.configureDockerECRCredentialHelper()
 		return
 	}
@@ -128,18 +147,15 @@ func (h *Host) InstallDocker() {
 	case "apt":
 		h.remote.MustExecute("sudo apt-get update -qq")
 		h.remote.MustExecute("sudo apt-get install -y docker.io")
-		h.remote.MustExecute("sudo apt-get install -y amazon-ecr-credential-helper")
 	case "yum":
 		h.remote.MustExecute("sudo yum install -y docker")
-		h.remote.MustExecute("sudo yum install -y amazon-ecr-credential-helper")
 	case "zypper":
 		h.remote.MustExecute("sudo zypper install -y docker")
-		// No official amazon-ecr-credential-helper package for zypper; download the binary directly.
-		h.remote.MustExecute(`ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && sudo curl -fsSL "https://github.com/awslabs/amazon-ecr-credential-helper/releases/latest/download/docker-credential-ecr-login_linux_${ARCH}" -o /usr/local/bin/docker-credential-ecr-login && sudo chmod +x /usr/local/bin/docker-credential-ecr-login`)
 	default:
 		h.t().Fatalf("unsupported package manager: %s", h.pkgManager)
 	}
 
+	h.installECRCredentialHelper()
 	h.configureDockerECRCredentialHelper()
 }
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -7,7 +7,6 @@
 package host
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"os/user"
@@ -91,53 +90,11 @@ func (h *Host) dockerImage(ecrPath, publicFallback string) string {
 	return strings.SplitN(reg, ",", 2)[0] + "/" + ecrPath
 }
 
-// ensureDockerLogin logs the host into the ECR registry when E2E_IMAGE_PULL_* is set, so pulls work.
-// It must be called whenever Docker is available (already installed or just installed).
-func (h *Host) ensureDockerLogin() {
-	store := runner.GetProfile().ParamStore()
-
-	registryStr, err := store.Get(parameters.ImagePullRegistry)
-	if err != nil {
-		var notFound parameters.ParameterNotFoundError
-		if errors.As(err, &notFound) {
-			h.t().Logf("skipping docker login (set E2E_IMAGE_PULL_* for private registry pulls)")
-			return
-		}
-		h.t().Fatalf("failed to get image pull registry: %v", err)
-	}
-
-	usernameStr, err := store.Get(parameters.ImagePullUsername)
-	if err != nil {
-		h.t().Fatalf("failed to get image pull username: %v", err)
-	}
-
-	passwordStr, err := store.Get(parameters.ImagePullPassword)
-	if err != nil {
-		h.t().Fatalf("failed to get image pull password: %v", err)
-	}
-
-	registries := strings.Split(registryStr, ",")
-	usernames := strings.Split(usernameStr, ",")
-	passwords := strings.Split(passwordStr, ",")
-
-	if len(registries) != len(usernames) || len(registries) != len(passwords) {
-		h.t().Fatalf("E2E_IMAGE_PULL_REGISTRY, E2E_IMAGE_PULL_USERNAME, and E2E_IMAGE_PULL_PASSWORD must have the same number of comma-separated entries")
-	}
-
-	for i := range registries {
-		password := passwords[i]
-		if strings.HasPrefix(password, "b64=") {
-			// GCP JSON service account keys contain characters that break shell quoting if
-			// passed directly. Decode into a shell variable first, then use that variable
-			// as the --password argument so the shell handles the quoting correctly.
-			// The b64= data itself is safe to inline (only base64 alphabet characters).
-			h.remote.MustExecute(fmt.Sprintf(`DOCKER_PWD=$(echo %s | base64 -d) && sudo docker login --username %s --password "$DOCKER_PWD" %s`, password[4:], usernames[i], registries[i]))
-		} else {
-			// ECR tokens are JWT-style base64url strings with no special characters,
-			// safe to pass directly to --password.
-			h.remote.MustExecute(fmt.Sprintf("sudo docker login --username %s --password %s %s", usernames[i], password, registries[i]))
-		}
-	}
+// configureDockerECRCredentialHelper writes credsStore: ecr-login into root's Docker config,
+// enabling automatic IAM-role-based authentication for ECR registries (including pull-through caches).
+// The amazon-ecr-credential-helper binary must already be on PATH.
+func (h *Host) configureDockerECRCredentialHelper() {
+	h.remote.MustExecute(`sudo mkdir -p /root/.docker && printf '{"credsStore":"ecr-login"}\n' | sudo tee /root/.docker/config.json > /dev/null`)
 }
 
 // TODO[@agent-devx]: Probably move this to the proper docker component defined in components/docker/component.go
@@ -163,7 +120,7 @@ func (h *Host) InstallDocker() {
 		require.NoErrorf(h.t(), err, "failed to start Docker, logs: %s", h.remote.MustExecute("sudo journalctl -xeu docker"))
 	}()
 	if _, err := h.remote.Execute("command -v docker"); err == nil {
-		h.ensureDockerLogin()
+		h.configureDockerECRCredentialHelper()
 		return
 	}
 
@@ -182,7 +139,7 @@ func (h *Host) InstallDocker() {
 		h.t().Fatalf("unsupported package manager: %s", h.pkgManager)
 	}
 
-	h.ensureDockerLogin()
+	h.configureDockerECRCredentialHelper()
 }
 
 // GetDockerRuntimePath returns the runtime path of a docker runtime

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -7,7 +7,6 @@
 package host
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -117,18 +116,17 @@ func (h *Host) ensureDockerLogin() {
 
 	for i := range registries {
 		password := passwords[i]
-		// Passwords with the "b64=" prefix are already base64-encoded (our convention for
-		// credentials that contain special characters, e.g. GCP JSON service account keys).
-		// For plain-text passwords (e.g. ECR tokens), encode them here so we can always
-		// use the same "base64 -d | docker login --password-stdin" pattern on the remote
-		// side — this avoids shell-quoting issues regardless of the password content.
-		var b64pwd string
 		if strings.HasPrefix(password, "b64=") {
-			b64pwd = password[4:]
+			// GCP JSON service account keys contain characters that break shell quoting if
+			// passed directly. Decode into a shell variable first, then use that variable
+			// as the --password argument so the shell handles the quoting correctly.
+			// The b64= data itself is safe to inline (only base64 alphabet characters).
+			h.remote.MustExecute(fmt.Sprintf(`DOCKER_PWD=$(echo %s | base64 -d) && sudo docker login --username %s --password "$DOCKER_PWD" %s`, password[4:], usernames[i], registries[i]))
 		} else {
-			b64pwd = base64.StdEncoding.EncodeToString([]byte(password))
+			// ECR tokens are JWT-style base64url strings with no special characters,
+			// safe to pass directly to --password.
+			h.remote.MustExecute(fmt.Sprintf("sudo docker login --username %s --password %s %s", usernames[i], password, registries[i]))
 		}
-		h.remote.MustExecute(fmt.Sprintf("echo %s | base64 -d | sudo docker login --username %s --password-stdin %s", b64pwd, usernames[i], registries[i]))
 	}
 }
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -580,8 +580,8 @@ func (h *Host) SetUmask(mask string) (oldmask string) {
 func (h *Host) SetupProxy() {
 	// Install Docker & the Squid Proxy
 	h.InstallDocker()
-	h.remote.MustExecute(fmt.Sprintf("sudo docker run -d --name squid-proxy -v /opt/fixtures/squid.conf:/etc/squid/squid.conf -p 3128:3128 %s",
-		h.dockerImage("dockerhub/ubuntu/squid:4.10-20.04_beta", "public.ecr.aws/ubuntu/squid:4.10-20.04_beta")))
+	h.remote.MustExecute("sudo docker run -d --name squid-proxy -v /opt/fixtures/squid.conf:/etc/squid/squid.conf -p 3128:3128 " +
+		h.dockerImage("dockerhub/ubuntu/squid:4.10-20.04_beta", "public.ecr.aws/ubuntu/squid:4.10-20.04_beta"))
 
 	squidIP := strings.TrimSpace(h.remote.MustExecute("sudo docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' squid-proxy"))
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -134,7 +134,8 @@ func (h *Host) InstallDocker() {
 		h.remote.MustExecute("sudo yum install -y amazon-ecr-credential-helper")
 	case "zypper":
 		h.remote.MustExecute("sudo zypper install -y docker")
-		h.remote.MustExecute("sudo zypper install -y amazon-ecr-credential-helper")
+		// No official amazon-ecr-credential-helper package for zypper; download the binary directly.
+		h.remote.MustExecute(`ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && sudo curl -fsSL "https://github.com/awslabs/amazon-ecr-credential-helper/releases/latest/download/docker-credential-ecr-login_linux_${ARCH}" -o /usr/local/bin/docker-credential-ecr-login && sudo chmod +x /usr/local/bin/docker-credential-ecr-login`)
 	default:
 		h.t().Fatalf("unsupported package manager: %s", h.pkgManager)
 	}

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -107,7 +107,18 @@ func (h *Host) installECRCredentialHelper() {
 	} else {
 		// No official amazon-ecr-credential-helper package for non-apt distros (zypper, yum on CentOS, etc.);
 		// download the binary directly.
-		h.remote.MustExecute(`ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && sudo curl -fsSL "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.12.0/linux-${ARCH}/docker-credential-ecr-login" -o /usr/bin/docker-credential-ecr-login && sudo chmod +x /usr/bin/docker-credential-ecr-login`)
+		var helperArch string
+		helperVersion := "0.12.0"
+		switch h.arch {
+		case e2eos.AMD64Arch:
+			helperArch = "amd64"
+		case e2eos.ARM64Arch:
+			helperArch = "arm64"
+		default:
+			h.t().Fatalf("unsupported architecture for ECR credential helper: %s", h.arch)
+		}
+		helperURL := fmt.Sprintf("https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/%s/linux-%s/docker-credential-ecr-login", helperVersion, helperArch)
+		h.remote.MustExecute(fmt.Sprintf(`sudo curl -fsSL "%s" -o /usr/bin/docker-credential-ecr-login && sudo chmod +x /usr/bin/docker-credential-ecr-login`, helperURL))
 	}
 }
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -7,6 +7,7 @@
 package host
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -115,7 +116,19 @@ func (h *Host) ensureDockerLogin() {
 	}
 
 	for i := range registries {
-		h.remote.MustExecute(fmt.Sprintf("sudo docker login --username %s --password %s %s", usernames[i], passwords[i], registries[i]))
+		password := passwords[i]
+		// Passwords with the "b64=" prefix are already base64-encoded (our convention for
+		// credentials that contain special characters, e.g. GCP JSON service account keys).
+		// For plain-text passwords (e.g. ECR tokens), encode them here so we can always
+		// use the same "base64 -d | docker login --password-stdin" pattern on the remote
+		// side — this avoids shell-quoting issues regardless of the password content.
+		var b64pwd string
+		if strings.HasPrefix(password, "b64=") {
+			b64pwd = password[4:]
+		} else {
+			b64pwd = base64.StdEncoding.EncodeToString([]byte(password))
+		}
+		h.remote.MustExecute(fmt.Sprintf("echo %s | base64 -d | sudo docker login --username %s --password-stdin %s", b64pwd, usernames[i], registries[i]))
 	}
 }
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -107,7 +107,7 @@ func (h *Host) installECRCredentialHelper() {
 	} else {
 		// No official amazon-ecr-credential-helper package for non-apt distros (zypper, yum on CentOS, etc.);
 		// download the binary directly.
-		h.remote.MustExecute(`ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && sudo curl -fsSL "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.12.0/linux-${ARCH}/docker-credential-ecr-login" -o /usr/local/bin/docker-credential-ecr-login && sudo chmod +x /usr/local/bin/docker-credential-ecr-login`)
+		h.remote.MustExecute(`ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && sudo curl -fsSL "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.12.0/linux-${ARCH}/docker-credential-ecr-login" -o /usr/bin/docker-credential-ecr-login && sudo chmod +x /usr/bin/docker-credential-ecr-login`)
 	}
 }
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -7,6 +7,7 @@
 package host
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os/user"
@@ -17,11 +18,14 @@ import (
 	"testing"
 	"time"
 
-	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	e2eos "github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
+
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/runner/parameters"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/utils/e2e/client"
 )
 
@@ -77,6 +81,45 @@ func (h *Host) setSystemdVersion() {
 	h.systemdVersion = version
 }
 
+// ensureDockerLogin logs the host into the ECR registry when E2E_IMAGE_PULL_* is set, so pulls work.
+// It must be called whenever Docker is available (already installed or just installed).
+func (h *Host) ensureDockerLogin() {
+	store := runner.GetProfile().ParamStore()
+
+	registryStr, err := store.Get(parameters.ImagePullRegistry)
+	if err != nil {
+		var notFound parameters.ParameterNotFoundError
+		if errors.As(err, &notFound) {
+			h.t().Logf("skipping docker login (set E2E_IMAGE_PULL_* for private registry pulls)")
+			return
+		}
+		h.t().Fatalf("failed to get image pull registry: %v", err)
+	}
+
+	usernameStr, err := store.Get(parameters.ImagePullUsername)
+	if err != nil {
+		h.t().Fatalf("failed to get image pull username: %v", err)
+	}
+
+	passwordStr, err := store.Get(parameters.ImagePullPassword)
+	if err != nil {
+		h.t().Fatalf("failed to get image pull password: %v", err)
+	}
+
+	registries := strings.Split(registryStr, ",")
+	usernames := strings.Split(usernameStr, ",")
+	passwords := strings.Split(passwordStr, ",")
+
+	if len(registries) != len(usernames) || len(registries) != len(passwords) {
+		h.t().Fatalf("E2E_IMAGE_PULL_REGISTRY, E2E_IMAGE_PULL_USERNAME, and E2E_IMAGE_PULL_PASSWORD must have the same number of comma-separated entries")
+	}
+
+	for i := range registries {
+		h.remote.MustExecute(fmt.Sprintf("sudo docker login --username %s --password %s %s", usernames[i], passwords[i], registries[i]))
+	}
+}
+
+// TODO[@agent-devx]: Probably move this to the proper docker component defined in components/docker/component.go
 // InstallDocker installs Docker on the host if it is not already installed.
 func (h *Host) InstallDocker() {
 	defer func() {
@@ -99,6 +142,7 @@ func (h *Host) InstallDocker() {
 		require.NoErrorf(h.t(), err, "failed to start Docker, logs: %s", h.remote.MustExecute("sudo journalctl -xeu docker"))
 	}()
 	if _, err := h.remote.Execute("command -v docker"); err == nil {
+		h.ensureDockerLogin()
 		return
 	}
 
@@ -106,13 +150,18 @@ func (h *Host) InstallDocker() {
 	case "apt":
 		h.remote.MustExecute("sudo apt-get update -qq")
 		h.remote.MustExecute("sudo apt-get install -y docker.io")
+		h.remote.MustExecute("sudo apt-get install -y amazon-ecr-credential-helper")
 	case "yum":
 		h.remote.MustExecute("sudo yum install -y docker")
+		h.remote.MustExecute("sudo yum install -y amazon-ecr-credential-helper")
 	case "zypper":
 		h.remote.MustExecute("sudo zypper install -y docker")
+		h.remote.MustExecute("sudo zypper install -y amazon-ecr-credential-helper")
 	default:
 		h.t().Fatalf("unsupported package manager: %s", h.pkgManager)
 	}
+
+	h.ensureDockerLogin()
 }
 
 // GetDockerRuntimePath returns the runtime path of a docker runtime
@@ -510,7 +559,7 @@ func (h *Host) SetUmask(mask string) (oldmask string) {
 func (h *Host) SetupProxy() {
 	// Install Docker & the Squid Proxy
 	h.InstallDocker()
-	h.remote.MustExecute("sudo docker run -d --name squid-proxy -v /opt/fixtures/squid.conf:/etc/squid/squid.conf -p 3128:3128 public.ecr.aws/ubuntu/squid:4.10-20.04_beta")
+	h.remote.MustExecute("sudo docker run -d --name squid-proxy -v /opt/fixtures/squid.conf:/etc/squid/squid.conf -p 3128:3128 669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/ubuntu/squid:4.10-20.04_beta")
 
 	squidIP := strings.TrimSpace(h.remote.MustExecute("sudo docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' squid-proxy"))
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -551,7 +551,7 @@ func (h *Host) SetupProxy() {
 	// Install Docker & the Squid Proxy
 	h.InstallDocker()
 	h.remote.MustExecute("sudo docker run -d --name squid-proxy -v /opt/fixtures/squid.conf:/etc/squid/squid.conf -p 3128:3128 " +
-		h.dockerImage("dockerhub/ubuntu/squid:4.10-20.04_beta", "public.ecr.aws/ubuntu/squid:4.10-20.04_beta"))
+		h.dockerImage("ecr-public/ubuntu/squid:4.10-20.04_beta", "public.ecr.aws/ubuntu/squid:4.10-20.04_beta"))
 
 	squidIP := strings.TrimSpace(h.remote.MustExecute("sudo docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' squid-proxy"))
 

--- a/test/new-e2e/tests/installer/host/host.go
+++ b/test/new-e2e/tests/installer/host/host.go
@@ -102,16 +102,12 @@ func (h *Host) installECRCredentialHelper() {
 	if _, err := h.remote.Execute("command -v docker-credential-ecr-login"); err == nil {
 		return
 	}
-	switch h.pkgManager {
-	case "apt":
+	if h.pkgManager == "apt" {
 		h.remote.MustExecute("sudo apt-get install -y amazon-ecr-credential-helper")
-	case "yum":
-		h.remote.MustExecute("sudo yum install -y amazon-ecr-credential-helper")
-	case "zypper":
-		// No official amazon-ecr-credential-helper package for zypper; download the binary directly.
-		h.remote.MustExecute(`ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && sudo curl -fsSL "https://github.com/awslabs/amazon-ecr-credential-helper/releases/latest/download/docker-credential-ecr-login_linux_${ARCH}" -o /usr/local/bin/docker-credential-ecr-login && sudo chmod +x /usr/local/bin/docker-credential-ecr-login`)
-	default:
-		h.t().Fatalf("unsupported package manager: %s", h.pkgManager)
+	} else {
+		// No official amazon-ecr-credential-helper package for non-apt distros (zypper, yum on CentOS, etc.);
+		// download the binary directly.
+		h.remote.MustExecute(`ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') && sudo curl -fsSL "https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.12.0/linux-${ARCH}/docker-credential-ecr-login" -o /usr/local/bin/docker-credential-ecr-login && sudo chmod +x /usr/local/bin/docker-credential-ecr-login`)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes docker authentication in installer E2E tests to work with multi-registry credentials, and updates image refs to use the ECR pull-through cache.

**Requires:** pierrelouis.veyrenc/ACIX-1309-image-pull-param-plumbing (for `ImagePullRegistry/Username/Password` parameter store keys)

Changes in `InstallDocker()`:
1. Installs `amazon-ecr-credential-helper` alongside docker for IAM-role-based ECR pulls
2. Calls new `ensureDockerLogin()` after docker is installed (or if already present)

New `ensureDockerLogin()`:
- Reads `E2E_IMAGE_PULL_{REGISTRY,USERNAME,PASSWORD}` from the parameter store
- Splits comma-separated lists and runs `docker login` for each registry separately
- Gracefully no-ops if `E2E_IMAGE_PULL_REGISTRY` is not set

Image ref updates:
- `python:3.8-slim` → ECR pull-through cache (dockerhub prefix)
- `ubuntu/squid:4.10-20.04_beta` → ECR pull-through cache (dockerhub prefix)

## Test plan
- [ ] `new-e2e-installer` tests pass: docker is installed, ECR creds helper configured, docker login succeeds for all configured registries
- [ ] Python app docker run works with the ECR image ref
- [ ] Squid proxy setup works with the ECR image ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)