### PR TITLE
Build rtloader with bazel in omnibus

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -78,9 +78,9 @@ build do
     if not windows_arch_i386? and ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
       do_windows_sysprobe = "--windows-sysprobe"
     end
-    command "dda inv -- -e rtloader.clean", :live_stream => Omnibus.logger.live_stream(:info)
-    command "dda inv -- -e rtloader.make --install-prefix \"#{windows_safe_path(python_3_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\" \\\"-DPython3_EXECUTABLE=#{windows_safe_path(python_3_embedded)}\\python.exe\\\" \\\"-DCMAKE_BUILD_TYPE=RelWithDebInfo\\\"\"", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
-    command "mv rtloader/bin/*.dll  #{install_dir}/bin/agent/"
+    command_on_repo_root "bazelisk run -- //rtloader:install --destdir=\"#{install_dir}/bin/agent\""
+    # Put the static rtloader library where it gets picked up by the go build linking to it
+    command_on_repo_root "bazelisk run -- //rtloader:install_static --destdir=\"#{project_dir}/rtloader/build/rtloader\""
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded #{do_windows_sysprobe} --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e systray.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   else

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -84,10 +84,12 @@ build do
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded #{do_windows_sysprobe} --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e systray.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   else
-    command "dda inv -- -e rtloader.clean", :live_stream => Omnibus.logger.live_stream(:info)
-    command "dda inv -- -e rtloader.make --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER -DPython3_EXECUTABLE=#{install_dir}/embedded/bin/python3'", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
-    command "dda inv -- -e rtloader.install", :live_stream => Omnibus.logger.live_stream(:info)
-
+    command_on_repo_root "bazelisk run -- //rtloader:install --destdir='#{install_dir}/embedded'"
+    sh_ext = if linux_target? then "so" else "dylib" end
+    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix" \
+      " --prefix '#{install_dir}/embedded'" \
+      " #{install_dir}/embedded/lib/libdatadog-agent-rtloader.#{sh_ext}" \
+      " #{install_dir}/embedded/lib/libdatadog-agent-three.#{sh_ext}"
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   end
 

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -87,6 +87,11 @@ cc_shared_library(
     deps = [":rtloader"],
 )
 
+cc_static_library(
+    name = "rtloader_static",
+    deps = [":rtloader"],
+)
+
 cc_import(
     name = "_rtloader_shared",
     shared_library = "//rtloader:datadog-agent-rtloader",
@@ -235,7 +240,10 @@ pkg_files(
 pkg_files(
     name = "rtloader_three_pkg_files",
     srcs = [":datadog-agent-three"],
-    prefix = "lib",
+    prefix = select({
+        "@platforms//os:windows": "",
+        "//conditions:default": "lib",
+    }),
 )
 
 so_symlink(
@@ -247,14 +255,31 @@ so_symlink(
 
 pkg_filegroup(
     name = "all_files",
-    srcs = [
-        ":rtloader_header_pkg_files",
-        ":rtloader_three_pkg_files",
-        ":rtloader_with_symlinks",
-    ],
+    srcs = select({
+        "@platforms//os:windows": [":rtloader_three_pkg_files"],
+        "//conditions:default": [
+            ":rtloader_header_pkg_files",
+            ":rtloader_three_pkg_files",
+            ":rtloader_with_symlinks",
+        ],
+    }),
 )
 
 pkg_install(
     name = "install",
     srcs = [":all_files"],
+)
+
+# Temporary install target meant as a way to integrate with non-bazelified Agent build
+pkg_install(
+    name = "install_static",
+    srcs = [":static_lib_files"],
+)
+
+pkg_files(
+    name = "static_lib_files",
+    srcs = [":rtloader_static"],
+    renames = {
+        ":rtloader_static": "libdatadog-agent-rtloader.a",
+    },
 )

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library", "cc_shared_library")
+load("@rules_pkg//pkg:install.bzl", "pkg_install")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")
 load("//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 load("//bazel/rules:so_symlink.bzl", "so_symlink")
 
@@ -32,6 +34,7 @@ cc_library(
         "rtloader/rtloader.cpp",
     ],
     hdrs = [":rtloader_headers"],
+    copts = ["-O2"],
     cxxopts = COMMON_CXXOPTS,
     linkopts = [
         # Make up for the fact that we may be using gcc and not g++
@@ -58,14 +61,18 @@ cc_library(
     deps = [":rtloader_headers"],
 )
 
-cc_library(
-    name = "rtloader_headers",
-    hdrs = [
+filegroup(
+    name = "rtloader_header_files",
+    srcs = [
         "common/rtloader_mem.h",
         "include/datadog_agent_rtloader.h",
-        "include/rtloader.h",
         "include/rtloader_types.h",
     ],
+)
+
+cc_library(
+    name = "rtloader_headers",
+    hdrs = [":rtloader_header_files"],
     includes = [
         ".",
         "common",
@@ -94,14 +101,6 @@ cc_library(
         ":_rtloader_shared",
         "//rtloader:rtloader_headers",
     ],
-)
-
-so_symlink(
-    name = "rtloader_lib_files",
-    src = ":datadog-agent-rtloader",
-    libname = "libdatadog-agent-rtloader",
-    prefix = "embedded",
-    version = VERSION,
 )
 
 dd_agent_expand_template(
@@ -145,12 +144,13 @@ cc_library(
         "three/three_mem.cpp",
     ],
     hdrs = ["common/cgo_free.h"],
-    copts = select({
+    copts = ["-O2"] + select({
         "@platforms//os:windows": [],
         "//conditions:default": [
             "-Wno-deprecated-register",
         ],
     }),
+    cxxopts = COMMON_CXXOPTS,
     includes = [
         ".",
         "common",
@@ -224,4 +224,37 @@ cc_shared_library(
     deps = [
         ":three",
     ],
+)
+
+pkg_files(
+    name = "rtloader_header_pkg_files",
+    srcs = [":rtloader_header_files"],
+    prefix = "include",
+)
+
+pkg_files(
+    name = "rtloader_three_pkg_files",
+    srcs = [":datadog-agent-three"],
+    prefix = "lib",
+)
+
+so_symlink(
+    name = "rtloader_with_symlinks",
+    src = ":datadog-agent-rtloader",
+    libname = "libdatadog-agent-rtloader",
+    version = VERSION,
+)
+
+pkg_filegroup(
+    name = "all_files",
+    srcs = [
+        ":rtloader_header_pkg_files",
+        ":rtloader_three_pkg_files",
+        ":rtloader_with_symlinks",
+    ],
+)
+
+pkg_install(
+    name = "install",
+    srcs = [":all_files"],
 )

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -11,20 +11,6 @@ COMMON_CXXOPTS = [
     "-std=c++11",
 ]
 
-dd_agent_expand_template(
-    name = "pc_gen",
-    out = "datadog-agent-rtloader.pc",
-    substitutions = {
-        "@CMAKE_INSTALL_PREFIX@": "{install_dir}/embedded",
-        "@CMAKE_INSTALL_LIBDIR@": "lib",
-        "@CMAKE_INSTALL_INCLUDEDIR@": "include",
-        "@PROJECT_NAME@": "datadog-agent-rtloader",
-        "@PROJECT_VERSION@": VERSION,
-        "@PROJECT_DESCRIPTION@": "CPython backend for the Datadog Agent",
-    },
-    template = "rtloader/datadog-agent-rtloader.pc.in",
-)
-
 cc_library(
     name = "rtloader",
     srcs = [

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -1,19 +1,6 @@
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library", "cc_shared_library")
-load("@rules_license//rules:license.bzl", "license")
 load("//bazel/rules:dd_agent_expand_template.bzl", "dd_agent_expand_template")
 load("//bazel/rules:so_symlink.bzl", "so_symlink")
-
-package(
-    default_package_metadata = [":license"],
-    default_visibility = ["@@//packages:__subpackages__"],
-)
-
-license(
-    name = "license",
-    license_kinds = ["@rules_license//licenses/spdx:Apache-2.0"],
-    license_text = "LICENSE",
-    visibility = ["//visibility:public"],
-)
 
 VERSION = "0.1.0"
 
@@ -157,7 +144,7 @@ cc_library(
         "three/three.h",
         "three/three_mem.cpp",
     ],
-    hdrs = [":three_headers"],
+    hdrs = ["common/cgo_free.h"],
     copts = select({
         "@platforms//os:windows": [],
         "//conditions:default": [
@@ -179,7 +166,6 @@ cc_library(
     }),
     local_defines = select({
         "@platforms//os:windows": [
-            # TODO: only set if not MSVC. But it might be OK do to anyway.
             "_hypot=hypot",
             "DATADOG_AGENT_THREE",
         ],
@@ -200,13 +186,6 @@ cc_library(
             "@cpython//:python_unix_shared",
         ],
     }),
-)
-
-cc_library(
-    name = "three_headers",
-    hdrs = ["common/cgo_free.h"],
-    includes = ["common"],
-    visibility = [":__subpackages__"],
 )
 
 cc_shared_library(


### PR DESCRIPTION
### What does this PR do?

Adds bazel-built rtloader to the omnibus build, replacing the cmake-built one.

### Motivation

Part of the Bazel migration ([ABLD-323](https://datadoghq.atlassian.net/browse/ABLD-323)).

### Describe how you validated your changes

- CI.
- integrations-core e2e tests against this branch: https://github.com/DataDog/integrations-core/actions/runs/23189896420

### Additional Notes

Size increases seem to be mainly related to the use of `-relro` when building with bazel, resulting in a more conservative layout. The reason the differences are larger in arm64 seems to come from the page size being larger in arm64 linux (gnu ld defaults to 64KB max-page-size).

An extra symlink was added by the `so_symlink` rule, following the pattern we've used with other libraries. This looks like a harmless change (we could probably even do away with any symlinks at all for this one).

[ABLD-323]: https://datadoghq.atlassian.net/browse/ABLD-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ