### PR TITLE
[AGENT-15835] Fix combine_connection_states false for network v2 check

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/const.go
+++ b/pkg/collector/corechecks/net/networkv2/const.go
@@ -467,6 +467,8 @@ var (
 )
 
 var (
+	// tcpStateMetricsSuffixMapping combines multiple TCP states into broader categories
+	// (the default behavior, matching combine_connection_states: true).
 	tcpStateMetricsSuffixMapping = map[string]map[string]string{
 		"ss": {
 			"ESTAB":      "established",
@@ -493,6 +495,39 @@ var (
 			"CLOSE_WAIT":  "closing",
 			"LAST_ACK":    "closing",
 			"LISTEN":      "listening",
+			"CLOSING":     "closing",
+			"NONE":        "connections", // sole UDP mapping
+		},
+	}
+
+	// tcpStateMetricsSuffixMappingUncombined maps each TCP state to its own individual
+	// metric suffix (matching combine_connection_states: false, mirroring the Python check).
+	tcpStateMetricsSuffixMappingUncombined = map[string]map[string]string{
+		"ss": {
+			"ESTAB":      "estab",
+			"SYN-SENT":   "syn_sent",
+			"SYN-RECV":   "syn_recv",
+			"FIN-WAIT-1": "fin_wait_1",
+			"FIN-WAIT-2": "fin_wait_2",
+			"TIME-WAIT":  "time_wait",
+			"CLOSE-WAIT": "close_wait",
+			"LAST-ACK":   "time_wait", // matches Python: last_ack is folded into time_wait
+			"LISTEN":     "listen",
+			"CLOSING":    "closing",
+			"UNCONN":     "unconn",
+			"NONE":       "connections", // sole UDP mapping
+		},
+		"netstat": {
+			"ESTABLISHED": "estab",
+			"SYN_SENT":    "syn_sent",
+			"SYN_RECV":    "syn_recv",
+			"FIN_WAIT1":   "fin_wait_1",
+			"FIN_WAIT2":   "fin_wait_2",
+			"TIME_WAIT":   "time_wait",
+			"CLOSE":       "close",
+			"CLOSE_WAIT":  "close_wait",
+			"LAST_ACK":    "time_wait", // matches Python: last_ack is folded into time_wait
+			"LISTEN":      "listen",
 			"CLOSING":     "closing",
 			"NONE":        "connections", // sole UDP mapping
 		},

--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -74,6 +74,7 @@ type networkInstanceConfig struct {
 	CollectCountMetrics       bool     `yaml:"collect_count_metrics"`
 	CollectConnectionState    bool     `yaml:"collect_connection_state"`
 	CollectConnectionQueues   bool     `yaml:"collect_connection_queues"`
+	CombineConnectionStates   bool     `yaml:"combine_connection_states"`
 	ExcludedInterfaces        []string `yaml:"excluded_interfaces"`
 	ExcludedInterfaceRe       string   `yaml:"excluded_interface_re"`
 	ExcludedInterfacePattern  *regexp.Regexp
@@ -194,7 +195,7 @@ func (c *NetworkCheck) Run() error {
 	if c.config.instance.CollectConnectionState {
 		netProcfsBasePath := c.net.GetNetProcBasePath()
 		for _, protocol := range []string{"udp4", "udp6", "tcp4", "tcp6"} {
-			submitConnectionStateMetrics(sender, protocol, c.config.instance.CollectConnectionQueues, netProcfsBasePath)
+			submitConnectionStateMetrics(sender, protocol, c.config.instance.CollectConnectionQueues, c.config.instance.CombineConnectionStates, netProcfsBasePath)
 		}
 	}
 
@@ -528,7 +529,7 @@ func checkSSExecutable() bool {
 	return true
 }
 
-func getSocketStateMetrics(protocol string, procfsPath string) (map[string]*connectionStateEntry, error) {
+func getSocketStateMetrics(protocol string, procfsPath string, suffixMapping map[string]string) (map[string]*connectionStateEntry, error) {
 	env := []string{"PROC_ROOT=" + procfsPath}
 	// Pass the IP version to `ss` because there's no built-in way of distinguishing between the IP versions in the output
 	// Also calls `ss` for each protocol, because on some systems (e.g. Ubuntu 14.04), there is a bug that print `tcp` even if it's `udp`
@@ -542,22 +543,21 @@ func getSocketStateMetrics(protocol string, procfsPath string) (map[string]*conn
 	if err != nil {
 		return nil, fmt.Errorf("error executing ss command: %v", err)
 	}
-	return parseSocketStatsMetrics(protocol, output)
+	return parseSocketStatsMetrics(protocol, output, suffixMapping)
 }
 
-func getNetstatStateMetrics(protocol string, _ string) (map[string]*connectionStateEntry, error) {
+func getNetstatStateMetrics(protocol string, _ string, suffixMapping map[string]string) (map[string]*connectionStateEntry, error) {
 	output, err := runCommandFunction([]string{"netstat", "-n", "-u", "-t", "-a"}, []string{})
 	if err != nil {
 		return nil, fmt.Errorf("error executing netstat command: %v", err)
 	}
-	return parseNetstatMetrics(protocol, output)
+	return parseNetstatMetrics(protocol, output, suffixMapping)
 }
 
 // why not sum here
-func parseSocketStatsMetrics(protocol, output string) (map[string]*connectionStateEntry, error) {
+func parseSocketStatsMetrics(protocol, output string, suffixMapping map[string]string) (map[string]*connectionStateEntry, error) {
 	results := make(map[string]*connectionStateEntry)
 
-	suffixMapping := tcpStateMetricsSuffixMapping["ss"]
 	if protocol[:3] == "udp" {
 		results["connections"] = &connectionStateEntry{
 			count: 0,
@@ -637,10 +637,9 @@ func parseSocketStatsMetrics(protocol, output string) (map[string]*connectionSta
 	return results, nil
 }
 
-func parseNetstatMetrics(protocol, output string) (map[string]*connectionStateEntry, error) {
+func parseNetstatMetrics(protocol, output string, suffixMapping map[string]string) (map[string]*connectionStateEntry, error) {
 	protocol = strings.ReplaceAll(protocol, "4", "") // the output entry is tcp, tcp6, udp, udp6 so we need to strip the 4
 	results := make(map[string]*connectionStateEntry)
-	suffixMapping := tcpStateMetricsSuffixMapping["netstat"]
 	if protocol[:3] == "udp" {
 		results["connections"] = &connectionStateEntry{
 			count: 0,
@@ -723,18 +722,29 @@ func submitConnectionStateMetrics(
 	sender sender.Sender,
 	protocolName string,
 	collectConnectionQueues bool,
+	combineConnectionStates bool,
 	procfsPath string,
 ) {
-	var getStateMetrics func(ipVersion string, procfsPath string) (map[string]*connectionStateEntry, error)
+	var getStateMetrics func(string, string, map[string]string) (map[string]*connectionStateEntry, error)
+	var tool string
 	if ssAvailableFunction() {
 		log.Debug("Using `ss` for connection state metrics")
 		getStateMetrics = getSocketStateMetrics
+		tool = "ss"
 	} else {
 		log.Debug("Using `netstat` for connection state metrics")
 		getStateMetrics = getNetstatStateMetrics
+		tool = "netstat"
 	}
 
-	results, err := getStateMetrics(protocolName, procfsPath)
+	var suffixMapping map[string]string
+	if combineConnectionStates {
+		suffixMapping = tcpStateMetricsSuffixMapping[tool]
+	} else {
+		suffixMapping = tcpStateMetricsSuffixMappingUncombined[tool]
+	}
+
+	results, err := getStateMetrics(protocolName, procfsPath, suffixMapping)
 	if err != nil {
 		log.Debug("Error getting connection state metrics:", err)
 		return
@@ -985,6 +995,7 @@ func newCheck(cfg config.Component) check.Check {
 		config: networkConfig{
 			instance: networkInstanceConfig{
 				CollectRateMetrics:        true,
+				CombineConnectionStates:   true,
 				ConntrackPath:             "",
 				WhitelistConntrackMetrics: []string{"max", "count"},
 				UseSudoConntrack:          true,

--- a/pkg/collector/corechecks/net/networkv2/network_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_test.go
@@ -1270,6 +1270,7 @@ func createTestNetworkCheck(mockNetStats networkStats) *NetworkCheck {
 		config: networkConfig{
 			instance: networkInstanceConfig{
 				CollectRateMetrics:        true,
+				CombineConnectionStates:   true,
 				WhitelistConntrackMetrics: []string{"max", "count"},
 				UseSudoConntrack:          true,
 			},
@@ -1282,6 +1283,7 @@ func TestDefaultConfiguration(t *testing.T) {
 	check.Configure(aggregator.NewNoOpSenderManager(), integration.FakeConfigHash, []byte(``), []byte(``), "test")
 
 	assert.Equal(t, false, check.config.instance.CollectConnectionState)
+	assert.Equal(t, true, check.config.instance.CombineConnectionStates)
 	assert.Equal(t, []string(nil), check.config.instance.ExcludedInterfaces)
 	assert.Equal(t, "", check.config.instance.ExcludedInterfaceRe)
 }
@@ -1300,8 +1302,22 @@ excluded_interface_re: "eth.*"
 
 	assert.Nil(t, err)
 	assert.Equal(t, true, check.config.instance.CollectConnectionState)
+	assert.Equal(t, true, check.config.instance.CombineConnectionStates)
 	assert.ElementsMatch(t, []string{"eth0", "lo0"}, check.config.instance.ExcludedInterfaces)
 	assert.Equal(t, "eth.*", check.config.instance.ExcludedInterfaceRe)
+}
+
+func TestConfigurationCombineConnectionStatesFalse(t *testing.T) {
+	check := createTestNetworkCheck(nil)
+	rawInstanceConfig := []byte(`
+collect_connection_state: true
+combine_connection_states: false
+`)
+	err := check.Configure(aggregator.NewNoOpSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+
+	assert.Nil(t, err)
+	assert.Equal(t, true, check.config.instance.CollectConnectionState)
+	assert.Equal(t, false, check.config.instance.CombineConnectionStates)
 }
 
 // TestGlobalProcfsPathUsedWhenInContainer validates that when procfs_path is set in the
@@ -2593,10 +2609,97 @@ UNCONN      0           0                 0.0.0.0:5355           0.0.0.0:*
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseSocketStatsMetrics(tc.protocol, tc.input)
+			got, err := parseSocketStatsMetrics(tc.protocol, tc.input, tcpStateMetricsSuffixMapping["ss"])
 			assert.NoError(t, err)
 			if diff := gocmp.Diff(tc.want, got, gocmp.Comparer(connectionStateEntryComparer)); diff != "" {
 				t.Errorf("socket statistics result parsing diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParseSocketStatMetricsUncombined(t *testing.T) {
+	testcases := []struct {
+		name     string
+		protocol string
+		input    string
+		want     map[string]*connectionStateEntry
+	}{
+		{
+			name:     "initializes tcp4 states",
+			protocol: "tcp4",
+			input: `
+State                  Recv-Q              Send-Q                                 Local Address:Port                              Peer Address:Port
+`,
+			want: map[string]*connectionStateEntry{
+				"estab":      emptyConnectionStateEntry(),
+				"syn_sent":   emptyConnectionStateEntry(),
+				"syn_recv":   emptyConnectionStateEntry(),
+				"fin_wait_1": emptyConnectionStateEntry(),
+				"fin_wait_2": emptyConnectionStateEntry(),
+				"time_wait":  emptyConnectionStateEntry(),
+				"close_wait": emptyConnectionStateEntry(),
+				"listen":     emptyConnectionStateEntry(),
+				"closing":    emptyConnectionStateEntry(),
+				"unconn":     emptyConnectionStateEntry(),
+			},
+		},
+		{
+			name:     "collects tcp4 states individually",
+			protocol: "tcp4",
+			input: `
+State          Recv-Q      Send-Q         Local Address:Port      Peer Address:Port
+LISTEN         0           4096           127.0.0.53%lo:53             0.0.0.0:*
+LISTEN         0           4096               0.0.0.0:27500          0.0.0.0:*
+ESTAB          0           0               192.168.64.6:38848    34.107.243.93:443
+SYN-SENT       0           1               192.168.64.6:46118   169.254.169.254:80
+FIN-WAIT-1     0           0               192.168.64.6:45000    34.107.243.93:443
+CLOSE-WAIT     0           0               192.168.64.6:45001    34.107.243.93:443
+TIME-WAIT      0           0        192.168.64.6%enp0s1:42804     38.145.32.21:80
+`,
+			want: map[string]*connectionStateEntry{
+				"estab": {
+					count: 1,
+					recvQ: []uint64{0},
+					sendQ: []uint64{0},
+				},
+				"syn_sent": {
+					count: 1,
+					recvQ: []uint64{0},
+					sendQ: []uint64{1},
+				},
+				"syn_recv":   emptyConnectionStateEntry(),
+				"fin_wait_1": {count: 1, recvQ: []uint64{0}, sendQ: []uint64{0}},
+				"fin_wait_2": emptyConnectionStateEntry(),
+				"time_wait":  {count: 1, recvQ: []uint64{0}, sendQ: []uint64{0}},
+				"close_wait": {count: 1, recvQ: []uint64{0}, sendQ: []uint64{0}},
+				"listen": {
+					count: 2,
+					recvQ: []uint64{0, 0},
+					sendQ: []uint64{4096, 4096},
+				},
+				"closing": emptyConnectionStateEntry(),
+				"unconn":  emptyConnectionStateEntry(),
+			},
+		},
+		{
+			name:     "initializes udp4 states",
+			protocol: "udp4",
+			input: `
+State                  Recv-Q              Send-Q                                 Local Address:Port                              Peer Address:Port
+`,
+			want: map[string]*connectionStateEntry{
+				"connections": emptyConnectionStateEntry(),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSocketStatsMetrics(tc.protocol, tc.input, tcpStateMetricsSuffixMappingUncombined["ss"])
+			assert.NoError(t, err)
+			if diff := gocmp.Diff(tc.want, got, gocmp.Comparer(connectionStateEntryComparer)); diff != "" {
+				t.Errorf("socket statistics uncombined result parsing diff (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -2765,13 +2868,214 @@ udp6       0      0 :::5353                 :::*
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := parseNetstatMetrics(tc.protocol, tc.input)
+			got, err := parseNetstatMetrics(tc.protocol, tc.input, tcpStateMetricsSuffixMapping["netstat"])
 			assert.NoError(t, err)
 			if diff := gocmp.Diff(tc.want, got, gocmp.Comparer(connectionStateEntryComparer)); diff != "" {
 				t.Errorf("netstat result parsing diff (-want +got):\n%s", diff)
 			}
 		})
 	}
+}
+
+func TestParseNetstatMetricsUncombined(t *testing.T) {
+	testcases := []struct {
+		name     string
+		protocol string
+		input    string
+		want     map[string]*connectionStateEntry
+	}{
+		{
+			name:     "initializes tcp4 states",
+			protocol: "tcp4",
+			input: `
+Active Internet connections (servers and established)
+Proto Recv-Q Send-Q Local Address           Foreign Address         State
+`,
+			want: map[string]*connectionStateEntry{
+				"estab":      emptyConnectionStateEntry(),
+				"syn_sent":   emptyConnectionStateEntry(),
+				"syn_recv":   emptyConnectionStateEntry(),
+				"fin_wait_1": emptyConnectionStateEntry(),
+				"fin_wait_2": emptyConnectionStateEntry(),
+				"time_wait":  emptyConnectionStateEntry(),
+				"close":      emptyConnectionStateEntry(),
+				"close_wait": emptyConnectionStateEntry(),
+				"listen":     emptyConnectionStateEntry(),
+				"closing":    emptyConnectionStateEntry(),
+			},
+		},
+		{
+			name:     "collects tcp4 states individually",
+			protocol: "tcp4",
+			input: `
+Active Internet connections (servers and established)
+Proto Recv-Q Send-Q Local Address           Foreign Address         State
+tcp        0      0 192.168.64.6:34816      34.49.51.44:443         TIME_WAIT
+tcp        0      0 192.168.64.6:33852      34.107.243.93:443       ESTABLISHED
+tcp        0      0 192.168.64.6:33853      34.107.243.93:443       CLOSE_WAIT
+tcp        0      0 192.168.64.6:33854      34.107.243.93:443       SYN_SENT
+tcp        0      0 192.168.64.6:33855      34.107.243.93:443       FIN_WAIT1
+tcp        0      0 192.168.64.6:33856      34.107.243.93:443       LAST_ACK
+tcp6       0      0 :::5355                 :::*                    LISTEN
+`,
+			want: map[string]*connectionStateEntry{
+				"estab":      {count: 1, recvQ: []uint64{0}, sendQ: []uint64{0}},
+				"syn_sent":   {count: 1, recvQ: []uint64{0}, sendQ: []uint64{0}},
+				"syn_recv":   emptyConnectionStateEntry(),
+				"fin_wait_1": {count: 1, recvQ: []uint64{0}, sendQ: []uint64{0}},
+				"fin_wait_2": emptyConnectionStateEntry(),
+				"time_wait":  {count: 2, recvQ: []uint64{0, 0}, sendQ: []uint64{0, 0}}, // TIME_WAIT + LAST_ACK both fold into time_wait
+				"close":      emptyConnectionStateEntry(),
+				"close_wait": {count: 1, recvQ: []uint64{0}, sendQ: []uint64{0}},
+				"listen":     emptyConnectionStateEntry(), // tcp6 entry filtered out for tcp4 protocol
+				"closing":    emptyConnectionStateEntry(),
+			},
+		},
+		{
+			name:     "initializes udp4 states",
+			protocol: "udp4",
+			input: `
+Active Internet connections (servers and established)
+Proto Recv-Q Send-Q Local Address           Foreign Address         State
+`,
+			want: map[string]*connectionStateEntry{
+				"connections": emptyConnectionStateEntry(),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseNetstatMetrics(tc.protocol, tc.input, tcpStateMetricsSuffixMappingUncombined["netstat"])
+			assert.NoError(t, err)
+			if diff := gocmp.Diff(tc.want, got, gocmp.Comparer(connectionStateEntryComparer)); diff != "" {
+				t.Errorf("netstat uncombined result parsing diff (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNetworkCheckUncombinedConnectionStates(t *testing.T) {
+	net := &fakeNetworkStats{
+		counterStats:                 []net.IOCountersStat{},
+		netstatAndSnmpCountersValues: map[string]net.ProtoCountersStat{},
+	}
+
+	ssAvailableFunction = func() bool { return false }
+	mockCommandRunner := new(MockCommandRunner)
+	runCommandFunction = mockCommandRunner.FakeRunCommand
+	// MockCommandRunner.FakeRunCommand returns full netstat data when "netstat" is in cmd
+
+	networkCheck := createTestNetworkCheck(net)
+	networkCheck.config.instance.CombineConnectionStates = false
+
+	rawInstanceConfig := []byte(`
+collect_connection_state: true
+combine_connection_states: false
+`)
+	mockSender := mocksender.NewMockSender(networkCheck.ID())
+	err := networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+	assert.Equal(t, false, networkCheck.config.instance.CombineConnectionStates)
+
+	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	filesystem = afero.NewMemMapFs()
+
+	err = networkCheck.Run()
+	assert.Nil(t, err)
+
+	var customTags []string
+
+	// MockCommandRunner returns 1 ESTABLISHED, 1 SYN_SENT, 1 SYN_RECV, 1 FIN_WAIT1, 1 FIN_WAIT2,
+	// 1 TIME_WAIT, 1 CLOSE, 1 CLOSE_WAIT, 1 LAST_ACK, 1 LISTEN, 1 CLOSING for tcp4.
+	// Expect granular metrics, NOT combined ones.
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.estab", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.syn_sent", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.syn_recv", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.fin_wait_1", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.fin_wait_2", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.time_wait", float64(2), "", customTags) // TIME_WAIT(1) + LAST_ACK(1)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.close", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.close_wait", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.listen", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.closing", float64(1), "", customTags)
+
+	// tcp6 has 2x each state in mock data
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.estab", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.syn_sent", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.syn_recv", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.fin_wait_1", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.fin_wait_2", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.time_wait", float64(4), "", customTags) // TIME_WAIT(2) + LAST_ACK(2)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.close", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.close_wait", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.listen", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.closing", float64(2), "", customTags)
+
+	// Combined metrics must NOT be emitted
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.established", mock.Anything, mock.Anything, mock.Anything)
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.opening", mock.Anything, mock.Anything, mock.Anything)
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.closing_combined", mock.Anything, mock.Anything, mock.Anything)
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.listening", mock.Anything, mock.Anything, mock.Anything)
+
+	// UDP should still emit "connections"
+	mockSender.AssertCalled(t, "Gauge", "system.net.udp4.connections", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.udp6.connections", float64(2), "", customTags)
+
+	mockSender.AssertCalled(t, "Commit")
+}
+
+func TestNetworkCheckUncombinedConnectionStatesSS(t *testing.T) {
+	net := &fakeNetworkStats{
+		counterStats:                 []net.IOCountersStat{},
+		netstatAndSnmpCountersValues: map[string]net.ProtoCountersStat{},
+	}
+
+	ssAvailableFunction = func() bool { return true }
+	mockCommandRunner := new(MockCommandRunner)
+	runCommandFunction = mockCommandRunner.FakeRunCommand
+	// MockCommandRunner returns ss data with ESTAB and TIME-WAIT for ss commands
+
+	networkCheck := createTestNetworkCheck(net)
+
+	rawInstanceConfig := []byte(`
+collect_connection_state: true
+combine_connection_states: false
+`)
+	mockSender := mocksender.NewMockSender(networkCheck.ID())
+	err := networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+
+	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	filesystem = afero.NewMemMapFs()
+
+	err = networkCheck.Run()
+	assert.Nil(t, err)
+
+	var customTags []string
+
+	// MockCommandRunner ss data has 1 ESTAB and 1 TIME-WAIT per protocol call.
+	// Uncombined: ESTAB → estab, TIME-WAIT → time_wait; all others are 0.
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.estab", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.time_wait", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.syn_sent", float64(0), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.close_wait", float64(0), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.listen", float64(0), "", customTags)
+
+	// Combined metrics must NOT be emitted
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.established", mock.Anything, mock.Anything, mock.Anything)
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.opening", mock.Anything, mock.Anything, mock.Anything)
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.listening", mock.Anything, mock.Anything, mock.Anything)
+
+	mockSender.AssertCalled(t, "Commit")
 }
 
 func connectionStateEntryComparer(a, b *connectionStateEntry) bool {

--- a/pkg/collector/corechecks/net/networkv2/network_windows.go
+++ b/pkg/collector/corechecks/net/networkv2/network_windows.go
@@ -36,6 +36,8 @@ const (
 )
 
 var (
+	// tcpStateMetricsSuffixMapping combines multiple TCP states into broader categories
+	// (the default behavior, matching combine_connection_states: true).
 	tcpStateMetricsSuffixMapping = map[string]string{
 		"ESTABLISHED":  "established",
 		"SYN_SENT":     "opening",
@@ -47,6 +49,21 @@ var (
 		"CLOSE_WAIT":   "closing",
 		"LAST_ACK":     "closing",
 		"LISTEN":       "listening",
+		"CLOSING":      "closing",
+	}
+	// tcpStateMetricsSuffixMappingUncombined maps each TCP state to its own individual
+	// metric suffix (matching combine_connection_states: false, mirroring the Python check).
+	tcpStateMetricsSuffixMappingUncombined = map[string]string{
+		"ESTABLISHED":  "estab",
+		"SYN_SENT":     "syn_sent",
+		"SYN_RECEIVED": "syn_recv",
+		"FIN_WAIT_1":   "fin_wait_1",
+		"FIN_WAIT_2":   "fin_wait_2",
+		"TIME_WAIT":    "time_wait",
+		"CLOSED":       "close",
+		"CLOSE_WAIT":   "close_wait",
+		"LAST_ACK":     "time_wait", // matches Python: last_ack is folded into time_wait
+		"LISTEN":       "listen",
 		"CLOSING":      "closing",
 	}
 	udpStateMetricsSuffixMapping = map[string]string{
@@ -66,6 +83,7 @@ type networkInstanceConfig struct {
 	CollectCountMetrics      bool     `yaml:"collect_count_metrics"`
 	CollectConnectionState   bool     `yaml:"collect_connection_state"`
 	CollectConnectionQueues  bool     `yaml:"collect_connection_queues"`
+	CombineConnectionStates  bool     `yaml:"combine_connection_states"`
 	ExcludedInterfaces       []string `yaml:"excluded_interfaces"`
 	ExcludedInterfaceRe      string   `yaml:"excluded_interface_re"`
 	ExcludedInterfacePattern *regexp.Regexp
@@ -117,7 +135,7 @@ func (c *NetworkCheck) Run() error {
 			if err != nil {
 				return err
 			}
-			submitConnectionsMetrics(sender, protocol, connectionsStats)
+			submitConnectionsMetrics(sender, protocol, connectionsStats, c.config.instance.CombineConnectionStates)
 		}
 	}
 
@@ -140,14 +158,18 @@ func (c *NetworkCheck) Run() error {
 	return nil
 }
 
-func submitConnectionsMetrics(sender sender.Sender, protocolName string, connectionsStats []net.ConnectionStat) {
+func submitConnectionsMetrics(sender sender.Sender, protocolName string, connectionsStats []net.ConnectionStat, combineConnectionStates bool) {
 	metricCount := map[string]float64{}
 	var stateMetricSuffixMapping map[string]string
 	switch protocolName {
 	case "udp4", "udp6":
 		stateMetricSuffixMapping = udpStateMetricsSuffixMapping
 	case "tcp4", "tcp6":
-		stateMetricSuffixMapping = tcpStateMetricsSuffixMapping
+		if combineConnectionStates {
+			stateMetricSuffixMapping = tcpStateMetricsSuffixMapping
+		} else {
+			stateMetricSuffixMapping = tcpStateMetricsSuffixMappingUncombined
+		}
 	}
 
 	for _, suffix := range stateMetricSuffixMapping {
@@ -344,7 +366,8 @@ func newCheck(_ config.Component) check.Check {
 		net:       defaultNetworkStats{},
 		config: networkConfig{
 			instance: networkInstanceConfig{
-				CollectRateMetrics: true,
+				CollectRateMetrics:      true,
+				CombineConnectionStates: true,
 			},
 		},
 	}

--- a/pkg/collector/corechecks/net/networkv2/network_windows_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_windows_test.go
@@ -80,7 +80,8 @@ func createTestNetworkCheck(mockNetStats networkStats) *NetworkCheck {
 		net: mockNetStats,
 		config: networkConfig{
 			instance: networkInstanceConfig{
-				CollectRateMetrics: true,
+				CollectRateMetrics:      true,
+				CombineConnectionStates: true,
 			},
 		},
 	}
@@ -91,6 +92,7 @@ func TestDefaultConfiguration(t *testing.T) {
 	check.Configure(aggregator.NewNoOpSenderManager(), integration.FakeConfigHash, []byte(``), []byte(``), "test")
 
 	assert.Equal(t, false, check.config.instance.CollectConnectionState)
+	assert.Equal(t, true, check.config.instance.CombineConnectionStates)
 	assert.Equal(t, []string(nil), check.config.instance.ExcludedInterfaces)
 	assert.Equal(t, "", check.config.instance.ExcludedInterfaceRe)
 }
@@ -635,4 +637,104 @@ excluded_interface_re: "eth[0-9]"
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.count", float64(31), "", lo0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.drop", float64(32), "", lo0Tags)
 	mockSender.AssertCalled(t, "Rate", "system.net.packets_out.error", float64(33), "", lo0Tags)
+}
+
+func TestNetworkCheckUncombinedConnectionStates(t *testing.T) {
+	netStats := &fakeNetworkStats{
+		connectionStatsUDP4: []net.ConnectionStat{
+			{Status: ""},
+		},
+		connectionStatsUDP6: []net.ConnectionStat{
+			{Status: ""},
+			{Status: ""},
+		},
+		connectionStatsTCP4: []net.ConnectionStat{
+			{Status: "ESTABLISHED"},
+			{Status: "SYN_SENT"},
+			{Status: "SYN_RECEIVED"},
+			{Status: "FIN_WAIT_1"},
+			{Status: "FIN_WAIT_2"},
+			{Status: "TIME_WAIT"},
+			{Status: "CLOSED"},
+			{Status: "CLOSE_WAIT"},
+			{Status: "LAST_ACK"},
+			{Status: "LISTEN"},
+			{Status: "CLOSING"},
+		},
+		connectionStatsTCP6: []net.ConnectionStat{
+			{Status: "ESTABLISHED"},
+			{Status: "SYN_SENT"},
+			{Status: "SYN_RECEIVED"},
+			{Status: "FIN_WAIT_1"},
+			{Status: "FIN_WAIT_2"},
+			{Status: "TIME_WAIT"},
+			{Status: "CLOSED"},
+			{Status: "CLOSE_WAIT"},
+			{Status: "LAST_ACK"},
+			{Status: "LISTEN"},
+			{Status: "CLOSING"},
+			{Status: "ESTABLISHED"},
+			{Status: "SYN_SENT"},
+		},
+		tcp4Stats: &mibTCPStats{},
+		tcp6Stats: &mibTCPStats{},
+	}
+
+	networkCheck := createTestNetworkCheck(netStats)
+
+	rawInstanceConfig := []byte(`
+collect_connection_state: true
+combine_connection_states: false
+`)
+
+	mockSender := mocksender.NewMockSender(networkCheck.ID())
+	err := networkCheck.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+	assert.Equal(t, false, networkCheck.config.instance.CombineConnectionStates)
+
+	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Rate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	err = networkCheck.Run()
+	assert.Nil(t, err)
+
+	var customTags []string
+
+	// Granular metrics expected for tcp4 (1 connection each state; LAST_ACK folds into time_wait)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.estab", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.syn_sent", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.syn_recv", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.fin_wait_1", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.fin_wait_2", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.time_wait", float64(2), "", customTags) // TIME_WAIT(1) + LAST_ACK(1)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.close", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.close_wait", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.listen", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp4.closing", float64(1), "", customTags)
+
+	// Granular metrics for tcp6 (11 states + 2 extra ESTABLISHED and SYN_SENT; LAST_ACK folds into time_wait)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.estab", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.syn_sent", float64(2), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.syn_recv", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.fin_wait_1", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.fin_wait_2", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.time_wait", float64(2), "", customTags) // TIME_WAIT(1) + LAST_ACK(1)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.close", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.close_wait", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.listen", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.tcp6.closing", float64(1), "", customTags)
+
+	// Combined metrics must NOT be emitted
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.established", mock.Anything, mock.Anything, mock.Anything)
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.opening", mock.Anything, mock.Anything, mock.Anything)
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.closing_combined", mock.Anything, mock.Anything, mock.Anything)
+	mockSender.AssertNotCalled(t, "Gauge", "system.net.tcp4.listening", mock.Anything, mock.Anything, mock.Anything)
+
+	// UDP still emits "connections"
+	mockSender.AssertCalled(t, "Gauge", "system.net.udp4.connections", float64(1), "", customTags)
+	mockSender.AssertCalled(t, "Gauge", "system.net.udp6.connections", float64(2), "", customTags)
+
+	mockSender.AssertCalled(t, "Commit")
 }

--- a/releasenotes/notes/network-check-combine-connection-states-e96d6212da4c543e.yaml
+++ b/releasenotes/notes/network-check-combine-connection-states-e96d6212da4c543e.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed the network check (v2) ignoring the ``combine_connection_states`` configuration option.
+    When set to ``false``, the check now emits granular per-state TCP metrics
+    (e.g. ``system.net.tcp4.close_wait``, ``system.net.tcp4.syn_sent``) instead of only
+    the combined ones (e.g. ``system.net.tcp4.closing``, ``system.net.tcp4.opening``),
+    restoring parity with the previous Python-based network check.


### PR DESCRIPTION
### What does this PR do?
Update the Go network v2 check to properly read the  `combine_connection_states` configuration and emit uncombined state metrics when set to false. 

### Motivation
Parity with previous Python implementation, an user noticed the regression after an update.

### Describe how you validated your changes
Unit tests, local testing.

### Additional Notes
