### PR TITLE
[observer] Component dependency system

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -363,6 +363,8 @@ type DetectionResult struct {
 type SeriesDetector interface {
 	// Name returns the analysis name for debugging.
 	Name() string
+	// Setup is called once all components are instantiated to resolve dependencies.
+	Setup(getComponent GetComponentFunc) error
 	// Detect examines a series and returns any detected anomalies.
 	Detect(series Series) DetectionResult
 }
@@ -469,13 +471,17 @@ type StorageReader interface {
 	// set of known series changes. Use this to cache ListSeries results and
 	// refresh them only when new series keys appear.
 	SeriesGeneration() uint64
- }
+}
+
+// Will return a component (extractor) by name (not the display name).
+type GetComponentFunc func(name string) any
 
 // Detector is the flexible detection interface where detectors pull data from storage.
 // This supports multivariate detection across multiple series.
 type Detector interface {
 	Name() string
-
+	// Setup is called once all components are instantiated to resolve dependencies.
+	Setup(getComponent GetComponentFunc) error
 	// Detect is called periodically by the scheduler.
 	// The detector queries storage for whatever data it needs.
 	// dataTime is the current data timestamp (for determinism - only read data <= dataTime).

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -477,8 +477,9 @@ type StorageReader interface {
 	SeriesGeneration() uint64
 }
 
-// Will return a component (extractor) by name (not the display name).
-type GetComponentFunc func(name string) any
+// GetComponentFunc returns a component (extractor, detector, or correlator) by name.
+// Returns an error if no component with the given name is registered.
+type GetComponentFunc func(name string) (any, error)
 
 // Detector is the flexible detection interface where detectors pull data from storage.
 // This supports multivariate detection across multiple series.

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -235,6 +235,8 @@ type ProfileView interface {
 type LogMetricsExtractor interface {
 	// Name returns the extractor name for debugging and logging.
 	Name() string
+	// Setup is called once all components are instantiated to resolve dependencies.
+	Setup(getComponent GetComponentFunc) error
 	// ProcessLog examines a log and returns any derived metrics.
 	ProcessLog(log LogView) []MetricOutput
 }
@@ -378,6 +380,8 @@ type SeriesDetector interface {
 type Correlator interface {
 	// Name returns the correlator name for debugging.
 	Name() string
+	// Setup is called once all components are instantiated to resolve dependencies.
+	Setup(getComponent GetComponentFunc) error
 	// ProcessAnomaly receives an anomaly event for accumulation.
 	ProcessAnomaly(a Anomaly)
 	// Advance performs time-based maintenance (eviction, window finalization)

--- a/comp/observer/impl/agent_internal_logs_test.go
+++ b/comp/observer/impl/agent_internal_logs_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/pkg/config/model"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
@@ -29,7 +30,7 @@ func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
 	pkgconfigsetup.Datadog().Set("observer.analysis.enabled", true, model.SourceAgentRuntime)
 	t.Cleanup(func() { pkgconfigsetup.Datadog().Set("observer.analysis.enabled", false, model.SourceAgentRuntime) })
 
-	provides := NewComponent(Requires{
+	provides, err := NewComponent(Requires{
 		AgentInternalLogTap: AgentInternalLogTapConfig{
 			Enabled:         &enabled,
 			SampleRateInfo:  &one,
@@ -37,6 +38,7 @@ func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
 			SampleRateTrace: &one,
 		},
 	})
+	require.NoError(t, err)
 	obs, ok := provides.Comp.(*observerImpl)
 	require.True(t, ok)
 	t.Cleanup(func() { pkglog.SetLogObserver(nil) })

--- a/comp/observer/impl/anomaly_correlator_leadlag.go
+++ b/comp/observer/impl/anomaly_correlator_leadlag.go
@@ -250,6 +250,9 @@ func (c *LeadLagCorrelator) Name() string {
 	return "lead_lag_correlator"
 }
 
+// Setup is a no-op for LeadLagCorrelator as it has no component dependencies.
+func (c *LeadLagCorrelator) Setup(_ observer.GetComponentFunc) error { return nil }
+
 // Process adds an anomaly and updates lag histograms for all source pairs.
 func (c *LeadLagCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()

--- a/comp/observer/impl/anomaly_correlator_leadlag.go
+++ b/comp/observer/impl/anomaly_correlator_leadlag.go
@@ -222,6 +222,8 @@ type LeadLagCorrelator struct {
 }
 
 // NewLeadLagCorrelator creates a new LeadLagCorrelator with the given config.
+var _ observer.Correlator = (*LeadLagCorrelator)(nil)
+
 func NewLeadLagCorrelator(config LeadLagConfig) *LeadLagCorrelator {
 	if config.MaxLagSeconds == 0 {
 		config.MaxLagSeconds = 30

--- a/comp/observer/impl/anomaly_correlator_surprise.go
+++ b/comp/observer/impl/anomaly_correlator_surprise.go
@@ -142,6 +142,9 @@ func (c *SurpriseCorrelator) Name() string {
 	return "surprise_correlator"
 }
 
+// Setup is a no-op for SurpriseCorrelator as it has no component dependencies.
+func (c *SurpriseCorrelator) Setup(_ observer.GetComponentFunc) error { return nil }
+
 // Process adds an anomaly and updates co-occurrence counts.
 func (c *SurpriseCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()

--- a/comp/observer/impl/anomaly_correlator_surprise.go
+++ b/comp/observer/impl/anomaly_correlator_surprise.go
@@ -107,6 +107,8 @@ type SurpriseCorrelator struct {
 }
 
 // NewSurpriseCorrelator creates a new SurpriseCorrelator with the given config.
+var _ observer.Correlator = (*SurpriseCorrelator)(nil)
+
 func NewSurpriseCorrelator(config SurpriseConfig) *SurpriseCorrelator {
 	if config.WindowSizeSeconds == 0 {
 		config.WindowSizeSeconds = 10

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -52,6 +52,8 @@ type TimeClusterCorrelator struct {
 }
 
 // NewTimeClusterCorrelator creates a new TimeClusterCorrelator with the given config.
+var _ observer.Correlator = (*TimeClusterCorrelator)(nil)
+
 func NewTimeClusterCorrelator(config TimeClusterConfig) *TimeClusterCorrelator {
 	if config.ProximitySeconds == 0 {
 		config.ProximitySeconds = 10

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -70,6 +70,9 @@ func (c *TimeClusterCorrelator) Name() string {
 	return "time_cluster_correlator"
 }
 
+// Setup is a no-op for TimeClusterCorrelator as it has no component dependencies.
+func (c *TimeClusterCorrelator) Setup(_ observer.GetComponentFunc) error { return nil }
+
 // Process adds an anomaly, either to an existing cluster or a new one.
 func (c *TimeClusterCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()
@@ -257,9 +260,9 @@ func (c *TimeClusterCorrelator) GetStats() map[string]interface{} {
 		"total_clusters":       len(c.clusters),
 		"total_anomalies":      totalAnomalies,
 		"largest_cluster_size": maxClusterSize,
-		"proximity_seconds": c.config.ProximitySeconds,
-		"window_seconds":    c.config.WindowSeconds,
-		"current_data_time": c.currentDataTime,
+		"proximity_seconds":    c.config.ProximitySeconds,
+		"window_seconds":       c.config.WindowSeconds,
+		"current_data_time":    c.currentDataTime,
 	}
 }
 

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -76,6 +76,8 @@ type CrossSignalCorrelator struct {
 	currentDataTime    int64 // latest data timestamp seen
 }
 
+var _ observer.Correlator = (*CrossSignalCorrelator)(nil)
+
 // NewCorrelator creates a new CrossSignalCorrelator with the given config.
 // If config has zero values, defaults are applied.
 func NewCorrelator(config CorrelatorConfig) *CrossSignalCorrelator {
@@ -94,6 +96,9 @@ func NewCorrelator(config CorrelatorConfig) *CrossSignalCorrelator {
 func (c *CrossSignalCorrelator) Name() string {
 	return "cross_signal_correlator"
 }
+
+// Setup is a no-op for CrossSignalCorrelator as it has no component dependencies.
+func (c *CrossSignalCorrelator) Setup(_ observer.GetComponentFunc) error { return nil }
 
 // Process implements Correlator. It adds an anomaly to the buffer
 // using its data timestamp and evicts old entries.

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -70,6 +70,15 @@ func defaultCatalog() *componentCatalog {
 				},
 				defaultEnabled: true,
 			},
+			{
+				name:        "log_pattern_extractor",
+				displayName: "Log Pattern Extractor",
+				kind:        componentExtractor,
+				factory: func() any {
+					return NewLogPatternExtractor()
+				},
+				defaultEnabled: true,
+			},
 			// ---- Detectors ----
 			{
 				name:        "cusum",

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -13,6 +13,7 @@ type componentKind int
 const (
 	componentDetector componentKind = iota
 	componentCorrelator
+	componentExtractor
 )
 
 // componentEntry describes a registered pipeline component (detector or correlator).
@@ -44,6 +45,31 @@ type componentCatalog struct {
 func defaultCatalog() *componentCatalog {
 	return &componentCatalog{
 		entries: []componentEntry{
+			// ---- Extractors ----
+			{
+				name:        "log_metrics_extractor",
+				displayName: "Log Metrics Extractor",
+				kind:        componentExtractor,
+				factory: func() any {
+					return &LogMetricsExtractor{
+						MaxEvalBytes: 4096,
+						ExcludeFields: map[string]struct{}{
+							"timestamp": {}, "ts": {}, "time": {},
+							"pid": {}, "ppid": {}, "uid": {}, "gid": {},
+						},
+					}
+				},
+				defaultEnabled: true,
+			},
+			{
+				name:        "connection_error_extractor",
+				displayName: "Connection Error Extractor",
+				kind:        componentExtractor,
+				factory: func() any {
+					return &ConnectionErrorExtractor{}
+				},
+				defaultEnabled: true,
+			},
 			// ---- Detectors ----
 			{
 				name:        "cusum",
@@ -170,11 +196,13 @@ func (c *componentCatalog) WithDefaultEnabled(name string, enabled bool) *compon
 
 // Instantiate creates component instances. The overrides map controls which
 // components are enabled; keys not present in overrides use the catalog default.
-// Returns the lists of enabled detectors and correlators ready for engine use,
-// plus a map of all component instances (enabled or not) for state management.
+// Returns the lists of enabled detectors, correlators, and extractors ready for
+// engine use, plus a map of all component instances (enabled or not) for state
+// management.
 func (c *componentCatalog) Instantiate(overrides map[string]bool) (
 	detectors []observerdef.Detector,
 	correlators []observerdef.Correlator,
+	extractors []observerdef.LogMetricsExtractor,
 	components map[string]*componentInstance,
 ) {
 	components = make(map[string]*componentInstance, len(c.entries))
@@ -210,9 +238,13 @@ func (c *componentCatalog) Instantiate(overrides map[string]bool) (
 			if cor, ok := instance.(observerdef.Correlator); ok {
 				correlators = append(correlators, cor)
 			}
+		case componentExtractor:
+			if ext, ok := instance.(observerdef.LogMetricsExtractor); ok {
+				extractors = append(extractors, ext)
+			}
 		}
 	}
-	return detectors, correlators, components
+	return detectors, correlators, extractors, components
 }
 
 // Entries returns a copy of all catalog entries (for UI/API use).
@@ -236,6 +268,21 @@ func catalogEnabledDetectors(components map[string]*componentInstance, catalog *
 			result = append(result, d)
 		} else if sd, ok := ci.instance.(observerdef.SeriesDetector); ok {
 			result = append(result, newSeriesDetectorAdapter(sd, defaultAggregations))
+		}
+	}
+	return result
+}
+
+// catalogEnabledExtractors returns the enabled LogMetricsExtractor instances from a components map.
+func catalogEnabledExtractors(components map[string]*componentInstance, catalog *componentCatalog) []observerdef.LogMetricsExtractor {
+	var result []observerdef.LogMetricsExtractor
+	for _, entry := range catalog.entries {
+		ci, ok := components[entry.name]
+		if !ok || !ci.enabled || ci.entry.kind != componentExtractor {
+			continue
+		}
+		if ext, ok := ci.instance.(observerdef.LogMetricsExtractor); ok {
+			result = append(result, ext)
 		}
 	}
 	return result

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -135,6 +135,14 @@ func newEngine(cfg engineConfig) *engine {
 		fmt.Printf("[cc] Setting up detector: %+v\n", detector.Name())
 		_ = detector.Setup(e.getComponent)
 	}
+	for _, correlator := range e.correlators {
+		// TODO: Handle errors
+		_ = correlator.Setup(e.getComponent)
+	}
+	for _, extractor := range e.extractors {
+		// TODO: Handle errors
+		_ = extractor.Setup(e.getComponent)
+	}
 
 	return e
 }

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -644,22 +644,23 @@ func (e *engine) ReplayStoredData() advanceResult {
 	}
 }
 
-// Returns a component (extractor, detector, correlator) by name or nil if not found.
-func (e *engine) getComponent(name string) any {
+// getComponent returns a component (extractor, detector, or correlator) by name.
+// Returns an error if no component with the given name is registered.
+func (e *engine) getComponent(name string) (any, error) {
 	for _, extractor := range e.extractors {
 		if extractor.Name() == name {
-			return extractor
+			return extractor, nil
 		}
 	}
 	for _, detector := range e.detectors {
 		if detector.Name() == name {
-			return detector
+			return detector, nil
 		}
 	}
 	for _, correlator := range e.correlators {
 		if correlator.Name() == name {
-			return correlator
+			return correlator, nil
 		}
 	}
-	return nil
+	return nil, fmt.Errorf("component %q not found", name)
 }

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -126,6 +127,13 @@ func newEngine(cfg engineConfig) *engine {
 		if lo, ok := d.(observerdef.LogObserver); ok {
 			e.logObservers = append(e.logObservers, lo)
 		}
+	}
+
+	// Call setup on each component, this could be used to resolve dependencies
+	for _, detector := range e.detectors {
+		// TODO: Handle errors
+		fmt.Printf("[cc] Setting up detector: %+v\n", detector.Name())
+		_ = detector.Setup(e.getComponent)
 	}
 
 	return e
@@ -613,4 +621,24 @@ func (e *engine) ReplayStoredData() advanceResult {
 		anomalies: allAnomalies,
 		telemetry: allTelemetry,
 	}
+}
+
+// Returns a component (extractor, detector, correlator) by name or nil if not found.
+func (e *engine) getComponent(name string) any {
+	for _, extractor := range e.extractors {
+		if extractor.Name() == name {
+			return extractor
+		}
+	}
+	for _, detector := range e.detectors {
+		if detector.Name() == name {
+			return detector
+		}
+	}
+	for _, correlator := range e.correlators {
+		if correlator.Name() == name {
+			return correlator
+		}
+	}
+	return nil
 }

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -105,7 +105,8 @@ type engineConfig struct {
 }
 
 // newEngine creates an engine with the given configuration.
-func newEngine(cfg engineConfig) *engine {
+// Returns an error if any component's Setup call fails.
+func newEngine(cfg engineConfig) (*engine, error) {
 	sched := cfg.scheduler
 	if sched == nil {
 		sched = &currentBehaviorPolicy{}
@@ -129,22 +130,24 @@ func newEngine(cfg engineConfig) *engine {
 		}
 	}
 
-	// Call setup on each component, this could be used to resolve dependencies
+	// Call Setup on every component so they can resolve cross-component dependencies.
 	for _, detector := range e.detectors {
-		// TODO: Handle errors
-		fmt.Printf("[cc] Setting up detector: %+v\n", detector.Name())
-		_ = detector.Setup(e.getComponent)
+		if err := detector.Setup(e.getComponent); err != nil {
+			return nil, fmt.Errorf("detector %q setup failed: %w", detector.Name(), err)
+		}
 	}
 	for _, correlator := range e.correlators {
-		// TODO: Handle errors
-		_ = correlator.Setup(e.getComponent)
+		if err := correlator.Setup(e.getComponent); err != nil {
+			return nil, fmt.Errorf("correlator %q setup failed: %w", correlator.Name(), err)
+		}
 	}
 	for _, extractor := range e.extractors {
-		// TODO: Handle errors
-		_ = extractor.Setup(e.getComponent)
+		if err := extractor.Setup(e.getComponent); err != nil {
+			return nil, fmt.Errorf("extractor %q setup failed: %w", extractor.Name(), err)
+		}
 	}
 
-	return e
+	return e, nil
 }
 
 // Subscribe registers an event sink to receive engine events.

--- a/comp/observer/impl/engine_test.go
+++ b/comp/observer/impl/engine_test.go
@@ -87,8 +87,9 @@ func (e *errorCorrelator) Setup(_ observerdef.GetComponentFunc) error {
 
 // --- Tests ---
 
-func newTestEngine(detectors []observerdef.Detector, correlators []observerdef.Correlator, extractors []observerdef.LogMetricsExtractor) *engine {
-	return newEngine(engineConfig{
+func newTestEngine(t testing.TB, detectors []observerdef.Detector, correlators []observerdef.Correlator, extractors []observerdef.LogMetricsExtractor) *engine {
+	t.Helper()
+	return mustNewEngine(t, engineConfig{
 		storage:     newTimeSeriesStorage(),
 		detectors:   detectors,
 		correlators: correlators,
@@ -101,7 +102,7 @@ func TestEngine_SetupCalledOnDetectors(t *testing.T) {
 	d1 := &spyDetector{name: "detector_a"}
 	d2 := &spyDetector{name: "detector_b"}
 
-	newTestEngine([]observerdef.Detector{d1, d2}, nil, nil)
+	newTestEngine(t, []observerdef.Detector{d1, d2}, nil, nil)
 
 	assert.True(t, d1.setupCalled, "Setup should be called on detector_a")
 	assert.True(t, d2.setupCalled, "Setup should be called on detector_b")
@@ -112,7 +113,7 @@ func TestEngine_SetupCalledOnCorrelators(t *testing.T) {
 	c1 := &spyCorrelator{name: "correlator_a"}
 	c2 := &spyCorrelator{name: "correlator_b"}
 
-	newTestEngine(nil, []observerdef.Correlator{c1, c2}, nil)
+	newTestEngine(t, nil, []observerdef.Correlator{c1, c2}, nil)
 
 	assert.True(t, c1.setupCalled, "Setup should be called on correlator_a")
 	assert.True(t, c2.setupCalled, "Setup should be called on correlator_b")
@@ -123,7 +124,7 @@ func TestEngine_SetupCalledOnExtractors(t *testing.T) {
 	e1 := &spyExtractor{name: "extractor_a"}
 	e2 := &spyExtractor{name: "extractor_b"}
 
-	newTestEngine(nil, nil, []observerdef.LogMetricsExtractor{e1, e2})
+	newTestEngine(t, nil, nil, []observerdef.LogMetricsExtractor{e1, e2})
 
 	assert.True(t, e1.setupCalled, "Setup should be called on extractor_a")
 	assert.True(t, e2.setupCalled, "Setup should be called on extractor_b")
@@ -135,7 +136,7 @@ func TestEngine_SetupDetectorCanResolveExtractor(t *testing.T) {
 	ext := &spyExtractor{name: "my_extractor"}
 	det := &spyDetector{name: "my_detector", resolvedName: "my_extractor"}
 
-	newTestEngine([]observerdef.Detector{det}, nil, []observerdef.LogMetricsExtractor{ext})
+	newTestEngine(t, []observerdef.Detector{det}, nil, []observerdef.LogMetricsExtractor{ext})
 
 	require.NotNil(t, det.resolved, "detector should resolve extractor via getComponent")
 	assert.Equal(t, ext, det.resolved)
@@ -147,7 +148,7 @@ func TestEngine_SetupCorrelatorCanResolveDetector(t *testing.T) {
 	det := &spyDetector{name: "my_detector"}
 	cor := &spyCorrelator{name: "my_correlator", resolvedName: "my_detector"}
 
-	newTestEngine([]observerdef.Detector{det}, []observerdef.Correlator{cor}, nil)
+	newTestEngine(t, []observerdef.Detector{det}, []observerdef.Correlator{cor}, nil)
 
 	require.NotNil(t, cor.resolved, "correlator should resolve detector via getComponent")
 	assert.Equal(t, det, cor.resolved)
@@ -159,7 +160,7 @@ func TestEngine_SetupExtractorCanResolveCorrelator(t *testing.T) {
 	cor := &spyCorrelator{name: "my_correlator"}
 	ext := &spyExtractor{name: "my_extractor", resolvedName: "my_correlator"}
 
-	newTestEngine(nil, []observerdef.Correlator{cor}, []observerdef.LogMetricsExtractor{ext})
+	newTestEngine(t, nil, []observerdef.Correlator{cor}, []observerdef.LogMetricsExtractor{ext})
 
 	require.NotNil(t, ext.resolved, "extractor should resolve correlator via getComponent")
 	assert.Equal(t, cor, ext.resolved)
@@ -170,7 +171,24 @@ func TestEngine_SetupExtractorCanResolveCorrelator(t *testing.T) {
 func TestEngine_SetupUnknownComponentReturnsNil(t *testing.T) {
 	det := &spyDetector{name: "my_detector", resolvedName: "does_not_exist"}
 
-	newTestEngine([]observerdef.Detector{det}, nil, nil)
+	newTestEngine(t, []observerdef.Detector{det}, nil, nil)
 
 	assert.Nil(t, det.resolved, "unknown component should resolve to nil")
+}
+
+// TestEngine_SetupErrorPropagated verifies that newEngine returns an error when a
+// component's Setup fails, including the component name in the error message.
+func TestEngine_SetupErrorPropagated(t *testing.T) {
+	failing := &errorCorrelator{}
+	failing.name = "bad_correlator"
+
+	_, err := newEngine(engineConfig{
+		storage:     newTimeSeriesStorage(),
+		correlators: []observerdef.Correlator{failing},
+	})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "bad_correlator")
+	assert.ErrorContains(t, err, "setup failed")
+	assert.True(t, failing.setupCalled)
 }

--- a/comp/observer/impl/engine_test.go
+++ b/comp/observer/impl/engine_test.go
@@ -1,0 +1,176 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// --- Spy helpers ---
+
+// spyDetector records Setup calls and can optionally look up a component by name.
+type spyDetector struct {
+	name         string
+	setupCalled  bool
+	resolvedName string
+	resolved     any
+}
+
+func (s *spyDetector) Name() string { return s.name }
+func (s *spyDetector) Setup(get observerdef.GetComponentFunc) error {
+	s.setupCalled = true
+	if s.resolvedName != "" {
+		s.resolved = get(s.resolvedName)
+	}
+	return nil
+}
+
+func (s *spyDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
+	return observerdef.DetectionResult{}
+}
+
+// spyCorrelator records Setup calls and can optionally look up a component by name.
+type spyCorrelator struct {
+	name         string
+	setupCalled  bool
+	resolvedName string
+	resolved     any
+}
+
+func (s *spyCorrelator) Name() string { return s.name }
+func (s *spyCorrelator) Setup(get observerdef.GetComponentFunc) error {
+	s.setupCalled = true
+	if s.resolvedName != "" {
+		s.resolved = get(s.resolvedName)
+	}
+	return nil
+}
+func (s *spyCorrelator) ProcessAnomaly(_ observerdef.Anomaly)                {}
+func (s *spyCorrelator) Advance(_ int64)                                     {}
+func (s *spyCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation { return nil }
+func (s *spyCorrelator) Reset()                                              {}
+
+// spyExtractor records Setup calls and can optionally look up a component by name.
+type spyExtractor struct {
+	name         string
+	setupCalled  bool
+	resolvedName string
+	resolved     any
+}
+
+func (s *spyExtractor) Name() string { return s.name }
+func (s *spyExtractor) Setup(get observerdef.GetComponentFunc) error {
+	s.setupCalled = true
+	if s.resolvedName != "" {
+		s.resolved = get(s.resolvedName)
+	}
+	return nil
+}
+func (s *spyExtractor) ProcessLog(_ observerdef.LogView) []observerdef.MetricOutput { return nil }
+
+// errorCorrelator returns an error from Setup.
+type errorCorrelator struct{ spyCorrelator }
+
+func (e *errorCorrelator) Setup(_ observerdef.GetComponentFunc) error {
+	e.setupCalled = true
+	return errors.New("setup failed")
+}
+
+// --- Tests ---
+
+func newTestEngine(detectors []observerdef.Detector, correlators []observerdef.Correlator, extractors []observerdef.LogMetricsExtractor) *engine {
+	return newEngine(engineConfig{
+		storage:     newTimeSeriesStorage(),
+		detectors:   detectors,
+		correlators: correlators,
+		extractors:  extractors,
+	})
+}
+
+// TestEngine_SetupCalledOnDetectors verifies that Setup is invoked for every detector.
+func TestEngine_SetupCalledOnDetectors(t *testing.T) {
+	d1 := &spyDetector{name: "detector_a"}
+	d2 := &spyDetector{name: "detector_b"}
+
+	newTestEngine([]observerdef.Detector{d1, d2}, nil, nil)
+
+	assert.True(t, d1.setupCalled, "Setup should be called on detector_a")
+	assert.True(t, d2.setupCalled, "Setup should be called on detector_b")
+}
+
+// TestEngine_SetupCalledOnCorrelators verifies that Setup is invoked for every correlator.
+func TestEngine_SetupCalledOnCorrelators(t *testing.T) {
+	c1 := &spyCorrelator{name: "correlator_a"}
+	c2 := &spyCorrelator{name: "correlator_b"}
+
+	newTestEngine(nil, []observerdef.Correlator{c1, c2}, nil)
+
+	assert.True(t, c1.setupCalled, "Setup should be called on correlator_a")
+	assert.True(t, c2.setupCalled, "Setup should be called on correlator_b")
+}
+
+// TestEngine_SetupCalledOnExtractors verifies that Setup is invoked for every extractor.
+func TestEngine_SetupCalledOnExtractors(t *testing.T) {
+	e1 := &spyExtractor{name: "extractor_a"}
+	e2 := &spyExtractor{name: "extractor_b"}
+
+	newTestEngine(nil, nil, []observerdef.LogMetricsExtractor{e1, e2})
+
+	assert.True(t, e1.setupCalled, "Setup should be called on extractor_a")
+	assert.True(t, e2.setupCalled, "Setup should be called on extractor_b")
+}
+
+// TestEngine_SetupDetectorCanResolveExtractor verifies that a detector can look up an
+// extractor by name via the getComponent function passed to Setup.
+func TestEngine_SetupDetectorCanResolveExtractor(t *testing.T) {
+	ext := &spyExtractor{name: "my_extractor"}
+	det := &spyDetector{name: "my_detector", resolvedName: "my_extractor"}
+
+	newTestEngine([]observerdef.Detector{det}, nil, []observerdef.LogMetricsExtractor{ext})
+
+	require.NotNil(t, det.resolved, "detector should resolve extractor via getComponent")
+	assert.Equal(t, ext, det.resolved)
+}
+
+// TestEngine_SetupCorrelatorCanResolveDetector verifies that a correlator can look up a
+// detector by name via the getComponent function passed to Setup.
+func TestEngine_SetupCorrelatorCanResolveDetector(t *testing.T) {
+	det := &spyDetector{name: "my_detector"}
+	cor := &spyCorrelator{name: "my_correlator", resolvedName: "my_detector"}
+
+	newTestEngine([]observerdef.Detector{det}, []observerdef.Correlator{cor}, nil)
+
+	require.NotNil(t, cor.resolved, "correlator should resolve detector via getComponent")
+	assert.Equal(t, det, cor.resolved)
+}
+
+// TestEngine_SetupExtractorCanResolveCorrelator verifies that an extractor can look up a
+// correlator by name via the getComponent function passed to Setup.
+func TestEngine_SetupExtractorCanResolveCorrelator(t *testing.T) {
+	cor := &spyCorrelator{name: "my_correlator"}
+	ext := &spyExtractor{name: "my_extractor", resolvedName: "my_correlator"}
+
+	newTestEngine(nil, []observerdef.Correlator{cor}, []observerdef.LogMetricsExtractor{ext})
+
+	require.NotNil(t, ext.resolved, "extractor should resolve correlator via getComponent")
+	assert.Equal(t, cor, ext.resolved)
+}
+
+// TestEngine_SetupUnknownComponentReturnsNil verifies that requesting a non-existent
+// component by name returns nil rather than panicking.
+func TestEngine_SetupUnknownComponentReturnsNil(t *testing.T) {
+	det := &spyDetector{name: "my_detector", resolvedName: "does_not_exist"}
+
+	newTestEngine([]observerdef.Detector{det}, nil, nil)
+
+	assert.Nil(t, det.resolved, "unknown component should resolve to nil")
+}

--- a/comp/observer/impl/engine_test.go
+++ b/comp/observer/impl/engine_test.go
@@ -29,7 +29,11 @@ func (s *spyDetector) Name() string { return s.name }
 func (s *spyDetector) Setup(get observerdef.GetComponentFunc) error {
 	s.setupCalled = true
 	if s.resolvedName != "" {
-		s.resolved = get(s.resolvedName)
+		c, err := get(s.resolvedName)
+		if err != nil {
+			return err
+		}
+		s.resolved = c
 	}
 	return nil
 }
@@ -50,7 +54,11 @@ func (s *spyCorrelator) Name() string { return s.name }
 func (s *spyCorrelator) Setup(get observerdef.GetComponentFunc) error {
 	s.setupCalled = true
 	if s.resolvedName != "" {
-		s.resolved = get(s.resolvedName)
+		c, err := get(s.resolvedName)
+		if err != nil {
+			return err
+		}
+		s.resolved = c
 	}
 	return nil
 }
@@ -71,7 +79,11 @@ func (s *spyExtractor) Name() string { return s.name }
 func (s *spyExtractor) Setup(get observerdef.GetComponentFunc) error {
 	s.setupCalled = true
 	if s.resolvedName != "" {
-		s.resolved = get(s.resolvedName)
+		c, err := get(s.resolvedName)
+		if err != nil {
+			return err
+		}
+		s.resolved = c
 	}
 	return nil
 }
@@ -166,14 +178,19 @@ func TestEngine_SetupExtractorCanResolveCorrelator(t *testing.T) {
 	assert.Equal(t, cor, ext.resolved)
 }
 
-// TestEngine_SetupUnknownComponentReturnsNil verifies that requesting a non-existent
-// component by name returns nil rather than panicking.
-func TestEngine_SetupUnknownComponentReturnsNil(t *testing.T) {
+// TestEngine_SetupUnknownComponentReturnsError verifies that requesting a non-existent
+// component via getComponent propagates an error through Setup and out of newEngine.
+func TestEngine_SetupUnknownComponentReturnsError(t *testing.T) {
 	det := &spyDetector{name: "my_detector", resolvedName: "does_not_exist"}
 
-	newTestEngine(t, []observerdef.Detector{det}, nil, nil)
+	_, err := newEngine(engineConfig{
+		storage:   newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{det},
+	})
 
-	assert.Nil(t, det.resolved, "unknown component should resolve to nil")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "does_not_exist")
+	assert.True(t, det.setupCalled)
 }
 
 // TestEngine_SetupErrorPropagated verifies that newEngine returns an error when a

--- a/comp/observer/impl/events.go
+++ b/comp/observer/impl/events.go
@@ -13,7 +13,7 @@ import (
 type engineEventKind int
 
 const (
-	eventAdvanceCompleted  engineEventKind = iota
+	eventAdvanceCompleted engineEventKind = iota
 	eventAnomalyCreated
 	eventCorrelationUpdated
 )

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -48,7 +48,7 @@ func (s *collectingSink) eventsOfKind(kind engineEventKind) []engineEvent {
 }
 
 func TestSubscribeAndUnsubscribe(t *testing.T) {
-	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	e := mustNewEngine(t, engineConfig{storage: newTimeSeriesStorage()})
 
 	sink := &collectingSink{}
 	unsub := e.Subscribe(sink)
@@ -69,7 +69,7 @@ func TestSubscribeAndUnsubscribe(t *testing.T) {
 }
 
 func TestMultipleSinksReceiveEvents(t *testing.T) {
-	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	e := mustNewEngine(t, engineConfig{storage: newTimeSeriesStorage()})
 
 	sink1 := &collectingSink{}
 	sink2 := &collectingSink{}
@@ -83,7 +83,7 @@ func TestMultipleSinksReceiveEvents(t *testing.T) {
 }
 
 func TestUnsubscribeOnlyAffectsTargetSink(t *testing.T) {
-	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	e := mustNewEngine(t, engineConfig{storage: newTimeSeriesStorage()})
 
 	sink1 := &collectingSink{}
 	sink2 := &collectingSink{}
@@ -140,7 +140,7 @@ func (c *resettableCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelat
 func (c *resettableCorrelator) Reset() { c.resetCount++ }
 
 func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:   newTimeSeriesStorage(),
 		detectors: []observerdef.Detector{&mockDetector{name: "noop"}},
 	})
@@ -164,7 +164,7 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 		{Source: "mem", DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|mem|"},
 	}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage: newTimeSeriesStorage(),
 		detectors: []observerdef.Detector{
 			&anomalyDetector{name: "test", anomalies: anomalies},
@@ -183,7 +183,7 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 }
 
 func TestAdvanceEmitsCorrelationUpdatedEvents(t *testing.T) {
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:     newTimeSeriesStorage(),
 		correlators: []observerdef.Correlator{&mockCorrelator{name: "time_cluster"}},
 	})
@@ -199,7 +199,7 @@ func TestAdvanceEmitsCorrelationUpdatedEvents(t *testing.T) {
 }
 
 func TestAdvanceWithReasonPreservesReason(t *testing.T) {
-	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	e := mustNewEngine(t, engineConfig{storage: newTimeSeriesStorage()})
 
 	sink := &collectingSink{}
 	e.Subscribe(sink)
@@ -212,7 +212,7 @@ func TestAdvanceWithReasonPreservesReason(t *testing.T) {
 }
 
 func TestNoEventOnSkippedAdvance(t *testing.T) {
-	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	e := mustNewEngine(t, engineConfig{storage: newTimeSeriesStorage()})
 	e.Advance(100) // advance first without sink
 
 	sink := &collectingSink{}
@@ -232,7 +232,7 @@ func TestReplayStoredDataEmitsEventsViaScheduler(t *testing.T) {
 		storage.Add("ns", "cpu", 1.0, sec, nil)
 	}
 
-	e := newEngine(engineConfig{storage: storage})
+	e := mustNewEngine(t, engineConfig{storage: storage})
 
 	sink := &collectingSink{}
 	e.Subscribe(sink)
@@ -256,7 +256,7 @@ func TestReplayStoredDataEmitsEventsViaScheduler(t *testing.T) {
 func TestEngineResetResetsDetectorsAndCorrelators(t *testing.T) {
 	detector := &resettableDetector{name: "detector"}
 	correlator := &resettableCorrelator{name: "correlator"}
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:     newTimeSeriesStorage(),
 		detectors:   []observerdef.Detector{detector},
 		correlators: []observerdef.Correlator{correlator},
@@ -323,7 +323,7 @@ func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 		},
 	}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage: newTimeSeriesStorage(),
 		detectors: []observerdef.Detector{
 			&anomalyDetector{name: "test_detector", anomalies: anomalies},
@@ -360,7 +360,7 @@ func TestFindingM2_EmptySourceSeriesIDCollision(t *testing.T) {
 		},
 	}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage: newTimeSeriesStorage(),
 		detectors: []observerdef.Detector{
 			&anomalyDetector{name: "log_detector", anomalies: anomalies},
@@ -394,7 +394,7 @@ func TestFindingM3_DedupAsymmetry(t *testing.T) {
 		},
 	}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage: newTimeSeriesStorage(),
 		detectors: []observerdef.Detector{
 			&anomalyDetector{name: "test_detector", anomalies: anomalies},
@@ -429,7 +429,7 @@ func TestFindingM4_UnboundedGrowthOfUniqueAnomalySources(t *testing.T) {
 	// Use a custom detector that generates a unique source on each Detect call.
 	det := &dynamicAnomalyDetector{prefix: "metric_"}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:   storage,
 		detectors: []observerdef.Detector{det},
 	})
@@ -458,7 +458,7 @@ func TestFindingM4_UnboundedGrowthOfAccumulatedCorrelations(t *testing.T) {
 	// A correlator that produces unique patterns on each Advance.
 	corr := &dynamicCorrelator{prefix: "pattern_"}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:     storage,
 		correlators: []observerdef.Correlator{corr},
 	})
@@ -483,7 +483,7 @@ func TestFindingM9_SetDetectorsRace(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:   storage,
 		detectors: []observerdef.Detector{&mockDetector{name: "initial"}},
 	})
@@ -516,7 +516,7 @@ func TestFindingM9_SetCorrelatorsRace(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:     storage,
 		correlators: []observerdef.Correlator{&mockCorrelator{name: "initial"}},
 	})
@@ -550,7 +550,7 @@ func TestFindingM10_ResetRace(t *testing.T) {
 	det := &resettableDetector{name: "det"}
 	corr := &resettableCorrelator{name: "corr"}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:     storage,
 		detectors:   []observerdef.Detector{det},
 		correlators: []observerdef.Correlator{corr},
@@ -588,7 +588,7 @@ func TestFindingM12_LogOnlyTimestampsSkippedInReplay(t *testing.T) {
 
 	extractor := &noopLogExtractor{}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:    storage,
 		extractors: []observerdef.LogMetricsExtractor{extractor},
 	})

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -105,7 +105,8 @@ type anomalyDetector struct {
 	anomalies []observerdef.Anomaly
 }
 
-func (d *anomalyDetector) Name() string { return d.name }
+func (d *anomalyDetector) Name() string                               { return d.name }
+func (d *anomalyDetector) Setup(_ observerdef.GetComponentFunc) error { return nil }
 func (d *anomalyDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: d.anomalies,
@@ -117,7 +118,8 @@ type resettableDetector struct {
 	resetCount int
 }
 
-func (d *resettableDetector) Name() string { return d.name }
+func (d *resettableDetector) Name() string                               { return d.name }
+func (d *resettableDetector) Setup(_ observerdef.GetComponentFunc) error { return nil }
 func (d *resettableDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }
@@ -128,9 +130,10 @@ type resettableCorrelator struct {
 	resetCount int
 }
 
-func (c *resettableCorrelator) Name() string                         { return c.name }
-func (c *resettableCorrelator) ProcessAnomaly(_ observerdef.Anomaly) {}
-func (c *resettableCorrelator) Advance(_ int64)                      {}
+func (c *resettableCorrelator) Name() string                               { return c.name }
+func (c *resettableCorrelator) Setup(_ observerdef.GetComponentFunc) error { return nil }
+func (c *resettableCorrelator) ProcessAnomaly(_ observerdef.Anomaly)       {}
+func (c *resettableCorrelator) Advance(_ int64)                            {}
 func (c *resettableCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation {
 	return nil
 }

--- a/comp/observer/impl/log_detector_connection_errors.go
+++ b/comp/observer/impl/log_detector_connection_errors.go
@@ -30,6 +30,9 @@ func (c *ConnectionErrorExtractor) Name() string {
 	return "connection_error_extractor"
 }
 
+// Setup is a no-op for ConnectionErrorExtractor as it has no component dependencies.
+func (c *ConnectionErrorExtractor) Setup(_ observer.GetComponentFunc) error { return nil }
+
 // ProcessLog checks if a log contains connection error patterns and returns a metric if so.
 // Anomaly detection is handled by metrics detection on the count aggregation of the emitted metric.
 func (c *ConnectionErrorExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -33,6 +33,9 @@ type LogMetricsExtractor struct {
 
 func (a *LogMetricsExtractor) Name() string { return "log_metrics_extractor" }
 
+// Setup is a no-op for LogMetricsExtractor as it has no component dependencies.
+func (a *LogMetricsExtractor) Setup(_ observer.GetComponentFunc) error { return nil }
+
 func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
 	content := log.GetContent()
 	tags := log.GetTags()

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -53,6 +53,8 @@ func (e *LogPatternExtractor) Name() string {
 	return "log_pattern_extractor"
 }
 
+func (e *LogPatternExtractor) Setup(_ observerdef.GetComponentFunc) error { return nil }
+
 // ProcessLog clusters the log message and emits a count metric for its pattern.
 func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) []observerdef.MetricOutput {
 	message := string(log.GetContent())

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -131,6 +131,10 @@ func (b *BOCPDDetector) Name() string {
 	return "bocpd_detector"
 }
 
+func (b *BOCPDDetector) Setup(getComponent observer.GetComponentFunc) error {
+	return nil
+}
+
 // Detect implements Detector. It discovers series, reads only newly visible
 // points, and updates per-series BOCPD posterior state incrementally.
 //

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -58,6 +58,10 @@ func (c *CUSUMDetector) Name() string {
 	return "cusum_detector"
 }
 
+func (c *CUSUMDetector) Setup(getComponent observer.GetComponentFunc) error {
+	return nil
+}
+
 // Analyze runs CUSUM on the series and returns an anomaly if a shift is detected.
 // The anomaly's Timestamp indicates when the shift was first detected (threshold crossing).
 func (c *CUSUMDetector) Detect(series observer.Series) observer.DetectionResult {

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -23,22 +23,22 @@ type RRCFScoredPoint struct {
 
 // RRCFScoreStats contains distribution statistics and full score history for threshold analysis.
 type RRCFScoreStats struct {
-	Enabled        bool              `json:"enabled"`
-	SampleCount    int               `json:"sampleCount"`
-	AlignedPoints  int               `json:"alignedPoints"`
-	ShinglesBuilt  int               `json:"shinglesBuilt"`
-	MinScore       float64           `json:"minScore"`
-	MaxScore       float64           `json:"maxScore"`
-	MeanScore      float64           `json:"meanScore"`
-	StddevScore    float64           `json:"stddevScore"`
-	P50            float64           `json:"p50"`
-	P75            float64           `json:"p75"`
-	P90            float64           `json:"p90"`
-	P95            float64           `json:"p95"`
-	P99            float64           `json:"p99"`
-	Config         RRCFConfigSummary `json:"config"`
-	Metrics        []string          `json:"metrics"`
-	Scores         []RRCFScoredPoint `json:"scores"`
+	Enabled       bool              `json:"enabled"`
+	SampleCount   int               `json:"sampleCount"`
+	AlignedPoints int               `json:"alignedPoints"`
+	ShinglesBuilt int               `json:"shinglesBuilt"`
+	MinScore      float64           `json:"minScore"`
+	MaxScore      float64           `json:"maxScore"`
+	MeanScore     float64           `json:"meanScore"`
+	StddevScore   float64           `json:"stddevScore"`
+	P50           float64           `json:"p50"`
+	P75           float64           `json:"p75"`
+	P90           float64           `json:"p90"`
+	P95           float64           `json:"p95"`
+	P99           float64           `json:"p99"`
+	Config        RRCFConfigSummary `json:"config"`
+	Metrics       []string          `json:"metrics"`
+	Scores        []RRCFScoredPoint `json:"scores"`
 }
 
 // RRCFConfigSummary is a JSON-friendly summary of RRCF configuration.
@@ -164,19 +164,23 @@ func NewRRCFDetector(config RRCFConfig) *RRCFDetector {
 	forest := newRCForest(config.NumTrees, config.TreeSize, shingleDim, 42)
 
 	return &RRCFDetector{
-		config:        config,
-		metrics:       metrics,
-		resolvedKeys:  make(map[string]observer.SeriesKey),
-		cursors:       make(map[string]int64),
-		forest:        forest,
-		recentScores:  make([]float64, 0, 100),
-		allScores:     make([]RRCFScoredPoint, 0, 1024),
+		config:       config,
+		metrics:      metrics,
+		resolvedKeys: make(map[string]observer.SeriesKey),
+		cursors:      make(map[string]int64),
+		forest:       forest,
+		recentScores: make([]float64, 0, 100),
+		allScores:    make([]RRCFScoredPoint, 0, 1024),
 	}
 }
 
 // Name returns the detector name.
 func (r *RRCFDetector) Name() string {
 	return "rrcf"
+}
+
+func (r *RRCFDetector) Setup(getComponent observer.GetComponentFunc) error {
+	return nil
 }
 
 // Detect implements Detector. It queries storage for system metrics,
@@ -491,8 +495,8 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 				Source:       "score",
 				DetectorName: r.Name(),
 				Title:        "RRCF multivariate anomaly",
-				Description:    fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),
-				Timestamp:      s.endTimestamp,
+				Description:  fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),
+				Timestamp:    s.endTimestamp,
 				DebugInfo: &observer.AnomalyDebugInfo{
 					CurrentValue:   score,
 					Threshold:      threshold,

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -197,25 +197,7 @@ func NewComponent(deps Requires) Provides {
 		}
 	}
 
-	detectors, correlators, _ := catalog.Instantiate(correlatorOverrides)
-
-	extractors := []observerdef.LogMetricsExtractor{
-		&LogMetricsExtractor{
-			MaxEvalBytes: 4096,
-			// Exclude metadata fields that shouldn't be metrics.
-			// These are common timestamp/ID fields that appear in event JSON.
-			ExcludeFields: map[string]struct{}{
-				"timestamp": {}, // event.Event.Ts serializes as "timestamp"
-				"ts":        {}, // alternate timestamp field name
-				"time":      {},
-				"pid":       {},
-				"ppid":      {},
-				"uid":       {},
-				"gid":       {},
-			},
-		},
-		&ConnectionErrorExtractor{},
-	}
+	detectors, correlators, extractors, _ := catalog.Instantiate(correlatorOverrides)
 
 	eng := newEngine(engineConfig{
 		storage:     newTimeSeriesStorage(),

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -176,7 +176,7 @@ func (l *logObs) GetTimestampUnixMilli() int64 {
 }
 
 // NewComponent creates an observer.Component.
-func NewComponent(deps Requires) Provides {
+func NewComponent(deps Requires) (Provides, error) {
 	catalog := defaultCatalog()
 
 	// Build correlator overrides from config keys (observer.correlators.<name>.enabled).
@@ -199,13 +199,16 @@ func NewComponent(deps Requires) Provides {
 
 	detectors, correlators, extractors, _ := catalog.Instantiate(correlatorOverrides)
 
-	eng := newEngine(engineConfig{
+	eng, err := newEngine(engineConfig{
 		storage:     newTimeSeriesStorage(),
 		extractors:  extractors,
 		detectors:   detectors,
 		correlators: correlators,
 		scheduler:   &currentBehaviorPolicy{},
 	})
+	if err != nil {
+		return Provides{}, fmt.Errorf("observer engine setup failed: %w", err)
+	}
 
 	// Wire reporters via event subscription.
 	// The reporterEventSink queries stateView for active correlations on each advance,
@@ -350,7 +353,7 @@ func NewComponent(deps Requires) Provides {
 	obs.fetcher.Start()
 	pkglog.Info("[observer] trace/profile fetcher started")
 
-	return Provides{Comp: obs}
+	return Provides{Comp: obs}, nil
 }
 
 func samplePass(rate float64, n uint64) bool {

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -445,6 +445,10 @@ func (a *seriesDetectorAdapter) Name() string {
 	return a.detector.Name()
 }
 
+func (a *seriesDetectorAdapter) Setup(getComponent observerdef.GetComponentFunc) error {
+	return a.detector.Setup(getComponent)
+}
+
 // Reset clears adapter-local caches and resets the wrapped detector when supported.
 func (a *seriesDetectorAdapter) Reset() {
 	a.lastVisibleCount = make(map[string]int)

--- a/comp/observer/impl/observer_test.go
+++ b/comp/observer/impl/observer_test.go
@@ -73,7 +73,8 @@ type countingSeriesDetector struct {
 	telemetry []observerdef.ObserverTelemetry
 }
 
-func (d *countingSeriesDetector) Name() string { return "counting" }
+func (d *countingSeriesDetector) Name() string                               { return "counting" }
+func (d *countingSeriesDetector) Setup(_ observerdef.GetComponentFunc) error { return nil }
 
 func (d *countingSeriesDetector) Detect(_ observerdef.Series) observerdef.DetectionResult {
 	return observerdef.DetectionResult{

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -23,21 +23,21 @@ type ObserverOutput struct {
 
 // ObserverMetadata describes the scenario and pipeline configuration.
 type ObserverMetadata struct {
-	Scenario           string   `json:"scenario"`
-	TimelineStart      int64    `json:"timeline_start"`
-	TimelineEnd        int64    `json:"timeline_end"`
-	DetectorsEnabled   []string `json:"detectors_enabled"`
-	CorrelatorsEnabled []string `json:"correlators_enabled"`
-	TotalAnomalyPeriods int     `json:"total_anomaly_periods"`
+	Scenario            string   `json:"scenario"`
+	TimelineStart       int64    `json:"timeline_start"`
+	TimelineEnd         int64    `json:"timeline_end"`
+	DetectorsEnabled    []string `json:"detectors_enabled"`
+	CorrelatorsEnabled  []string `json:"correlators_enabled"`
+	TotalAnomalyPeriods int      `json:"total_anomaly_periods"`
 }
 
 // ObserverCorrelation is one correlation cluster.
 // Always includes the time span (pattern, period_start, period_end).
 // Verbose mode adds title, member_series, and nested anomalies.
 type ObserverCorrelation struct {
-	Pattern          string            `json:"pattern"`
-	PeriodStart int64 `json:"period_start"`
-	PeriodEnd   int64 `json:"period_end"`
+	Pattern      string            `json:"pattern"`
+	PeriodStart  int64             `json:"period_start"`
+	PeriodEnd    int64             `json:"period_end"`
 	Title        string            `json:"title,omitempty"`
 	MemberSeries []string          `json:"member_series,omitempty"`
 	Anomalies    []ObserverAnomaly `json:"anomalies,omitempty"`
@@ -90,7 +90,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 	outCorrelations := make([]ObserverCorrelation, len(correlations))
 	for i, corr := range correlations {
 		oc := ObserverCorrelation{
-			Pattern:            corr.Pattern,
+			Pattern:     corr.Pattern,
 			PeriodStart: corr.FirstSeen,
 			PeriodEnd:   corr.LastUpdated,
 		}
@@ -117,11 +117,11 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 
 	output := ObserverOutput{
 		Metadata: ObserverMetadata{
-			Scenario:           scenario,
-			TimelineStart:      timelineStart,
-			TimelineEnd:        timelineEnd,
-			DetectorsEnabled:   detectorNames,
-			CorrelatorsEnabled: correlatorNames,
+			Scenario:            scenario,
+			TimelineStart:       timelineStart,
+			TimelineEnd:         timelineEnd,
+			DetectorsEnabled:    detectorNames,
+			CorrelatorsEnabled:  correlatorNames,
 			TotalAnomalyPeriods: len(outCorrelations),
 		},
 		AnomalyPeriods: outCorrelations,

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -21,11 +21,14 @@ type staticCorrelator struct {
 	correlations []observerdef.ActiveCorrelation
 }
 
-func (c *staticCorrelator) Name() string                                        { return "static" }
-func (c *staticCorrelator) ProcessAnomaly(_ observerdef.Anomaly)                {}
-func (c *staticCorrelator) Advance(_ int64)                                     {}
-func (c *staticCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation { return c.correlations }
-func (c *staticCorrelator) Reset()                                              {}
+func (c *staticCorrelator) Name() string                               { return "static" }
+func (c *staticCorrelator) Setup(_ observerdef.GetComponentFunc) error { return nil }
+func (c *staticCorrelator) ProcessAnomaly(_ observerdef.Anomaly)       {}
+func (c *staticCorrelator) Advance(_ int64)                            {}
+func (c *staticCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation {
+	return c.correlations
+}
+func (c *staticCorrelator) Reset() {}
 
 // newTestBenchForOutput creates a minimal TestBench with injected state for testing
 // observer output. No scenarios dir or registry needed.

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -32,8 +32,8 @@ func (c *staticCorrelator) Reset() {}
 
 // newTestBenchForOutput creates a minimal TestBench with injected state for testing
 // observer output. No scenarios dir or registry needed.
-func newTestBenchForOutput() *TestBench {
-	eng := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+func newTestBenchForOutput(t testing.TB) *TestBench {
+	eng := mustNewEngine(t, engineConfig{storage: newTimeSeriesStorage()})
 	return &TestBench{
 		engine:     eng,
 		catalog:    testbenchCatalog(),
@@ -69,7 +69,7 @@ func testCorrelation() observerdef.ActiveCorrelation {
 }
 
 func TestWriteObserverOutput_EmptyScenario(t *testing.T) {
-	tb := newTestBenchForOutput()
+	tb := newTestBenchForOutput(t)
 
 	outPath := filepath.Join(t.TempDir(), "results.json")
 	err := tb.WriteObserverOutput(outPath, false)
@@ -91,7 +91,7 @@ func TestWriteObserverOutput_EmptyScenario(t *testing.T) {
 }
 
 func TestWriteObserverOutput_NonVerbose(t *testing.T) {
-	tb := newTestBenchForOutput()
+	tb := newTestBenchForOutput(t)
 	tb.loadedScenario = "test_scenario"
 	tb.engine.Storage().Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"})
 	tb.engine.Storage().Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"})
@@ -126,7 +126,7 @@ func TestWriteObserverOutput_NonVerbose(t *testing.T) {
 }
 
 func TestWriteObserverOutput_Verbose(t *testing.T) {
-	tb := newTestBenchForOutput()
+	tb := newTestBenchForOutput(t)
 	tb.loadedScenario = "test_scenario"
 	tb.engine.Storage().Add("parquet", "cpu.user", 1.0, 1000, []string{"host:a"})
 	tb.engine.Storage().Add("parquet", "cpu.user", 2.0, 2000, []string{"host:a"})
@@ -184,7 +184,7 @@ func TestWriteObserverOutput_Verbose(t *testing.T) {
 }
 
 func TestWriteObserverOutput_TimelineBoundsFromStorage(t *testing.T) {
-	tb := newTestBenchForOutput()
+	tb := newTestBenchForOutput(t)
 	tb.engine.Storage().Add("parquet", "disk.io", 10.0, 5000, []string{"device:sda"})
 	tb.engine.Storage().Add("parquet", "disk.io", 20.0, 9000, []string{"device:sda"})
 
@@ -202,7 +202,7 @@ func TestWriteObserverOutput_TimelineBoundsFromStorage(t *testing.T) {
 }
 
 func TestWriteObserverOutput_ValidJSON(t *testing.T) {
-	tb := newTestBenchForOutput()
+	tb := newTestBenchForOutput(t)
 	tb.loadedScenario = "json_validity_check"
 	tb.engine.SetCorrelators([]observerdef.Correlator{&staticCorrelator{correlations: []observerdef.ActiveCorrelation{
 		{

--- a/comp/observer/impl/profile_test.go
+++ b/comp/observer/impl/profile_test.go
@@ -36,7 +36,7 @@ func buildRealisticEngine(numMetrics, numSeconds int, windowSec int64) *engine {
 	storage := buildRealisticStorage(numMetrics, numSeconds)
 
 	catalog := testbenchCatalog()
-	detectors, correlators, _ := catalog.Instantiate(nil)
+	detectors, correlators, _, _ := catalog.Instantiate(nil)
 
 	// Apply window to all seriesDetectorAdapters.
 	if windowSec > 0 {

--- a/comp/observer/impl/profile_test.go
+++ b/comp/observer/impl/profile_test.go
@@ -32,7 +32,7 @@ func buildRealisticStorage(numMetrics, numSeconds int) *timeSeriesStorage {
 }
 
 // buildRealisticEngine creates an engine with windowed or unbounded detectors.
-func buildRealisticEngine(numMetrics, numSeconds int, windowSec int64) *engine {
+func buildRealisticEngine(tb testing.TB, numMetrics, numSeconds int, windowSec int64) *engine {
 	storage := buildRealisticStorage(numMetrics, numSeconds)
 
 	catalog := testbenchCatalog()
@@ -48,7 +48,7 @@ func buildRealisticEngine(numMetrics, numSeconds int, windowSec int64) *engine {
 		}
 	}
 
-	return newEngine(engineConfig{
+	return mustNewEngine(tb, engineConfig{
 		storage:     storage,
 		detectors:   detectors,
 		correlators: correlators,
@@ -60,7 +60,7 @@ func buildRealisticEngine(numMetrics, numSeconds int, windowSec int64) *engine {
 //	go test -run=^$ -bench=BenchmarkReplayStoredData -cpuprofile=/tmp/observer_cpu.prof -benchtime=1x ./comp/observer/impl/
 //	go tool pprof -http=:8081 /tmp/observer_cpu.prof
 func BenchmarkReplayStoredData(b *testing.B) {
-	e := buildRealisticEngine(200, 576, 0)
+	e := buildRealisticEngine(b, 200, 576, 0)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		e.Reset()
@@ -70,7 +70,7 @@ func BenchmarkReplayStoredData(b *testing.B) {
 
 // BenchmarkReplayStoredData_Window300 profiles with a 300s window.
 func BenchmarkReplayStoredData_Window300(b *testing.B) {
-	e := buildRealisticEngine(200, 576, 300)
+	e := buildRealisticEngine(b, 200, 576, 300)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		e.Reset()
@@ -80,7 +80,7 @@ func BenchmarkReplayStoredData_Window300(b *testing.B) {
 
 // BenchmarkReplayStoredData_Window60 profiles with a 60s window.
 func BenchmarkReplayStoredData_Window60(b *testing.B) {
-	e := buildRealisticEngine(200, 576, 60)
+	e := buildRealisticEngine(b, 200, 576, 60)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		e.Reset()
@@ -90,7 +90,7 @@ func BenchmarkReplayStoredData_Window60(b *testing.B) {
 
 // BenchmarkReplayStoredData_Small is a smaller variant for quick iteration.
 func BenchmarkReplayStoredData_Small(b *testing.B) {
-	e := buildRealisticEngine(50, 100, 0)
+	e := buildRealisticEngine(b, 50, 100, 0)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		e.Reset()

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -392,10 +392,11 @@ type mockHTMLCorrelator struct {
 	correlations []observer.ActiveCorrelation
 }
 
-func (m *mockHTMLCorrelator) Name() string                          { return "mock_correlator" }
-func (m *mockHTMLCorrelator) ProcessAnomaly(_ observer.Anomaly)     {}
-func (m *mockHTMLCorrelator) Advance(_ int64)                       {}
-func (m *mockHTMLCorrelator) Reset()                                {}
+func (m *mockHTMLCorrelator) Name() string                            { return "mock_correlator" }
+func (m *mockHTMLCorrelator) Setup(_ observer.GetComponentFunc) error { return nil }
+func (m *mockHTMLCorrelator) ProcessAnomaly(_ observer.Anomaly)       {}
+func (m *mockHTMLCorrelator) Advance(_ int64)                         {}
+func (m *mockHTMLCorrelator) Reset()                                  {}
 func (m *mockHTMLCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	return m.correlations
 }

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -19,7 +19,7 @@ func TestStateView_StorageAccess(t *testing.T) {
 	storage.Add("ns", "cpu", 2.0, 101, nil)
 	storage.Add("ns", "mem", 512.0, 100, []string{"host:a"})
 
-	e := newEngine(engineConfig{storage: storage})
+	e := mustNewEngine(t, engineConfig{storage: storage})
 	sv := e.StateView()
 
 	// ListSeries
@@ -48,7 +48,7 @@ func TestStateView_StorageAccess(t *testing.T) {
 }
 
 func TestStateView_Anomalies(t *testing.T) {
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage: newTimeSeriesStorage(),
 	})
 	sv := e.StateView()
@@ -129,7 +129,7 @@ func TestStateView_DetectorsAndCorrelators(t *testing.T) {
 	detector := &mockDetector{name: "mock_det"}
 	correlator := &mockCorrelator{name: "mock_corr"}
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:     newTimeSeriesStorage(),
 		detectors:   []observerdef.Detector{detector},
 		correlators: []observerdef.Correlator{correlator},
@@ -152,7 +152,7 @@ func TestStateView_SchedulingState(t *testing.T) {
 	storage.Add("ns", "cpu", 1.0, 100, nil)
 	storage.Add("ns", "cpu", 2.0, 200, nil)
 
-	e := newEngine(engineConfig{storage: storage})
+	e := mustNewEngine(t, engineConfig{storage: storage})
 	sv := e.StateView()
 
 	if sv.LastAnalyzedTime() != 0 {
@@ -166,7 +166,7 @@ func TestStateView_SchedulingState(t *testing.T) {
 }
 
 func TestStateView_Telemetry(t *testing.T) {
-	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	e := mustNewEngine(t, engineConfig{storage: newTimeSeriesStorage()})
 	sv := e.StateView()
 
 	// Initially empty
@@ -214,7 +214,7 @@ func TestFindingM11_StateViewListDetectorsRace(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:   storage,
 		detectors: []observerdef.Detector{&mockDetector{name: "det1"}},
 	})
@@ -246,7 +246,7 @@ func TestFindingM11_StateViewListCorrelatorsRace(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:     storage,
 		correlators: []observerdef.Correlator{&mockCorrelator{name: "corr1"}},
 	})
@@ -278,7 +278,7 @@ func TestFindingM11_StateViewActiveCorrelationsRace(t *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 
-	e := newEngine(engineConfig{
+	e := mustNewEngine(t, engineConfig{
 		storage:     storage,
 		correlators: []observerdef.Correlator{&mockCorrelator{name: "corr1"}},
 	})

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -192,7 +192,8 @@ type mockDetector struct {
 	name string
 }
 
-func (d *mockDetector) Name() string { return d.name }
+func (d *mockDetector) Name() string                               { return d.name }
+func (d *mockDetector) Setup(_ observerdef.GetComponentFunc) error { return nil }
 func (d *mockDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{}
 }
@@ -203,6 +204,7 @@ type mockCorrelator struct {
 }
 
 func (c *mockCorrelator) Name() string                                        { return c.name }
+func (c *mockCorrelator) Setup(_ observerdef.GetComponentFunc) error          { return nil }
 func (c *mockCorrelator) ProcessAnomaly(_ observerdef.Anomaly)                {}
 func (c *mockCorrelator) Advance(_ int64)                                     {}
 func (c *mockCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation { return nil }

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -7,9 +7,19 @@ package observerimpl
 
 import (
 	"fmt"
+	"testing"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/stretchr/testify/require"
 )
+
+// mustNewEngine is a test helper that calls newEngine and fails the test if it returns an error.
+func mustNewEngine(t testing.TB, cfg engineConfig) *engine {
+	t.Helper()
+	e, err := newEngine(cfg)
+	require.NoError(t, err)
+	return e
+}
 
 // mockLogView implements observer.LogView for testing.
 type mockLogView struct {

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -33,7 +33,8 @@ type dynamicAnomalyDetector struct {
 	currentIndex int
 }
 
-func (d *dynamicAnomalyDetector) Name() string { return "dynamic_anomaly_detector" }
+func (d *dynamicAnomalyDetector) Name() string                               { return "dynamic_anomaly_detector" }
+func (d *dynamicAnomalyDetector) Setup(_ observerdef.GetComponentFunc) error { return nil }
 func (d *dynamicAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{
@@ -54,9 +55,10 @@ type dynamicCorrelator struct {
 	currentIndex int
 }
 
-func (c *dynamicCorrelator) Name() string                         { return "dynamic_correlator" }
-func (c *dynamicCorrelator) ProcessAnomaly(_ observerdef.Anomaly) {}
-func (c *dynamicCorrelator) Advance(_ int64)                      {}
+func (c *dynamicCorrelator) Name() string                               { return "dynamic_correlator" }
+func (c *dynamicCorrelator) Setup(_ observerdef.GetComponentFunc) error { return nil }
+func (c *dynamicCorrelator) ProcessAnomaly(_ observerdef.Anomaly)       {}
+func (c *dynamicCorrelator) Advance(_ int64)                            {}
 func (c *dynamicCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation {
 	return []observerdef.ActiveCorrelation{
 		{
@@ -72,7 +74,8 @@ func (c *dynamicCorrelator) Reset() { c.currentIndex = 0 }
 // This simulates a log at a timestamp that produces no virtual metrics.
 type noopLogExtractor struct{}
 
-func (e *noopLogExtractor) Name() string { return "noop_extractor" }
+func (e *noopLogExtractor) Name() string                               { return "noop_extractor" }
+func (e *noopLogExtractor) Setup(_ observerdef.GetComponentFunc) error { return nil }
 func (e *noopLogExtractor) ProcessLog(_ observerdef.LogView) []observerdef.MetricOutput {
 	return nil
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -179,18 +179,7 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 	}
 
 	catalog := testbenchCatalog()
-	detectors, correlators, components := catalog.Instantiate(config.EnableOverrides)
-
-	extractors := []observerdef.LogMetricsExtractor{
-		&LogMetricsExtractor{
-			MaxEvalBytes: 4096,
-			ExcludeFields: map[string]struct{}{
-				"timestamp": {}, "ts": {}, "time": {},
-				"pid": {}, "ppid": {}, "uid": {}, "gid": {},
-			},
-		},
-		&ConnectionErrorExtractor{},
-	}
+	detectors, correlators, extractors, components := catalog.Instantiate(config.EnableOverrides)
 
 	eng := newEngine(engineConfig{
 		storage:     newTimeSeriesStorage(),
@@ -558,7 +547,6 @@ func (r *parquetTraceStatRow) GetDurationNano() uint64       { return r.data.Dur
 func (r *parquetTraceStatRow) GetOkSummary() []byte          { return r.data.OkSummary }
 func (r *parquetTraceStatRow) GetErrorSummary() []byte       { return r.data.ErrorSummary }
 func (r *parquetTraceStatRow) GetPeerTags() []string         { return r.data.PeerTags }
-
 
 // resetAllState resets all registered components that support Reset().
 func (tb *TestBench) resetAllState() {

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -181,13 +181,16 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 	catalog := testbenchCatalog()
 	detectors, correlators, extractors, components := catalog.Instantiate(config.EnableOverrides)
 
-	eng := newEngine(engineConfig{
+	eng, err := newEngine(engineConfig{
 		storage:     newTimeSeriesStorage(),
 		extractors:  extractors,
 		detectors:   detectors,
 		correlators: correlators,
 		scheduler:   &currentBehaviorPolicy{},
 	})
+	if err != nil {
+		return nil, fmt.Errorf("testbench engine setup failed: %w", err)
+	}
 
 	hub := newSSEHub()
 	stop := make(chan struct{})


### PR DESCRIPTION
### What does this PR do?

This adds a way for anomaly detection components to get references to other components.

- Add `Setup` to `LogMetricsExtractor`, `Correlator`, `MetricsDetector` and `Detector` (and all implementations)
- Add and update tests
- Add function to get component
- Add error handling to the engine setup

### Motivation

Log detectors / correlators will need dependencies to get patterns from the extractor for the anomaly description ([example](https://github.com/DataDog/datadog-agent/pull/47925/changes#diff-0a0439138163f1ce2f8b6bdc0ea7293708c78242e908c6f0353cd47001a4320fR122-R133))

### Describe how you validated your changes

### Additional Notes
