### PR TITLE
[EBPF] gpu: gate device.unhealthy on kube device plugin availability

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/model"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/nvidia"
 	gpuspec "github.com/DataDog/datadog-agent/pkg/collector/corechecks/gpu/spec"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
@@ -847,6 +848,9 @@ func TestDisabledCollectorsConfiguration(t *testing.T) {
 }
 
 func TestMetricsFollowSpec(t *testing.T) {
+	// required to emit gpu.devices.unhealthy metric
+	env.SetFeatures(t, env.KubernetesDevicePlugins)
+
 	metricsSpec, err := gpuspec.LoadMetricsSpec()
 	require.NoError(t, err)
 	archFile, err := gpuspec.LoadArchitecturesSpec()

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
@@ -450,6 +451,10 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 		{
 			Name: "device_unhealthy_count",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
+				if (!env.IsFeaturePresent(env.KubernetesDevicePlugins)) {
+					return nil, 0, ddnvml.NewNvmlAPIErrorOrNil("GetUnhealthyDevices", nvml.ERROR_NOT_SUPPORTED)
+				}
+
 				gpu, err := deps.Workloadmeta.GetGPU(device.GetDeviceInfo().UUID)
 				if err != nil {
 					return nil, 0, err

--- a/pkg/collector/corechecks/gpu/nvidia/stateless.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless.go
@@ -451,7 +451,7 @@ func createStatelessAPIs(deps *CollectorDependencies) []apiCallInfo {
 		{
 			Name: "device_unhealthy_count",
 			Handler: func(device ddnvml.Device, _ uint64) ([]Metric, uint64, error) {
-				if (!env.IsFeaturePresent(env.KubernetesDevicePlugins)) {
+				if !env.IsFeaturePresent(env.KubernetesDevicePlugins) {
 					return nil, 0, ddnvml.NewNvmlAPIErrorOrNil("GetUnhealthyDevices", nvml.ERROR_NOT_SUPPORTED)
 				}
 

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -609,4 +610,63 @@ func TestProcessDetailListArchitectureSupport(t *testing.T) {
 			require.Equal(t, tt.supported, hasProcessDetailAPICall)
 		})
 	}
+}
+
+func TestDeviceUnhealthyMetricFeatureGate(t *testing.T) {
+	tests := []struct {
+		name           string
+		features       []env.Feature
+		expectMetrics  bool
+		expectError    bool
+	}{
+		{
+			name:          "not emitted when kubernetes device plugins feature is absent",
+			features:      nil,
+			expectMetrics: false,
+			expectError:   true,
+		},
+		{
+			name:          "emitted when kubernetes device plugins feature is present",
+			features:      []env.Feature{env.KubernetesDevicePlugins},
+			expectMetrics: true,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env.SetFeatures(t, tt.features...)
+
+			device := setupMockDevice(t, nil)
+			wmeta := testutil.GetWorkloadMetaMockWithDefaultGPUs(t)
+			apis := createStatelessAPIs(&CollectorDependencies{Workloadmeta: wmeta})
+			deviceUnhealthyAPI := findAPICallByName(t, apis, "device_unhealthy_count")
+
+			gotMetrics, _, err := deviceUnhealthyAPI.Handler(device, 0)
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.expectMetrics {
+				require.Len(t, gotMetrics, 1)
+				require.Equal(t, "device.unhealthy", gotMetrics[0].Name)
+			} else {
+				require.Empty(t, gotMetrics)
+			}
+		})
+	}
+}
+
+func findAPICallByName(t *testing.T, apis []apiCallInfo, name string) apiCallInfo {
+	t.Helper()
+	for _, api := range apis {
+		if api.Name == name {
+			return api
+		}
+	}
+
+	require.FailNowf(t, "api call not found", "expected API call %q to exist", name)
+	return apiCallInfo{}
 }

--- a/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
+++ b/pkg/collector/corechecks/gpu/nvidia/stateless_test.go
@@ -614,10 +614,10 @@ func TestProcessDetailListArchitectureSupport(t *testing.T) {
 
 func TestDeviceUnhealthyMetricFeatureGate(t *testing.T) {
 	tests := []struct {
-		name           string
-		features       []env.Feature
-		expectMetrics  bool
-		expectError    bool
+		name          string
+		features      []env.Feature
+		expectMetrics bool
+		expectError   bool
 	}{
 		{
 			name:          "not emitted when kubernetes device plugins feature is absent",

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/DataDog/datadog-agent/pkg/config/env"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
@@ -53,9 +52,6 @@ func TestLoadArchitecturesNotEmpty(t *testing.T) {
 // the NVML mock configured from architectures.yaml returns API behavior that matches the capability flags
 // (gpm, unsupported_fields_by_device_mode). This validates that the mock actually applies the spec.
 func TestMockCapabilitiesMatchArchitectureSpec(t *testing.T) {
-	// required to emit gpu.devices.unhealthy metric
-	env.SetFeatures(t, env.KubernetesDevicePlugins)
-
 	archSpecFile, err := LoadArchitecturesSpec()
 	require.NoError(t, err)
 

--- a/pkg/collector/corechecks/gpu/spec/spec_test.go
+++ b/pkg/collector/corechecks/gpu/spec/spec_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	ddnvml "github.com/DataDog/datadog-agent/pkg/gpu/safenvml"
 	"github.com/DataDog/datadog-agent/pkg/gpu/testutil"
 )
@@ -52,6 +53,9 @@ func TestLoadArchitecturesNotEmpty(t *testing.T) {
 // the NVML mock configured from architectures.yaml returns API behavior that matches the capability flags
 // (gpm, unsupported_fields_by_device_mode). This validates that the mock actually applies the spec.
 func TestMockCapabilitiesMatchArchitectureSpec(t *testing.T) {
+	// required to emit gpu.devices.unhealthy metric
+	env.SetFeatures(t, env.KubernetesDevicePlugins)
+
 	archSpecFile, err := LoadArchitecturesSpec()
 	require.NoError(t, err)
 


### PR DESCRIPTION
### What does this PR do?

Gates `gpu.device.unhealthy` emission on Kubernetes device-plugin health availability.

### Motivation

The unhealthy signal depends on kubelet device-plugin health. Without that source, emitting the metric can be misleading.

### Describe how you validated your changes

Unit tests added.
Ran the NVIDIA GPU check test suite with NVML test tags.

### Additional Notes