### PR TITLE
Build obfuscate package with Bazel and enable remaining rtloader test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -72,7 +72,6 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude pkg/networkconfigmanagement
 # gazelle:exclude pkg/networkdevice
 # gazelle:exclude pkg/networkpath
-# gazelle:exclude pkg/obfuscate
 # gazelle:exclude pkg/opentelemetry-mapping-go
 # gazelle:exclude pkg/orchestrator
 # gazelle:exclude pkg/persistentcache

--- a/deps/go.MODULE.bazel
+++ b/deps/go.MODULE.bazel
@@ -330,6 +330,7 @@ use_repo(
     "com_github_opencontainers_image_spec",
     "com_github_opencontainers_runtime_spec",
     "com_github_openshift_api",
+    "com_github_outcaste_io_ristretto",
     "com_github_pahanini_go_grpc_bidirectional_streaming_example",
     "com_github_patrickmn_go_cache",
     "com_github_pierrec_lz4_v4",

--- a/pkg/obfuscate/BUILD.bazel
+++ b/pkg/obfuscate/BUILD.bazel
@@ -1,0 +1,53 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "obfuscate",
+    srcs = [
+        "cache.go",
+        "credit_cards.go",
+        "http.go",
+        "ip_address.go",
+        "json.go",
+        "json_scanner.go",
+        "memcached.go",
+        "obfuscate.go",
+        "redis.go",
+        "redis_tokenizer.go",
+        "sql.go",
+        "sql_tokenizer.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/obfuscate",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_datadog_datadog_go_v5//statsd",
+        "@com_github_datadog_go_sqllexer//:go-sqllexer",
+        "@com_github_outcaste_io_ristretto//:ristretto",
+        "@com_github_outcaste_io_ristretto//z",
+        "@org_uber_go_atomic//:atomic",
+    ],
+)
+
+go_test(
+    name = "obfuscate_test",
+    srcs = [
+        "cache_test.go",
+        "credit_cards_test.go",
+        "http_test.go",
+        "ip_address_test.go",
+        "json_test.go",
+        "memcached_test.go",
+        "obfuscate_test.go",
+        "redis_test.go",
+        "redis_tokenizer_test.go",
+        "sql_fuzz_test.go",
+        "sql_test.go",
+        "sql_tokenizer_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    embed = [":obfuscate"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_uber_go_atomic//:atomic",
+    ],
+)

--- a/rtloader/test/datadog_agent/BUILD.bazel
+++ b/rtloader/test/datadog_agent/BUILD.bazel
@@ -8,15 +8,12 @@ rtloader_test_go_library(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/obfuscate",
         "//rtloader/test/common",
         "//rtloader/test/helpers",
-        "@com_github_datadog_datadog_agent_pkg_obfuscate//:obfuscate",
     ],
 )
 
-# TODO(agent-build): remove manual tag once pkg/ is migrated to Bazel.
-# @com_github_datadog_datadog_agent_pkg_obfuscate is excluded from bazelify_go_work
-# (via `# gazelle:exclude pkg` in the root BUILD.bazel) so it cannot be fetched yet.
 rtloader_go_test(
     name = "datadog_agent_test",
     srcs = [
@@ -24,6 +21,5 @@ rtloader_go_test(
         "datadog_agent_test.go",
     ],
     embed = [":datadog_agent"],
-    tags = ["manual"],
     deps = ["//rtloader/test/helpers"],
 )


### PR DESCRIPTION
### What does this PR do?

Adds BUILD file to `/pkg/obfuscate` (via gazelle, having lifted the corresponding exclude), and removes the `manual` tag from the rtloader test that depends on this package, such that tests run under `bazel test //...` invocations.

### Motivation

As part of [ABLD-323](https://datadoghq.atlassian.net/browse/ABLD-323), making sure that all rtloader tests are covered before deprecating the CMake builds entirely.

### Describe how you validated your changes

Everything relevant runs on CI.

### Additional Notes


[ABLD-323]: https://datadoghq.atlassian.net/browse/ABLD-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ