### PR TITLE
Run `bazel mod tidy` before `go work sync`

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -378,13 +378,15 @@ def _go_only_tidy(ctx, verbose: bool):
 
 
 def _bazel_tidy(ctx, verbose: bool):
-    # 1. go.work + **/go.mod -> **/go.mod (sync each workspace module's deps to the workspace build list)
-    bazel("run", "//:go", "work", "sync")
-    # 2. **/*.go + **/go.mod -> **/go.mod, **/go.sum (reconcile each module's requirements with its actual imports)
-    bazel("run", "//:go_mod_tidy_all", *(("--", "-x") if verbose else ()))
-    # 3. go.work + **/go.mod -> deps/go.MODULE.bazel (update use_repo declarations)
+    # 1. deps/go.MODULE.bazel ↺ (prune stale use_repo declarations to not hinder next `bazel` commands)
     bazel("mod", "tidy")
-    # 4. deps/go.MODULE.bazel + /BUILD.bazel + **/*.go + **/go.mod -> **/BUILD.bazel (infer build rules from Go source)
+    # 2. go.work + **/go.mod -> **/go.mod (sync each workspace module's deps to the workspace build list)
+    bazel("run", "//:go", "work", "sync")
+    # 3. **/*.go + **/go.mod -> **/go.mod, **/go.sum (reconcile each module's requirements with its actual imports)
+    bazel("run", "//:go_mod_tidy_all", *(("--", "-x") if verbose else ()))
+    # 4. go.work + **/go.mod -> deps/go.MODULE.bazel (update use_repo declarations)
+    bazel("mod", "tidy")
+    # 5. deps/go.MODULE.bazel + /BUILD.bazel + **/*.go + **/go.mod -> **/BUILD.bazel (infer build rules from Go source)
     bazel("run", "//:gazelle")
 
 


### PR DESCRIPTION
### What does this PR do?
Run `bazel mod tidy` as the first step of `inv tidy` so that stale `use_repo` declarations in `deps/go.MODULE.bazel` are pruned before any subsequent `bazel` command tries to load the workspace.

### Motivation
See [internal discussion](https://dd.slack.com/archives/C08SK4B0FK8/p1773737438264459).
When a Go dependency is removed, `deps/go.MODULE.bazel` may still reference it via `use_repo`.
This causes `bazel run //:go work sync` the previous first step) to fail with errors like:
```
deps/go.MODULE.bazel:5:24: The module extension go_deps defined in @gazelle//:extensions.bzl reported incorrect imports of repositories via use_repo():

Imported, but not created by the extension (will cause the build to fail):
    com_github_datadog_gopsutil

Fix the use_repo calls by running 'bazel mod tidy'.
ERROR: module extension @@gazelle+//:extensions.bzl%go_deps does not generate repository "com_github_datadog_gopsutil", yet it is imported as "com_github_datadog_gopsutil" in the usage at deps/go.MODULE.bazel:5:24
```
`bazel mod tidy` is idempotent and cheap when nothing changed, so running it first is safe in all cases.

### Describe how you validated your changes
Reproduced the failure from commit 7c4b8fd42604e4348cb582873ee127c5ef1d517d by leaving the stale `use_repo` entry in place and confirmed `inv tidy` now self-heals it without manual intervention.