### PR TITLE
Bar.fins/usm e2e tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1288,15 +1288,17 @@ workflow:
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
-.on_windows_systemprobe_or_e2e_changes:
+.on_systemprobe_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
   - changes:
       paths:
         - pkg/discovery/module/*
         - pkg/network/**/*
+        - pkg/process/checks/**/*
         - pkg/process/monitor/*
         - pkg/util/kernel/**/*
         - test/new-e2e/tests/sysprobe-functional/**/*
+        - test/new-e2e/tests/usm/**/*
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 

--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -621,6 +621,20 @@ new-e2e-sbom:
     matrix:
       - EXTRA_PARAMS: --run "TestSBOMKindSuite"
 
+new-e2e-usm:
+  extends: .new_e2e_template
+  needs:
+    - !reference [.needs_new_e2e_template]
+    - agent_deb-x64-a7
+    - qa_agent_linux
+  rules:
+    - !reference [.on_systemprobe_or_e2e_changes]
+    - !reference [.manual]
+  variables:
+    TARGETS: ./tests/usm
+    EXTRA_PARAMS: --run TestPythonRemoteTagsLinuxSuite
+    TEAM: cloud-network-monitoring
+
 new-e2e-discovery:
   extends: .new_e2e_template
   needs:

--- a/.gitlab/windows/test/e2e/windows.yml
+++ b/.gitlab/windows/test/e2e/windows.yml
@@ -184,7 +184,7 @@ new-e2e-netpath-windows:
 new-e2e-windows-systemprobe:
   extends: .new_e2e_template
   rules:
-    - !reference [.on_windows_systemprobe_or_e2e_changes]
+    - !reference [.on_systemprobe_or_e2e_changes]
     - !reference [.manual]
   needs:
     - !reference [.needs_new_e2e_template]
@@ -198,6 +198,10 @@ new-e2e-windows-systemprobe:
     matrix:
       - EXTRA_PARAMS: --run TestUSMAutoTaggingSuite
       - EXTRA_PARAMS: --run TestVMSuite
+      - TARGETS: ./tests/usm
+        EXTRA_PARAMS: --run TestIISRemoteTagsSuite
+      - TARGETS: ./tests/usm
+        EXTRA_PARAMS: --run TestHTTPRemoteTagsWindowsSuite
 
 new-e2e-windows-security-agent:
   extends: .new_e2e_template

--- a/test/new-e2e/tests/usm/config.go
+++ b/test/new-e2e/tests/usm/config.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+// Package usm contains E2E tests for Universal Service Monitoring
+package usm
+
+import _ "embed"
+
+// systemProbeConfig defines the system-probe configuration for USM HTTP monitoring.
+//
+//go:embed config/usm.yaml
+var systemProbeConfig string

--- a/test/new-e2e/tests/usm/config.go
+++ b/test/new-e2e/tests/usm/config.go
@@ -12,3 +12,7 @@ import _ "embed"
 //
 //go:embed config/usm.yaml
 var systemProbeConfig string
+
+// systemProbeConfigDirect is systemProbeConfig with direct send enabled
+// (payloads sent directly from system-probe instead of process-agent).
+var systemProbeConfigDirect = systemProbeConfig + "\nnetwork_config:\n  direct_send: true\n"

--- a/test/new-e2e/tests/usm/config/usm.yaml
+++ b/test/new-e2e/tests/usm/config/usm.yaml
@@ -1,0 +1,6 @@
+log_level: debug
+service_monitoring_config:
+  enabled: true
+  enable_http_monitoring: true
+  process_service_inference:
+    enabled: true

--- a/test/new-e2e/tests/usm/ec2_1host_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_python_test.go
@@ -24,7 +24,7 @@ type pythonRemoteTagsLinuxSuite struct {
 }
 
 func TestPythonRemoteTagsLinuxSuite(t *testing.T) {
-	//t.Skip("Skip until lower connection capture rate on Linux is resolved")
+	t.Skip("Skip until lower connection capture rate on Linux is resolved")
 	t.Parallel()
 
 	e2eParams := []e2e.SuiteOption{

--- a/test/new-e2e/tests/usm/ec2_1host_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_python_test.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package usm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+
+	"github.com/stretchr/testify/require"
+)
+
+// pythonRemoteTagsLinuxSuite tests remote service tags with a Python HTTP server on Linux.
+type pythonRemoteTagsLinuxSuite struct {
+	e2e.BaseSuite[environments.Host]
+}
+
+func TestPythonRemoteTagsLinuxSuite(t *testing.T) {
+	//t.Skip("Skip until lower connection capture rate on Linux is resolved")
+	t.Parallel()
+
+	e2eParams := []e2e.SuiteOption{
+		e2e.WithProvisioner(awshost.Provisioner(
+			awshost.WithRunOptions(
+				scenec2.WithAgentOptions(
+					agentparams.WithAgentConfig("log_level: debug"),
+					agentparams.WithSystemProbeConfig(systemProbeConfig),
+					agentparams.WithPipeline("102560690"),
+				),
+			),
+		)),
+	}
+
+	e2e.Run(t, &pythonRemoteTagsLinuxSuite{}, e2eParams...)
+}
+
+func (s *pythonRemoteTagsLinuxSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+
+	host := s.Env().RemoteHost
+
+	// Verify python3 is available on the host.
+	_, err := host.Execute("python3 --version")
+	require.NoError(s.T(), err, "python3 not found on remote host")
+
+	// Write and start socket-based HTTP servers on ports 8081 and 8082.
+	_, err = host.WriteFile("/tmp/httpserver.py", []byte(httpServerScript))
+	require.NoError(s.T(), err, "failed to write HTTP server script")
+	host.MustExecute("nohup python3 /tmp/httpserver.py 8081 > /tmp/http8081.log 2>&1 </dev/null &")
+	host.MustExecute("nohup python3 /tmp/httpserver.py 8082 > /tmp/http8082.log 2>&1 </dev/null &")
+
+	time.Sleep(2 * time.Second)
+
+	_, err = host.Execute(`python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8081/')"`)
+	require.NoError(s.T(), err, "HTTP server on port 8081 not responding")
+	_, err = host.Execute(`python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8082/')"`)
+	require.NoError(s.T(), err, "HTTP server on port 8082 not responding")
+}
+
+func (s *pythonRemoteTagsLinuxSuite) BeforeTest(suiteName, testName string) {
+	s.BaseSuite.BeforeTest(suiteName, testName)
+
+	if !s.BaseSuite.IsDevMode() {
+		s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	}
+}
+
+// TestPythonRemoteServiceTags verifies that connections to Python HTTP servers
+// have RemoteServiceTagsIdx >= 0 with process-based remote service tags.
+func (s *pythonRemoteTagsLinuxSuite) TestPythonRemoteServiceTags() {
+	t := s.T()
+	host := s.Env().RemoteHost
+
+	const requestsPerPort = 4000
+	sendPythonHTTPRequests(host, "python3", requestsPerPort)
+	fetchAndAssertTaggedConnections(t, s.Env().FakeIntake.Client(), "python", requestsPerPort)
+}

--- a/test/new-e2e/tests/usm/ec2_1host_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_python_test.go
@@ -33,7 +33,7 @@ func TestPythonRemoteTagsLinuxSuite(t *testing.T) {
 				scenec2.WithAgentOptions(
 					agentparams.WithAgentConfig("log_level: debug"),
 					agentparams.WithSystemProbeConfig(systemProbeConfig),
-					agentparams.WithPipeline("102560690"),
+					agentparams.WithPipeline("102564312"),
 				),
 			),
 		)),

--- a/test/new-e2e/tests/usm/ec2_1host_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_python_test.go
@@ -24,8 +24,8 @@ type pythonRemoteTagsLinuxSuite struct {
 }
 
 func TestPythonRemoteTagsLinuxSuite(t *testing.T) {
-	t.Skip("Skip until lower connection capture rate on Linux is resolved")
 	t.Parallel()
+	t.Skip("Skip until lower connection capture rate on Linux is resolved")
 
 	e2eParams := []e2e.SuiteOption{
 		e2e.WithProvisioner(awshost.Provisioner(
@@ -82,4 +82,27 @@ func (s *pythonRemoteTagsLinuxSuite) TestPythonRemoteServiceTags() {
 	const requestsPerPort = 4000
 	sendPythonHTTPRequests(host, "python3", requestsPerPort)
 	fetchAndAssertTaggedConnections(t, s.Env().FakeIntake.Client(), "python", requestsPerPort)
+}
+
+// pythonRemoteTagsDirectLinuxSuite is the direct send variant of pythonRemoteTagsLinuxSuite.
+type pythonRemoteTagsDirectLinuxSuite struct {
+	pythonRemoteTagsLinuxSuite
+}
+
+func TestPythonRemoteTagsDirectLinuxSuite(t *testing.T) {
+	t.Parallel()
+	t.Skip("Skip until lower connection capture rate on Linux is resolved")
+
+	e2eParams := []e2e.SuiteOption{
+		e2e.WithProvisioner(awshost.Provisioner(
+			awshost.WithRunOptions(
+				scenec2.WithAgentOptions(
+					agentparams.WithAgentConfig("log_level: debug"),
+					agentparams.WithSystemProbeConfig(systemProbeConfigDirect),
+				),
+			),
+		)),
+	}
+
+	e2e.Run(t, &pythonRemoteTagsDirectLinuxSuite{}, e2eParams...)
 }

--- a/test/new-e2e/tests/usm/ec2_1host_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_python_test.go
@@ -33,7 +33,6 @@ func TestPythonRemoteTagsLinuxSuite(t *testing.T) {
 				scenec2.WithAgentOptions(
 					agentparams.WithAgentConfig("log_level: debug"),
 					agentparams.WithSystemProbeConfig(systemProbeConfig),
-					agentparams.WithPipeline("102564312"), // TODO: remove once dependency branch is merged to main
 				),
 			),
 		)),

--- a/test/new-e2e/tests/usm/ec2_1host_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_python_test.go
@@ -33,7 +33,7 @@ func TestPythonRemoteTagsLinuxSuite(t *testing.T) {
 				scenec2.WithAgentOptions(
 					agentparams.WithAgentConfig("log_level: debug"),
 					agentparams.WithSystemProbeConfig(systemProbeConfig),
-					agentparams.WithPipeline("102564312"),
+					agentparams.WithPipeline("102564312"), // TODO: remove once dependency branch is merged to main
 				),
 			),
 		)),

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_iis_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_iis_test.go
@@ -49,7 +49,6 @@ func iisHostProvisionerWindows() provisioners.PulumiEnvRunFunc[environments.Wind
 			ec2windows.WithAgentOptions(
 				agentparams.WithAgentConfig("log_level: debug"),
 				agentparams.WithSystemProbeConfig(systemProbeConfig),
-				agentparams.WithPipeline("102564312"), // TODO: remove once dependency branch is merged to main
 			),
 		}
 		params := ec2windows.GetRunParams(opts...)

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_iis_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_iis_test.go
@@ -49,7 +49,7 @@ func iisHostProvisionerWindows() provisioners.PulumiEnvRunFunc[environments.Wind
 			ec2windows.WithAgentOptions(
 				agentparams.WithAgentConfig("log_level: debug"),
 				agentparams.WithSystemProbeConfig(systemProbeConfig),
-				agentparams.WithPipeline("102560690"),
+				agentparams.WithPipeline("102564312"),
 			),
 		}
 		params := ec2windows.GetRunParams(opts...)

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_iis_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_iis_test.go
@@ -49,7 +49,7 @@ func iisHostProvisionerWindows() provisioners.PulumiEnvRunFunc[environments.Wind
 			ec2windows.WithAgentOptions(
 				agentparams.WithAgentConfig("log_level: debug"),
 				agentparams.WithSystemProbeConfig(systemProbeConfig),
-				agentparams.WithPipeline("102564312"),
+				agentparams.WithPipeline("102564312"), // TODO: remove once dependency branch is merged to main
 			),
 		}
 		params := ec2windows.GetRunParams(opts...)

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_iis_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_iis_test.go
@@ -1,0 +1,152 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package usm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/resources/aws"
+	ec2windows "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2/windows"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners"
+	"github.com/DataDog/datadog-agent/test/new-e2e/tests/windows"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type iisRemoteTagsSuite struct {
+	e2e.BaseSuite[environments.WindowsHost]
+}
+
+func TestIISRemoteTagsSuite(t *testing.T) {
+	t.Parallel()
+
+	s := &iisRemoteTagsSuite{}
+
+	e2eParams := []e2e.SuiteOption{
+		e2e.WithProvisioner(provisioners.NewTypedPulumiProvisioner("iisHost", iisHostProvisionerWindows(), nil)),
+	}
+
+	e2e.Run(t, s, e2eParams...)
+}
+
+func iisHostProvisionerWindows() provisioners.PulumiEnvRunFunc[environments.WindowsHost] {
+	return func(ctx *pulumi.Context, env *environments.WindowsHost) error {
+		awsEnv, err := aws.NewEnvironment(ctx)
+		if err != nil {
+			return err
+		}
+		opts := []ec2windows.RunOption{
+			ec2windows.WithAgentOptions(
+				agentparams.WithAgentConfig("log_level: debug"),
+				agentparams.WithSystemProbeConfig(systemProbeConfig),
+				agentparams.WithPipeline("102560690"),
+			),
+		}
+		params := ec2windows.GetRunParams(opts...)
+		return ec2windows.RunWithEnv(ctx, awsEnv, env, params)
+	}
+}
+
+func (s *iisRemoteTagsSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+
+	host := s.Env().RemoteHost
+
+	// Install IIS BEFORE deploying binaries so system-probe's IIS ETW provider
+	// initializes correctly when the agent services restart.
+	err := windows.InstallIIS(host)
+	require.NoError(s.T(), err, "failed to install IIS")
+
+	sites := []windows.IISSiteDefinition{
+		{
+			Name:        "DatadogTestSiteA",
+			BindingPort: "*:8081:",
+		},
+		{
+			Name:        "DatadogTestSiteB",
+			BindingPort: "*:8082:",
+		},
+	}
+	err = windows.CreateIISSite(host, sites)
+	require.NoError(s.T(), err, "failed to create IIS sites")
+
+	// Write a default document so IIS returns 200 instead of 403.14
+	for _, site := range sites {
+		sitePath := "c:/tmp/inetpub/" + site.Name + "/index.html"
+		_, err = host.WriteFile(sitePath, []byte("<html><body>ok</body></html>"))
+		require.NoError(s.T(), err, "failed to write default document for %s", site.Name)
+	}
+
+	// Restart the agent so system-probe's IIS ETW provider initializes
+	// now that IIS is installed. In CI the agent was started before IIS.
+	host.MustExecute("Stop-Service datadogagent -Force")
+	time.Sleep(5 * time.Second)
+	host.MustExecute("Start-Service datadogagent")
+	time.Sleep(15 * time.Second)
+
+	// In CI, the provisioner installs the agent built from the current branch.
+	// For local dev, uncomment to deploy locally-built binaries:
+	// deployWindowsBinaries(s.T(), host)
+}
+
+func (s *iisRemoteTagsSuite) BeforeTest(suiteName, testName string) {
+	s.BaseSuite.BeforeTest(suiteName, testName)
+
+	if !s.BaseSuite.IsDevMode() {
+		s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	}
+}
+
+// TestIISRemoteServiceTags verifies that connections to IIS sites have
+// RemoteServiceTagsIdx >= 0 with tags containing http.iis.sitename: prefix.
+// It sends connections to each site sequentially, verifying tags after each,
+// then sends to the second site to exercise cache key replacement in the IIS
+// ETW tag cache when ephemeral ports are reused (cache entries have 2-minute TTL).
+func (s *iisRemoteTagsSuite) TestIISRemoteServiceTags() {
+	t := s.T()
+	host := s.Env().RemoteHost
+	const count = 1000
+
+	// Flush any stale data from previous runs (e.g. when reusing --keep-stack).
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+
+	// Step 1: send 1000 connections to site A (port 8081), hold 20s, then verify.
+	sendWindowsKeepAliveRequestsToPort(host, 8081, count, 20)
+	time.Sleep(30 * time.Second)
+
+	cnx, err := s.Env().FakeIntake.Client().GetConnections()
+	require.NoError(t, err, "GetConnections() error")
+	require.NotNil(t, cnx, "GetConnections() returned nil")
+
+	stats := getConnectionStats(t, cnx, "http.iis.sitename:")
+	assertTaggedConnectionsOnPort(t, stats, "siteA", 8081, count)
+	assert.True(t, stats.tagsByPort[8081]["http.iis.sitename:DatadogTestSiteA"],
+		"siteA: port 8081 should be tagged with DatadogTestSiteA")
+
+	// Step 2: quickly send 1000 connections to site B (port 8082).
+	// Ephemeral ports from step 1 are recycled by the OS, exercising IIS ETW
+	// cache key replacement (entries have a 2-minute TTL).
+	s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	sendWindowsKeepAliveRequestsToPort(host, 8082, count, 20)
+	time.Sleep(30 * time.Second)
+
+	cnx, err = s.Env().FakeIntake.Client().GetConnections()
+	require.NoError(t, err, "GetConnections() error")
+	require.NotNil(t, cnx, "GetConnections() returned nil")
+
+	stats = getConnectionStats(t, cnx, "http.iis.sitename:")
+	assertTaggedConnectionsOnPort(t, stats, "siteB", 8082, count)
+	assert.True(t, stats.tagsByPort[8082]["http.iis.sitename:DatadogTestSiteB"],
+		"siteB: port 8082 should be tagged with DatadogTestSiteB")
+}

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
@@ -1,0 +1,101 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package usm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	ec2windows "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2/windows"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	winawshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host/windows"
+
+	"github.com/stretchr/testify/require"
+)
+
+// httpRemoteTagsWindowsSuite tests remote service tags with an HTTP listener on Windows.
+type httpRemoteTagsWindowsSuite struct {
+	e2e.BaseSuite[environments.WindowsHost]
+}
+
+func TestHTTPRemoteTagsWindowsSuite(t *testing.T) {
+	t.Parallel()
+
+	e2eParams := []e2e.SuiteOption{
+		e2e.WithProvisioner(winawshost.Provisioner(
+			winawshost.WithRunOptions(
+				ec2windows.WithAgentOptions(
+					agentparams.WithAgentConfig("log_level: debug"),
+					agentparams.WithSystemProbeConfig(systemProbeConfig),
+					agentparams.WithPipeline("102560690"),
+				),
+			),
+		)),
+	}
+
+	e2e.Run(t, &httpRemoteTagsWindowsSuite{}, e2eParams...)
+}
+
+func (s *httpRemoteTagsWindowsSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+
+	host := s.Env().RemoteHost
+
+	// Kill anything listening on test ports from previous runs on a reused stack.
+	host.Execute(`(Get-NetTCPConnection -LocalPort 8081,8082 -State Listen -ErrorAction SilentlyContinue).OwningProcess | Sort-Object -Unique | ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }`)
+	time.Sleep(2 * time.Second)
+
+	// Find the embedded Python executable.
+	pythonExe := `C:\Program Files\Datadog\Datadog Agent\embedded3\python.exe`
+	out, err := host.Execute(`Test-Path "` + pythonExe + `"`)
+	require.Contains(s.T(), out, "True", "embedded Python not found at %s", pythonExe)
+
+	// Write the shared socket-based HTTP server script.
+	host.MustExecute(`New-Item -ItemType Directory -Force -Path C:\temp | Out-Null`)
+	_, err = host.WriteFile(`C:\temp\httpserver.py`, []byte(httpServerScript))
+	require.NoError(s.T(), err, "failed to write HTTP server script")
+
+	// Start servers using WMI to create truly detached processes that survive SSH session cleanup.
+	// Start-Process spawned children get killed when the SSH session ends; WMI-created processes
+	// are fully detached from the session.
+	for _, port := range []string{"8081", "8082"} {
+		out, err = host.Execute(`$r = Invoke-CimMethod -ClassName Win32_Process -MethodName Create -Arguments @{` +
+			`CommandLine='"` + pythonExe + `" C:\temp\httpserver.py ` + port + `'}; ` +
+			`Write-Output "port` + port + `: pid=$($r.ProcessId) rc=$($r.ReturnValue)"`)
+		require.NoError(s.T(), err, "WMI process creation failed for port %s", port)
+		require.Contains(s.T(), out, "rc=0", "WMI process creation returned non-zero for port %s", port)
+	}
+
+	time.Sleep(5 * time.Second)
+
+	_, err = host.Execute("Invoke-WebRequest -UseBasicParsing http://localhost:8081/")
+	require.NoError(s.T(), err, "Python HTTP server on port 8081 not responding")
+	_, err = host.Execute("Invoke-WebRequest -UseBasicParsing http://localhost:8082/")
+	require.NoError(s.T(), err, "Python HTTP server on port 8082 not responding")
+}
+
+func (s *httpRemoteTagsWindowsSuite) BeforeTest(suiteName, testName string) {
+	s.BaseSuite.BeforeTest(suiteName, testName)
+
+	if !s.BaseSuite.IsDevMode() {
+		s.Env().FakeIntake.Client().FlushServerAndResetAggregators()
+	}
+}
+
+// TestHTTPRemoteServiceTags verifies that connections to HTTP listeners
+// have RemoteServiceTagsIdx >= 0 with process-based remote service tags.
+func (s *httpRemoteTagsWindowsSuite) TestHTTPRemoteServiceTags() {
+	t := s.T()
+	host := s.Env().RemoteHost
+
+	const requestsPerPort = 4000
+	sendWindowsKeepAliveRequestsToPort(host, 8081, requestsPerPort, 20)
+	sendWindowsKeepAliveRequestsToPort(host, 8082, requestsPerPort, 20)
+	fetchAndAssertTaggedConnections(t, s.Env().FakeIntake.Client(), "http", requestsPerPort)
+}

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
@@ -32,7 +32,7 @@ func TestHTTPRemoteTagsWindowsSuite(t *testing.T) {
 				ec2windows.WithAgentOptions(
 					agentparams.WithAgentConfig("log_level: debug"),
 					agentparams.WithSystemProbeConfig(systemProbeConfig),
-					agentparams.WithPipeline("102564312"),
+					agentparams.WithPipeline("102564312"), // TODO: remove once dependency branch is merged to main
 				),
 			),
 		)),

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
@@ -53,12 +53,12 @@ func (s *httpRemoteTagsWindowsSuite) SetupSuite() {
 
 	// Find the embedded Python executable.
 	pythonExe := `C:\Program Files\Datadog\Datadog Agent\embedded3\python.exe`
-	out, err := host.Execute(`Test-Path "` + pythonExe + `"`)
+	out, _ := host.Execute(`Test-Path "` + pythonExe + `"`)
 	require.Contains(s.T(), out, "True", "embedded Python not found at %s", pythonExe)
 
 	// Write the shared socket-based HTTP server script.
 	host.MustExecute(`New-Item -ItemType Directory -Force -Path C:\temp | Out-Null`)
-	_, err = host.WriteFile(`C:\temp\httpserver.py`, []byte(httpServerScript))
+	_, err := host.WriteFile(`C:\temp\httpserver.py`, []byte(httpServerScript))
 	require.NoError(s.T(), err, "failed to write HTTP server script")
 
 	// Start servers using WMI to create truly detached processes that survive SSH session cleanup.

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
@@ -32,7 +32,6 @@ func TestHTTPRemoteTagsWindowsSuite(t *testing.T) {
 				ec2windows.WithAgentOptions(
 					agentparams.WithAgentConfig("log_level: debug"),
 					agentparams.WithSystemProbeConfig(systemProbeConfig),
-					agentparams.WithPipeline("102564312"), // TODO: remove once dependency branch is merged to main
 				),
 			),
 		)),

--- a/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
+++ b/test/new-e2e/tests/usm/ec2_1host_wkit_python_test.go
@@ -32,7 +32,7 @@ func TestHTTPRemoteTagsWindowsSuite(t *testing.T) {
 				ec2windows.WithAgentOptions(
 					agentparams.WithAgentConfig("log_level: debug"),
 					agentparams.WithSystemProbeConfig(systemProbeConfig),
-					agentparams.WithPipeline("102560690"),
+					agentparams.WithPipeline("102564312"),
 				),
 			),
 		)),

--- a/test/new-e2e/tests/usm/helpers.go
+++ b/test/new-e2e/tests/usm/helpers.go
@@ -109,7 +109,7 @@ func getConnectionStats(t *testing.T, cnx *aggregator.ConnectionsAggregator, req
 		tagsByPort:       make(map[int32]map[string]bool),
 	}
 
-	cnx.ForeachConnection(func(conn *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
+	cnx.ForeachConnection(func(conn *agentmodel.Connection, cc *agentmodel.CollectorConnections, _ string) {
 		port := conn.Raddr.Port
 		if port != 8081 && port != 8082 {
 			return

--- a/test/new-e2e/tests/usm/helpers.go
+++ b/test/new-e2e/tests/usm/helpers.go
@@ -1,0 +1,170 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package usm
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	agentmodel "github.com/DataDog/agent-payload/v5/process"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/components"
+	"github.com/DataDog/datadog-agent/test/fakeintake/aggregator"
+	fi "github.com/DataDog/datadog-agent/test/fakeintake/client"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// httpServerScript is a minimal HTTP server using only the socket module.
+// It supports keep-alive connections and is used on both Linux and Windows.
+const httpServerScript = `import socket, sys
+port = int(sys.argv[1])
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("0.0.0.0", port))
+s.listen(8192)
+while True:
+    conn, addr = s.accept()
+    conn.recv(4096)
+    conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok")
+    conn.close()
+`
+
+// sendPythonHTTPRequests sends requestsPerPort keep-alive HTTP GET requests to each
+// of ports 8081 and 8082, then holds the process alive for 20 seconds so the agent
+// has time to capture all connections before they are cleaned up at process exit.
+func sendPythonHTTPRequests(host *components.RemoteHost, pythonCmd string, requestsPerPort int) {
+	host.MustExecute(fmt.Sprintf(`bash -c 'ulimit -n 16384 && %s -c "
+import http.client, time
+
+conns = []
+for port in [8081, 8082]:
+    for i in range(%d):
+        c = http.client.HTTPConnection(\"127.0.0.1\", port)
+        c.request(\"GET\", \"/\")
+        c.getresponse()
+        conns.append(c)
+
+time.sleep(90)
+print(\"done\")
+"'`, pythonCmd, requestsPerPort))
+}
+
+// sendWindowsKeepAliveRequestsToPort opens count keep-alive connections to
+// localhost:<port>, holds them open for holdSeconds, then closes them.
+func sendWindowsKeepAliveRequestsToPort(host *components.RemoteHost, port, count, holdSeconds int) {
+	connLimit := count + 100
+	host.MustExecute(fmt.Sprintf(
+		`[System.Net.ServicePointManager]::DefaultConnectionLimit = %d; `+
+			`$resps = [System.Collections.ArrayList]::new(); `+
+			`1..%d | ForEach-Object { `+
+			`$r = [System.Net.HttpWebRequest]::Create("http://localhost:%d/"); `+
+			`$r.KeepAlive = $true; `+
+			`$r.ConnectionGroupName = [guid]::NewGuid().ToString(); `+
+			`[void]$resps.Add($r.GetResponse()) }; `+
+			`Start-Sleep -Seconds %d; `+
+			`$resps | ForEach-Object { $_.Close() }`,
+		connLimit, count, port, holdSeconds))
+}
+
+// fetchAndAssertTaggedConnections waits for the agent to forward connections to
+// fakeintake, then asserts that connections on ports 8081/8082 have the expected tags.
+func fetchAndAssertTaggedConnections(t *testing.T, fi *fi.Client, label string, minPerPort int) {
+	t.Helper()
+
+	time.Sleep(60 * time.Second)
+
+	cnx, err := fi.GetConnections()
+	require.NoError(t, err, "GetConnections() error")
+	require.NotNil(t, cnx, "GetConnections() returned nil")
+
+	stats := getConnectionStats(t, cnx, "process_context:")
+	assertTaggedConnectionsOnPort(t, stats, label, 8081, minPerPort)
+	assertTaggedConnectionsOnPort(t, stats, label, 8082, minPerPort)
+}
+
+// connectionStats holds the results of counting connections on test ports from FakeIntake.
+type connectionStats struct {
+	connsByPort      map[int32]int
+	untaggedByPort   map[int32]int
+	missingByTagPort map[int32]map[string]int
+	tagsByPort       map[int32]map[string]bool
+}
+
+// getConnectionStats fetches connections from FakeIntake and counts connections
+// on ports 8081/8082. For each connection it checks whether all requiredTagPrefixes
+// are present in the remote service tags, counting how many connections are missing each.
+func getConnectionStats(t *testing.T, cnx *aggregator.ConnectionsAggregator, requiredTagPrefixes ...string) connectionStats {
+	t.Helper()
+	stats := connectionStats{
+		connsByPort:      make(map[int32]int),
+		untaggedByPort:   make(map[int32]int),
+		missingByTagPort: make(map[int32]map[string]int),
+		tagsByPort:       make(map[int32]map[string]bool),
+	}
+
+	cnx.ForeachConnection(func(conn *agentmodel.Connection, cc *agentmodel.CollectorConnections, hostname string) {
+		port := conn.Raddr.Port
+		if port != 8081 && port != 8082 {
+			return
+		}
+		stats.connsByPort[port]++
+		if stats.missingByTagPort[port] == nil {
+			stats.missingByTagPort[port] = make(map[string]int)
+		}
+		if conn.RemoteServiceTagsIdx < 0 {
+			stats.untaggedByPort[port]++
+			for _, prefix := range requiredTagPrefixes {
+				stats.missingByTagPort[port][prefix]++
+			}
+			return
+		}
+		remoteTags := cc.GetTags(int(conn.RemoteServiceTagsIdx))
+		if stats.tagsByPort[port] == nil {
+			stats.tagsByPort[port] = make(map[string]bool)
+		}
+		found := make(map[string]bool)
+		for _, tag := range remoteTags {
+			stats.tagsByPort[port][tag] = true
+			for _, prefix := range requiredTagPrefixes {
+				if strings.HasPrefix(tag, prefix) {
+					found[prefix] = true
+				}
+			}
+		}
+		for _, prefix := range requiredTagPrefixes {
+			if !found[prefix] {
+				stats.missingByTagPort[port][prefix]++
+			}
+		}
+	})
+
+	return stats
+}
+
+// assertTaggedConnectionsOnPort asserts that at least minConns connections were captured
+// on a specific port, that none are untagged, and that no connections are missing any
+// required tag prefix.
+func assertTaggedConnectionsOnPort(t *testing.T, stats connectionStats, label string, port int32, minConns int) {
+	t.Helper()
+
+	t.Logf("%s: port%d=%d untagged=%d missingByTag=%v tags=%v",
+		label, port, stats.connsByPort[port], stats.untaggedByPort[port],
+		stats.missingByTagPort[port], stats.tagsByPort[port])
+
+	assert.GreaterOrEqual(t, stats.connsByPort[port], minConns,
+		"%s: port %d should have at least %d connections", label, port, minConns)
+	assert.Equal(t, 0, stats.untaggedByPort[port],
+		"%s: port %d has untagged connections", label, port)
+	for prefix, count := range stats.missingByTagPort[port] {
+		assert.Equal(t, 0, count,
+			"%s: %d/%d connections missing required tag prefix %q", label, count,
+			stats.connsByPort[port], prefix)
+	}
+}


### PR DESCRIPTION
### What does this PR do?
E2E tests for remote service tags on Linux (Python), Windows (Python), and Windows (IIS). Agent binaries are installed from pipeline 102560690 on bar.fins/add-dependency-map-logic-same-host-services.

### Motivation
Make sure the remote tags feature works correctly

### Describe how you validated your changes
running thosw e2e + unit test

### Additional Notes
https://datadoghq.atlassian.net/browse/USMON-1523