### PR TITLE
[APPSEC] Fix injection validation and testing RBAC for istio-gateway and envoy-gateway

### DIFF
--- a/pkg/clusteragent/appsec/envoygateway/envoy.go
+++ b/pkg/clusteragent/appsec/envoygateway/envoy.go
@@ -60,7 +60,7 @@ func (e *envoyGatewayInjectionPattern) Mode() appsecconfig.InjectionMode {
 func (e *envoyGatewayInjectionPattern) IsInjectionPossible(ctx context.Context) error {
 	// Check if the processor service name is configured (required for envoy-gateway)
 	if e.config.Processor.ServiceName == "" {
-		return fmt.Errorf("processor service name is required for envoy-gateway proxy type but is not configured")
+		return stdErrors.New("processor service name is required for envoy-gateway proxy type but is not configured")
 	}
 
 	// Verify the processor service exists in the cluster

--- a/pkg/clusteragent/appsec/envoygateway/envoy.go
+++ b/pkg/clusteragent/appsec/envoygateway/envoy.go
@@ -58,12 +58,25 @@ func (e *envoyGatewayInjectionPattern) Mode() appsecconfig.InjectionMode {
 }
 
 func (e *envoyGatewayInjectionPattern) IsInjectionPossible(ctx context.Context) error {
+	// Check if the processor service name is configured (required for envoy-gateway)
+	if e.config.Processor.ServiceName == "" {
+		return fmt.Errorf("processor service name is required for envoy-gateway proxy type but is not configured")
+	}
+
+	// Verify the processor service exists in the cluster
+	_, err := e.client.Resource(schema.GroupVersionResource{Resource: "services", Version: "v1"}).
+		Namespace(e.config.Processor.Namespace).
+		Get(ctx, e.config.Processor.ServiceName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("processor service %q not found in namespace %q: %w", e.config.Processor.ServiceName, e.config.Processor.Namespace, err)
+	}
+
 	gvrToName := func(gvr schema.GroupVersionResource) string {
 		return gvr.Resource + "." + gvr.Group
 	}
 
 	// Check if the EnvoyExtensionPolicy CRD is present
-	_, err := e.client.Resource(crdGVR).Get(ctx, gvrToName(extensionGVR), metav1.GetOptions{})
+	_, err = e.client.Resource(crdGVR).Get(ctx, gvrToName(extensionGVR), metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return fmt.Errorf("%w: EnvoyExtensionPolicy CRD not found, is the Envoy Gateway installed in the cluster? Cannot enable appsec proxy injection for envoy-gateway", err)
 	}

--- a/pkg/clusteragent/appsec/envoygateway/envoy.go
+++ b/pkg/clusteragent/appsec/envoygateway/envoy.go
@@ -39,6 +39,7 @@ var (
 	gatewayGVR   = schema.GroupVersionResource{Resource: "gateways", Group: "gateway.networking.k8s.io", Version: "v1"}
 	extensionGVR = schema.GroupVersionResource{Resource: "envoyextensionpolicies", Group: "gateway.envoyproxy.io", Version: "v1alpha1"}
 	crdGVR       = schema.GroupVersionResource{Resource: "customresourcedefinitions", Group: "apiextensions.k8s.io", Version: "v1"}
+	serviceGVR   = schema.GroupVersionResource{Resource: "services", Group: "", Version: "v1"}
 )
 
 var _ appsecconfig.InjectionPattern = (*envoyGatewayInjectionPattern)(nil)
@@ -64,7 +65,7 @@ func (e *envoyGatewayInjectionPattern) IsInjectionPossible(ctx context.Context) 
 	}
 
 	// Verify the processor service exists in the cluster
-	_, err := e.client.Resource(schema.GroupVersionResource{Resource: "services", Version: "v1"}).
+	_, err := e.client.Resource(serviceGVR).
 		Namespace(e.config.Processor.Namespace).
 		Get(ctx, e.config.Processor.ServiceName, metav1.GetOptions{})
 	if err != nil {
@@ -82,7 +83,7 @@ func (e *envoyGatewayInjectionPattern) IsInjectionPossible(ctx context.Context) 
 	}
 
 	if err != nil {
-		return fmt.Errorf("%w: errog getting EnvoyExtensionPolicy", err)
+		return fmt.Errorf("%w: error getting EnvoyExtensionPolicy", err)
 	}
 
 	// Check if the Gateway CRDs is present
@@ -92,7 +93,7 @@ func (e *envoyGatewayInjectionPattern) IsInjectionPossible(ctx context.Context) 
 	}
 
 	if err != nil {
-		return fmt.Errorf("%w: errog getting Gateway", err)
+		return fmt.Errorf("%w: error getting Gateway", err)
 	}
 
 	// Check if the ReferenceGrant CRD is present
@@ -102,7 +103,7 @@ func (e *envoyGatewayInjectionPattern) IsInjectionPossible(ctx context.Context) 
 	}
 
 	if err != nil {
-		return fmt.Errorf("%w: errog getting ReferenceGrant", err)
+		return fmt.Errorf("%w: error getting ReferenceGrant", err)
 	}
 
 	return nil

--- a/pkg/clusteragent/appsec/envoygateway/envoy.go
+++ b/pkg/clusteragent/appsec/envoygateway/envoy.go
@@ -39,7 +39,6 @@ var (
 	gatewayGVR   = schema.GroupVersionResource{Resource: "gateways", Group: "gateway.networking.k8s.io", Version: "v1"}
 	extensionGVR = schema.GroupVersionResource{Resource: "envoyextensionpolicies", Group: "gateway.envoyproxy.io", Version: "v1alpha1"}
 	crdGVR       = schema.GroupVersionResource{Resource: "customresourcedefinitions", Group: "apiextensions.k8s.io", Version: "v1"}
-	serviceGVR   = schema.GroupVersionResource{Resource: "services", Group: "", Version: "v1"}
 )
 
 var _ appsecconfig.InjectionPattern = (*envoyGatewayInjectionPattern)(nil)
@@ -64,20 +63,12 @@ func (e *envoyGatewayInjectionPattern) IsInjectionPossible(ctx context.Context) 
 		return stdErrors.New("processor service name is required for envoy-gateway proxy type but is not configured")
 	}
 
-	// Verify the processor service exists in the cluster
-	_, err := e.client.Resource(serviceGVR).
-		Namespace(e.config.Processor.Namespace).
-		Get(ctx, e.config.Processor.ServiceName, metav1.GetOptions{})
-	if err != nil {
-		return fmt.Errorf("processor service %q not found in namespace %q: %w", e.config.Processor.ServiceName, e.config.Processor.Namespace, err)
-	}
-
 	gvrToName := func(gvr schema.GroupVersionResource) string {
 		return gvr.Resource + "." + gvr.Group
 	}
 
 	// Check if the EnvoyExtensionPolicy CRD is present
-	_, err = e.client.Resource(crdGVR).Get(ctx, gvrToName(extensionGVR), metav1.GetOptions{})
+	_, err := e.client.Resource(crdGVR).Get(ctx, gvrToName(extensionGVR), metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return fmt.Errorf("%w: EnvoyExtensionPolicy CRD not found, is the Envoy Gateway installed in the cluster? Cannot enable appsec proxy injection for envoy-gateway", err)
 	}

--- a/pkg/clusteragent/appsec/istio/gateway.go
+++ b/pkg/clusteragent/appsec/istio/gateway.go
@@ -43,7 +43,7 @@ func (g *istioNativeGatewayPattern) IsInjectionPossible(ctx context.Context) err
 		if g.config.Processor.ServiceName == "" {
 			return errors.New("processor service name is required for istio-gateway in external mode but is not configured")
 		}
-		_, err := g.client.Resource(schema.GroupVersionResource{Resource: "services", Version: "v1"}).
+		_, err := g.client.Resource(serviceGVR).
 			Namespace(g.config.Processor.Namespace).
 			Get(ctx, g.config.Processor.ServiceName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/clusteragent/appsec/istio/gateway.go
+++ b/pkg/clusteragent/appsec/istio/gateway.go
@@ -37,6 +37,19 @@ func (g *istioNativeGatewayPattern) Namespace() string {
 }
 
 func (g *istioNativeGatewayPattern) IsInjectionPossible(ctx context.Context) error {
+	// In external mode, verify the processor service exists
+	if g.config.Mode == appsecconfig.InjectionModeExternal {
+		if g.config.Processor.ServiceName == "" {
+			return fmt.Errorf("processor service name is required for istio-gateway in external mode but is not configured")
+		}
+		_, err := g.client.Resource(schema.GroupVersionResource{Resource: "services", Version: "v1"}).
+			Namespace(g.config.Processor.Namespace).
+			Get(ctx, g.config.Processor.ServiceName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("processor service %q not found in namespace %q: %w", g.config.Processor.ServiceName, g.config.Processor.Namespace, err)
+		}
+	}
+
 	gvrToName := func(gvr schema.GroupVersionResource) string {
 		return gvr.Resource + "." + gvr.Group
 	}

--- a/pkg/clusteragent/appsec/istio/gateway.go
+++ b/pkg/clusteragent/appsec/istio/gateway.go
@@ -9,6 +9,7 @@ package istio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
@@ -40,7 +41,7 @@ func (g *istioNativeGatewayPattern) IsInjectionPossible(ctx context.Context) err
 	// In external mode, verify the processor service exists
 	if g.config.Mode == appsecconfig.InjectionModeExternal {
 		if g.config.Processor.ServiceName == "" {
-			return fmt.Errorf("processor service name is required for istio-gateway in external mode but is not configured")
+			return errors.New("processor service name is required for istio-gateway in external mode but is not configured")
 		}
 		_, err := g.client.Resource(schema.GroupVersionResource{Resource: "services", Version: "v1"}).
 			Namespace(g.config.Processor.Namespace).

--- a/pkg/clusteragent/appsec/istio/gateway.go
+++ b/pkg/clusteragent/appsec/istio/gateway.go
@@ -38,16 +38,10 @@ func (g *istioNativeGatewayPattern) Namespace() string {
 }
 
 func (g *istioNativeGatewayPattern) IsInjectionPossible(ctx context.Context) error {
-	// In external mode, verify the processor service exists
+	// In external mode, verify the processor service name is configured
 	if g.config.Mode == appsecconfig.InjectionModeExternal {
 		if g.config.Processor.ServiceName == "" {
 			return errors.New("processor service name is required for istio-gateway in external mode but is not configured")
-		}
-		_, err := g.client.Resource(serviceGVR).
-			Namespace(g.config.Processor.Namespace).
-			Get(ctx, g.config.Processor.ServiceName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("processor service %q not found in namespace %q: %w", g.config.Processor.ServiceName, g.config.Processor.Namespace, err)
 		}
 	}
 

--- a/pkg/clusteragent/appsec/istio/istio.go
+++ b/pkg/clusteragent/appsec/istio/istio.go
@@ -41,6 +41,7 @@ var (
 	istioGatewayGVR = schema.GroupVersionResource{Resource: "gateways", Group: "networking.istio.io", Version: "v1"}
 	filterGVR       = schema.GroupVersionResource{Resource: "envoyfilters", Group: "networking.istio.io", Version: "v1alpha3"}
 	crdGVR          = schema.GroupVersionResource{Resource: "customresourcedefinitions", Group: "apiextensions.k8s.io", Version: "v1"}
+	serviceGVR      = schema.GroupVersionResource{Resource: "services", Group: "", Version: "v1"}
 )
 
 type istioInjectionPattern struct {
@@ -60,7 +61,7 @@ func (i *istioInjectionPattern) IsInjectionPossible(ctx context.Context) error {
 		if i.config.Processor.ServiceName == "" {
 			return errors.New("processor service name is required for istio in external mode but is not configured")
 		}
-		_, err := i.client.Resource(schema.GroupVersionResource{Resource: "services", Version: "v1"}).
+		_, err := i.client.Resource(serviceGVR).
 			Namespace(i.config.Processor.Namespace).
 			Get(ctx, i.config.Processor.ServiceName, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/clusteragent/appsec/istio/istio.go
+++ b/pkg/clusteragent/appsec/istio/istio.go
@@ -58,7 +58,7 @@ func (i *istioInjectionPattern) IsInjectionPossible(ctx context.Context) error {
 	// In external mode, verify the processor service exists
 	if i.config.Mode == appsecconfig.InjectionModeExternal {
 		if i.config.Processor.ServiceName == "" {
-			return fmt.Errorf("processor service name is required for istio in external mode but is not configured")
+			return errors.New("processor service name is required for istio in external mode but is not configured")
 		}
 		_, err := i.client.Resource(schema.GroupVersionResource{Resource: "services", Version: "v1"}).
 			Namespace(i.config.Processor.Namespace).

--- a/pkg/clusteragent/appsec/istio/istio.go
+++ b/pkg/clusteragent/appsec/istio/istio.go
@@ -41,7 +41,6 @@ var (
 	istioGatewayGVR = schema.GroupVersionResource{Resource: "gateways", Group: "networking.istio.io", Version: "v1"}
 	filterGVR       = schema.GroupVersionResource{Resource: "envoyfilters", Group: "networking.istio.io", Version: "v1alpha3"}
 	crdGVR          = schema.GroupVersionResource{Resource: "customresourcedefinitions", Group: "apiextensions.k8s.io", Version: "v1"}
-	serviceGVR      = schema.GroupVersionResource{Resource: "services", Group: "", Version: "v1"}
 )
 
 type istioInjectionPattern struct {
@@ -56,16 +55,10 @@ func (i *istioInjectionPattern) Mode() appsecconfig.InjectionMode {
 }
 
 func (i *istioInjectionPattern) IsInjectionPossible(ctx context.Context) error {
-	// In external mode, verify the processor service exists
+	// In external mode, verify the processor service name is configured
 	if i.config.Mode == appsecconfig.InjectionModeExternal {
 		if i.config.Processor.ServiceName == "" {
 			return errors.New("processor service name is required for istio in external mode but is not configured")
-		}
-		_, err := i.client.Resource(serviceGVR).
-			Namespace(i.config.Processor.Namespace).
-			Get(ctx, i.config.Processor.ServiceName, metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("processor service %q not found in namespace %q: %w", i.config.Processor.ServiceName, i.config.Processor.Namespace, err)
 		}
 	}
 

--- a/pkg/clusteragent/appsec/istio/istio.go
+++ b/pkg/clusteragent/appsec/istio/istio.go
@@ -55,6 +55,19 @@ func (i *istioInjectionPattern) Mode() appsecconfig.InjectionMode {
 }
 
 func (i *istioInjectionPattern) IsInjectionPossible(ctx context.Context) error {
+	// In external mode, verify the processor service exists
+	if i.config.Mode == appsecconfig.InjectionModeExternal {
+		if i.config.Processor.ServiceName == "" {
+			return fmt.Errorf("processor service name is required for istio in external mode but is not configured")
+		}
+		_, err := i.client.Resource(schema.GroupVersionResource{Resource: "services", Version: "v1"}).
+			Namespace(i.config.Processor.Namespace).
+			Get(ctx, i.config.Processor.ServiceName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("processor service %q not found in namespace %q: %w", i.config.Processor.ServiceName, i.config.Processor.Namespace, err)
+		}
+	}
+
 	gvrToName := func(gvr schema.GroupVersionResource) string {
 		return gvr.Resource + "." + gvr.Group
 	}

--- a/pkg/clusteragent/appsec/istio/sidecar.go
+++ b/pkg/clusteragent/appsec/istio/sidecar.go
@@ -40,6 +40,9 @@ func (e *istioGatewaySidecarPattern) ShouldMutatePod(pod *corev1.Pod) bool {
 	}
 
 	gatewayClassName := pod.Labels[gatewayClassNamePodLabel]
+	if gatewayClassName == "" {
+		return false
+	}
 
 	gateway, err := e.client.Resource(gatewayClassGVR).Get(context.TODO(), gatewayClassName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/clusteragent/appsec/testdata/cluster-agent-rbac.yml
+++ b/pkg/clusteragent/appsec/testdata/cluster-agent-rbac.yml
@@ -279,6 +279,14 @@ rules:
   - get
   - create
   - delete
+- apiGroups:
+  - "networking.istio.io"
+  resources:
+  - gateways
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### What does this PR do?

Fixes three bugs discovered during live testing on minikube, and adds missing RBAC.

#### 1. `envoy-gateway`: processor service validation in `IsInjectionPossible`

When `ServiceName` is empty (e.g. a cluster configured in sidecar mode where envoy-gateway is auto-detected), the `grantManager` attempted to create a `ReferenceGrant` with `spec.to[0].name: ""`, causing a continuous requeue loop with a Kubernetes validation error. `IsInjectionPossible` now verifies the processor service exists before the pattern starts.

#### 2. `istio` / `istio-gateway`: same check, external mode only

The same processor service existence check is added to both istio patterns' `IsInjectionPossible`, but gated on `InjectionModeExternal`. Sidecar mode uses localhost and has no external service to validate.

#### 3. `istio` sidecar pattern: guard empty gateway class label

The new `istio-gateway` MatchCondition (`'istio' in object.metadata.labels`) causes standard Istio gateway pods to be sent to the admission webhook. All registered sidecar patterns' `ShouldMutatePod` is then called, including the K8s Gateway API one, which tried `Get("")` on a GatewayClass when the pod had no `gateway.networking.k8s.io/gateway-class-name` label, producing repeated `error getting gatewayclass : name is required` warnings. Added an early `return false` guard.

#### 4. RBAC

Added `get/list/watch` on `gateways.networking.istio.io` to `cluster-agent-rbac.yml`. Required for the `istio-gateway` informer, `selectorMatchesPod`, and deletion coordination checks.

### Motivation

These bugs all surface when deploying the new `istio-gateway` proxy type (merged in the preceding PR) alongside existing Envoy Gateway or K8s Gateway API patterns in a cluster running sidecar mode.

### Describe how you validated your changes

- All 130 appsec tests pass: `dda inv test --targets=./pkg/clusteragent/appsec/... --build-exclude=systemd`
- Live validated on minikube: after the fixes, the cluster-agent logs show no more `name is required` or `spec.to[0].name` errors
- Confirmed `istio-gateway` sidecar injection works end-to-end: the `datadog-appsec-processor` sidecar is injected into the Istio ingress gateway pod, and the processor logs `external_processing: first request received` when traffic passes through

### Additional Notes

The RBAC change must be applied to the cluster-agent ClusterRole in any deployment that enables the `istio-gateway` proxy type.