### PR TITLE
Fix linter issues and simplify code in observer component

### DIFF
--- a/.copyright-overrides.yml
+++ b/.copyright-overrides.yml
@@ -242,6 +242,7 @@ github.com/dgraph-io/badger:
  - "Copyright 2020 Dgraph Labs, Inc. and Contributors"
  - "Copyright 2021 Dgraph Labs, Inc. and Contributors"
 github.com/mostynb/go-grpc-compression: "Copyright 2023 Mostyn Bramley-Moore."
+github.com/minio/c2goasm: "Copyright (C) 2017 Minio, Inc."
 github.com/minio/sha256-simd: ["Copyright 2016 Minio, Inc.", "Copyright 2018 Kristofer Peterson"]
 github.com/stormcat24/protodep: "Copyright Akinori Yamada"
 go4.org/mem: "Copyright 2020 The Go4 AUTHORS"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -309,9 +309,54 @@ core,github.com/alecthomas/participle/lexer/ebnf/internal,MIT,Copyright (C) 2017
 core,github.com/alecthomas/participle/v2,MIT,Copyright (C) 2017 Alec Thomas | Copyright (C) 2017-2022 Alec Thomas
 core,github.com/alecthomas/participle/v2/lexer,MIT,Copyright (C) 2017 Alec Thomas | Copyright (C) 2017-2022 Alec Thomas
 core,github.com/alecthomas/units,MIT,Copyright (C) 2014 Alec Thomas
+core,github.com/andybalholm/brotli,MIT,"Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors"
+core,github.com/andybalholm/brotli/matchfinder,MIT,"Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors"
 core,github.com/antchfx/xmlquery,MIT,Copyright (c) 2016 Zheng Chun
 core,github.com/antchfx/xpath,MIT,Copyright (c) 2016 Zheng Chun
 core,github.com/antlr4-go/antlr/v4,BSD-3-Clause,Copyright (c) 2012-2023 The ANTLR Project. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/array,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/arrio,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/bitutil,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/compute,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/compute/exec,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/compute/internal/kernels,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/decimal,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/decimal128,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/decimal256,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/encoded,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/endian,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/extensions,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/flight,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/flight/gen/flight,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/float16,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/internal,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/internal/debug,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/internal/dictutils,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/internal/flatbuf,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/ipc,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/memory,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/memory/internal/cgoalloc,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/memory/mallocator,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/arrow/scalar,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/internal/bitutils,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/internal/hashing,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/internal/json,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/internal/utils,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/compress,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/file,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/internal/bmi,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/internal/debug,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/internal/encoding,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/internal/encryption,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/internal/gen-go/parquet,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/internal/thrift,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/internal/utils,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/metadata,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/pqarrow,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/schema,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
+core,github.com/apache/arrow-go/v18/parquet/variant,Apache-2.0,Copyright (c) 2009 The Go Authors. All rights reserved
 core,github.com/apache/thrift/lib/go/thrift,Apache-2.0,"Copyright (C) 2006 - 2019, The Apache Software Foundation | Copyright (c) 2006- Facebook | Copyright (c) 2006-2008 Alexander Chemeris | Copyright (c) 2007 Thomas Porschberg <thomas@randspringer.de> | Copyright (c) 2008- Patrick Collison <patrick@collison.ie> | Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved | Copyright 2012 Twitter, Inc"
 core,github.com/aquasecurity/go-gem-version,Apache-2.0,Copyright (c) 2020 Teppei Fukuda (knqyf263)
 core,github.com/aquasecurity/go-npm-version/pkg,Apache-2.0,Copyright (c) 2020 Teppei Fukuda (knqyf263)
@@ -1183,6 +1228,7 @@ core,github.com/google/cel-go/interpreter,Apache-2.0,Copyright (c) 2018 The Go A
 core,github.com/google/cel-go/interpreter/functions,Apache-2.0,Copyright (c) 2018 The Go Authors. All rights reserved
 core,github.com/google/cel-go/parser,Apache-2.0,Copyright (c) 2018 The Go Authors. All rights reserved
 core,github.com/google/cel-go/parser/gen,Apache-2.0,Copyright (c) 2018 The Go Authors. All rights reserved
+core,github.com/google/flatbuffers/go,Apache-2.0,Copyright (c) 2014 Google
 core,github.com/google/gnostic-models/compiler,Apache-2.0,"Copyright 2017-2022, Google LLC."
 core,github.com/google/gnostic-models/extensions,Apache-2.0,"Copyright 2017-2022, Google LLC"
 core,github.com/google/gnostic-models/jsonschema,Apache-2.0,"Copyright 2017-2022, Google LLC"
@@ -1406,6 +1452,8 @@ core,github.com/justincormack/go-memfd/msyscall,MIT,Copyright (c) 2017 Justin Co
 core,github.com/kballard/go-shellquote,MIT,Copyright (C) 2014 Kevin Ballard
 core,github.com/kevinburke/ssh_config,MIT,"Copyright (c) 2013 - 2017 Thomas Pelletier, Eric Anderton | Copyright (c) 2017 Kevin Burke"
 core,github.com/kjk/lzma,BSD-3-Clause,"Copyright (c) 2010, Andrei Vieru. All rights reserved"
+core,github.com/klauspost/asmfmt,MIT,Copyright (c) 2015 Klaus Post
+core,github.com/klauspost/asmfmt/cmd/asmfmt,BSD-3-Clause,Copyright (c) 2012 The Go Authors. All rights reserved | Copyright (c) 2015 Klaus Post
 core,github.com/klauspost/compress,BSD-3-Clause,Copyright (c) 2011 The Snappy-Go Authors. All rights reserved | Copyright (c) 2012 The Go Authors. All rights reserved | Copyright (c) 2015 Klaus Post | Copyright (c) 2019 Klaus Post. All rights reserved | Copyright 2016 The filepathx Authors | Copyright 2016-2017 The New York Times Company
 core,github.com/klauspost/compress/flate,BSD-3-Clause,Copyright (c) 2011 The Snappy-Go Authors. All rights reserved | Copyright (c) 2012 The Go Authors. All rights reserved | Copyright (c) 2015 Klaus Post | Copyright (c) 2019 Klaus Post. All rights reserved | Copyright 2016 The filepathx Authors | Copyright 2016-2017 The New York Times Company
 core,github.com/klauspost/compress/fse,BSD-3-Clause,Copyright (c) 2011 The Snappy-Go Authors. All rights reserved | Copyright (c) 2012 The Go Authors. All rights reserved | Copyright (c) 2015 Klaus Post | Copyright (c) 2019 Klaus Post. All rights reserved | Copyright 2016 The filepathx Authors | Copyright 2016-2017 The New York Times Company
@@ -1503,6 +1551,8 @@ core,github.com/mdlayher/netlink/nlenc,MIT,Copyright (C) 2016-2022 Matt Layher
 core,github.com/mdlayher/socket,MIT,Copyright (C) 2021 Matt Layher
 core,github.com/mdlayher/vsock,MIT,Copyright (C) 2017-2022 Matt Layher
 core,github.com/miekg/dns,BSD-3-Clause,"Alex A. Skinner | Alex Sergeyev | Andrew Tunnell-Jones | Ask Bjørn Hansen | Copyright (c) 2009, The Go Authors. Extensions copyright (c) 2011, Miek Gieben | Copyright 2009 The Go Authors. All rights reserved. Use of this source code | Copyright 2011 Miek Gieben. All rights reserved. Use of this source code is | Copyright 2014 CloudFlare. All rights reserved. Use of this source code is | Dave Cheney | Dusty Wilson | James Hartig | Marek Majkowski | Miek Gieben <miek@miek.nl> | Omri Bahumi | Peter van Dijk | copyright (c) 2011 Miek Gieben"
+core,github.com/minio/asm2plan9s,Apache-2.0,Copyright (c) 2001-2011 Peter Johnson and other Yasm developers
+core,github.com/minio/c2goasm,Apache-2.0,"Copyright (C) 2017 Minio, Inc."
 core,github.com/minio/sha256-simd,Apache-2.0,"Copyright 2016 Minio, Inc. | Copyright 2018 Kristofer Peterson"
 core,github.com/mitchellh/copystructure,MIT,Copyright (c) 2013 Mitchell Hashimoto
 core,github.com/mitchellh/go-homedir,MIT,Copyright (c) 2013 Mitchell Hashimoto

--- a/cmd/observer-testbench/main_test.go
+++ b/cmd/observer-testbench/main_test.go
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package main
+
+import (
+	"testing"
+
+	"go.uber.org/fx"
+
+	recorderfx "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/fx"
+	"github.com/DataDog/datadog-agent/comp/core"
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	secretsnoopfx "github.com/DataDog/datadog-agent/comp/core/secrets/fx-noop"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFxApp(t *testing.T) {
+	fxutil.TestOneShot(t, func() {
+		err := fxutil.OneShot(run,
+			recorderfx.Module(),
+			core.Bundle(),
+			secretsnoopfx.Module(),
+			fx.Supply(core.BundleParams{
+				ConfigParams: config.NewAgentParams(""),
+				LogParams:    log.ForOneShot("", "off", true),
+			}),
+			fx.Supply(CLIParams{}),
+		)
+		require.NoError(t, err)
+	})
+}

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -469,7 +469,7 @@ type StorageReader interface {
 	// set of known series changes. Use this to cache ListSeries results and
 	// refresh them only when new series keys appear.
 	SeriesGeneration() uint64
- }
+}
 
 // Detector is the flexible detection interface where detectors pull data from storage.
 // This supports multivariate detection across multiple series.

--- a/comp/observer/impl/agent_internal_logs_test.go
+++ b/comp/observer/impl/agent_internal_logs_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
+	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/config/model"
-	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
@@ -26,10 +26,11 @@ func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
 	pkglog.SetLoggerName("CORE")
 
 	// Enable analysis pipeline so GetHandle returns a real handle (not noop).
-	pkgconfigsetup.Datadog().Set("observer.analysis.enabled", true, model.SourceAgentRuntime)
-	t.Cleanup(func() { pkgconfigsetup.Datadog().Set("observer.analysis.enabled", false, model.SourceAgentRuntime) })
+	cfg := configmock.New(t)
+	cfg.Set("observer.analysis.enabled", true, model.SourceAgentRuntime)
 
 	provides := NewComponent(Requires{
+		Config: cfg,
 		AgentInternalLogTap: AgentInternalLogTapConfig{
 			Enabled:         &enabled,
 			SampleRateInfo:  &one,

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -257,9 +257,9 @@ func (c *TimeClusterCorrelator) GetStats() map[string]interface{} {
 		"total_clusters":       len(c.clusters),
 		"total_anomalies":      totalAnomalies,
 		"largest_cluster_size": maxClusterSize,
-		"proximity_seconds": c.config.ProximitySeconds,
-		"window_seconds":    c.config.WindowSeconds,
-		"current_data_time": c.currentDataTime,
+		"proximity_seconds":    c.config.ProximitySeconds,
+		"window_seconds":       c.config.WindowSeconds,
+		"current_data_time":    c.currentDataTime,
 	}
 }
 

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -229,17 +229,8 @@ func (c *CrossSignalCorrelator) collectMatchingAnomalies(pattern correlationPatt
 	return result
 }
 
-// buildReport creates a ReportOutput for a matched pattern.
-// NOTE: This method is currently unused (dead code). It exists as a reference
-// for how a correlator might construct a ReportOutput.
-func (c *CrossSignalCorrelator) buildReport(pattern correlationPattern, _ map[observer.MetricName]struct{}) observer.ReportOutput {
-	return observer.ReportOutput{
-		ActiveCorrelations: c.ActiveCorrelations(),
-	}
-}
-
-// GetBuffer returns the current buffer (for testing).
-func (c *CrossSignalCorrelator) GetBuffer() []timestampedAnomaly {
+// getBuffer returns the current buffer (for testing).
+func (c *CrossSignalCorrelator) getBuffer() []timestampedAnomaly {
 	return c.buffer
 }
 

--- a/comp/observer/impl/anomaly_processor_correlator_test.go
+++ b/comp/observer/impl/anomaly_processor_correlator_test.go
@@ -124,7 +124,7 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 	correlator.Advance(1031)
 
 	// Verify buffer only contains the two recent anomalies
-	assert.Len(t, correlator.GetBuffer(), 2)
+	assert.Len(t, correlator.getBuffer(), 2)
 }
 
 func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
@@ -185,7 +185,7 @@ func TestCorrelator_BufferNotClearedAfterAdvance(t *testing.T) {
 	require.Len(t, activeCorrs2, 3)
 
 	// Buffer should still have all entries
-	assert.Len(t, correlator.GetBuffer(), 3)
+	assert.Len(t, correlator.getBuffer(), 3)
 }
 
 func TestCorrelator_Name(t *testing.T) {

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -254,11 +254,6 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 	return result
 }
 
-// runDetectorsAndCorrelators runs all detectors and feeds results through correlators.
-func (e *engine) runDetectorsAndCorrelators(upTo int64) advanceResult {
-	return e.runDetectorsAndCorrelatorsSnapshot(upTo, e.detectors, e.correlators)
-}
-
 // runDetectorsAndCorrelatorsSnapshot runs the given detectors and correlators.
 // Uses explicit slices so the caller can snapshot them under a lock.
 func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []observerdef.Detector, correlators []observerdef.Correlator) advanceResult {
@@ -348,13 +343,12 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 	}
 	if _, ok := e.rawAnomalyIndex[key]; ok {
 		return false // exact duplicate
-	} else {
-		if e.rawAnomalyIndex == nil {
-			e.rawAnomalyIndex = make(map[anomalyDedupKey]int)
-		}
-		e.rawAnomalyIndex[key] = len(e.rawAnomalies)
-		e.rawAnomalies = append(e.rawAnomalies, anomaly)
 	}
+	if e.rawAnomalyIndex == nil {
+		e.rawAnomalyIndex = make(map[anomalyDedupKey]int)
+	}
+	e.rawAnomalyIndex[key] = len(e.rawAnomalies)
+	e.rawAnomalies = append(e.rawAnomalies, anomaly)
 
 	// Evict old anomalies if window is set
 	needsReindex := false

--- a/comp/observer/impl/events.go
+++ b/comp/observer/impl/events.go
@@ -13,7 +13,7 @@ import (
 type engineEventKind int
 
 const (
-	eventAdvanceCompleted  engineEventKind = iota
+	eventAdvanceCompleted engineEventKind = iota
 	eventAnomalyCreated
 	eventCorrelationUpdated
 )

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -106,7 +106,7 @@ type anomalyDetector struct {
 }
 
 func (d *anomalyDetector) Name() string { return d.name }
-func (d *anomalyDetector) Detect(_ observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
+func (d *anomalyDetector) Detect(_ observerdef.StorageReader, _ int64) observerdef.DetectionResult {
 	return observerdef.DetectionResult{
 		Anomalies: d.anomalies,
 	}
@@ -473,7 +473,7 @@ func TestFindingM4_UnboundedGrowthOfAccumulatedCorrelations(t *testing.T) {
 			"expected bounded growth but map grows without eviction", corrCount)
 }
 
-func TestFindingM9_SetDetectorsRace(t *testing.T) {
+func TestFindingM9_SetDetectorsRace(_ *testing.T) {
 	// SetDetectors replaces engine slices without a lock.
 	// Running concurrently with Advance should trigger the race detector.
 
@@ -509,7 +509,7 @@ func TestFindingM9_SetDetectorsRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFindingM9_SetCorrelatorsRace(t *testing.T) {
+func TestFindingM9_SetCorrelatorsRace(_ *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 
@@ -540,7 +540,7 @@ func TestFindingM9_SetCorrelatorsRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFindingM10_ResetRace(t *testing.T) {
+func TestFindingM10_ResetRace(_ *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -413,7 +413,7 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 		Source:         observer.MetricName(seriesName),
 		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
 		DetectorName:   b.Name(),
-		Title:          fmt.Sprintf("BOCPD changepoint detected: %s", seriesName),
+		Title:          "BOCPD changepoint detected: " + seriesName,
 		Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",
 			seriesName, triggerType, triggerValue, triggerThreshold, cpProb, b.ShortRunLength, shortRunMass),
 		Tags:      series.Tags,

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -165,7 +165,7 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 			}
 			return &observer.Anomaly{
 				Source: observer.MetricName(series.Name),
-				Title:  fmt.Sprintf("CUSUM shift detected: %s", series.Name),
+				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ above baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
 				Tags:      series.Tags,
@@ -186,7 +186,7 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 			}
 			return &observer.Anomaly{
 				Source: observer.MetricName(series.Name),
-				Title:  fmt.Sprintf("CUSUM shift detected: %s", series.Name),
+				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ below baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
 				Tags:      series.Tags,

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -23,22 +23,22 @@ type RRCFScoredPoint struct {
 
 // RRCFScoreStats contains distribution statistics and full score history for threshold analysis.
 type RRCFScoreStats struct {
-	Enabled        bool              `json:"enabled"`
-	SampleCount    int               `json:"sampleCount"`
-	AlignedPoints  int               `json:"alignedPoints"`
-	ShinglesBuilt  int               `json:"shinglesBuilt"`
-	MinScore       float64           `json:"minScore"`
-	MaxScore       float64           `json:"maxScore"`
-	MeanScore      float64           `json:"meanScore"`
-	StddevScore    float64           `json:"stddevScore"`
-	P50            float64           `json:"p50"`
-	P75            float64           `json:"p75"`
-	P90            float64           `json:"p90"`
-	P95            float64           `json:"p95"`
-	P99            float64           `json:"p99"`
-	Config         RRCFConfigSummary `json:"config"`
-	Metrics        []string          `json:"metrics"`
-	Scores         []RRCFScoredPoint `json:"scores"`
+	Enabled       bool              `json:"enabled"`
+	SampleCount   int               `json:"sampleCount"`
+	AlignedPoints int               `json:"alignedPoints"`
+	ShinglesBuilt int               `json:"shinglesBuilt"`
+	MinScore      float64           `json:"minScore"`
+	MaxScore      float64           `json:"maxScore"`
+	MeanScore     float64           `json:"meanScore"`
+	StddevScore   float64           `json:"stddevScore"`
+	P50           float64           `json:"p50"`
+	P75           float64           `json:"p75"`
+	P90           float64           `json:"p90"`
+	P95           float64           `json:"p95"`
+	P99           float64           `json:"p99"`
+	Config        RRCFConfigSummary `json:"config"`
+	Metrics       []string          `json:"metrics"`
+	Scores        []RRCFScoredPoint `json:"scores"`
 }
 
 // RRCFConfigSummary is a JSON-friendly summary of RRCF configuration.
@@ -164,13 +164,13 @@ func NewRRCFDetector(config RRCFConfig) *RRCFDetector {
 	forest := newRCForest(config.NumTrees, config.TreeSize, shingleDim, 42)
 
 	return &RRCFDetector{
-		config:        config,
-		metrics:       metrics,
-		resolvedKeys:  make(map[string]observer.SeriesKey),
-		cursors:       make(map[string]int64),
-		forest:        forest,
-		recentScores:  make([]float64, 0, 100),
-		allScores:     make([]RRCFScoredPoint, 0, 1024),
+		config:       config,
+		metrics:      metrics,
+		resolvedKeys: make(map[string]observer.SeriesKey),
+		cursors:      make(map[string]int64),
+		forest:       forest,
+		recentScores: make([]float64, 0, 100),
+		allScores:    make([]RRCFScoredPoint, 0, 1024),
 	}
 }
 
@@ -491,8 +491,8 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 				Source:       "score",
 				DetectorName: r.Name(),
 				Title:        "RRCF multivariate anomaly",
-				Description:    fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),
-				Timestamp:      s.endTimestamp,
+				Description:  fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),
+				Timestamp:    s.endTimestamp,
 				DebugInfo: &observer.AnomalyDebugInfo{
 					CurrentValue:   score,
 					Threshold:      threshold,

--- a/comp/observer/impl/notify.go
+++ b/comp/observer/impl/notify.go
@@ -7,6 +7,7 @@ package observerimpl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -36,7 +37,7 @@ func newEventSender(cfg config.Component, logger log.Component) (*eventSender, e
 	}
 	apiKey := cfg.GetString("api_key")
 	if apiKey == "" {
-		return nil, fmt.Errorf("api_key is not set in configuration")
+		return nil, errors.New("api_key is not set in configuration")
 	}
 	ctx := context.WithValue(
 		datadog.NewDefaultContext(context.Background()),

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -182,18 +182,16 @@ func NewComponent(deps Requires) Provides {
 	// Build correlator overrides from config keys (observer.correlators.<name>.enabled).
 	cfg := deps.Config
 	var correlatorOverrides map[string]bool
-	if cfg != nil {
-		for _, entry := range catalog.Entries() {
-			if entry.kind != componentCorrelator {
-				continue
+	for _, entry := range catalog.Entries() {
+		if entry.kind != componentCorrelator {
+			continue
+		}
+		key := "observer.correlators." + entry.name + ".enabled"
+		if cfg.IsKnown(key) {
+			if correlatorOverrides == nil {
+				correlatorOverrides = make(map[string]bool)
 			}
-			key := "observer.correlators." + entry.name + ".enabled"
-			if deps.Config.IsKnown(key) {
-				if correlatorOverrides == nil {
-					correlatorOverrides = make(map[string]bool)
-				}
-				correlatorOverrides[entry.name] = deps.Config.GetBool(key)
-			}
+			correlatorOverrides[entry.name] = cfg.GetBool(key)
 		}
 	}
 
@@ -224,7 +222,7 @@ func NewComponent(deps Requires) Provides {
 	// Set up handle function based on recording and analysis configuration.
 	// Recording (observer.recording.enabled) enables parquet writers and the fetcher.
 	// Analysis (observer.analysis.enabled) enables the anomaly detection pipeline.
-	analysisEnabled := cfg != nil && cfg.GetBool("observer.analysis.enabled")
+	analysisEnabled := cfg.GetBool("observer.analysis.enabled")
 
 	obs.handleFunc = obs.noopHandle
 	if analysisEnabled {
@@ -236,7 +234,7 @@ func NewComponent(deps Requires) Provides {
 	}
 
 	// Optionally add the event reporter when sending is enabled via config.
-	if deps.Config != nil && deps.Config.GetBool("observer.event_reporter.sending_enabled") {
+	if cfg.GetBool("observer.event_reporter.sending_enabled") {
 		if sender, err := newEventSender(deps.Config, deps.Log); err != nil {
 			deps.Log.Warnf("[observer] event_reporter disabled: %v", err)
 		} else {

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -23,21 +23,21 @@ type ObserverOutput struct {
 
 // ObserverMetadata describes the scenario and pipeline configuration.
 type ObserverMetadata struct {
-	Scenario           string   `json:"scenario"`
-	TimelineStart      int64    `json:"timeline_start"`
-	TimelineEnd        int64    `json:"timeline_end"`
-	DetectorsEnabled   []string `json:"detectors_enabled"`
-	CorrelatorsEnabled []string `json:"correlators_enabled"`
-	TotalAnomalyPeriods int     `json:"total_anomaly_periods"`
+	Scenario            string   `json:"scenario"`
+	TimelineStart       int64    `json:"timeline_start"`
+	TimelineEnd         int64    `json:"timeline_end"`
+	DetectorsEnabled    []string `json:"detectors_enabled"`
+	CorrelatorsEnabled  []string `json:"correlators_enabled"`
+	TotalAnomalyPeriods int      `json:"total_anomaly_periods"`
 }
 
 // ObserverCorrelation is one correlation cluster.
 // Always includes the time span (pattern, period_start, period_end).
 // Verbose mode adds title, member_series, and nested anomalies.
 type ObserverCorrelation struct {
-	Pattern          string            `json:"pattern"`
-	PeriodStart int64 `json:"period_start"`
-	PeriodEnd   int64 `json:"period_end"`
+	Pattern      string            `json:"pattern"`
+	PeriodStart  int64             `json:"period_start"`
+	PeriodEnd    int64             `json:"period_end"`
 	Title        string            `json:"title,omitempty"`
 	MemberSeries []string          `json:"member_series,omitempty"`
 	Anomalies    []ObserverAnomaly `json:"anomalies,omitempty"`
@@ -90,7 +90,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 	outCorrelations := make([]ObserverCorrelation, len(correlations))
 	for i, corr := range correlations {
 		oc := ObserverCorrelation{
-			Pattern:            corr.Pattern,
+			Pattern:     corr.Pattern,
 			PeriodStart: corr.FirstSeen,
 			PeriodEnd:   corr.LastUpdated,
 		}
@@ -117,11 +117,11 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 
 	output := ObserverOutput{
 		Metadata: ObserverMetadata{
-			Scenario:           scenario,
-			TimelineStart:      timelineStart,
-			TimelineEnd:        timelineEnd,
-			DetectorsEnabled:   detectorNames,
-			CorrelatorsEnabled: correlatorNames,
+			Scenario:            scenario,
+			TimelineStart:       timelineStart,
+			TimelineEnd:         timelineEnd,
+			DetectorsEnabled:    detectorNames,
+			CorrelatorsEnabled:  correlatorNames,
 			TotalAnomalyPeriods: len(outCorrelations),
 		},
 		AnomalyPeriods: outCorrelations,

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -21,11 +21,13 @@ type staticCorrelator struct {
 	correlations []observerdef.ActiveCorrelation
 }
 
-func (c *staticCorrelator) Name() string                                        { return "static" }
-func (c *staticCorrelator) ProcessAnomaly(_ observerdef.Anomaly)                {}
-func (c *staticCorrelator) Advance(_ int64)                                     {}
-func (c *staticCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation { return c.correlations }
-func (c *staticCorrelator) Reset()                                              {}
+func (c *staticCorrelator) Name() string                         { return "static" }
+func (c *staticCorrelator) ProcessAnomaly(_ observerdef.Anomaly) {}
+func (c *staticCorrelator) Advance(_ int64)                      {}
+func (c *staticCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation {
+	return c.correlations
+}
+func (c *staticCorrelator) Reset() {}
 
 // newTestBenchForOutput creates a minimal TestBench with injected state for testing
 // observer output. No scenarios dir or registry needed.

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// Package patterns provides log tokenization and clustering utilities.
 package patterns
 
 import (
@@ -18,10 +19,10 @@ type IDComputeInfo struct {
 }
 
 func (idComputeInfo *IDComputeInfo) NextID() int64 {
-	newId := idComputeInfo.Offset + idComputeInfo.Index*idComputeInfo.Stride
+	newID := idComputeInfo.Offset + idComputeInfo.Index*idComputeInfo.Stride
 	idComputeInfo.Index++
 
-	return newId
+	return newID
 }
 
 // Cluster represents a group of similar log messages.
@@ -288,8 +289,8 @@ func canMergeTokenLists(pattern, incoming []Token) bool {
 func canMergeTokens(a, b Token) bool {
 	if a.Type != b.Type {
 		switch {
-		case (a.Type == TypeNumericValue && b.Type == TypeHttpStatusCode) ||
-			(a.Type == TypeHttpStatusCode && b.Type == TypeNumericValue):
+		case (a.Type == TypeNumericValue && b.Type == TypeHTTPStatusCode) ||
+			(a.Type == TypeHTTPStatusCode && b.Type == TypeNumericValue):
 			return true
 		default:
 			return false
@@ -323,9 +324,9 @@ func canMergeTokens(a, b Token) bool {
 		return true
 	case TypeEmailAddress:
 		return true
-	case TypeHttpMethod:
+	case TypeHTTPMethod:
 		return true
-	case TypeHttpStatusCode:
+	case TypeHTTPStatusCode:
 		return true
 	case TypeSeverity:
 		return true

--- a/comp/observer/impl/patterns/cluster_test.go
+++ b/comp/observer/impl/patterns/cluster_test.go
@@ -431,7 +431,7 @@ func TestHexDumpMerge(t *testing.T) {
 
 func TestMergeTokensCrossType(t *testing.T) {
 	// HttpStatusCode and NumericValue should be mergeable (both number-like)
-	a := HttpStatusCodeToken("200")
+	a := HTTPStatusCodeToken("200")
 	b := NumericValueToken("887")
 	if !canMergeTokens(a, b) {
 		t.Error("HttpStatusCode and NumericValue should be mergeable")

--- a/comp/observer/impl/patterns/signature_test.go
+++ b/comp/observer/impl/patterns/signature_test.go
@@ -74,13 +74,13 @@ func TestSignatureAuthority(t *testing.T) {
 	assertTokenSignature(t, "regularHostName:port",
 		AuthorityToken(&hostReg, 22, true, "", false))
 
-	hostIp := Token{Type: TypeIPv4Address, Value: "12.23.34.45"}
+	hostIP := Token{Type: TypeIPv4Address, Value: "12.23.34.45"}
 	assertTokenSignature(t, "user@ipv4:port",
-		AuthorityToken(&hostIp, 22, true, "user", true))
+		AuthorityToken(&hostIP, 22, true, "user", true))
 
-	hostIp6 := Token{Type: TypeIPv6Address, Value: "2001:db8:85a3::8a2e:370:7334"}
+	hostIP6 := Token{Type: TypeIPv6Address, Value: "2001:db8:85a3::8a2e:370:7334"}
 	assertTokenSignature(t, "user@ipv6:port",
-		AuthorityToken(&hostIp6, 22, true, "user", true))
+		AuthorityToken(&hostIP6, 22, true, "user", true))
 }
 
 func TestSignatureWord(t *testing.T) {
@@ -148,13 +148,13 @@ func TestSignatureSeverity(t *testing.T) {
 }
 
 func TestSignatureHttpMethod(t *testing.T) {
-	assertTokenSignature(t, "HttpMethod{value=*}", HttpMethodToken("GET"))
-	assertTokenSignature(t, "HttpMethod{value=*}", HttpMethodToken("POST"))
+	assertTokenSignature(t, "HttpMethod{value=*}", HTTPMethodToken("GET"))
+	assertTokenSignature(t, "HttpMethod{value=*}", HTTPMethodToken("POST"))
 }
 
 func TestSignatureHttpStatusCode(t *testing.T) {
-	assertTokenSignature(t, "HttpStatusCode{value=*}", HttpStatusCodeToken("200"))
-	assertTokenSignature(t, "HttpStatusCode{value=*}", HttpStatusCodeToken("404"))
+	assertTokenSignature(t, "HttpStatusCode{value=*}", HTTPStatusCodeToken("200"))
+	assertTokenSignature(t, "HttpStatusCode{value=*}", HTTPStatusCodeToken("404"))
 }
 
 func TestSignatureWhitespace(t *testing.T) {

--- a/comp/observer/impl/patterns/token.go
+++ b/comp/observer/impl/patterns/token.go
@@ -26,8 +26,8 @@ const (
 	TypeURI
 	TypeAuthority
 	TypeEmailAddress
-	TypeHttpMethod
-	TypeHttpStatusCode
+	TypeHTTPMethod
+	TypeHTTPStatusCode
 	TypeSeverity
 	TypeHexDump
 	TypeKVSequence
@@ -61,9 +61,9 @@ func (t TokenType) String() string {
 		return "Authority"
 	case TypeEmailAddress:
 		return "EmailAddress"
-	case TypeHttpMethod:
+	case TypeHTTPMethod:
 		return "HttpMethod"
-	case TypeHttpStatusCode:
+	case TypeHTTPStatusCode:
 		return "HttpStatusCode"
 	case TypeSeverity:
 		return "Severity"
@@ -110,7 +110,7 @@ type Token struct {
 
 	// HexDump-specific
 	DispLen  int
-	HasAscii bool
+	HasASCII bool
 
 	// KV-specific
 	KVKeys    []string
@@ -151,7 +151,7 @@ func LocalTimeToken(format, rawText string) Token {
 	return Token{Type: TypeLocalTime, Value: rawText, DateFormat: format}
 }
 
-func IPv4Token(text string, a, b, c, d int) Token {
+func IPv4Token(text string, _, _, _, _ int) Token {
 	return Token{Type: TypeIPv4Address, Value: text}
 }
 
@@ -236,24 +236,24 @@ func EmailToken(localPart, domain string) Token {
 	}
 }
 
-func HttpMethodToken(method string) Token {
-	return Token{Type: TypeHttpMethod, Value: method}
+func HTTPMethodToken(method string) Token {
+	return Token{Type: TypeHTTPMethod, Value: method}
 }
 
-func HttpStatusCodeToken(code string) Token {
-	return Token{Type: TypeHttpStatusCode, Value: code}
+func HTTPStatusCodeToken(code string) Token {
+	return Token{Type: TypeHTTPStatusCode, Value: code}
 }
 
 func SeverityToken(level string) Token {
 	return Token{Type: TypeSeverity, Value: level}
 }
 
-func HexDumpToken(text string, dispLen int, hasAscii bool) Token {
+func HexDumpToken(text string, dispLen int, hasASCII bool) Token {
 	return Token{
 		Type:     TypeHexDump,
 		Value:    text,
 		DispLen:  dispLen,
-		HasAscii: hasAscii,
+		HasASCII: hasASCII,
 	}
 }
 
@@ -297,9 +297,9 @@ func (t Token) Signature() string {
 		return authoritySignature(t)
 	case TypeEmailAddress:
 		return "localPart@domain"
-	case TypeHttpMethod:
+	case TypeHTTPMethod:
 		return "HttpMethod{value=*}"
-	case TypeHttpStatusCode:
+	case TypeHTTPStatusCode:
 		return "HttpStatusCode{value=*}"
 	case TypeSeverity:
 		return "Severity{value=*}"
@@ -374,7 +374,7 @@ func hostSignature(t Token) string {
 
 func hexDumpSignature(t Token) string {
 	ascii := "F"
-	if t.HasAscii {
+	if t.HasASCII {
 		ascii = "T"
 	}
 	return fmt.Sprintf("HexDump[dl:%d|ascii:%s]", t.DispLen, ascii)

--- a/comp/observer/impl/patterns/tokenizer.go
+++ b/comp/observer/impl/patterns/tokenizer.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 )
 
 const (
@@ -138,7 +137,7 @@ func tryHexDump(s, fullMsg string, pos int) (Token, int) {
 	}
 
 	rest := s[trailingWS:]
-	hasAscii := false
+	hasASCII := false
 	asciiEnd := 0
 
 	if len(rest) > 0 && rest[0] != '\n' && rest[0] != '\r' {
@@ -158,7 +157,7 @@ func tryHexDump(s, fullMsg string, pos int) (Token, int) {
 				}
 			}
 			if allPrintable {
-				hasAscii = true
+				hasASCII = true
 				asciiEnd = len(candidate)
 			}
 		}
@@ -171,8 +170,8 @@ func tryHexDump(s, fullMsg string, pos int) (Token, int) {
 	if fullEnd < len(fullMsg) {
 		ch := fullMsg[fullEnd]
 		if ch != ' ' && ch != '\t' && ch != '\n' && ch != '\r' {
-			if hasAscii {
-				hasAscii = false
+			if hasASCII {
+				hasASCII = false
 				endPos = trailingWS
 				text = strings.TrimRight(s[:endPos], " \t")
 				endPos = len(text)
@@ -180,7 +179,7 @@ func tryHexDump(s, fullMsg string, pos int) (Token, int) {
 		}
 	}
 
-	return HexDumpToken(text, dispLen, hasAscii), endPos
+	return HexDumpToken(text, dispLen, hasASCII), endPos
 }
 
 // ---- Date/Time patterns ----
@@ -525,7 +524,7 @@ func tryEmail(s string) (Token, int) {
 
 var reIPv4WithPort = regexp.MustCompile(`^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?::(\d+))?`)
 
-func tryIPv4Authority(s, fullMsg string, pos int) (Token, int) {
+func tryIPv4Authority(s, _ string, _ int) (Token, int) {
 	m := reIPv4WithPort.FindStringSubmatch(s)
 	if m == nil {
 		return Token{}, 0
@@ -729,7 +728,7 @@ func tryNumberOrStatusCode(s string) (Token, int) {
 		code, _ := strconv.Atoi(intPart)
 		if isValidHTTPStatus(code) {
 			if i >= len(s) || s[i] != '.' {
-				return HttpStatusCodeToken(intPart), len(intPart)
+				return HTTPStatusCodeToken(intPart), len(intPart)
 			}
 		}
 	}
@@ -787,7 +786,7 @@ func tryWordOrKeyword(s string) (Token, int) {
 	text := s[:i]
 
 	if httpMethods[text] {
-		return HttpMethodToken(text), i
+		return HTTPMethodToken(text), i
 	}
 	if severityKeywords[text] {
 		return SeverityToken(text), i
@@ -868,17 +867,12 @@ func cleanDateFormat(format string) string {
 
 // ---- Character classification ----
 
-func isDigit(b byte) bool         { return b >= '0' && b <= '9' }
-func isAlpha(b byte) bool         { return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') }
-func isAlphaNum(b byte) bool      { return isAlpha(b) || isDigit(b) || b == '_' }
-func isWhitespace(b byte) bool    { return b == ' ' || b == '\t' || b == '\n' || b == '\r' }
-func isAlphaNumOrDot(b byte) bool { return isAlphaNum(b) || b == '.' }
+func isDigit(b byte) bool      { return b >= '0' && b <= '9' }
+func isAlpha(b byte) bool      { return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') }
+func isAlphaNum(b byte) bool   { return isAlpha(b) || isDigit(b) || b == '_' }
+func isWhitespace(b byte) bool { return b == ' ' || b == '\t' || b == '\n' || b == '\r' }
 
 func isWordChar(b byte) bool {
-	return isAlpha(b) || isDigit(b) || b == '_' || b == '-'
-}
-
-func isWordCharNoDot(b byte) bool {
 	return isAlpha(b) || isDigit(b) || b == '_' || b == '-'
 }
 
@@ -926,29 +920,14 @@ func isFollowedByAlpha(s string, pos int) bool {
 	return isAlpha(s[pos])
 }
 
-func isFollowedByWordChar(s string, pos int) bool {
-	if pos >= len(s) {
-		return false
-	}
-	return isWordChar(s[pos])
-}
-
-func hasOnlyDigits(s string) bool {
-	for _, c := range s {
-		if !unicode.IsDigit(c) {
-			return false
-		}
-	}
-	return len(s) > 0
-}
-
 const (
-	SEVERITY_UNKNOWN = iota
-	// Logs that should have ~ no impact on anomaly detection
-	SEVERITY_DEBUG
-	SEVERITY_INFO
-	// Logs that should have the most impact on anomaly detection and RCA (warning+ logs)
-	SEVERITY_ERROR
+	SeverityUnknown = iota
+	// SeverityDebug represents logs that should have ~ no impact on anomaly detection
+	SeverityDebug
+	// SeverityInfo represents informational logs
+	SeverityInfo
+	// SeverityError represents logs that should have the most impact on anomaly detection and RCA (warning+ logs)
+	SeverityError
 )
 
 // GetSeverity returns the severity of a log
@@ -958,25 +937,25 @@ func GetSeverity(tokens []Token) int {
 		// We cannot use severity token type because it's not always parsed for that
 		switch strings.ToUpper(token.Value) {
 		case "DEBUG", "D":
-			return SEVERITY_DEBUG
+			return SeverityDebug
 		case "INFO", "I":
-			return SEVERITY_INFO
+			return SeverityInfo
 		case "ERROR", "ERR", "E", "WARNING", "WARN", "W":
-			return SEVERITY_ERROR
+			return SeverityError
 		}
 	}
-	return SEVERITY_UNKNOWN
+	return SeverityUnknown
 }
 
 func GetSeverityString(severity int) string {
 	switch severity {
-	case SEVERITY_DEBUG:
+	case SeverityDebug:
 		return "DEBUG"
-	case SEVERITY_INFO:
+	case SeverityInfo:
 		return "INFO"
-	case SEVERITY_ERROR:
+	case SeverityError:
 		return "ERROR"
-	case SEVERITY_UNKNOWN:
+	case SeverityUnknown:
 		return "UNKNOWN"
 	default:
 		fmt.Fprintf(os.Stderr, "warning: Invalid severity: %d\n", severity)

--- a/comp/observer/impl/patterns/tokenizer_test.go
+++ b/comp/observer/impl/patterns/tokenizer_test.go
@@ -37,30 +37,6 @@ func assertTokenTypes(t *testing.T, msg string, expected []TokenType) {
 	}
 }
 
-func assertTokenValues(t *testing.T, msg string, expectedTypes []TokenType, expectedValues []string) {
-	t.Helper()
-	tokens := NewTokenizer().Tokenize(msg)
-	if len(tokens) != len(expectedTypes) {
-		t.Errorf("Tokenize(%q): got %d tokens, want %d", msg, len(tokens), len(expectedTypes))
-		for i, tok := range tokens {
-			t.Logf("  token[%d]: type=%v value=%q", i, tok.Type, tok.Value)
-		}
-		return
-	}
-	for i := range expectedTypes {
-		if tokens[i].Type != expectedTypes[i] {
-			t.Errorf("Tokenize(%q): token[%d] type = %v, want %v (value=%q)",
-				msg, i, tokens[i].Type, expectedTypes[i], tokens[i].Value)
-		}
-		if expectedValues != nil && i < len(expectedValues) && expectedValues[i] != "" {
-			if tokens[i].Value != expectedValues[i] {
-				t.Errorf("Tokenize(%q): token[%d] value = %q, want %q",
-					msg, i, tokens[i].Value, expectedValues[i])
-			}
-		}
-	}
-}
-
 func dumpTokens(t *testing.T, msg string) {
 	t.Helper()
 	tokens := NewTokenizer().Tokenize(msg)
@@ -231,44 +207,44 @@ func TestTokenizeEmail(t *testing.T) {
 // --- HTTP Method ---
 
 func TestTokenizeHTTPMethod(t *testing.T) {
-	assertTokenTypes(t, "GET", []TokenType{TypeHttpMethod})
-	assertTokenTypes(t, "POST", []TokenType{TypeHttpMethod})
-	assertTokenTypes(t, "PUT", []TokenType{TypeHttpMethod})
-	assertTokenTypes(t, "DELETE", []TokenType{TypeHttpMethod})
-	assertTokenTypes(t, "PATCH", []TokenType{TypeHttpMethod})
-	assertTokenTypes(t, "HEAD", []TokenType{TypeHttpMethod})
-	assertTokenTypes(t, "OPTIONS", []TokenType{TypeHttpMethod})
+	assertTokenTypes(t, "GET", []TokenType{TypeHTTPMethod})
+	assertTokenTypes(t, "POST", []TokenType{TypeHTTPMethod})
+	assertTokenTypes(t, "PUT", []TokenType{TypeHTTPMethod})
+	assertTokenTypes(t, "DELETE", []TokenType{TypeHTTPMethod})
+	assertTokenTypes(t, "PATCH", []TokenType{TypeHTTPMethod})
+	assertTokenTypes(t, "HEAD", []TokenType{TypeHTTPMethod})
+	assertTokenTypes(t, "OPTIONS", []TokenType{TypeHTTPMethod})
 
 	// DELETED is NOT an HTTP method
 	tokens := NewTokenizer().Tokenize("DELETED")
-	if tokens[0].Type == TypeHttpMethod {
+	if tokens[0].Type == TypeHTTPMethod {
 		t.Error("DELETED should not be an HTTP method")
 	}
 
 	// "GET /url" -> HttpMethod + Whitespace + Path
 	assertTokenTypes(t, "\"GET /url\"", []TokenType{
-		TypeSpecialCharacter, TypeHttpMethod, TypeWhitespace, TypePathQueryFragment, TypeSpecialCharacter,
+		TypeSpecialCharacter, TypeHTTPMethod, TypeWhitespace, TypePathQueryFragment, TypeSpecialCharacter,
 	})
 }
 
 // --- HTTP Status Code ---
 
 func TestTokenizeHTTPStatusCode(t *testing.T) {
-	assertTokenTypes(t, "200", []TokenType{TypeHttpStatusCode})
-	assertTokenTypes(t, "404", []TokenType{TypeHttpStatusCode})
-	assertTokenTypes(t, "500", []TokenType{TypeHttpStatusCode})
-	assertTokenTypes(t, "201", []TokenType{TypeHttpStatusCode})
-	assertTokenTypes(t, "302", []TokenType{TypeHttpStatusCode})
+	assertTokenTypes(t, "200", []TokenType{TypeHTTPStatusCode})
+	assertTokenTypes(t, "404", []TokenType{TypeHTTPStatusCode})
+	assertTokenTypes(t, "500", []TokenType{TypeHTTPStatusCode})
+	assertTokenTypes(t, "201", []TokenType{TypeHTTPStatusCode})
+	assertTokenTypes(t, "302", []TokenType{TypeHTTPStatusCode})
 
 	// 200OK -> HttpStatusCode + Word
 	tokens := NewTokenizer().Tokenize("200OK")
-	if len(tokens) != 2 || tokens[0].Type != TypeHttpStatusCode || tokens[1].Type != TypeWord {
+	if len(tokens) != 2 || tokens[0].Type != TypeHTTPStatusCode || tokens[1].Type != TypeWord {
 		t.Errorf("expected HttpStatusCode + Word for '200OK', got %v", tok(tokens))
 	}
 
 	// 234 is NOT a valid HTTP status code -> NumericValue
 	tokens = NewTokenizer().Tokenize("234")
-	if tokens[0].Type == TypeHttpStatusCode {
+	if tokens[0].Type == TypeHTTPStatusCode {
 		t.Error("234 should be NumericValue, not HttpStatusCode")
 	}
 }
@@ -452,8 +428,8 @@ func TestTokenizeHexDump(t *testing.T) {
 	if tokens[0].DispLen != 4 {
 		t.Errorf("expected DispLen=4, got %d", tokens[0].DispLen)
 	}
-	if tokens[0].HasAscii {
-		t.Error("expected HasAscii=false")
+	if tokens[0].HasASCII {
+		t.Error("expected HasASCII=false")
 	}
 
 	tokens = tokenizer.Tokenize("00000000: 02 f3 82 00")
@@ -481,8 +457,8 @@ func TestTokenizeHexDumpWithAscii(t *testing.T) {
 		dumpTokens(t, "00000000: 01 02 03 04 05 Ascii")
 		t.Fatal("expected HexDump token")
 	}
-	if !tokens[0].HasAscii {
-		t.Error("expected HasAscii=true")
+	if !tokens[0].HasASCII {
+		t.Error("expected HasASCII=true")
 	}
 
 	tokens = tokenizer.Tokenize("0010: DB 8A 8E 01 00 .....")
@@ -490,8 +466,8 @@ func TestTokenizeHexDumpWithAscii(t *testing.T) {
 		dumpTokens(t, "0010: DB 8A 8E 01 00 .....")
 		t.Fatal("expected HexDump")
 	}
-	if !tokens[0].HasAscii {
-		t.Error("expected HasAscii=true for '.....''")
+	if !tokens[0].HasASCII {
+		t.Error("expected HasASCII=true for '.....''")
 	}
 }
 
@@ -545,10 +521,10 @@ func TestTokenizeWholeMessageJSON(t *testing.T) {
 	foundStatus := false
 	foundMethod := false
 	for _, tok := range tokens {
-		if tok.Type == TypeHttpStatusCode && tok.Value == "200" {
+		if tok.Type == TypeHTTPStatusCode && tok.Value == "200" {
 			foundStatus = true
 		}
-		if tok.Type == TypeHttpMethod && tok.Value == "GET" {
+		if tok.Type == TypeHTTPMethod && tok.Value == "GET" {
 			foundMethod = true
 		}
 	}
@@ -580,11 +556,11 @@ func TestTokenizeGCStats(t *testing.T) {
 
 func TestGetSeverity(t *testing.T) {
 	tok := NewTokenizer()
-	assert.Equal(t, SEVERITY_INFO, GetSeverity(tok.Tokenize("INFO: 10.244.1.XXX:XXXX - * /*/* HTTP/1.1 200 OK")))
-	assert.Equal(t, SEVERITY_ERROR, GetSeverity(tok.Tokenize("ERROR: yyyy/MM/dd HH:mm:ss - * : status=[500-502]")))
-	assert.Equal(t, SEVERITY_ERROR, GetSeverity(tok.Tokenize("yyyy-MM-dd HH:mm:ss,SSS ERROR - Session creation failed: 500 {\"info\":\"failed to create session\"}")))
-	assert.Equal(t, SEVERITY_INFO, GetSeverity(tok.Tokenize("INFO: session write failed: dial tcp 10.96.103.154:6379: connect: connection refused")))
-	assert.Equal(t, SEVERITY_UNKNOWN, GetSeverity(tok.Tokenize("yyyy-MM-dd HH:mm:ss,SSS - Some log")))
-	assert.Equal(t, SEVERITY_DEBUG, GetSeverity(tok.Tokenize("yyyy-MM-dd HH:mm:ss,SSS [DEBUG] - Some log")))
-	assert.Equal(t, SEVERITY_INFO, GetSeverity(tok.Tokenize("[2026-02-23T17:15:20.385Z] Info : [us1-ddbuild-io] New rules in place")))
+	assert.Equal(t, SeverityInfo, GetSeverity(tok.Tokenize("INFO: 10.244.1.XXX:XXXX - * /*/* HTTP/1.1 200 OK")))
+	assert.Equal(t, SeverityError, GetSeverity(tok.Tokenize("ERROR: yyyy/MM/dd HH:mm:ss - * : status=[500-502]")))
+	assert.Equal(t, SeverityError, GetSeverity(tok.Tokenize("yyyy-MM-dd HH:mm:ss,SSS ERROR - Session creation failed: 500 {\"info\":\"failed to create session\"}")))
+	assert.Equal(t, SeverityInfo, GetSeverity(tok.Tokenize("INFO: session write failed: dial tcp 10.96.103.154:6379: connect: connection refused")))
+	assert.Equal(t, SeverityUnknown, GetSeverity(tok.Tokenize("yyyy-MM-dd HH:mm:ss,SSS - Some log")))
+	assert.Equal(t, SeverityDebug, GetSeverity(tok.Tokenize("yyyy-MM-dd HH:mm:ss,SSS [DEBUG] - Some log")))
+	assert.Equal(t, SeverityInfo, GetSeverity(tok.Tokenize("[2026-02-23T17:15:20.385Z] Info : [us1-ddbuild-io] New rules in place")))
 }

--- a/comp/observer/impl/reporter_html.go
+++ b/comp/observer/impl/reporter_html.go
@@ -142,7 +142,7 @@ func (r *HTMLReporter) Start(addr string) error {
 
 	go func() {
 		if err := r.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			// Log error but don't crash - server might be stopped intentionally
+			log.Printf("[observer] HTMLReporter server error: %v", err)
 		}
 	}()
 
@@ -803,7 +803,7 @@ func (r *HTMLReporter) handleDashboard(w http.ResponseWriter, req *http.Request)
 }
 
 // handleAPIReports returns JSON array of recent reports.
-func (r *HTMLReporter) handleAPIReports(w http.ResponseWriter, req *http.Request) {
+func (r *HTMLReporter) handleAPIReports(w http.ResponseWriter, _ *http.Request) {
 	r.mu.RLock()
 	reports := make([]timestampedReport, len(r.reports))
 	copy(reports, r.reports)
@@ -1114,7 +1114,7 @@ type rawAnomalyOutput struct {
 }
 
 // handleAPICorrelations returns currently active correlations.
-func (r *HTMLReporter) handleAPICorrelations(w http.ResponseWriter, req *http.Request) {
+func (r *HTMLReporter) handleAPICorrelations(w http.ResponseWriter, _ *http.Request) {
 	r.mu.RLock()
 	correlationState := r.correlationState
 	r.mu.RUnlock()
@@ -1164,7 +1164,7 @@ func seriesIDsToStringSlice(ids []observer.SeriesID) []string {
 }
 
 // handleAPIRawAnomalies returns all raw anomalies from detector implementations.
-func (r *HTMLReporter) handleAPIRawAnomalies(w http.ResponseWriter, req *http.Request) {
+func (r *HTMLReporter) handleAPIRawAnomalies(w http.ResponseWriter, _ *http.Request) {
 	r.mu.RLock()
 	rawState := r.rawAnomalyState
 	r.mu.RUnlock()
@@ -1210,7 +1210,7 @@ func (r *HTMLReporter) handleAPITimeClusterClusters(w http.ResponseWriter, _ *ht
 	w.Header().Set("Content-Type", "application/json")
 
 	if tc == nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"clusters": []interface{}{},
 			"error":    "TimeClusterCorrelator not enabled",
 		})
@@ -1218,7 +1218,7 @@ func (r *HTMLReporter) handleAPITimeClusterClusters(w http.ResponseWriter, _ *ht
 	}
 
 	clusters := tc.GetClusters()
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"clusters": clusters,
 	})
 }
@@ -1232,7 +1232,7 @@ func (r *HTMLReporter) handleAPITimeClusterStats(w http.ResponseWriter, _ *http.
 	w.Header().Set("Content-Type", "application/json")
 
 	if tc == nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"enabled": false,
 			"error":   "TimeClusterCorrelator not enabled",
 		})
@@ -1241,7 +1241,7 @@ func (r *HTMLReporter) handleAPITimeClusterStats(w http.ResponseWriter, _ *http.
 
 	stats := tc.GetStats()
 	stats["enabled"] = true
-	json.NewEncoder(w).Encode(stats)
+	_ = json.NewEncoder(w).Encode(stats)
 }
 
 const timeClusterPageHTML = `<!DOCTYPE html>

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -392,10 +392,10 @@ type mockHTMLCorrelator struct {
 	correlations []observer.ActiveCorrelation
 }
 
-func (m *mockHTMLCorrelator) Name() string                          { return "mock_correlator" }
-func (m *mockHTMLCorrelator) ProcessAnomaly(_ observer.Anomaly)     {}
-func (m *mockHTMLCorrelator) Advance(_ int64)                       {}
-func (m *mockHTMLCorrelator) Reset()                                {}
+func (m *mockHTMLCorrelator) Name() string                      { return "mock_correlator" }
+func (m *mockHTMLCorrelator) ProcessAnomaly(_ observer.Anomaly) {}
+func (m *mockHTMLCorrelator) Advance(_ int64)                   {}
+func (m *mockHTMLCorrelator) Reset()                            {}
 func (m *mockHTMLCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	return m.correlations
 }

--- a/comp/observer/impl/series_pair_key.go
+++ b/comp/observer/impl/series_pair_key.go
@@ -29,8 +29,3 @@ func (k seriesPairKey) hashKey() string {
 	b := string(k.B)
 	return strconv.Itoa(len(a)) + ":" + a + strconv.Itoa(len(b)) + ":" + b
 }
-
-// displayKey returns a human-readable key for logs/debug payloads.
-func (k seriesPairKey) displayKey() string {
-	return string(k.A) + "<>" + string(k.B)
-}

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -208,7 +208,7 @@ func (c *mockCorrelator) Advance(_ int64)                                     {}
 func (c *mockCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelation { return nil }
 func (c *mockCorrelator) Reset()                                              {}
 
-func TestFindingM11_StateViewListDetectorsRace(t *testing.T) {
+func TestFindingM11_StateViewListDetectorsRace(_ *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 
@@ -240,7 +240,7 @@ func TestFindingM11_StateViewListDetectorsRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFindingM11_StateViewListCorrelatorsRace(t *testing.T) {
+func TestFindingM11_StateViewListCorrelatorsRace(_ *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 
@@ -272,7 +272,7 @@ func TestFindingM11_StateViewListCorrelatorsRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFindingM11_StateViewActiveCorrelationsRace(t *testing.T) {
+func TestFindingM11_StateViewActiveCorrelationsRace(_ *testing.T) {
 	storage := newTimeSeriesStorage()
 	storage.Add("ns", "cpu", 1.0, 1, nil)
 

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -150,39 +151,10 @@ func (s *seriesStats) toSeries(agg Aggregate) observer.Series {
 	}
 }
 
-// toSeriesUpTo returns a Series with only points where Timestamp <= upTo.
-// Uses binary search on the sorted timestamps column.
-func (s *seriesStats) toSeriesUpTo(agg Aggregate, upTo int64) observer.Series {
-	end := sort.Search(len(s.timestamps), func(i int) bool {
-		return s.timestamps[i] > upTo
-	})
-	points := make([]observer.Point, end)
-	col := s.aggregateColumn(agg)
-	for i := 0; i < end; i++ {
-		points[i] = observer.Point{
-			Timestamp: s.timestamps[i],
-			Value:     col[i],
-		}
-	}
-	return observer.Series{
-		Namespace: s.Namespace,
-		Name:      s.Name,
-		Tags:      s.Tags,
-		Points:    points,
-	}
-}
-
 // searchAfter returns the index of the first timestamp > value using binary search.
 func searchAfter(timestamps []int64, value int64) int {
 	return sort.Search(len(timestamps), func(i int) bool {
 		return timestamps[i] > value
-	})
-}
-
-// searchAtOrAfter returns the index of the first timestamp >= value using binary search.
-func searchAtOrAfter(timestamps []int64, value int64) int {
-	return sort.Search(len(timestamps), func(i int) bool {
-		return timestamps[i] >= value
 	})
 }
 
@@ -704,7 +676,7 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 	if aggStr != "" {
 		return fmt.Sprintf("%d:%s", numID, aggStr)
 	}
-	return fmt.Sprintf("%d", numID)
+	return strconv.Itoa(numID)
 }
 
 // FullKeyForNumericID returns the internal storage key for a compact numeric ID.

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -406,7 +406,7 @@ func TestGetSeriesRange_OutOfOrderInsert(t *testing.T) {
 	assert.Equal(t, int64(30), result.Points[2].Timestamp)
 }
 
-func TestFindingH1_StorageNamespacesRace(t *testing.T) {
+func TestFindingH1_StorageNamespacesRace(_ *testing.T) {
 	s := newTimeSeriesStorage()
 
 	var wg sync.WaitGroup
@@ -431,7 +431,7 @@ func TestFindingH1_StorageNamespacesRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFindingH1_StorageTimeBoundsRace(t *testing.T) {
+func TestFindingH1_StorageTimeBoundsRace(_ *testing.T) {
 	s := newTimeSeriesStorage()
 
 	var wg sync.WaitGroup
@@ -454,7 +454,7 @@ func TestFindingH1_StorageTimeBoundsRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFindingH1_StorageMaxTimestampRace(t *testing.T) {
+func TestFindingH1_StorageMaxTimestampRace(_ *testing.T) {
 	s := newTimeSeriesStorage()
 
 	var wg sync.WaitGroup
@@ -477,7 +477,7 @@ func TestFindingH1_StorageMaxTimestampRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFindingH1_StorageListAllSeriesCompactRace(t *testing.T) {
+func TestFindingH1_StorageListAllSeriesCompactRace(_ *testing.T) {
 	s := newTimeSeriesStorage()
 
 	var wg sync.WaitGroup
@@ -500,7 +500,7 @@ func TestFindingH1_StorageListAllSeriesCompactRace(t *testing.T) {
 	wg.Wait()
 }
 
-func TestFindingH1_StorageDroppedValueStatsRace(t *testing.T) {
+func TestFindingH1_StorageDroppedValueStatsRace(_ *testing.T) {
 	s := newTimeSeriesStorage()
 
 	var wg sync.WaitGroup

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -7,6 +7,7 @@ package observerimpl
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,7 +19,6 @@ import (
 	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
-	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
@@ -26,8 +26,8 @@ type logDataView struct {
 	data *recorderdef.LogData
 }
 
-// Ensure logDataView implements observer.LogView
-var _ observer.LogView = (*logDataView)(nil)
+// Ensure logDataView implements observerdef.LogView
+var _ observerdef.LogView = (*logDataView)(nil)
 
 func (v *logDataView) GetContent() []byte {
 	return v.data.Content
@@ -109,7 +109,7 @@ type TestBench struct {
 	episodeInfo    *EpisodeInfo
 
 	// Logs and log anomalies (testbench-specific, not in engine)
-	rawLogs                []observer.LogView
+	rawLogs                []observerdef.LogView
 	logAnomalies           []observerdef.Anomaly            // all anomalies from log detectors
 	logAnomaliesByDetector map[string][]observerdef.Anomaly // anomalies grouped by detector name
 
@@ -407,7 +407,7 @@ func (tb *TestBench) LoadScenario(name string) error {
 // Uses batch loading for efficiency - reads all metrics at once instead of streaming.
 func (tb *TestBench) loadParquetDir(dir string) error {
 	if tb.config.Recorder == nil {
-		return fmt.Errorf("recorder component not configured - cannot load parquet files")
+		return errors.New("recorder component not configured - cannot load parquet files")
 	}
 
 	storage := tb.engine.Storage()
@@ -743,8 +743,8 @@ func (tb *TestBench) GetComponents() []ComponentInfo {
 	return components
 }
 
-// GetStorage returns the storage (for API handlers).
-func (tb *TestBench) GetStorage() *timeSeriesStorage {
+// getStorage returns the storage (for API handlers).
+func (tb *TestBench) getStorage() *timeSeriesStorage {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 	return tb.engine.Storage()

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -337,13 +337,13 @@ func (api *TestBenchAPI) handleProgress(w http.ResponseWriter, _ *http.Request) 
 }
 
 // handleStatus returns the current status.
-func (api *TestBenchAPI) handleStatus(w http.ResponseWriter, r *http.Request) {
+func (api *TestBenchAPI) handleStatus(w http.ResponseWriter, _ *http.Request) {
 	status := api.tb.GetStatus()
 	api.writeJSON(w, status)
 }
 
 // handleScenarios lists available scenarios.
-func (api *TestBenchAPI) handleScenarios(w http.ResponseWriter, r *http.Request) {
+func (api *TestBenchAPI) handleScenarios(w http.ResponseWriter, _ *http.Request) {
 	scenarios, err := api.tb.ListScenarios()
 	if err != nil {
 		api.writeError(w, http.StatusInternalServerError, err.Error())
@@ -383,14 +383,14 @@ func (api *TestBenchAPI) handleScenarioAction(w http.ResponseWriter, r *http.Req
 }
 
 // handleComponents returns registered components.
-func (api *TestBenchAPI) handleComponents(w http.ResponseWriter, r *http.Request) {
+func (api *TestBenchAPI) handleComponents(w http.ResponseWriter, _ *http.Request) {
 	components := api.tb.GetComponents()
 	api.writeJSON(w, components)
 }
 
 // handleSeriesList returns all available series.
-func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, r *http.Request) {
-	storage := api.tb.GetStorage()
+func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request) {
+	storage := api.tb.getStorage()
 	if storage == nil {
 		api.writeJSON(w, []interface{}{})
 		return
@@ -480,7 +480,7 @@ func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericI
 		return
 	}
 
-	storage := api.tb.GetStorage()
+	storage := api.tb.getStorage()
 	if storage == nil {
 		api.writeError(w, http.StatusServiceUnavailable, "no data loaded")
 		return
@@ -607,7 +607,7 @@ func (api *TestBenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namesp
 		}
 	}
 
-	storage := api.tb.GetStorage()
+	storage := api.tb.getStorage()
 	if storage == nil {
 		api.writeError(w, http.StatusServiceUnavailable, "no data loaded")
 		return
@@ -719,7 +719,7 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 	}
 
 	detectorComponentMap := api.tb.GetDetectorComponentMap()
-	storage := api.tb.GetStorage()
+	storage := api.tb.getStorage()
 
 	toResponse := func(a observerdef.Anomaly) anomalyResponse {
 		sourceSeriesID := string(a.SourceSeriesID)
@@ -952,9 +952,9 @@ func (api *TestBenchAPI) handleLogsSummary(w http.ResponseWriter, r *http.Reques
 }
 
 // handleCorrelations returns detected correlations.
-func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, r *http.Request) {
+func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Request) {
 	correlations := api.tb.GetCorrelations()
-	storage := api.tb.GetStorage()
+	storage := api.tb.getStorage()
 
 	type anomalyOutput struct {
 		Source      string   `json:"source"`
@@ -1029,7 +1029,7 @@ func seriesIDsToStrings(ids []observerdef.SeriesID) []string {
 }
 
 // handleLeadLag returns lead-lag edges.
-func (api *TestBenchAPI) handleLeadLag(w http.ResponseWriter, r *http.Request) {
+func (api *TestBenchAPI) handleLeadLag(w http.ResponseWriter, _ *http.Request) {
 	edges, enabled := api.tb.GetLeadLagEdges()
 	if edges == nil {
 		edges = []LeadLagEdge{}
@@ -1041,7 +1041,7 @@ func (api *TestBenchAPI) handleLeadLag(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleSurprise returns surprise edges.
-func (api *TestBenchAPI) handleSurprise(w http.ResponseWriter, r *http.Request) {
+func (api *TestBenchAPI) handleSurprise(w http.ResponseWriter, _ *http.Request) {
 	edges, enabled := api.tb.GetSurpriseEdges()
 	if edges == nil {
 		edges = []SurpriseEdge{}
@@ -1053,7 +1053,7 @@ func (api *TestBenchAPI) handleSurprise(w http.ResponseWriter, r *http.Request) 
 }
 
 // handleStats returns correlator statistics.
-func (api *TestBenchAPI) handleStats(w http.ResponseWriter, r *http.Request) {
+func (api *TestBenchAPI) handleStats(w http.ResponseWriter, _ *http.Request) {
 	stats := api.tb.GetCorrelatorStats()
 	api.writeJSON(w, stats)
 }
@@ -1106,7 +1106,7 @@ func (api *TestBenchAPI) handleCompressedCorrelations(w http.ResponseWriter, r *
 	}
 	groups := cloneCompressedGroups(api.tb.GetCompressedCorrelations(threshold))
 	// Translate MemberSources from full keys to compact numeric IDs.
-	if storage := api.tb.GetStorage(); storage != nil {
+	if storage := api.tb.getStorage(); storage != nil {
 		for i := range groups {
 			for j, src := range groups[i].MemberSources {
 				groups[i].MemberSources[j] = storage.CompactSeriesID(src)
@@ -1129,5 +1129,5 @@ func (api *TestBenchAPI) writeJSON(w http.ResponseWriter, data interface{}) {
 func (api *TestBenchAPI) writeError(w http.ResponseWriter, status int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(map[string]string{"error": message})
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
 }


### PR DESCRIPTION
## Summary
- Fix linter issues across observer component tests and implementation files
- Fix license headers
- Simplify code in `comp/observer/impl/`

## Test plan
- [ ] Verify linters pass: `dda inv linter.go --targets=./comp/observer/...`
- [ ] Verify tests pass: `dda inv test --targets=./comp/observer/...`

Replaces #47882 (which was polluted by an accidental `git merge main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)