### PR TITLE
Silence more license_csv.bzl DEBUG `print`s by default

### DIFF
--- a/compliance/license_csv.bzl
+++ b/compliance/license_csv.bzl
@@ -96,7 +96,7 @@ def _handle_attribute_provider(
         print("##-- %s: %s" % (kind, str(metadata_provider)))
     if not kind:
         return
-    if kind == SHIP_SOURCE_ATTR_KIND:
+    if kind == SHIP_SOURCE_ATTR_KIND and DEBUG_LEVEL > 0:  # ~60 lines on cold analysis
         # buildifier: disable=print
         print("TODO: Couple this to creating the offer file.  Implementation TBD.")
 
@@ -225,8 +225,9 @@ def _license_csv_impl(ctx):
     # For the next few months of co-development with supply-chain, print a
     # report of what we have. It's not the final output. It just helps see what
     # we have.
-    # buildifier: disable=print
-    print("Report: \n   %s\n" % "\n   ".join(report))
+    if DEBUG_LEVEL > 0:  # ~1500 lines on cold analysis
+        # buildifier: disable=print
+        print("Report: \n   %s\n" % "\n   ".join(report))
 
     # Now do the work of turning this into something good.
 


### PR DESCRIPTION
### What does this PR do?
Gate two `print()` calls in `license_csv.bzl` on `DEBUG_LEVEL > 0`, annotated with their measured overhead per cold analysis:
- the "TODO: ... Implementation TBD." reminder (~60 lines),
- the "Report: ..." dump (~1500 lines).

### Motivation
Received feedback from users indicating that Bazel's console output was excessively verbose, hindering their ability to follow progress and diagnose potential issues.

On a cold analysis, the unconditional prints indeed produced ~1560 lines (97% of the total `bazel build //...` output).

### Describe how you validated your changes
`bazel shutdown && bazel build //...` now produces ~40 lines (including progress lines, merged by default unless the output console is redirected).

### Additional Notes
Set `DEBUG_LEVEL = 1` in `compliance/license_csv.bzl` to restore the verbose output.