### PR TITLE
Update default config

### DIFF
--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -202,7 +202,7 @@ func NewComponent(deps Requires) Provides {
 	detectors, correlators, extractors, _ := catalog.Instantiate(nil)
 
 	eng := newEngine(engineConfig{
-		storage:     newTimeSeriesStorage(),
+		storage:     newTimeSeriesStorage(deps.Log),
 		extractors:  extractors,
 		detectors:   detectors,
 		correlators: correlators,

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -190,6 +190,8 @@ func NewComponent(deps Requires) Provides {
 				key = "observer.detectors." + entry.name + ".enabled"
 			case componentCorrelator:
 				key = "observer.correlators." + entry.name + ".enabled"
+			case componentExtractor:
+				key = "observer.extractors." + entry.name + ".enabled"
 			default:
 				continue
 			}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -179,25 +179,27 @@ func (l *logObs) GetTimestampUnixMilli() int64 {
 func NewComponent(deps Requires) Provides {
 	catalog := defaultCatalog()
 
-	// Build correlator overrides from config keys (observer.correlators.<name>.enabled).
+	// Apply config overrides to catalog defaults
+	// (observer.detectors.<name>.enabled, observer.correlators.<name>.enabled).
 	cfg := deps.Config
-	var correlatorOverrides map[string]bool
 	if cfg != nil {
 		for _, entry := range catalog.Entries() {
-			if entry.kind != componentCorrelator {
+			var key string
+			switch entry.kind {
+			case componentDetector:
+				key = "observer.detectors." + entry.name + ".enabled"
+			case componentCorrelator:
+				key = "observer.correlators." + entry.name + ".enabled"
+			default:
 				continue
 			}
-			key := "observer.correlators." + entry.name + ".enabled"
-			if deps.Config.IsKnown(key) {
-				if correlatorOverrides == nil {
-					correlatorOverrides = make(map[string]bool)
-				}
-				correlatorOverrides[entry.name] = deps.Config.GetBool(key)
+			if cfg.IsKnown(key) {
+				catalog = catalog.WithDefaultEnabled(entry.name, cfg.GetBool(key))
 			}
 		}
 	}
 
-	detectors, correlators, extractors, _ := catalog.Instantiate(correlatorOverrides)
+	detectors, correlators, extractors, _ := catalog.Instantiate(nil)
 
 	eng := newEngine(engineConfig{
 		storage:     newTimeSeriesStorage(),

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -234,6 +234,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		s.seriesIDKeys = append(s.seriesIDKeys, key)
 		s.seriesIDStats = append(s.seriesIDStats, stats)
 		s.seriesGen++
+		log.Printf("[INFO] new observer series: namespace=%q name=%q tags=%v", namespace, name, tags)
 	}
 	stats.writeGeneration++
 

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -8,19 +8,20 @@ package observerimpl
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"math"
 	"os"
 	"sort"
 	"strings"
 	"sync"
 
+	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
 // timeSeriesStorage is an internal storage for time series data.
 type timeSeriesStorage struct {
 	mu     sync.RWMutex
+	logger log.Component
 	series map[string]*seriesStats
 
 	// observationTimestamps tracks all timestamps where observations occurred,
@@ -189,14 +190,19 @@ func searchAtOrAfter(timestamps []int64, value int64) int {
 }
 
 // newTimeSeriesStorage creates a new time series storage.
-func newTimeSeriesStorage() *timeSeriesStorage {
-	return &timeSeriesStorage{
+// An optional log.Component can be passed; if nil, log calls are silently dropped.
+func newTimeSeriesStorage(logger ...log.Component) *timeSeriesStorage {
+	s := &timeSeriesStorage{
 		series:                make(map[string]*seriesStats),
 		observationTimestamps: make(map[int64]struct{}),
 		seriesIDs:             make(map[string]observer.SeriesHandle),
 		droppedByMetric:       make(map[string]int64),
 		sampledDrops:          make(map[string]int),
 	}
+	if len(logger) > 0 && logger[0] != nil {
+		s.logger = logger[0]
+	}
+	return s
 }
 
 // Add records a data point for a named metric in a namespace.
@@ -234,7 +240,9 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		s.seriesIDKeys = append(s.seriesIDKeys, key)
 		s.seriesIDStats = append(s.seriesIDStats, stats)
 		s.seriesGen++
-		log.Printf("[INFO] new observer series: namespace=%q name=%q tags=%v", namespace, name, tags)
+		if s.logger != nil {
+			s.logger.Infof("[observer] new series: namespace=%q name=%q tags=%v", namespace, name, tags)
+		}
 	}
 	stats.writeGeneration++
 
@@ -295,8 +303,10 @@ func (s *timeSeriesStorage) recordDroppedValue(reason, namespace, name string, v
 	sampled := s.sampledDrops[metricKey]
 	if sampled < 3 {
 		s.sampledDrops[metricKey] = sampled + 1
-		log.Printf("[observer] dropped %s metric value namespace=%q metric=%q value=%g ts=%d tags=%v sample=%d",
-			reason, namespace, name, value, timestamp, tags, sampled+1)
+		if s.logger != nil {
+			s.logger.Warnf("[observer] dropped %s metric value namespace=%q metric=%q value=%g ts=%d tags=%v sample=%d",
+				reason, namespace, name, value, timestamp, tags, sampled+1)
+		}
 	}
 }
 

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -337,7 +337,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	// Observer
 	// Capture agent-internal logs via pkg/util/log hook and route them through the observer.
 	// Default enabled; can be disabled if needed.
-	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.enabled", true)
+	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.enabled", false)
 	// Sampling for agent-internal logs forwarded to the observer.
 	// Warn+ and above are never sampled; these apply to info/debug/trace only.
 	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.sample_rate_info", 0.0)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -365,10 +365,15 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.metrics.high_frequency_interval", 0*time.Second) // 0 = disabled
 	config.BindEnvAndSetDefault("observer.event_reporter.sending_enabled", false)
 
+	// Observer detector toggles (override catalog defaults)
+	config.BindEnvAndSetDefault("observer.detectors.cusum.enabled", true)
+	config.BindEnvAndSetDefault("observer.detectors.bocpd.enabled", false)
+	config.BindEnvAndSetDefault("observer.detectors.rrcf.enabled", false)
+
 	// Observer correlator toggles (override catalog defaults)
-	config.BindEnvAndSetDefault("observer.correlators.cross_signal.enabled", true)
+	config.BindEnvAndSetDefault("observer.correlators.cross_signal.enabled", false)
 	config.BindEnvAndSetDefault("observer.correlators.time_cluster.enabled", true)
-	config.BindEnvAndSetDefault("observer.correlators.lead_lag.enabled", true)
+	config.BindEnvAndSetDefault("observer.correlators.lead_lag.enabled", false)
 	config.BindEnvAndSetDefault("observer.correlators.surprise.enabled", false)
 
 	// Auto exit configuration

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -376,6 +376,11 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.correlators.lead_lag.enabled", false)
 	config.BindEnvAndSetDefault("observer.correlators.surprise.enabled", false)
 
+	// Observer extractor toggles (override catalog defaults)
+	config.BindEnvAndSetDefault("observer.extractors.log_metrics_extractor.enabled", false)
+	config.BindEnvAndSetDefault("observer.extractors.connection_error_extractor.enabled", false)
+	config.BindEnvAndSetDefault("observer.extractors.log_pattern_extractor.enabled", false)
+
 	// Auto exit configuration
 	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)
 	config.BindEnvAndSetDefault("auto_exit.noprocess.enabled", false)

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -340,8 +340,8 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.enabled", true)
 	// Sampling for agent-internal logs forwarded to the observer.
 	// Warn+ and above are never sampled; these apply to info/debug/trace only.
-	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.sample_rate_info", 0.2)
-	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.sample_rate_debug", 0.05)
+	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.sample_rate_info", 0.0)
+	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.sample_rate_debug", 0.0)
 	config.BindEnvAndSetDefault("observer.capture_agent_internal_logs.sample_rate_trace", 0.0)
 	// Debug: dump all observer metrics to a file periodically
 	config.BindEnvAndSetDefault("observer.debug_dump_path", "")
@@ -369,7 +369,7 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.correlators.cross_signal.enabled", true)
 	config.BindEnvAndSetDefault("observer.correlators.time_cluster.enabled", true)
 	config.BindEnvAndSetDefault("observer.correlators.lead_lag.enabled", true)
-	config.BindEnvAndSetDefault("observer.correlators.surprise.enabled", true)
+	config.BindEnvAndSetDefault("observer.correlators.surprise.enabled", false)
 
 	// Auto exit configuration
 	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)


### PR DESCRIPTION
## Summary
- Set `observer.capture_agent_internal_logs.sample_rate_info` to `0.0` (was `0.2`)
- Set `observer.capture_agent_internal_logs.sample_rate_debug` to `0.0` (was `0.05`)
- Disable `observer.correlators.surprise` by default (was `true`)

## Test plan
- [ ] Verify observer behavior with updated sampling rates