### PR TITLE
fix(ci): skip broken container openshift E2E tests

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -306,6 +306,7 @@ new-e2e-containers-eks:
     ON_NIGHTLY_FIPS: "true"
   retry: !reference [.retry_only_infra_failure, retry]
 
+# TODO: Re-enable when openshift test infrastructure is stable
 new-e2e-containers-openshift-init:
   stage: e2e_init
   extends: .new_e2e_template
@@ -313,6 +314,7 @@ new-e2e-containers-openshift-init:
     - go_e2e_deps
     - go_tools_deps
   rules:
+    - when: never # Skip: openshift test is broken
     - !reference [.on_e2e_main_release_or_rc]
     - changes:
         paths:
@@ -335,9 +337,11 @@ new-e2e-containers-openshift-init:
   allow_failure: true
   retry: !reference [.retry_only_infra_failure, retry]
 
+# TODO: Re-enable when openshift test infrastructure is stable
 new-e2e-containers-openshift:
   extends: .new_e2e_template_needs_container_deploy_linux
   rules:
+    - when: never # Skip: openshift test is broken
     - !reference [.on_e2e_main_release_or_rc]
     - changes:
         paths:


### PR DESCRIPTION
## Summary
- Skip the broken container OpenShift E2E tests (`new-e2e-containers-openshift-init` and `new-e2e-containers-openshift`) by adding `when: never` rules

## Test plan
- [ ] Verify the OpenShift E2E jobs no longer run in CI pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)