### PR TITLE
feat(trace): Add Semantic accessors for Span tags, apply lib in "http.status_code" lookup

### DIFF
--- a/pkg/trace/semantics/lookup.go
+++ b/pkg/trace/semantics/lookup.go
@@ -7,12 +7,14 @@ package semantics
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 )
 
 // Accessor provides attribute access for semantic lookups.
 // Implementations may return not-found from GetInt64/GetFloat64 when the
-// underlying store has no numeric type information (e.g. map[string]string).
+// underlying store has no numeric type information (e.g. map[string]string),
+// or not-found from GetString when the store has no string values (e.g. map[string]float64).
 type Accessor interface {
 	GetString(key string) string
 	GetInt64(key string) (int64, bool)
@@ -49,6 +51,44 @@ func (a StringMapAccessor) GetInt64(_ string) (int64, bool) {
 // GetFloat64 always returns (0, false) for the same reason as GetInt64.
 func (a StringMapAccessor) GetFloat64(_ string) (float64, bool) {
 	return 0, false
+}
+
+// MetricsMapAccessor adapts a map[string]float64 into an Accessor (e.g. DD span Metrics).
+// GetString always returns ""; string-typed registry entries are intentionally skipped
+// because map[string]float64 holds no string values. Use DDSpanAccessor, which routes
+// string lookups to StringMapAccessor (meta) instead.
+type MetricsMapAccessor struct {
+	m map[string]float64
+}
+
+// NewMetricsMapAccessor returns a MetricsMapAccessor for a map[string]float64.
+func NewMetricsMapAccessor(m map[string]float64) MetricsMapAccessor {
+	return MetricsMapAccessor{m: m}
+}
+
+// GetString always returns "". map[string]float64 holds no string values.
+func (a MetricsMapAccessor) GetString(_ string) string { return "" }
+
+// GetFloat64 returns the value directly, or (0, false) if missing or nil map.
+func (a MetricsMapAccessor) GetFloat64(key string) (float64, bool) {
+	if a.m == nil {
+		return 0, false
+	}
+	v, ok := a.m[key]
+	return v, ok
+}
+
+// GetInt64 converts the float64 value to int64 if it is an exact integer, or (0, false) otherwise.
+func (a MetricsMapAccessor) GetInt64(key string) (int64, bool) {
+	v, ok := a.GetFloat64(key)
+	if !ok {
+		return 0, false
+	}
+	i := int64(v)
+	if float64(i) != v || math.IsInf(v, 0) || math.IsNaN(v) {
+		return 0, false
+	}
+	return i, true
 }
 
 // LookupResult contains the result of a semantic attribute lookup.

--- a/pkg/trace/semantics/lookup_dd.go
+++ b/pkg/trace/semantics/lookup_dd.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package semantics
+
+// DDSpanAccessor provides typed access to combined DD span meta and metrics maps.
+// meta (map[string]string) is the primary store for string attributes.
+// metrics (map[string]float64) is the primary store for numeric attributes.
+type DDSpanAccessor struct {
+	meta    StringMapAccessor
+	metrics MetricsMapAccessor
+}
+
+// NewDDSpanAccessor returns a DDSpanAccessor for DD span meta and metrics maps.
+func NewDDSpanAccessor(meta map[string]string, metrics map[string]float64) DDSpanAccessor {
+	return DDSpanAccessor{
+		meta:    NewStringMapAccessor(meta),
+		metrics: NewMetricsMapAccessor(metrics),
+	}
+}
+
+// GetString returns the value from meta, or "" if missing.
+func (a DDSpanAccessor) GetString(key string) string {
+	return a.meta.GetString(key)
+}
+
+// GetFloat64 returns the value from metrics, or (0, false) if missing.
+func (a DDSpanAccessor) GetFloat64(key string) (float64, bool) {
+	return a.metrics.GetFloat64(key)
+}
+
+// GetInt64 returns the value from metrics as int64 if it is an exact integer, or (0, false) otherwise.
+func (a DDSpanAccessor) GetInt64(key string) (int64, bool) {
+	return a.metrics.GetInt64(key)
+}

--- a/pkg/trace/semantics/lookup_dd.go
+++ b/pkg/trace/semantics/lookup_dd.go
@@ -5,6 +5,12 @@
 
 package semantics
 
+import (
+	"math"
+
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
+)
+
 // DDSpanAccessor provides typed access to combined DD span meta and metrics maps.
 // meta (map[string]string) is the primary store for string attributes.
 // metrics (map[string]float64) is the primary store for numeric attributes.
@@ -34,4 +40,66 @@ func (a DDSpanAccessor) GetFloat64(key string) (float64, bool) {
 // GetInt64 returns the value from metrics as int64 if it is an exact integer, or (0, false) otherwise.
 func (a DDSpanAccessor) GetInt64(key string) (int64, bool) {
 	return a.metrics.GetInt64(key)
+}
+
+// DDSpanAccessorV1 adapts an *idx.InternalSpan into an Accessor.
+//
+// Attribute routing is strictly typed:
+//   - GetString returns a value only if the attribute is stored as a StringValueRef.
+//   - GetFloat64 returns a value only if the attribute is stored as a DoubleValue.
+//   - GetInt64 returns a value for IntValue or exact-integer DoubleValue.
+type DDSpanAccessorV1 struct {
+	span *idx.InternalSpan
+}
+
+// NewDDSpanAccessorV1 returns a DDSpanAccessorV1 for the given InternalSpan.
+func NewDDSpanAccessorV1(s *idx.InternalSpan) DDSpanAccessorV1 {
+	return DDSpanAccessorV1{span: s}
+}
+
+// GetString returns the attribute value if it is a StringValueRef, or "" otherwise.
+func (a DDSpanAccessorV1) GetString(key string) string {
+	attr, ok := a.span.GetAttribute(key)
+	if !ok || attr == nil {
+		return ""
+	}
+	v, ok := attr.Value.(*idx.AnyValue_StringValueRef)
+	if !ok {
+		return ""
+	}
+	return a.span.Strings.Get(v.StringValueRef)
+}
+
+// GetFloat64 returns the attribute value if it is a DoubleValue, or (0, false) otherwise.
+func (a DDSpanAccessorV1) GetFloat64(key string) (float64, bool) {
+	attr, ok := a.span.GetAttribute(key)
+	if !ok || attr == nil {
+		return 0, false
+	}
+	v, ok := attr.Value.(*idx.AnyValue_DoubleValue)
+	if !ok {
+		return 0, false
+	}
+	return v.DoubleValue, true
+}
+
+// GetInt64 returns the attribute value for IntValue directly, or converts an exact-integer
+// DoubleValue. Returns (0, false) for NaN, Inf, fractional doubles, or missing/wrong-typed attributes.
+func (a DDSpanAccessorV1) GetInt64(key string) (int64, bool) {
+	attr, ok := a.span.GetAttribute(key)
+	if !ok || attr == nil {
+		return 0, false
+	}
+	switch v := attr.Value.(type) {
+	case *idx.AnyValue_IntValue:
+		return v.IntValue, true
+	case *idx.AnyValue_DoubleValue:
+		f := v.DoubleValue
+		i := int64(f)
+		if float64(i) != f || math.IsInf(f, 0) || math.IsNaN(f) {
+			return 0, false
+		}
+		return i, true
+	}
+	return 0, false
 }

--- a/pkg/trace/semantics/lookup_dd_test.go
+++ b/pkg/trace/semantics/lookup_dd_test.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package semantics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDDSpanAccessor(t *testing.T) {
+	t.Run("GetString reads from meta", func(t *testing.T) {
+		a := NewDDSpanAccessor(
+			map[string]string{"span.kind": "server"},
+			map[string]float64{},
+		)
+		assert.Equal(t, "server", a.GetString("span.kind"))
+	})
+
+	t.Run("GetString does not read from metrics", func(t *testing.T) {
+		a := NewDDSpanAccessor(
+			map[string]string{},
+			map[string]float64{"span.kind": 1},
+		)
+		assert.Equal(t, "", a.GetString("span.kind"))
+	})
+
+	t.Run("GetInt64 reads from metrics", func(t *testing.T) {
+		a := NewDDSpanAccessor(
+			map[string]string{},
+			map[string]float64{"http.status_code": 200},
+		)
+		v, ok := a.GetInt64("http.status_code")
+		assert.True(t, ok)
+		assert.Equal(t, int64(200), v)
+	})
+
+	t.Run("GetInt64 does not read from meta", func(t *testing.T) {
+		a := NewDDSpanAccessor(
+			map[string]string{"http.status_code": "200"},
+			map[string]float64{},
+		)
+		_, ok := a.GetInt64("http.status_code")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetFloat64 reads from metrics", func(t *testing.T) {
+		a := NewDDSpanAccessor(
+			map[string]string{},
+			map[string]float64{"sampling.priority": 1.0},
+		)
+		v, ok := a.GetFloat64("sampling.priority")
+		assert.True(t, ok)
+		assert.Equal(t, 1.0, v)
+	})
+
+	t.Run("GetFloat64 does not read from meta", func(t *testing.T) {
+		a := NewDDSpanAccessor(
+			map[string]string{"sampling.priority": "1.0"},
+			map[string]float64{},
+		)
+		_, ok := a.GetFloat64("sampling.priority")
+		assert.False(t, ok)
+	})
+
+	t.Run("http.status_code in metrics resolves via int64 registry entry", func(t *testing.T) {
+		r, err := NewEmbeddedRegistry()
+		require.NoError(t, err)
+
+		// Newer agents store http.status_code in Metrics as float64(200).
+		a := NewDDSpanAccessor(
+			map[string]string{},
+			map[string]float64{"http.status_code": 200},
+		)
+		v, ok := LookupInt64(r, a, ConceptHTTPStatusCode)
+		assert.True(t, ok)
+		assert.Equal(t, int64(200), v)
+
+		s := LookupString(r, a, ConceptHTTPStatusCode)
+		assert.Equal(t, "200", s)
+	})
+
+	t.Run("http.status_code in meta resolves via string registry entry", func(t *testing.T) {
+		r, err := NewEmbeddedRegistry()
+		require.NoError(t, err)
+
+		// Older agents store http.status_code in Meta as a string.
+		a := NewDDSpanAccessor(
+			map[string]string{"http.status_code": "404"},
+			map[string]float64{},
+		)
+		v, ok := LookupInt64(r, a, ConceptHTTPStatusCode)
+		assert.True(t, ok)
+		assert.Equal(t, int64(404), v)
+
+		s := LookupString(r, a, ConceptHTTPStatusCode)
+		assert.Equal(t, "404", s)
+	})
+
+	t.Run("nil maps return empty/false", func(t *testing.T) {
+		a := NewDDSpanAccessor(nil, nil)
+		assert.Equal(t, "", a.GetString("key"))
+		_, ok := a.GetInt64("key")
+		assert.False(t, ok)
+		_, ok = a.GetFloat64("key")
+		assert.False(t, ok)
+	})
+}

--- a/pkg/trace/semantics/lookup_dd_test.go
+++ b/pkg/trace/semantics/lookup_dd_test.go
@@ -6,8 +6,10 @@
 package semantics
 
 import (
+	"math"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -108,5 +110,148 @@ func TestDDSpanAccessor(t *testing.T) {
 		assert.False(t, ok)
 		_, ok = a.GetFloat64("key")
 		assert.False(t, ok)
+	})
+}
+
+// newTestSpanV1 builds an InternalSpan and sets attributes via SetAttributeFromString
+// (which stores integers as IntValue and strings as StringValueRef) and SetFloat64Attribute.
+func newTestSpanV1() *idx.InternalSpan {
+	st := idx.NewStringTable()
+	s := idx.NewInternalSpan(st, &idx.Span{Attributes: make(map[uint32]*idx.AnyValue)})
+	return s
+}
+
+func TestDDSpanAccessorV1(t *testing.T) {
+	t.Run("GetString returns value for string attribute", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetStringAttribute("http.method", "GET")
+		a := NewDDSpanAccessorV1(s)
+		assert.Equal(t, "GET", a.GetString("http.method"))
+	})
+
+	t.Run("GetString returns empty for int attribute", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetAttributeFromString("http.status_code", "200") // stored as IntValue
+		a := NewDDSpanAccessorV1(s)
+		assert.Equal(t, "", a.GetString("http.status_code"))
+	})
+
+	t.Run("GetString returns empty for float attribute", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetFloat64Attribute("sampling.priority", 1.5)
+		a := NewDDSpanAccessorV1(s)
+		assert.Equal(t, "", a.GetString("sampling.priority"))
+	})
+
+	t.Run("GetString returns empty for missing key", func(t *testing.T) {
+		s := newTestSpanV1()
+		a := NewDDSpanAccessorV1(s)
+		assert.Equal(t, "", a.GetString("missing"))
+	})
+
+	t.Run("GetFloat64 returns value for double attribute", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetFloat64Attribute("sampling.priority", 1.5)
+		a := NewDDSpanAccessorV1(s)
+		v, ok := a.GetFloat64("sampling.priority")
+		assert.True(t, ok)
+		assert.Equal(t, 1.5, v)
+	})
+
+	t.Run("GetFloat64 returns false for int attribute", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetAttributeFromString("http.status_code", "200") // stored as IntValue
+		a := NewDDSpanAccessorV1(s)
+		_, ok := a.GetFloat64("http.status_code")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetFloat64 returns false for string attribute", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetStringAttribute("http.method", "GET")
+		a := NewDDSpanAccessorV1(s)
+		_, ok := a.GetFloat64("http.method")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 returns value for int attribute", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetAttributeFromString("http.status_code", "200") // stored as IntValue
+		a := NewDDSpanAccessorV1(s)
+		v, ok := a.GetInt64("http.status_code")
+		assert.True(t, ok)
+		assert.Equal(t, int64(200), v)
+	})
+
+	t.Run("GetInt64 converts exact DoubleValue", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetFloat64Attribute("http.status_code", 200.0)
+		a := NewDDSpanAccessorV1(s)
+		v, ok := a.GetInt64("http.status_code")
+		assert.True(t, ok)
+		assert.Equal(t, int64(200), v)
+	})
+
+	t.Run("GetInt64 rejects fractional DoubleValue", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetFloat64Attribute("http.status_code", 200.5)
+		a := NewDDSpanAccessorV1(s)
+		_, ok := a.GetInt64("http.status_code")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 rejects NaN", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetFloat64Attribute("http.status_code", math.NaN())
+		a := NewDDSpanAccessorV1(s)
+		_, ok := a.GetInt64("http.status_code")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 rejects Inf", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetFloat64Attribute("http.status_code", math.Inf(1))
+		a := NewDDSpanAccessorV1(s)
+		_, ok := a.GetInt64("http.status_code")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 returns false for string attribute", func(t *testing.T) {
+		s := newTestSpanV1()
+		s.SetStringAttribute("http.method", "GET")
+		a := NewDDSpanAccessorV1(s)
+		_, ok := a.GetInt64("http.method")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 returns false for missing key", func(t *testing.T) {
+		s := newTestSpanV1()
+		a := NewDDSpanAccessorV1(s)
+		_, ok := a.GetInt64("missing")
+		assert.False(t, ok)
+	})
+
+	t.Run("integration: LookupInt64 with IntValue storage", func(t *testing.T) {
+		r, err := NewEmbeddedRegistry()
+		require.NoError(t, err)
+
+		s := newTestSpanV1()
+		s.SetAttributeFromString("http.status_code", "404") // stored as IntValue
+		a := NewDDSpanAccessorV1(s)
+		v, ok := LookupInt64(r, a, ConceptHTTPStatusCode)
+		assert.True(t, ok)
+		assert.Equal(t, int64(404), v)
+	})
+
+	t.Run("integration: LookupInt64 with DoubleValue storage", func(t *testing.T) {
+		r, err := NewEmbeddedRegistry()
+		require.NoError(t, err)
+
+		s := newTestSpanV1()
+		s.SetFloat64Attribute("http.status_code", 503.0)
+		a := NewDDSpanAccessorV1(s)
+		v, ok := LookupInt64(r, a, ConceptHTTPStatusCode)
+		assert.True(t, ok)
+		assert.Equal(t, int64(503), v)
 	})
 }

--- a/pkg/trace/semantics/lookup_dd_test.go
+++ b/pkg/trace/semantics/lookup_dd_test.go
@@ -255,3 +255,115 @@ func TestDDSpanAccessorV1(t *testing.T) {
 		assert.Equal(t, int64(503), v)
 	})
 }
+
+// BenchmarkStringLookup_DDSpan compares direct meta map access vs semantic LookupString
+// on a DD V0 span.
+func BenchmarkStringLookup_DDSpan(b *testing.B) {
+	reg := DefaultRegistry()
+	meta := map[string]string{"http.status_code": "200"}
+	metrics := map[string]float64{}
+	accessor := NewDDSpanAccessor(meta, metrics)
+
+	b.Run("Direct", func(b *testing.B) {
+		for b.Loop() {
+			_ = meta["http.status_code"]
+		}
+	})
+
+	b.Run("Semantic", func(b *testing.B) {
+		for b.Loop() {
+			_ = LookupString(reg, accessor, ConceptHTTPStatusCode)
+		}
+	})
+
+	b.Run("SemanticWithAccessor", func(b *testing.B) {
+		for b.Loop() {
+			a := NewDDSpanAccessor(meta, metrics)
+			_ = LookupString(reg, a, ConceptHTTPStatusCode)
+		}
+	})
+}
+
+// BenchmarkInt64Lookup_DDSpan compares direct metrics map access vs semantic LookupInt64
+// on a DD V0 span.
+func BenchmarkInt64Lookup_DDSpan(b *testing.B) {
+	reg := DefaultRegistry()
+	meta := map[string]string{}
+	metrics := map[string]float64{"http.status_code": 200}
+	accessor := NewDDSpanAccessor(meta, metrics)
+
+	b.Run("Direct", func(b *testing.B) {
+		for b.Loop() {
+			_ = metrics["http.status_code"]
+		}
+	})
+
+	b.Run("Semantic", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = LookupInt64(reg, accessor, ConceptHTTPStatusCode)
+		}
+	})
+
+	b.Run("SemanticWithAccessor", func(b *testing.B) {
+		for b.Loop() {
+			a := NewDDSpanAccessor(meta, metrics)
+			_, _ = LookupInt64(reg, a, ConceptHTTPStatusCode)
+		}
+	})
+}
+
+// BenchmarkStringLookup_DDSpanV1 compares direct InternalSpan attribute access vs semantic
+// LookupString on a DD V1 span (string attribute path).
+func BenchmarkStringLookup_DDSpanV1(b *testing.B) {
+	reg := DefaultRegistry()
+	s := newTestSpanV1()
+	s.SetStringAttribute("http.status_code", "200")
+	accessor := NewDDSpanAccessorV1(s)
+
+	b.Run("Direct", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = s.GetAttributeAsString("http.status_code")
+		}
+	})
+
+	b.Run("Semantic", func(b *testing.B) {
+		for b.Loop() {
+			_ = LookupString(reg, accessor, ConceptHTTPStatusCode)
+		}
+	})
+
+	b.Run("SemanticWithAccessor", func(b *testing.B) {
+		for b.Loop() {
+			a := NewDDSpanAccessorV1(s)
+			_ = LookupString(reg, a, ConceptHTTPStatusCode)
+		}
+	})
+}
+
+// BenchmarkInt64Lookup_DDSpanV1 compares direct InternalSpan attribute access vs semantic
+// LookupInt64 on a DD V1 span.
+func BenchmarkInt64Lookup_DDSpanV1(b *testing.B) {
+	reg := DefaultRegistry()
+	s := newTestSpanV1()
+	s.SetAttributeFromString("http.status_code", "200")
+	accessor := NewDDSpanAccessorV1(s)
+
+	b.Run("Direct", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = s.GetAttributeAsFloat64("http.status_code")
+		}
+	})
+
+	b.Run("Semantic", func(b *testing.B) {
+		for b.Loop() {
+			_, _ = LookupInt64(reg, accessor, ConceptHTTPStatusCode)
+		}
+	})
+
+	b.Run("SemanticWithAccessor", func(b *testing.B) {
+		for b.Loop() {
+			a := NewDDSpanAccessorV1(s)
+			_, _ = LookupInt64(reg, a, ConceptHTTPStatusCode)
+		}
+	})
+}

--- a/pkg/trace/semantics/lookup_test.go
+++ b/pkg/trace/semantics/lookup_test.go
@@ -6,6 +6,7 @@
 package semantics
 
 import (
+	"math"
 	"strconv"
 	"testing"
 
@@ -132,6 +133,63 @@ func TestStringMapAccessor(t *testing.T) {
 
 		s := LookupString(r, accessor, ConceptHTTPStatusCode)
 		assert.Equal(t, "404", s)
+	})
+}
+
+func TestMetricsMapAccessor(t *testing.T) {
+	t.Run("GetString always returns empty", func(t *testing.T) {
+		a := NewMetricsMapAccessor(map[string]float64{"key": 200})
+		assert.Equal(t, "", a.GetString("key"))
+	})
+
+	t.Run("GetFloat64 returns value directly", func(t *testing.T) {
+		a := NewMetricsMapAccessor(map[string]float64{"x": 1.5})
+		v, ok := a.GetFloat64("x")
+		assert.True(t, ok)
+		assert.Equal(t, 1.5, v)
+	})
+
+	t.Run("GetFloat64 returns false for missing key", func(t *testing.T) {
+		a := NewMetricsMapAccessor(map[string]float64{})
+		_, ok := a.GetFloat64("missing")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetFloat64 returns false for nil map", func(t *testing.T) {
+		a := NewMetricsMapAccessor(nil)
+		_, ok := a.GetFloat64("key")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 returns exact integer", func(t *testing.T) {
+		a := NewMetricsMapAccessor(map[string]float64{"status": 404})
+		v, ok := a.GetInt64("status")
+		assert.True(t, ok)
+		assert.Equal(t, int64(404), v)
+	})
+
+	t.Run("GetInt64 rejects fractional float", func(t *testing.T) {
+		a := NewMetricsMapAccessor(map[string]float64{"x": 1.5})
+		_, ok := a.GetInt64("x")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 rejects NaN", func(t *testing.T) {
+		a := NewMetricsMapAccessor(map[string]float64{"x": math.NaN()})
+		_, ok := a.GetInt64("x")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 rejects Inf", func(t *testing.T) {
+		a := NewMetricsMapAccessor(map[string]float64{"x": math.Inf(1)})
+		_, ok := a.GetInt64("x")
+		assert.False(t, ok)
+	})
+
+	t.Run("GetInt64 returns false for missing key", func(t *testing.T) {
+		a := NewMetricsMapAccessor(map[string]float64{})
+		_, ok := a.GetInt64("missing")
+		assert.False(t, ok)
 	})
 }
 

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -15,7 +15,6 @@ import (
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
 	"github.com/DataDog/datadog-agent/pkg/trace/semantics"
-	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"google.golang.org/genproto/googleapis/rpc/code"
 )
 
@@ -75,11 +74,12 @@ func getStatusCode(meta map[string]string, metrics map[string]float64) uint32 {
 }
 
 func getStatusCodeV1(s *idx.InternalSpan) uint32 {
-	code, ok := s.GetAttributeAsFloat64(traceutil.TagStatusCode)
-	if ok {
-		return uint32(code)
+	a := semantics.NewDDSpanAccessorV1(s)
+	v, ok := semantics.LookupInt64(ddRegistry, a, semantics.ConceptHTTPStatusCode)
+	if !ok {
+		return 0
 	}
-	return 0
+	return uint32(v)
 }
 
 // NewAggregationFromSpan creates a new aggregation from the provided span and env

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -14,10 +14,12 @@ import (
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
-	"github.com/DataDog/datadog-agent/pkg/trace/log"
+	"github.com/DataDog/datadog-agent/pkg/trace/semantics"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 	"google.golang.org/genproto/googleapis/rpc/code"
 )
+
+var ddRegistry = semantics.DefaultRegistry()
 
 const (
 	tagSynthetics    = "synthetics"
@@ -64,21 +66,12 @@ type PayloadAggregationKey struct {
 }
 
 func getStatusCode(meta map[string]string, metrics map[string]float64) uint32 {
-	code, ok := metrics[traceutil.TagStatusCode]
-	if ok {
-		// only 7.39.0+, for lesser versions, always use Meta
-		return uint32(code)
-	}
-	strC := meta[traceutil.TagStatusCode]
-	if strC == "" {
+	a := semantics.NewDDSpanAccessor(meta, metrics)
+	v, ok := semantics.LookupInt64(ddRegistry, a, semantics.ConceptHTTPStatusCode)
+	if !ok {
 		return 0
 	}
-	c, err := strconv.ParseUint(strC, 10, 32)
-	if err != nil {
-		log.Debugf("Invalid status code %s. Using 0.", strC)
-		return 0
-	}
-	return uint32(c)
+	return uint32(v)
 }
 
 func getStatusCodeV1(s *idx.InternalSpan) uint32 {

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -8,6 +8,7 @@ package stats
 
 import (
 	"hash/fnv"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -64,13 +65,24 @@ type PayloadAggregationKey struct {
 	BaseService     string
 }
 
+func toStatusCode(v int64) (uint32, bool) {
+	if v < 0 || v > math.MaxUint32 {
+		return 0, false
+	}
+	return uint32(v), true
+}
+
 func getStatusCode(meta map[string]string, metrics map[string]float64) uint32 {
 	a := semantics.NewDDSpanAccessor(meta, metrics)
 	v, ok := semantics.LookupInt64(ddRegistry, a, semantics.ConceptHTTPStatusCode)
 	if !ok {
 		return 0
 	}
-	return uint32(v)
+	code, ok := toStatusCode(v)
+	if !ok {
+		return 0
+	}
+	return code
 }
 
 func getStatusCodeV1(s *idx.InternalSpan) uint32 {
@@ -79,7 +91,11 @@ func getStatusCodeV1(s *idx.InternalSpan) uint32 {
 	if !ok {
 		return 0
 	}
-	return uint32(v)
+	code, ok := toStatusCode(v)
+	if !ok {
+		return 0
+	}
+	return code
 }
 
 // NewAggregationFromSpan creates a new aggregation from the provided span and env

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace/idx"
 	"github.com/DataDog/datadog-agent/pkg/trace/traceutil"
 )
 
@@ -43,6 +44,56 @@ func TestGetStatusCode(t *testing.T) {
 		}, 200},
 	} {
 		got := getStatusCode(tt.in.Meta, tt.in.Metrics)
+		assert.Equal(t, tt.out, got, tt.name)
+	}
+}
+
+func newTestInternalSpanV1() *idx.InternalSpan {
+	st := idx.NewStringTable()
+	return idx.NewInternalSpan(st, &idx.Span{Attributes: make(map[uint32]*idx.AnyValue)})
+}
+
+func TestGetStatusCodeV1(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   *idx.InternalSpan
+		out  uint32
+	}{
+		// Empty span.
+		{"empty", newTestInternalSpanV1(), 0},
+		// Status code stored as IntValue (SetAttributeFromString uses IntValue for integer strings).
+		{"int value", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetAttributeFromString(traceutil.TagStatusCode, "200")
+			return s
+		}(), 200},
+		// Status code stored as DoubleValue (SetFloat64Attribute).
+		{"double value", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetFloat64Attribute(traceutil.TagStatusCode, 302)
+			return s
+		}(), 302},
+		// String value stored as StringValueRef.
+		{"string value", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetStringAttribute(traceutil.TagStatusCode, "404")
+			return s
+		}(), 404},
+		// OTel 1.21+ key (fallback via semantics registry).
+		{"otel key int value", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetAttributeFromString("http.response.status_code", "503")
+			return s
+		}(), 503},
+		// DD key takes precedence over OTel key when both are present.
+		{"dd key wins over otel", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetAttributeFromString(traceutil.TagStatusCode, "200")
+			s.SetAttributeFromString("http.response.status_code", "503")
+			return s
+		}(), 200},
+	} {
+		got := getStatusCodeV1(tt.in)
 		assert.Equal(t, tt.out, got, tt.name)
 	}
 }

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -16,42 +16,34 @@ import (
 
 func TestGetStatusCode(t *testing.T) {
 	for _, tt := range []struct {
-		in  *pb.Span
-		out uint32
+		name string
+		in   *pb.Span
+		out  uint32
 	}{
-		{
-			&pb.Span{},
-			0,
-		},
-		{
-			&pb.Span{
-				Meta: map[string]string{"http.status_code": "200"},
-			},
-			200,
-		},
-		{
-			&pb.Span{
-				Metrics: map[string]float64{"http.status_code": 302},
-			},
-			302,
-		},
-		{
-			&pb.Span{
-				Meta:    map[string]string{"http.status_code": "200"},
-				Metrics: map[string]float64{"http.status_code": 302},
-			},
-			302,
-		},
-		{
-			&pb.Span{
-				Meta: map[string]string{"http.status_code": "x"},
-			},
-			0,
-		},
+		// Empty span.
+		{"empty", &pb.Span{}, 0},
+		// Status code in Meta only (older agents, string-typed).
+		{"meta only", &pb.Span{Meta: map[string]string{"http.status_code": "200"}}, 200},
+		// Status code in Metrics only (agents 7.39.0+, float64-typed).
+		{"metrics only", &pb.Span{Metrics: map[string]float64{"http.status_code": 302}}, 302},
+		// Metrics takes precedence over Meta when both are present.
+		{"metrics wins", &pb.Span{
+			Meta:    map[string]string{"http.status_code": "200"},
+			Metrics: map[string]float64{"http.status_code": 302},
+		}, 302},
+		// Unparseable string returns 0.
+		{"invalid string", &pb.Span{Meta: map[string]string{"http.status_code": "x"}}, 0},
+		// OTel 1.21+ key in Meta (fallback via semantics registry).
+		{"otel key in meta", &pb.Span{Meta: map[string]string{"http.response.status_code": "404"}}, 404},
+		// OTel 1.21+ key in Metrics (fallback via semantics registry).
+		{"otel key in metrics", &pb.Span{Metrics: map[string]float64{"http.response.status_code": 503}}, 503},
+		// DD key takes precedence over OTel key when both present.
+		{"dd key wins over otel", &pb.Span{
+			Meta: map[string]string{"http.status_code": "200", "http.response.status_code": "503"},
+		}, 200},
 	} {
-		if got := getStatusCode(tt.in.Meta, tt.in.Metrics); got != tt.out {
-			t.Fatalf("Expected %d, got %d", tt.out, got)
-		}
+		got := getStatusCode(tt.in.Meta, tt.in.Metrics)
+		assert.Equal(t, tt.out, got, tt.name)
 	}
 }
 

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -34,6 +34,8 @@ func TestGetStatusCode(t *testing.T) {
 		}, 302},
 		// Unparseable string returns 0.
 		{"invalid string", &pb.Span{Meta: map[string]string{"http.status_code": "x"}}, 0},
+		// Negative value returns 0.
+		{"negative", &pb.Span{Meta: map[string]string{"http.status_code": "-1"}}, 0},
 		// OTel 1.21+ key in Meta (fallback via semantics registry).
 		{"otel key in meta", &pb.Span{Meta: map[string]string{"http.response.status_code": "404"}}, 404},
 		// OTel 1.21+ key in Metrics (fallback via semantics registry).
@@ -92,6 +94,12 @@ func TestGetStatusCodeV1(t *testing.T) {
 			s.SetAttributeFromString("http.response.status_code", "503")
 			return s
 		}(), 200},
+		// Negative IntValue returns 0.
+		{"negative int value", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetAttributeFromString(traceutil.TagStatusCode, "-1")
+			return s
+		}(), 0},
 	} {
 		got := getStatusCodeV1(tt.in)
 		assert.Equal(t, tt.out, got, tt.name)


### PR DESCRIPTION
# What does this PR do?

Adds DDSpanAccessor (V0) and DDSpanAccessorV1 (V1) — typed Accessor implementations that wrap DD span attributes for both the old (meta/metrics maps) and new (InternalSpan) payloads. Wires both into getStatusCode and getStatusCodeV1 as the first concrete use of the registry for HTTP status code lookups.

#  Motivation

This is part of an ongoing effort to replace hardcoded tag lookups with a consistent semantics registry. Rather than each callsite manually probing specific tag names, the registry centralizes attribute precedence and type handling. The accessors introduced here are the core building blocks: any component that needs to read a semantic concept from a span can now do so uniformly:

```go
  a := semantics.NewDDSpanAccessor(span.Meta, span.Metrics)
  code, ok := semantics.LookupInt64(registry, a, semantics.ConceptHTTPStatusCode)

  // or for V1:
  a := semantics.NewDDSpanAccessorV1(span)
  code, ok := semantics.LookupInt64(registry, a, semantics.ConceptHTTPStatusCode)
```

HTTP status code is the first concept wired up end-to-end for both payload versions.

#  Describe how you validated your changes

Added unit tests.

#  Additional Notes

None.