### PR TITLE
Support bazel test //... in macos

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -16,12 +16,12 @@ bazel:test:linux-arm64:
 bazel:test:macos-amd64:
   extends: [ .bazel:test, .bazel:runner:macos-amd64 ]
   script:
-    - bazel test //bazel/tests/... //rtloader/...
+    - bazel test //...
 
 bazel:test:macos-arm64:
   extends: [ .bazel:test, .bazel:runner:macos-arm64 ]
   script:
-    - bazel test //bazel/tests/... //rtloader/...
+    - bazel test //...
 
 bazel:test:windows-amd64:
   extends: [ .bazel:test, .bazel:runner:windows-amd64 ]

--- a/deps/attr/attr.BUILD.bazel
+++ b/deps/attr/attr.BUILD.bazel
@@ -41,6 +41,7 @@ copy_file(
         "@@//:linux_arm64": "config-linux-arm64.h",
     }),
     out = "config.h",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_library(

--- a/deps/dbus/dbus.BUILD.bazel
+++ b/deps/dbus/dbus.BUILD.bazel
@@ -21,6 +21,7 @@ copy_file(
         "@@//:linux_arm64": "config-linux-arm64.h",
     }),
     out = "config.h",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_library(

--- a/deps/freetds/overlay/freetds.BUILD.bazel
+++ b/deps/freetds/overlay/freetds.BUILD.bazel
@@ -46,6 +46,7 @@ copy_file(
         "@platforms//os:linux": "linux/include/config.h",
     }),
     out = "include/config.h",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_library(

--- a/deps/gcrypt/gcrypt.BUILD.bazel
+++ b/deps/gcrypt/gcrypt.BUILD.bazel
@@ -738,6 +738,7 @@ cc_library(
         ":libmpi",
         ":librandom",
     ],
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_shared_library(

--- a/deps/gpg-error/gpg-error.BUILD.bazel
+++ b/deps/gpg-error/gpg-error.BUILD.bazel
@@ -124,6 +124,7 @@ copy_file(
         "@//:linux_arm64": "config-linux-aarch64.h",
     }),
     out = "src/config.h",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_library(
@@ -210,6 +211,7 @@ genrule(
     tools = [":mkheader"],
     outs = ["src/gpg-error.h"],
     cmd = select({"@@//:%s" % config: mkheader_cmds[config] for config in config_to_abi.keys()}),
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_library(

--- a/deps/libxml2/overlay.BUILD.bazel
+++ b/deps/libxml2/overlay.BUILD.bazel
@@ -24,6 +24,7 @@ copy_file(
         "@@//:linux_arm64": "config-linux-arm64.h",
     }),
     out = "config.h",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 expand_template(

--- a/deps/libxslt/overlay.BUILD.bazel
+++ b/deps/libxslt/overlay.BUILD.bazel
@@ -23,6 +23,7 @@ copy_file(
         "@@//:linux_arm64": "config-linux-arm64.h",
     }),
     out = "config.h",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 expand_template(

--- a/deps/popt.BUILD.bazel
+++ b/deps/popt.BUILD.bazel
@@ -57,6 +57,7 @@ cc_library(
     ],
     strip_include_prefix = "src",
     visibility = ["//visibility:public"],
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_shared_library(

--- a/deps/rpm/rpm.BUILD.bazel
+++ b/deps/rpm/rpm.BUILD.bazel
@@ -22,6 +22,7 @@ copy_file(
         "@//:linux_arm64": "config-linux-arm64.h",
     }),
     out = "config.h",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_library(

--- a/deps/xmlsec/xmlsec.BUILD.bazel
+++ b/deps/xmlsec/xmlsec.BUILD.bazel
@@ -23,6 +23,7 @@ copy_file(
         "@@//:linux_arm64": "config-linux-arm64.h",
     }),
     out = "config.h",
+    target_compatible_with = ["@platforms//os:linux"],
 )
 
 cc_library(

--- a/packages/install_dir/BUILD.bazel
+++ b/packages/install_dir/BUILD.bazel
@@ -37,10 +37,7 @@ filegroup(
         "//packages/agent:linux_heroku": [
             "@curl//:all_files",
         ],
-        "//conditions:default": [
-            # This will become "//deps/openscap:all_deps" in the future
-            "@popt",
-        ],
+        "//conditions:default": [],
     }),
 )
 

--- a/pkg/procmgr/rust/BUILD.bazel
+++ b/pkg/procmgr/rust/BUILD.bazel
@@ -17,6 +17,7 @@ proto_library(
 rust_prost_library(
     name = "process_manager_rust_proto",
     proto = ":process_manager_proto",
+    target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
### What does this PR do?

Mark linux-only compatible targets in Bazel such that we can run `bazel test //...` locally and on CI.

### Motivation

More coverage on CI for macos, and local convenience to run all tests at once.

### Describe how you validated your changes

Local and CI run of `bazel test //...` on macos machines.

### Additional Notes
