### PR TITLE
chore: [SVLS-8727] fix container app env var parsing crash

### DIFF
--- a/cmd/serverless-init/cloudservice/containerapp.go
+++ b/cmd/serverless-init/cloudservice/containerapp.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/serverless-init/metric"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+	ddlog "github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ContainerApp has helper functions for getting specific Azure Container App data
@@ -52,6 +53,7 @@ const (
 	ContainerAppOrigin = "containerapp"
 
 	containerAppPrefix = "azure.containerapp"
+	regionFallback     = "unknown"
 )
 
 // GetTags returns a map of Azure-related tags
@@ -60,7 +62,12 @@ func (c *ContainerApp) GetTags() map[string]string {
 	appDNSSuffix := os.Getenv(ContainerAppDNSSuffix)
 
 	appDNSSuffixTokens := strings.Split(appDNSSuffix, ".")
-	region := appDNSSuffixTokens[len(appDNSSuffixTokens)-3]
+	region := regionFallback
+	if len(appDNSSuffixTokens) >= 3 {
+		region = appDNSSuffixTokens[len(appDNSSuffixTokens)-3]
+	} else {
+		ddlog.Debugf("CONTAINER_APP_ENV_DNS_SUFFIX has unexpected format %q, defaulting region to %s", appDNSSuffix, regionFallback)
+	}
 
 	revision := os.Getenv(ContainerAppRevision)
 	replica := os.Getenv(ContainerAppReplicaName)

--- a/cmd/serverless-init/cloudservice/containerapp_test.go
+++ b/cmd/serverless-init/cloudservice/containerapp_test.go
@@ -78,6 +78,32 @@ func TestGetContainerAppTagsBeforeInit(t *testing.T) {
 	assert.Equal(t, "/subscriptions/test_subscription_id/resourcegroups/test_resource_group/providers/microsoft.app/containerapps/test_app", tags["aca.resource.id"])
 }
 
+func TestGetContainerAppTagsEmptyDNSSuffix(t *testing.T) {
+	service := NewContainerApp()
+	t.Setenv("CONTAINER_APP_NAME", "test_app")
+	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "")
+	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
+	t.Setenv("CONTAINER_APP_REPLICA_NAME", "test--replica")
+
+	tags := service.GetTags()
+
+	assert.Equal(t, "unknown", tags["region"])
+	assert.Equal(t, "unknown", tags[acaRegion])
+}
+
+func TestGetContainerAppTagsShortDNSSuffix(t *testing.T) {
+	service := NewContainerApp()
+	t.Setenv("CONTAINER_APP_NAME", "test_app")
+	t.Setenv("CONTAINER_APP_ENV_DNS_SUFFIX", "foo.bar")
+	t.Setenv("CONTAINER_APP_REVISION", "test_revision")
+	t.Setenv("CONTAINER_APP_REPLICA_NAME", "test--replica")
+
+	tags := service.GetTags()
+
+	assert.Equal(t, "unknown", tags["region"])
+	assert.Equal(t, "unknown", tags[acaRegion])
+}
+
 func TestInitHasErrorsWhenMissingSubscriptionId(t *testing.T) {
 	service := NewContainerApp()
 	if os.Getenv("SERVERLESS_TEST") == "true" {


### PR DESCRIPTION
### What does this PR do?
Prevent a crash on ACA env var parsing.

### Motivation
In some unexpected environments the env var isn't being parsed correctly.

### Describe how you validated your changes
Unit tests.