### PR TITLE
Fix network check reading container network namespace instead of host in Docker (AGENT-15840)

### DIFF
--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -120,6 +120,7 @@ func (n defaultNetworkStats) IOCounters(pernic bool) ([]net.IOCountersStat, erro
 	stats, err := net.IOCountersByFile(pernic, netDevPath)
 	if err != nil {
 		// Fallback to default when path is missing (e.g. tests with mocked proc, or non-standard setup)
+		log.Debugf("network check: IOCountersByFile(%s) failed, falling back to net.IOCounters: %v", netDevPath, err)
 		return net.IOCounters(pernic)
 	}
 	return stats, nil

--- a/pkg/collector/corechecks/net/networkv2/network.go
+++ b/pkg/collector/corechecks/net/networkv2/network.go
@@ -113,7 +113,16 @@ type connectionStateEntry struct {
 }
 
 func (n defaultNetworkStats) IOCounters(pernic bool) ([]net.IOCountersStat, error) {
-	return net.IOCounters(pernic)
+	// Use explicit path so that in containerized environments we read from the host
+	// namespace (e.g. /host/proc/1/net/dev) instead of the container's /host/proc/net/dev
+	// which is a symlink to self and resolves to the container namespace (AGENT-15840).
+	netDevPath := filepath.Join(n.GetNetProcBasePath(), "net/dev")
+	stats, err := net.IOCountersByFile(pernic, netDevPath)
+	if err != nil {
+		// Fallback to default when path is missing (e.g. tests with mocked proc, or non-standard setup)
+		return net.IOCounters(pernic)
+	}
+	return stats, nil
 }
 
 func (n defaultNetworkStats) ProtoCounters(protocols []string) ([]net.ProtoCountersStat, error) {

--- a/pkg/collector/corechecks/net/networkv2/network_test.go
+++ b/pkg/collector/corechecks/net/networkv2/network_test.go
@@ -11,6 +11,8 @@ package networkv2
 import (
 	"bufio"
 	"bytes"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -1999,6 +2001,71 @@ func TestFetchEthtoolStatsENODEVOnStats(t *testing.T) {
 
 	expectedTags := []string{"device:enodev_stats_iface", "driver_name:ena", "driver_version:mock_version", "queue:0"}
 	mockSender.AssertNotCalled(t, "MonotonicCount", "system.net.ena.queue.tx_packets", mock.Anything, "", expectedTags)
+}
+
+// minimalProcNetDev is a tiny /proc/net/dev-shaped file for gopsutil IOCountersByFile (see IOCountersByFileWithContext in gopsutil).
+const minimalProcNetDev = `Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+fixture0: 100 2 0 0 0 0 0 0 200 3 0 0 0
+`
+
+// writeMinimalProcNetDev creates netDir/dev with minimalProcNetDev so gopsutil IOCountersByFile can parse it.
+func writeMinimalProcNetDev(t *testing.T, netDir string) {
+	t.Helper()
+	assert.NoError(t, os.MkdirAll(netDir, 0o755))
+	assert.NoError(t, os.WriteFile(filepath.Join(netDir, "dev"), []byte(minimalProcNetDev), 0o644))
+}
+
+// iocountersIfaceNamesSorted returns interface names from stats, sorted, for order-independent comparison.
+func iocountersIfaceNamesSorted(stats []net.IOCountersStat) []string {
+	names := make([]string, len(stats))
+	for i, s := range stats {
+		names[i] = s.Name
+	}
+	slices.Sort(names)
+	return names
+}
+
+// TestDefaultNetworkStatsIOCounters exercises defaultNetworkStats.IOCounters: the happy path uses net.IOCountersByFile
+// on an explicit net/dev path; if that file is missing, the implementation falls back to net.IOCounters (AGENT-15840).
+func TestDefaultNetworkStatsIOCounters(t *testing.T) {
+	// Non-container layout: GetNetProcBasePath() equals procPath, so we read <procPath>/net/dev via IOCountersByFile.
+	t.Run("IOCountersByFile_plain_procfs", func(t *testing.T) {
+		tmp := t.TempDir()
+		writeMinimalProcNetDev(t, filepath.Join(tmp, "net"))
+		stats, err := defaultNetworkStats{procPath: tmp}.IOCounters(true)
+		assert.NoError(t, err)
+		idx := slices.IndexFunc(stats, func(s net.IOCountersStat) bool { return s.Name == "fixture0" })
+		assert.NotEqual(t, -1, idx)
+		assert.Equal(t, uint64(100), stats[idx].BytesRecv)
+		assert.Equal(t, uint64(200), stats[idx].BytesSent)
+		assert.Equal(t, uint64(2), stats[idx].PacketsRecv)
+		assert.Equal(t, uint64(3), stats[idx].PacketsSent)
+	})
+	// Docker + mounted host proc: GetNetProcBasePath() is procPath + "/1", so we read <procRoot>/1/net/dev (host PID 1 netns),
+	// not <procRoot>/net/dev (symlink into the container netns).
+	t.Run("IOCountersByFile_docker_pid1_net", func(t *testing.T) {
+		t.Setenv("DOCKER_DD_AGENT", "true")
+		tmp := t.TempDir()
+		procRoot := filepath.Join(tmp, "hostproc")
+		writeMinimalProcNetDev(t, filepath.Join(procRoot, "1", "net"))
+		stats, err := defaultNetworkStats{procPath: procRoot}.IOCounters(true)
+		assert.NoError(t, err)
+		idx := slices.IndexFunc(stats, func(s net.IOCountersStat) bool { return s.Name == "fixture0" })
+		assert.NotEqual(t, -1, idx)
+		assert.Equal(t, uint64(100), stats[idx].BytesRecv)
+	})
+	// When <base>/net/dev does not exist, IOCountersByFile errors and we fall back to net.IOCounters(pernic);
+	// interface list should match a direct net.IOCounters call (counters may differ between two calls, names should not).
+	t.Run("fallback_net_IOCounters", func(t *testing.T) {
+		n := defaultNetworkStats{procPath: filepath.Join(t.TempDir(), "no-net-dev")}
+		baseline, err := net.IOCounters(true)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, baseline)
+		got, err := n.IOCounters(true)
+		assert.NoError(t, err)
+		assert.Equal(t, iocountersIfaceNamesSorted(baseline), iocountersIfaceNamesSorted(got))
+	})
 }
 
 func TestNetstatAndSnmpCountersUsingCorrectMockedProcfsPath(t *testing.T) {

--- a/releasenotes/notes/fix-networkv2-docker-host-proc-net-metrics-a8b3c7d1e2f40596.yaml
+++ b/releasenotes/notes/fix-networkv2-docker-host-proc-net-metrics-a8b3c7d1e2f40596.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes ``system.net.*`` metrics when the Agent runs in Docker with the host's procfs
+    mounted (for example ``/host/proc`` with host PID namespace). The Go network check
+    (network v2) now reads ``/proc/1/net/dev`` under that mount so interface stats match
+    the host; previously ``/proc/net/dev`` could resolve in the container network namespace
+    and report wrong or missing traffic (regression in Agent 7.73+).


### PR DESCRIPTION
### What does this PR do?
Makes the Go-based network check (networkv2) read host network stats when the agent runs in Docker with the host’s proc mounted (e.g. `/host/proc`). It does this by using `net.IOCountersByFile` with the path from `GetNetProcBasePath()` (e.g. `/host/proc/1/net/dev`) instead of `net.IOCounters()`, which ends up reading `/host/proc/net/dev`. That path is a symlink to `self/net` and resolves in the container’s network namespace, so `system.net.*` metrics were reporting container traffic instead of host traffic. If the explicit path is missing (e.g. tests or non-standard setups), the code falls back to `net.IOCounters(pernic)`.

### Motivation
After upgrading to Agent 7.73+, customers running the agent in Docker with `--cgroupns host --pid host` and `/host/proc` mounted (as in our docs) saw `system.net.*` metrics drop or reflect the container’s network namespace instead of the host’s. The root cause is that `/host/proc/net/dev` resolves to the container’s namespace, while `/host/proc/1/net/dev` gives the host’s. This restores the intended behavior so the network check reports host-level stats in that setup. Fixes [AGENT-15840](https://datadoghq.atlassian.net/browse/AGENT-15840).

### Describe how you validated your changes
- Code: `GetNetProcBasePath()` already returns the host proc base in containers (e.g. `/host/proc/1` when `DOCKER_DD_AGENT` is set and `procPath != "/proc"`). The change only switches `IOCounters` to use that path via `IOCountersByFile`, with a fallback to `net.IOCounters` on error so existing tests and non-standard configs keep working.
- Tests: Networkv2 tests are Linux-only (`//go:build linux`). Run on a Linux host or in CI:
`dda inv test --targets=./pkg/collector/corechecks/net/networkv2` 
(On macOS the same target builds but runs 0 tests for this package.)
- Manual: In an environment matching the customer setup (Docker with `/host/proc` mounted and `DOCKER_DD_AGENT` set), confirm `system.net.*` metrics reflect host interfaces and traffic, not the container’s.

### Additional Notes
- Workaround for affected customers until this is released: set `DD_USE_NETWORKV2_CHECK=false` and `DD_NETWORK_CHECK_USE_CORE_LOADER=false` to use the Python network check, which does not have this issue.
- The Python network check does not use gopsutil for `/proc/net/dev`, so it was unaffected. The regression is specific to the Go network check default in 7.73+.

[AGENT-15840]: https://datadoghq.atlassian.net/browse/AGENT-15840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ