### PR TITLE
Switch `bazel` remote config from executor to cache with fallback

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -31,13 +31,11 @@ common:lint --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=
 
 # Linux config ---------------------------------------------------------------------------------------------------------
 common:linux --strategy=sandboxed
-common:linux --remote_local_fallback_strategy=sandboxed
 
 # macOS config ---------------------------------------------------------------------------------------------------------
 common:macos --features=-macos_default_link_flags # https://github.com/bazelbuild/bazel/issues/23312
 common:macos --macos_minimum_os=11.0 # Keep in sync with https://docs.datadoghq.com/agent/supported_platforms/?tab=macos
 common:macos --strategy=sandboxed
-common:macos --remote_local_fallback_strategy=sandboxed
 
 # Windows config -------------------------------------------------------------------------------------------------------
 common:windows --strategy=standalone # Valid values are: [dynamic_worker, standalone, dynamic, remote, worker, local]
@@ -53,10 +51,10 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
-common:cache --remote_executor=grpcs://buildbarn-frontend.us1.ddbuild.io:443
+common:cache --remote_cache=grpcs://buildbarn-frontend.us1.ddbuild.io:443
 common:cache --remote_instance_name=ci/datadog-agent
-common:cache --remote_local_fallback # best-effort for --remote_executor on transient connection errors (no such host)
-common:cache --incompatible_remote_local_fallback_for_remote_cache # same for --remote_cache (exit 34)
+common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
+common:cache --incompatible_remote_local_fallback_for_remote_cache # works only if --remote_local_fallback is also set
 common:cache --remote_retries=1
 common:cache --remote_timeout=60
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -53,11 +53,10 @@ common:windows --shell_executable=C:/tools/msys64/usr/bin/bash.exe
 # Remote cache config --------------------------------------------------------------------------------------------------
 # datadog-agent virtually isolates caching instance from its parent (which is remote-caching).
 # If entry isn't found in datadog-agent, it will be searched in remote-caching.
-# Fallback doesn't work for --remote_cache, therefore, setting --remote_executor and --strategy to sandboxed
-# to use cache capabilities in combination with sandboxing.
 common:cache --remote_executor=grpcs://buildbarn-frontend.us1.ddbuild.io:443
 common:cache --remote_instance_name=ci/datadog-agent
-common:cache --remote_local_fallback # best-effort on transient connection errors (no such host)
+common:cache --remote_local_fallback # best-effort for --remote_executor on transient connection errors (no such host)
+common:cache --incompatible_remote_local_fallback_for_remote_cache # same for --remote_cache (exit 34)
 common:cache --remote_retries=1
 common:cache --remote_timeout=60
 


### PR DESCRIPTION
### What does this PR do?
Adjust the `cache` Bazel config following a complete review of the remote flags:
1. switch `--remote_executor` to `--remote_cache` since RBE infrastructure is not ready,
2. add `--incompatible_remote_local_fallback_for_remote_cache` to enable local fallback on remote cache failures,
3. remove `--remote_local_fallback_strategy=sandboxed` from the `linux` and `macos` configs, which became dead letter.

### Motivation
[Earlier discussion](https://dd.slack.com/archives/C08SK4B0FK8/p1773737357223759).

#### 1. `--remote_executor` to `--remote_cache`
The build farm is used as a remote cache, not a remote executor.
[Quoting](https://github.com/DataDog/datadog-agent/pull/47945#issuecomment-4164806630) @JSGette, who filed bazelbuild/bazel#29129:
> fallback is basically broken for remote executor if an endpoint is unavailable **before** the build. So if buildbarn was to fail **during** the build Bazel would just continue locally.

#### 2. `--incompatible_remote_local_fallback_for_remote_cache`
The flag was introduced with Bazel 8.5.1 (bazelbuild/bazel#27996) since `--remote_local_fallback` alone does not cover cache-layer failures.
Both flags are required because [they are AND-gated at the single decision point](https://github.com/bazelbuild/bazel/blob/9.0.1/src/main/java/com/google/devtools/build/lib/remote/RemoteSpawnCache.java#L191):
```java
          boolean shouldLocalFallback =
              options.remoteLocalFallbackForRemoteCache && options.remoteLocalFallback;
```
Without **both** flags, a `RemoteExecutionCapabilitiesException` (capabilities fetch failure) causes a hard build failure instead of a local fallback.

#### 3. `--remote_local_fallback_strategy` removal
The flag is unreachable in a `--remote_cache`-only setup: its single call site is `RemoteSpawnRunner.execLocally()`, gated by `RemoteExecutionService.mayBeExecutedRemotely()`, which requires `remoteExecutor != null`.
It is also `@Deprecated` (bazelbuild/bazel#7480).

### Describe how you validated your changes
The flag is a no-op outside `--config=cache` (local builds unaffected by default), but CI benefits from it by default.

### Additional Notes
The stale `registerRemoteSpawnStrategy()` javadoc (["otherwise does nothing"](https://github.com/bazelbuild/bazel/blob/9.0.1/src/main/java/com/google/devtools/build/lib/remote/RemoteActionContextProvider.java#L195-L196) when no executor is set) is a known source-reading hazard: the null-check was deliberately removed in bazelbuild/bazel#13490 (2021), moving the guard to `canExec()`.
The javadoc was never updated.