### PR TITLE
feat(renovate): Enable cargo manager for Rust dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "enabledManagers": ["custom.regex", "pre-commit", "github-actions", "dockerfile", "docker-compose"],
+    "enabledManagers": ["custom.regex", "pre-commit", "github-actions", "dockerfile", "docker-compose", "cargo"],
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
     "platformCommit": "enabled",


### PR DESCRIPTION
### What does this PR do?

Adds the `cargo` manager to the Renovate configuration, enabling automated dependency updates for Rust crates via `Cargo.toml` files.

### Motivation

Continue the Dependabot-to-Renovate migration by enabling Renovate's built-in cargo manager. This allows Renovate to scan `Cargo.toml` files in the repository and propose PRs for Rust dependency updates.

### Describe how you validated your changes

Renovate will pick up the new manager on its next scheduled run. The change is additive — it only adds `"cargo"` to the `enabledManagers` list with no other config modifications.

### Additional Notes

Part of the ongoing Dependabot → Renovate migration effort.