### PR TITLE
Consolidate `bazel` invocations in the Python code

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -379,15 +379,15 @@ def _go_only_tidy(ctx, verbose: bool):
 
 def _bazel_tidy(ctx, verbose: bool):
     # 1. deps/go.MODULE.bazel ↺ (prune stale use_repo declarations to not hinder next `bazel` commands)
-    bazel("mod", "tidy")
+    bazel(ctx, "mod", "tidy")
     # 2. go.work + **/go.mod -> **/go.mod (sync each workspace module's deps to the workspace build list)
-    bazel("run", "//:go", "work", "sync")
+    bazel(ctx, "run", "//:go", "work", "sync")
     # 3. **/*.go + **/go.mod -> **/go.mod, **/go.sum (reconcile each module's requirements with its actual imports)
-    bazel("run", "//:go_mod_tidy_all", *(("--", "-x") if verbose else ()))
+    bazel(ctx, "run", "//:go_mod_tidy_all", *(("--", "-x") if verbose else ()))
     # 4. go.work + **/go.mod -> deps/go.MODULE.bazel (update use_repo declarations)
-    bazel("mod", "tidy")
+    bazel(ctx, "mod", "tidy")
     # 5. deps/go.MODULE.bazel + /BUILD.bazel + **/*.go + **/go.mod -> **/BUILD.bazel (infer build rules from Go source)
-    bazel("run", "//:gazelle")
+    bazel(ctx, "run", "//:gazelle")
 
 
 @task(autoprint=True)

--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -7,6 +7,9 @@ import shutil
 import subprocess
 import sys
 
+from invoke import Exit
+from invoke.context import Context
+
 from tasks.libs.common.color import color_message
 
 
@@ -14,9 +17,15 @@ def bazel_not_found_message(color: str) -> str:
     return color_message("Please run `inv install-tools` for `bazel` support!", color)
 
 
-def bazel(*args: str, capture_output: bool = False) -> None | str:
+def bazel(ctx: Context, *args: str, capture_output: bool = False, sudo: bool = False) -> None | str:
     """Execute a bazel command. Returns the captured standard output as string if capture_output=True."""
 
-    cmd = shutil.which("bazel") or sys.exit(bazel_not_found_message("red"))
-    print(color_message(shlex.join(("bazel", *args)), "bold"), file=sys.stderr)
-    return (subprocess.check_output if capture_output else subprocess.check_call)((cmd, *args), text=True)
+    if not shutil.which("bazel"):
+        raise Exit(bazel_not_found_message("red"))
+    result = (ctx.sudo if sudo else ctx.run)(
+        (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(("bazel", *args)),
+        echo=True,
+        in_stream=False,
+        **({"hide": "out"} if capture_output else {"pty": sys.stdout.isatty()}),  # type: ignore[dict-item]
+    )
+    return result.stdout if capture_output else None

--- a/tasks/libs/common/gomodules.py
+++ b/tasks/libs/common/gomodules.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import ClassVar
 
 import yaml
+from invoke.context import Context
 
 import tasks
 from tasks.libs.build.bazel import bazel
@@ -230,11 +231,12 @@ class GoModule:
 
         return "v0" + agent_version[1:]
 
-    def __compute_dependencies(self):
+    def __compute_dependencies(self, ctx: Context):
         """
         Computes the list of github.com/DataDog/datadog-agent/ dependencies of the module.
         """
         output = bazel(
+            ctx,
             "run",
             "//internal/tools/modparser",
             "--",
@@ -272,10 +274,9 @@ class GoModule:
         """Return the absolute path of the Go module go.mod file."""
         return self.full_path() + "/go.mod"
 
-    @property
-    def dependencies(self):
+    def dependencies(self, ctx: Context):
         if not self._dependencies:
-            self._dependencies = self.__compute_dependencies()
+            self._dependencies = self.__compute_dependencies(ctx)
         return self._dependencies
 
     @property

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -85,7 +85,7 @@ def go_work(ctx: Context):
     """
     Update the go work to use all the modules defined in modules.yml
     """
-    bazel("run", "//:write_go_work")
+    bazel(ctx, "run", "//:write_go_work")
 
 
 @task

--- a/tasks/pkg_template.py
+++ b/tasks/pkg_template.py
@@ -5,9 +5,9 @@ from tasks.libs.build.bazel import bazel
 
 
 @task
-def generate(_: Context):
+def generate(ctx: Context):
     """
     Generate the code for the template package.
     Takes the code from the Go standard library and applies the patches.
     """
-    bazel("run", "//pkg/template:generate")
+    bazel(ctx, "run", "//pkg/template:generate")

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -124,7 +124,7 @@ def update_modules(ctx, release_branch=None, version=None, trust=False):
     with agent_context(ctx, release_branch, skip_checkout=release_branch is None):
         modules = get_default_modules()
         for module in modules.values():
-            for dependency in module.dependencies:
+            for dependency in module.dependencies(ctx):
                 dependency_mod = modules[dependency]
                 if (
                     agent_version.startswith('6')

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -22,6 +22,7 @@ from invoke.tasks import task
 
 from tasks.build_tags import UNIT_TEST_TAGS, get_default_build_tags
 from tasks.flavor import AgentFlavor
+from tasks.libs.build.bazel import bazel
 from tasks.libs.build.ninja import NinjaWriter
 from tasks.libs.ciproviders.gitlab_api import ReferenceTag
 from tasks.libs.common.color import color_message
@@ -410,7 +411,7 @@ def build_libpcap(ctx, env: dict, arch: Arch | None = None):
             ctx.run(f"echo 'libpcap version {version} already exists at {target_file}'")
             return
 
-    ctx.run(f"bazelisk run -- @libpcap//:install --destdir='{embedded_path}'")
+    bazel(ctx, "run", "--", "@libpcap//:install", f"--destdir={embedded_path}")
     ctx.run(f"strip -g {target_file}")
     return
 
@@ -1268,13 +1269,9 @@ def bazel_build_ebpf(ctx: Context, arch: Arch, build_dir: str, strip: bool = Tru
         inplace_targets = _BAZEL_EBPF_INPLACE_TARGETS
 
     all_targets = _BAZEL_EBPF_PREBUILT_TARGETS + _BAZEL_EBPF_CORE_TARGETS + list(inplace_targets.keys())
-    targets_str = " ".join(all_targets)
-
     print(f"Building {len(all_targets)} eBPF targets via Bazel...")
-    ctx.run(f"bazelisk build {targets_str}")
-
-    result = ctx.run("bazelisk info bazel-bin", hide=True)
-    bazel_bin = result.stdout.strip()
+    bazel(ctx, "build", *all_targets)
+    bazel_bin = bazel(ctx, "info", "bazel-bin", capture_output=True).strip()
 
     co_re_dir = os.path.join(build_dir, "co-re")
     os.makedirs(build_dir, exist_ok=True)
@@ -1349,7 +1346,7 @@ def build_object_files(
         # Install Bazel-managed LLVM BPF tools (needed for stripping and runtime compilation).
         sudo = "" if is_root() else "sudo"
         ctx.run(f"{sudo} mkdir -p /opt/datadog-agent/embedded/bin")
-        ctx.run(f"{sudo} bazelisk run -- @llvm_bpf//:install --destdir=/opt/datadog-agent")
+        bazel(ctx, "run", "--", "@llvm_bpf//:install", "--destdir=/opt/datadog-agent", sudo=not is_root())
 
         # Build eBPF .o files via Bazel
         bazel_build_ebpf(ctx, arch_obj, build_dir)
@@ -1403,16 +1400,16 @@ def build_rust_binaries(ctx: Context, arch: Arch, output_dir: Path | None = None
         "arm64": "//bazel/platforms:linux_arm64",
     }
 
-    platform_flag = ""
+    platform_flags = []
     if arch.kmt_arch in platform_map:
-        platform_flag = f"--platforms={platform_map[arch.kmt_arch]}"
+        platform_flags.append(f"--platforms={platform_map[arch.kmt_arch]}")
 
     for source_path in RUST_BINARIES:
         if packages and not any(source_path.startswith(package) for package in packages):
             continue
 
         install_dest = output_dir / source_path if output_dir else Path(source_path)
-        ctx.run(f"bazelisk run {platform_flag} -- @//{source_path}:install --destdir={install_dest}")
+        bazel(ctx, "run", *platform_flags, "--", f"@//{source_path}:install", f"--destdir={install_dest}")
 
 
 _BAZEL_CWS_BALOUM_TARGETS = {
@@ -1439,10 +1436,8 @@ def build_cws_object_files(
 
     if with_unit_test:
         targets = list(_BAZEL_CWS_BALOUM_TARGETS.keys())
-        ctx.run(f"bazelisk build {' '.join(targets)}")
-
-        result = ctx.run("bazelisk info bazel-bin", hide=True)
-        bazel_bin = result.stdout.strip()
+        bazel(ctx, "build", *targets)
+        bazel_bin = bazel(ctx, "info", "bazel-bin", capture_output=True).strip()
 
         for target, dest_name in _BAZEL_CWS_BALOUM_TARGETS.items():
             label_path, name = target.lstrip("/").rsplit(":", 1)

--- a/tasks/unit_tests/libs/build/bazel_tests.py
+++ b/tasks/unit_tests/libs/build/bazel_tests.py
@@ -2,24 +2,26 @@ import os
 import unittest
 from unittest.mock import patch
 
+from invoke import Context, Exit, MockContext
+
 from tasks.libs.build.bazel import bazel
 from tasks.libs.common.utils import get_repo_root
 
 
 class TestBazel(unittest.TestCase):
     def test_bazel_call(self):
-        self.assertEqual(bazel("info", "release"), 0)
+        self.assertIsNone(bazel(Context(), "info", "release"))
 
     def test_bazel_output(self):
         expected_version = (get_repo_root() / ".bazelversion").read_text().strip()
-        actual_output = bazel("info", "release", capture_output=True).strip()
+        actual_output = bazel(Context(), "info", "release", capture_output=True).strip()
         self.assertEqual(actual_output, f"release {expected_version}")
 
     @patch.dict(os.environ, {"PATH": os.devnull})
     def test_bazel_not_found(self):
-        with self.assertRaises(SystemExit) as cm:
-            bazel("info")
-        self.assertIn("Please run `inv install-tools` for `bazel` support!", cm.exception.code)
+        with self.assertRaises(Exit) as cm:
+            bazel(MockContext(), "info")
+        self.assertIn("Please run `inv install-tools` for `bazel` support!", cm.exception.message)
 
 
 if __name__ == "__main__":

--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -95,7 +95,7 @@ def update_go(
     res = ctx.run("go version")
     if res and res.stdout.startswith(f"go version go{version} "):
         print("Updating the code in pkg/template...")
-        bazel("run", "//pkg/template:generate")
+        bazel(ctx, "run", "//pkg/template:generate")
         print("Running the tidy task...")
         tidy(ctx)
     else:


### PR DESCRIPTION
### What does this PR do?
Unify calls to `bazel` from Python with _tailored_ `ctx.run`s.

This includes the transitional `bazel` helper and callers predating the helper.

### Motivation
Favor a single point of maintenance (tested) that:
1. provides an actionable error message should `bazel` be missing (`inv install-tools`),
2. preserves `bazel`'s colored output (pseudo-tty, unless captured),
3. doesn't bury actual errors under frames of Python internals (incurred by `subprocess.check_call`/`check_output`),
4. takes over the burden of `invoke` lacking shell-agnostic command lines (pyinvoke/invoke#2, pyinvoke/invoke#312, pyinvoke/invoke#341, pyinvoke/invoke#514, pyinvoke/invoke#698 and counting).

### Describe how you validated your changes
Ran the existing unit tests:
```sh
python -m pytest tasks/unit_tests/libs/build/bazel_tests.py
```