### PR TITLE
feat(metricsstore): add PushGauge API and per-key metric entries

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller.go
+++ b/pkg/clusteragent/autoscaling/workload/controller.go
@@ -130,7 +130,7 @@ func NewController(
 	c.scaler = newScaler(restMapper, scaleClient)
 
 	// Initialize metrics store
-	c.metricsStore = metricsstore.NewMetricsStore(metrics.GeneratePodAutoscalerMetrics, localSender, c.IsLeader, globalTagsFunc)
+	c.metricsStore = metricsstore.NewMetricsStore(metrics.GeneratePodAutoscalerMetrics, metrics.KeyTagsFromAnnotations, localSender, c.IsLeader, globalTagsFunc)
 	c.store.RegisterObserver(
 		autoscaling.Observer{
 			SetFunc: func(key string, _ autoscaling.SenderID) {

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator.go
@@ -9,6 +9,8 @@
 package metrics
 
 import (
+	"encoding/json"
+
 	corev1 "k8s.io/api/core/v1"
 
 	datadoghqcommon "github.com/DataDog/datadog-operator/api/datadoghq/common"
@@ -16,10 +18,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/metricsstore"
 	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
 	metricPrefix = "datadog.cluster_agent.autoscaling.workload"
+
+	// adTagsAnnotation is the Kubernetes annotation key whose value is a JSON
+	// array of Datadog tags to attach to all metrics for the annotated object.
+	adTagsAnnotation = "ad.datadoghq.com/tags"
 )
 
 // Tag generation helper functions
@@ -208,4 +215,37 @@ func GeneratePodAutoscalerMetrics(internal *model.PodAutoscalerInternal) metrics
 	})
 
 	return metrics
+}
+
+// KeyTagsFromAnnotations extracts Datadog tags from the ad.datadoghq.com/tags
+// annotation on the upstream DatadogPodAutoscaler CR. The annotation value must
+// be a JSON object mapping tag keys to tag values, e.g.:
+//
+//	{"env": "prod", "team": "backend"}
+//
+// Each key-value pair is converted to the "key:value" Datadog tag format.
+// It is used as the keyTagsFunc for the MetricsStore so that those tags are
+// appended to every metric emitted for the corresponding autoscaler key.
+func KeyTagsFromAnnotations(internal *model.PodAutoscalerInternal) []string {
+	if internal == nil {
+		return nil
+	}
+	cr := internal.UpstreamCR()
+	if cr == nil {
+		return nil
+	}
+	raw, ok := cr.Annotations[adTagsAnnotation]
+	if !ok || raw == "" {
+		return nil
+	}
+	var tagMap map[string]string
+	if err := json.Unmarshal([]byte(raw), &tagMap); err != nil {
+		log.Warnf("Failed to parse %s annotation for %s/%s: %v", adTagsAnnotation, cr.Namespace, cr.Name, err)
+		return nil
+	}
+	tags := make([]string, 0, len(tagMap))
+	for k, v := range tagMap {
+		tags = append(tags, k+":"+v)
+	}
+	return tags
 }

--- a/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
+++ b/pkg/clusteragent/autoscaling/workload/metrics/generator_test.go
@@ -521,3 +521,75 @@ func TestGeneratePodAutoscalerMetrics_NilObject(t *testing.T) {
 	metrics := GeneratePodAutoscalerMetrics(nil)
 	assert.Nil(t, metrics)
 }
+
+func TestKeyTagsFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		expectedTags []string
+	}{
+		{
+			name:         "nil internal",
+			annotations:  nil,
+			expectedTags: nil,
+		},
+		{
+			name:         "no annotation",
+			annotations:  map[string]string{},
+			expectedTags: nil,
+		},
+		{
+			name:         "empty annotation value",
+			annotations:  map[string]string{adTagsAnnotation: ""},
+			expectedTags: nil,
+		},
+		{
+			name:         "valid annotation",
+			annotations:  map[string]string{adTagsAnnotation: `{"env": "prod", "team": "backend"}`},
+			expectedTags: []string{"env:prod", "team:backend"},
+		},
+		{
+			name:         "single tag",
+			annotations:  map[string]string{adTagsAnnotation: `{"env": "staging"}`},
+			expectedTags: []string{"env:staging"},
+		},
+		{
+			name:         "invalid JSON",
+			annotations:  map[string]string{adTagsAnnotation: `not-json`},
+			expectedTags: nil,
+		},
+		{
+			name:         "wrong JSON type (array instead of object)",
+			annotations:  map[string]string{adTagsAnnotation: `["env:prod"]`},
+			expectedTags: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var internal *model.PodAutoscalerInternal
+			if tt.name != "nil internal" {
+				obj := model.FakePodAutoscalerInternal{
+					UpstreamCR: &datadoghq.DatadogPodAutoscaler{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:   "test-ns",
+							Name:        "test-dpa",
+							Annotations: tt.annotations,
+						},
+					},
+				}.Build()
+				internal = &obj
+			}
+
+			tags := KeyTagsFromAnnotations(internal)
+
+			if tt.expectedTags == nil {
+				assert.Nil(t, tags)
+			} else {
+				slices.Sort(tags)
+				slices.Sort(tt.expectedTags)
+				assert.Equal(t, tt.expectedTags, tags)
+			}
+		})
+	}
+}

--- a/pkg/clusteragent/metricsstore/store.go
+++ b/pkg/clusteragent/metricsstore/store.go
@@ -9,6 +9,8 @@ package metricsstore
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,35 +18,123 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// keyEntry holds the metrics for a single store key, protected by a RWMutex.
+// It stores both generated metrics (from Add) and pushed gauges (from PushGauge)
+// in the same map, keyed by metric identity.
+// keyTags holds per-key tags extracted from the object at Add time (e.g. from
+// the ad.datadoghq.com/tags annotation); they are appended to every metric for
+// this key when sending.
+type keyEntry struct {
+	mu      sync.RWMutex
+	metrics map[string]StructuredMetric // identity → metric
+	keyTags []string
+}
+
+func newKeyEntry() *keyEntry {
+	return &keyEntry{
+		metrics: make(map[string]StructuredMetric),
+	}
+}
+
+// metricIdentity returns a stable string key for a metric based on its name
+// and sorted tags, used as the upsert key in the pushed map.
+func metricIdentity(name string, tags []string) string {
+	sorted := slices.Clone(tags)
+	slices.Sort(sorted)
+
+	size := len(name) + 1 // name + '\x00'
+	for _, t := range sorted {
+		size += len(t) + 1 // tag + ','
+	}
+	if len(sorted) > 0 {
+		size-- // no trailing comma
+	}
+
+	var b strings.Builder
+	b.Grow(size)
+	b.WriteString(name)
+	b.WriteByte('\x00')
+	for i, t := range sorted {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(t)
+	}
+	return b.String()
+}
+
 // MetricsStore stores structured metrics for any cluster-agent resource
 // and sends them periodically via a Datadog Sender
 type MetricsStore[T any] struct {
-	metrics             sync.Map // map[string]StructuredMetrics
+	metrics             sync.Map // map[string]*keyEntry
 	generateMetricsFunc func(T) StructuredMetrics
+	keyTagsFunc         func(T) []string
 	sender              sender.Sender
 	isLeader            func() bool
 	globalTagsFunc      func() []string
 }
 
 // NewMetricsStore creates a new metrics store.
+// keyTagsFunc, if non-nil, is called on every Add to extract per-key tags from
+// the object (e.g. from the ad.datadoghq.com/tags annotation). Those tags are
+// stored in the keyEntry and appended to every metric for that key at send time.
 // globalTagsFunc, if non-nil, is called on every WriteAll to retrieve tags that
 // are appended to every metric (e.g. orch_cluster_id from the tagger).
-func NewMetricsStore[T any](generateFunc func(T) StructuredMetrics, senderInstance sender.Sender, isLeaderFunc func() bool, globalTagsFunc func() []string) *MetricsStore[T] {
+func NewMetricsStore[T any](generateFunc func(T) StructuredMetrics, keyTagsFunc func(T) []string, senderInstance sender.Sender, isLeaderFunc func() bool, globalTagsFunc func() []string) *MetricsStore[T] {
 	return &MetricsStore[T]{
 		generateMetricsFunc: generateFunc,
+		keyTagsFunc:         keyTagsFunc,
 		sender:              senderInstance,
 		isLeader:            isLeaderFunc,
 		globalTagsFunc:      globalTagsFunc,
 	}
 }
 
-// Add adds or updates metrics for an object.
+// Add adds or updates the generated metrics for an object.
+// It fully replaces all metrics for the key, including any previously pushed gauges.
+// If a keyTagsFunc was provided at construction, it is called to extract per-key
+// tags from obj (e.g. from the ad.datadoghq.com/tags annotation), which are
+// stored on the keyEntry and appended to every metric for this key at send time.
 func (m *MetricsStore[T]) Add(key string, obj T) {
 	log.Tracef("Adding/updating metrics for key: %s", key)
-	m.metrics.Store(key, m.generateMetricsFunc(obj))
+	generated := m.generateMetricsFunc(obj)
+
+	actual, _ := m.metrics.LoadOrStore(key, newKeyEntry())
+	e := actual.(*keyEntry)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	newMetrics := make(map[string]StructuredMetric, len(generated))
+	for _, metric := range generated {
+		newMetrics[metricIdentity(metric.Name, metric.Tags)] = metric
+	}
+	e.metrics = newMetrics
+
+	if m.keyTagsFunc != nil {
+		e.keyTags = m.keyTagsFunc(obj)
+	}
 }
 
-// Delete removes metrics for an object.
+// PushGauge adds or updates a gauge metric for a specific key.
+// Multiple gauges with the same metric name but different tags are stored as separate entries.
+// Calling PushGauge again with the same name and tags updates the existing value.
+func (m *MetricsStore[T]) PushGauge(key, metricName string, value float64, tags []string) {
+	actual, _ := m.metrics.LoadOrStore(key, newKeyEntry())
+	e := actual.(*keyEntry)
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.metrics[metricIdentity(metricName, tags)] = StructuredMetric{
+		Name:  metricName,
+		Type:  MetricTypeGauge,
+		Value: value,
+		Tags:  slices.Clone(tags),
+	}
+}
+
+// Delete removes all metrics for a key, including both generated and pushed gauges.
 func (m *MetricsStore[T]) Delete(key string) {
 	log.Tracef("Deleting metrics for key: %s", key)
 	m.metrics.Delete(key)
@@ -62,29 +152,34 @@ func (m *MetricsStore[T]) WriteAll() error {
 		globalTags = m.globalTagsFunc()
 	}
 
-	m.metrics.Range(func(key, value interface{}) bool {
-		metrics, ok := value.(StructuredMetrics)
-		if !ok {
-			log.Warnf("Invalid metrics type in store for key %v", key)
-			return true
+	sendMetric := func(metric StructuredMetric, keyTags []string) {
+		tags := metric.Tags
+		if len(keyTags) > 0 || len(globalTags) > 0 {
+			tags = tags[:len(tags):len(tags)]
+			tags = append(tags, keyTags...)
+			tags = append(tags, globalTags...)
 		}
+		switch metric.Type {
+		case MetricTypeGauge:
+			m.sender.Gauge(metric.Name, metric.Value, "", tags)
+		case MetricTypeMonotonicCount:
+			m.sender.MonotonicCount(metric.Name, metric.Value, "", tags)
+		case MetricTypeCount:
+			m.sender.Count(metric.Name, metric.Value, "", tags)
+		default:
+			log.Warnf("Unknown metric type %v for metric %s", metric.Type, metric.Name)
+		}
+	}
 
-		log.Tracef("Submitting %d metrics for key: %v", len(metrics), key)
-		for _, metric := range metrics {
-			tags := metric.Tags
-			if len(globalTags) > 0 {
-				tags = append(tags, globalTags...)
-			}
-			switch metric.Type {
-			case MetricTypeGauge:
-				m.sender.Gauge(metric.Name, metric.Value, "", tags)
-			case MetricTypeMonotonicCount:
-				m.sender.MonotonicCount(metric.Name, metric.Value, "", tags)
-			case MetricTypeCount:
-				m.sender.Count(metric.Name, metric.Value, "", tags)
-			default:
-				log.Warnf("Unknown metric type %v for metric %s", metric.Type, metric.Name)
-			}
+	m.metrics.Range(func(key, value interface{}) bool {
+		e := value.(*keyEntry)
+
+		e.mu.RLock()
+		defer e.mu.RUnlock()
+
+		log.Tracef("Submitting %d metrics for key: %v", len(e.metrics), key)
+		for _, metric := range e.metrics {
+			sendMetric(metric, e.keyTags)
 		}
 		return true
 	})

--- a/pkg/clusteragent/metricsstore/store_test.go
+++ b/pkg/clusteragent/metricsstore/store_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestNewMetricsStore(t *testing.T) {
-	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, nil, nil)
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, nil, nil, nil)
 
 	assert.NotNil(t, store)
 	assert.NotNil(t, store.generateMetricsFunc)
@@ -25,18 +25,21 @@ func TestMetricsStoreAdd(t *testing.T) {
 		return StructuredMetrics{
 			{Name: "test.metric", Type: MetricTypeGauge, Value: 1.0, Tags: []string{"test:tag"}},
 		}
-	}, nil, nil, nil)
+	}, nil, nil, nil, nil)
 
 	key := "test-ns/test-resource"
-
 	store.Add(key, nil)
 
 	var foundKey string
 	store.metrics.Range(func(k, v interface{}) bool {
 		foundKey = k.(string)
-		metrics := v.(StructuredMetrics)
-		assert.Len(t, metrics, 1)
-		assert.Equal(t, "test.metric", metrics[0].Name)
+		e := v.(*keyEntry)
+		e.mu.RLock()
+		defer e.mu.RUnlock()
+		assert.Len(t, e.metrics, 1)
+		for _, metric := range e.metrics {
+			assert.Equal(t, "test.metric", metric.Name)
+		}
 		return true
 	})
 
@@ -48,7 +51,7 @@ func TestMetricsStoreDelete(t *testing.T) {
 		return StructuredMetrics{
 			{Name: "test.metric", Type: MetricTypeGauge, Value: 1.0, Tags: []string{"test:tag"}},
 		}
-	}, nil, nil, nil)
+	}, nil, nil, nil, nil)
 
 	key := "test-ns/test-resource"
 
@@ -60,5 +63,173 @@ func TestMetricsStoreDelete(t *testing.T) {
 	store.Delete(key)
 
 	_, ok = store.metrics.Load(key)
+	assert.False(t, ok)
+}
+
+func TestPushGauge_SingleMetric(t *testing.T) {
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, nil, nil, nil)
+	key := "test-ns/test-resource"
+
+	store.PushGauge(key, "cpu.limit", 4.0, []string{"container:app"})
+
+	actual, ok := store.metrics.Load(key)
+	assert.True(t, ok)
+	e := actual.(*keyEntry)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	assert.Len(t, e.metrics, 1)
+}
+
+func TestPushGauge_SameNameDifferentTags(t *testing.T) {
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, nil, nil, nil)
+	key := "test-ns/test-resource"
+
+	store.PushGauge(key, "cpu.limit", 4.0, []string{"container:app"})
+	store.PushGauge(key, "cpu.limit", 8.0, []string{"container:sidecar"})
+
+	actual, ok := store.metrics.Load(key)
+	assert.True(t, ok)
+	e := actual.(*keyEntry)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	assert.Len(t, e.metrics, 2)
+}
+
+func TestPushGauge_SameNameSameTagsUpdatesValue(t *testing.T) {
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, nil, nil, nil)
+	key := "test-ns/test-resource"
+
+	store.PushGauge(key, "cpu.limit", 4.0, []string{"container:app"})
+	store.PushGauge(key, "cpu.limit", 8.0, []string{"container:app"})
+
+	actual, ok := store.metrics.Load(key)
+	assert.True(t, ok)
+	e := actual.(*keyEntry)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	assert.Len(t, e.metrics, 1)
+	for _, m := range e.metrics {
+		assert.Equal(t, 8.0, m.Value)
+	}
+}
+
+func TestPushGauge_TagOrderNormalized(t *testing.T) {
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, nil, nil, nil)
+	key := "test-ns/test-resource"
+
+	store.PushGauge(key, "cpu.limit", 4.0, []string{"b:2", "a:1"})
+	store.PushGauge(key, "cpu.limit", 8.0, []string{"a:1", "b:2"})
+
+	actual, ok := store.metrics.Load(key)
+	assert.True(t, ok)
+	e := actual.(*keyEntry)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	// Different tag order resolves to the same identity → single entry, last value wins
+	assert.Len(t, e.metrics, 1)
+	for _, m := range e.metrics {
+		assert.Equal(t, 8.0, m.Value)
+	}
+}
+
+func TestPushGauge_CoexistsWithGenerated(t *testing.T) {
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics {
+		return StructuredMetrics{
+			{Name: "generated.metric", Type: MetricTypeGauge, Value: 1.0, Tags: []string{"gen:tag"}},
+		}
+	}, nil, nil, nil, nil)
+	key := "test-ns/test-resource"
+
+	store.PushGauge(key, "pushed.metric", 2.0, []string{"pushed:tag"})
+	store.PushGauge(key, "pushed.metric2", 3.0, []string{"pushed:tag"})
+	store.Add(key, nil)
+
+	actual, ok := store.metrics.Load(key)
+	assert.True(t, ok)
+	e := actual.(*keyEntry)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	// Add replaces the whole map; only the generated metric remains
+	assert.Len(t, e.metrics, 1)
+}
+
+func TestPushGauge_TagsAreCloned(t *testing.T) {
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, nil, nil, nil)
+	key := "test-ns/test-resource"
+
+	tags := []string{"container:app", "version:1"}
+	store.PushGauge(key, "cpu.limit", 4.0, tags)
+
+	// Mutate the original slice after the call
+	tags[0] = "container:mutated"
+
+	actual, ok := store.metrics.Load(key)
+	assert.True(t, ok)
+	e := actual.(*keyEntry)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	id := metricIdentity("cpu.limit", []string{"container:app", "version:1"})
+	stored, found := e.metrics[id]
+	assert.True(t, found, "entry should still be found under the original identity")
+	assert.Equal(t, "container:app", stored.Tags[0], "stored tags must not reflect caller mutation")
+}
+
+func TestAdd_KeyTagsStoredFromKeyTagsFunc(t *testing.T) {
+	store := NewMetricsStore(
+		func(_ interface{}) StructuredMetrics { return nil },
+		func(_ interface{}) []string { return []string{"env:prod", "team:backend"} },
+		nil, nil, nil,
+	)
+	key := "test-ns/test-resource"
+
+	store.Add(key, nil)
+
+	actual, ok := store.metrics.Load(key)
+	assert.True(t, ok)
+	e := actual.(*keyEntry)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	assert.Equal(t, []string{"env:prod", "team:backend"}, e.keyTags)
+}
+
+func TestAdd_KeyTagsUpdatedOnSubsequentAdd(t *testing.T) {
+	callCount := 0
+	store := NewMetricsStore(
+		func(_ interface{}) StructuredMetrics { return nil },
+		func(_ interface{}) []string {
+			callCount++
+			if callCount == 1 {
+				return []string{"env:staging"}
+			}
+			return []string{"env:prod"}
+		},
+		nil, nil, nil,
+	)
+	key := "test-ns/test-resource"
+
+	store.Add(key, nil)
+	store.Add(key, nil)
+
+	actual, ok := store.metrics.Load(key)
+	assert.True(t, ok)
+	e := actual.(*keyEntry)
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	assert.Equal(t, []string{"env:prod"}, e.keyTags)
+}
+
+func TestDelete_RemovesAllMetrics(t *testing.T) {
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics {
+		return StructuredMetrics{
+			{Name: "generated.metric", Type: MetricTypeGauge, Value: 1.0, Tags: []string{"gen:tag"}},
+		}
+	}, nil, nil, nil, nil)
+	key := "test-ns/test-resource"
+
+	store.Add(key, nil)
+	store.PushGauge(key, "pushed.metric", 2.0, []string{"pushed:tag"})
+	store.Delete(key)
+
+	_, ok := store.metrics.Load(key)
 	assert.False(t, ok)
 }

--- a/pkg/clusteragent/metricsstore/writer_test.go
+++ b/pkg/clusteragent/metricsstore/writer_test.go
@@ -29,7 +29,7 @@ func TestWriteAll_Leader(t *testing.T) {
 			{Name: "test.gauge", Type: MetricTypeGauge, Value: 42.0, Tags: []string{"tag1:value1"}},
 			{Name: "test.count", Type: MetricTypeCount, Value: 10.0, Tags: []string{"tag2:value2"}},
 		}
-	}, mockSender, func() bool { return true }, nil)
+	}, nil, mockSender, func() bool { return true }, nil)
 
 	store.Add("key1", nil)
 
@@ -49,7 +49,7 @@ func TestWriteAll_NonLeader(t *testing.T) {
 		return StructuredMetrics{
 			{Name: "test.gauge", Type: MetricTypeGauge, Value: 42.0, Tags: []string{"tag1:value1"}},
 		}
-	}, mockSender, func() bool { return false }, nil)
+	}, nil, mockSender, func() bool { return false }, nil)
 
 	store.Add("key1", nil)
 
@@ -64,7 +64,7 @@ func TestWriteAll_EmptyStore(t *testing.T) {
 	mockSender := mocksender.NewMockSender("")
 	mockSender.On("Commit").Return()
 
-	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, mockSender, func() bool { return true }, nil)
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, mockSender, func() bool { return true }, nil)
 
 	err := store.WriteAll()
 	assert.NoError(t, err)
@@ -84,7 +84,7 @@ func TestWriteAll_MultipleMetrics(t *testing.T) {
 			{Name: "test.metric2", Type: MetricTypeGauge, Value: 2.0, Tags: []string{"test:tag"}},
 			{Name: "test.metric3", Type: MetricTypeCount, Value: 3.0, Tags: []string{"test:tag"}},
 		}
-	}, mockSender, func() bool { return true }, nil)
+	}, nil, mockSender, func() bool { return true }, nil)
 
 	store.Add("key1", nil)
 	store.Add("key2", nil)
@@ -108,7 +108,71 @@ func TestWriteAll_GlobalTagsAppended(t *testing.T) {
 		return StructuredMetrics{
 			{Name: "test.gauge", Type: MetricTypeGauge, Value: 1.0, Tags: []string{"metric:tag"}},
 		}
-	}, mockSender, func() bool { return true }, func() []string { return []string{"global:tag"} })
+	}, nil, mockSender, func() bool { return true }, func() []string { return []string{"global:tag"} })
+
+	store.Add("key1", nil)
+
+	err := store.WriteAll()
+	assert.NoError(t, err)
+
+	mockSender.AssertExpectations(t)
+}
+
+func TestWriteAll_PushedGauges(t *testing.T) {
+	mockSender := mocksender.NewMockSender("")
+	mockSender.On("Gauge", "cpu.limit", 4.0, "", []string{"container:app"}).Return()
+	mockSender.On("Gauge", "cpu.limit", 8.0, "", []string{"container:sidecar"}).Return()
+	mockSender.On("Commit").Return()
+
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics { return nil }, nil, mockSender, func() bool { return true }, nil)
+
+	store.PushGauge("key1", "cpu.limit", 4.0, []string{"container:app"})
+	store.PushGauge("key1", "cpu.limit", 8.0, []string{"container:sidecar"})
+
+	err := store.WriteAll()
+	assert.NoError(t, err)
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 2)
+}
+
+func TestWriteAll_PushedGaugesCoexistWithGenerated(t *testing.T) {
+	mockSender := mocksender.NewMockSender("")
+	mockSender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	mockSender.On("Commit").Return()
+
+	store := NewMetricsStore(func(_ interface{}) StructuredMetrics {
+		return StructuredMetrics{
+			{Name: "generated.metric", Type: MetricTypeGauge, Value: 1.0, Tags: []string{"gen:tag"}},
+		}
+	}, nil, mockSender, func() bool { return true }, nil)
+
+	store.Add("key1", nil)
+	store.PushGauge("key1", "cpu.limit", 4.0, []string{"container:app"})
+	store.PushGauge("key1", "cpu.limit", 8.0, []string{"container:sidecar"})
+
+	err := store.WriteAll()
+	assert.NoError(t, err)
+
+	mockSender.AssertNumberOfCalls(t, "Gauge", 3)
+}
+
+func TestWriteAll_KeyTagsAppended(t *testing.T) {
+	mockSender := mocksender.NewMockSender("")
+	mockSender.On("Gauge", "test.gauge", 1.0, "", []string{"metric:tag", "env:prod", "global:tag"}).Return()
+	mockSender.On("Commit").Return()
+
+	store := NewMetricsStore(
+		func(_ interface{}) StructuredMetrics {
+			return StructuredMetrics{
+				{Name: "test.gauge", Type: MetricTypeGauge, Value: 1.0, Tags: []string{"metric:tag"}},
+			}
+		},
+		func(_ interface{}) []string { return []string{"env:prod"} },
+		mockSender,
+		func() bool { return true },
+		func() []string { return []string{"global:tag"} },
+	)
 
 	store.Add("key1", nil)
 
@@ -127,7 +191,7 @@ func TestWriteAllPeriodically_CancelsOnContext(t *testing.T) {
 		return StructuredMetrics{
 			{Name: "test.metric", Type: MetricTypeGauge, Value: 1.0, Tags: []string{"test:tag"}},
 		}
-	}, mockSender, func() bool { return true }, nil)
+	}, nil, mockSender, func() bool { return true }, nil)
 
 	store.Add("key1", nil)
 


### PR DESCRIPTION
### What does this PR do?

Modifiy the cluster agent autoscaling metricsstore used to expose DPA metrics

- Introduce keyEntry struct to hold per-key metrics under a RWMutex
- Add metricIdentity helper for stable name+tags deduplication key
- Add PushGauge method to upsert individual gauge metrics per key
- Refactor WriteAll to dispatch via sendMetric helper and fix tag slice aliasing
- Add tests for PushGauge (single, same name/different tags, upsert, tag normalization, coexistence with generated metrics)
- Add writer tests for pushed gauges flushed by WriteAll

### Motivation

Support also push DPA metrics logic for metrics generating during the reconciliation loop

### Describe how you validated your changes

### Additional Notes
