### PR TITLE
check cilium/ebpf compatibility with opentelemetry-ebpf-profiler in CI

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -156,6 +156,7 @@ integration_tests_otel        @DataDog/opentelemetry-agent
 docker_image_build_otel       @DataDog/opentelemetry-agent
 build_otel_agent_*            @DataDog/opentelemetry-agent
 build_host_profiler_*         @DataDog/opentelemetry-agent @DataDog/profiling-full-host @DataDog/agent-build
+profiler_deps_check           @DataDog/profiling-full-host
 ddot_byoc_*                   @DataDog/opentelemetry-agent
 datadog_otel_components_ocb_build  @DataDog/opentelemetry-agent
 docker_integration_tests      @DataDog/container-integrations

--- a/.gitlab/build/source_test/profiler_deps_check.yml
+++ b/.gitlab/build/source_test/profiler_deps_check.yml
@@ -1,0 +1,26 @@
+---
+# Validates that shared transitive dependencies (e.g. cilium/ebpf) between the
+# agent and the opentelemetry-ebpf-profiler remain compatible.
+#
+# The profiler's eBPF unwinder depends on specific cilium/ebpf APIs. Bumping
+# cilium/ebpf in the agent without first updating the profiler fork can silently
+# break unwinding at runtime.
+profiler_deps_check:
+  stage: source_test
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
+  tags: ["arch:amd64", "specific:true"]
+  rules:
+    - !reference [.except_mergequeue]
+    - changes:
+        paths:
+          - go.mod
+          - go.sum
+        compare_to: $COMPARE_TO_BRANCH
+      when: on_success
+    - when: manual
+      allow_failure: true
+  needs: ["go_deps"]
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+  script:
+    - dda inv -- -e go-deps.validate-profiler-deps

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -583,18 +583,18 @@ def validate_profiler_deps(ctx: Context):
     the profiler's unwinding e2e tests directly from the agent CI whenever a
     common transitive dependency changes.
     """
-    # Resolve the profiler module's local directory so we can read its go.mod.
-    res = ctx.run(f"go list -m -json {EBPF_PROFILER_MODULE}", hide=True, warn=True)
+    # Download the profiler module (extracts it from the cache if needed) and
+    # get the path to its go.mod directly from the download output.
+    res = ctx.run(f"go mod download -json {EBPF_PROFILER_MODULE}", hide=True, warn=True)
     if not res or not res.ok:
-        raise Exit(f"Could not resolve {EBPF_PROFILER_MODULE}. Run 'go mod download' first.", code=1)
+        raise Exit(f"Could not download {EBPF_PROFILER_MODULE}.", code=1)
 
-    mod_info = json.loads(res.stdout)
-    mod_dir = mod_info.get("Dir")
-    if not mod_dir:
-        raise Exit(f"{EBPF_PROFILER_MODULE} has no local directory. Run 'go mod download' first.", code=1)
+    go_mod_path = json.loads(res.stdout).get("GoMod")
+    if not go_mod_path:
+        raise Exit(f"Could not locate go.mod for {EBPF_PROFILER_MODULE}.", code=1)
 
     # Parse the profiler's go.mod to find its required cilium/ebpf version.
-    res = ctx.run(f"go mod edit -json {os.path.join(mod_dir, 'go.mod')}", hide=True, warn=True)
+    res = ctx.run(f"go mod edit -json {go_mod_path}", hide=True, warn=True)
     if not res or not res.ok:
         raise Exit(f"Could not parse {EBPF_PROFILER_MODULE} go.mod.", code=1)
     profiler_requires = {req["Path"]: req["Version"] for req in json.loads(res.stdout).get("Require", [])}

--- a/tasks/go_deps.py
+++ b/tasks/go_deps.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import shutil
 import tempfile
@@ -562,3 +563,68 @@ def graph(
     if auto_open:
         print(f"Opening {fmt} file")
         ctx.run(f"open {fmtfile}")
+
+
+EBPF_PROFILER_MODULE = "go.opentelemetry.io/ebpf-profiler"
+CILIUM_EBPF_MODULE = "github.com/cilium/ebpf"
+
+
+@task
+def validate_profiler_deps(ctx: Context):
+    """Check that the agent's cilium/ebpf version is compatible with the
+    opentelemetry-ebpf-profiler.
+
+    cilium/ebpf introduces breaking API changes across minor versions. Bumping
+    it in the agent without first updating the profiler fork can silently break
+    eBPF unwinding at runtime.
+
+    TODO: This is a short-term guardrail. The long-term solution is to mirror
+    the profiler's coredump test data to Datadog-owned blob storage and run
+    the profiler's unwinding e2e tests directly from the agent CI whenever a
+    common transitive dependency changes.
+    """
+    # Resolve the profiler module's local directory so we can read its go.mod.
+    res = ctx.run(f"go list -m -json {EBPF_PROFILER_MODULE}", hide=True, warn=True)
+    if not res or not res.ok:
+        raise Exit(f"Could not resolve {EBPF_PROFILER_MODULE}. Run 'go mod download' first.", code=1)
+
+    mod_info = json.loads(res.stdout)
+    mod_dir = mod_info.get("Dir")
+    if not mod_dir:
+        raise Exit(f"{EBPF_PROFILER_MODULE} has no local directory. Run 'go mod download' first.", code=1)
+
+    # Parse the profiler's go.mod to find its required cilium/ebpf version.
+    res = ctx.run(f"go mod edit -json {os.path.join(mod_dir, 'go.mod')}", hide=True, warn=True)
+    if not res or not res.ok:
+        raise Exit(f"Could not parse {EBPF_PROFILER_MODULE} go.mod.", code=1)
+    profiler_requires = {req["Path"]: req["Version"] for req in json.loads(res.stdout).get("Require", [])}
+
+    profiler_version = profiler_requires.get(CILIUM_EBPF_MODULE)
+    if profiler_version is None:
+        raise Exit(f"{CILIUM_EBPF_MODULE} not found in {EBPF_PROFILER_MODULE} go.mod.", code=1)
+
+    # Get the version the agent resolved.
+    res = ctx.run(f"go list -m -json {CILIUM_EBPF_MODULE}", hide=True, warn=True)
+    if not res or not res.ok:
+        raise Exit(f"Could not resolve {CILIUM_EBPF_MODULE} in agent go.mod.", code=1)
+    agent_version = json.loads(res.stdout).get("Version", "")
+
+    # Patch-level differences are fine; major.minor must match.
+    if agent_version.split(".")[:2] == profiler_version.split(".")[:2]:
+        print(
+            color_message(
+                f"OK: {CILIUM_EBPF_MODULE} {agent_version} (agent) is compatible with {profiler_version} ({EBPF_PROFILER_MODULE})",
+                "green",
+            )
+        )
+    else:
+        print(
+            color_message(
+                f"MISMATCH: {CILIUM_EBPF_MODULE} version is incompatible with {EBPF_PROFILER_MODULE}!\n"
+                f"  Agent uses:     {agent_version}\n"
+                f"  Profiler needs: {profiler_version}\n"
+                f"  Please reach out to #profiling-full-host-project to update the profiler fork and validate its e2e tests before bumping cilium/ebpf here.",
+                "red",
+            )
+        )
+        raise Exit(code=1)


### PR DESCRIPTION
### What does this PR do?

https://datadoghq.atlassian.net/browse/PROF-14049

check cilium/ebpf compatibility with opentelemetry-ebpf-profiler in CI

### Motivation

cilium/ebpf bumps routinely introduce breaking API changes. When the agent bumps it without first updating the profiler fork, eBPF unwinding breaks silently. Add a go-deps.validate-profiler-deps invoke task that reads both go.mod files (via go mod edit -json) and fails if the major.minor versions diverge, plus a CI job that runs it on go.mod changes.

### Describe how you validated your changes

Tested that it fails in https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1515602904

### Additional Notes

N/A