### PR TITLE
Small fixes for testbench frontend

### DIFF
--- a/cmd/observer-testbench/ui/src/components/AnomalySwimlane.tsx
+++ b/cmd/observer-testbench/ui/src/components/AnomalySwimlane.tsx
@@ -109,6 +109,11 @@ export function AnomalySwimlane({
     const innerWidth = width - margin.left - margin.right;
     const totalHeight = totalInnerHeight + margin.top + margin.bottom;
 
+    if (width <= margin.left + margin.right || innerWidth <= 0) {
+      d3.select(svgRef.current).selectAll('*').remove();
+      return;
+    }
+
     d3.select(svgRef.current).selectAll('*').remove();
 
     const svg = d3

--- a/cmd/observer-testbench/ui/src/components/CompressedGroupCard.tsx
+++ b/cmd/observer-testbench/ui/src/components/CompressedGroupCard.tsx
@@ -25,6 +25,8 @@ interface CompressedGroupCardProps {
 
 export function CompressedGroupCard({ group }: CompressedGroupCardProps) {
   const color = getCorrelatorColor(group.correlator);
+  const commonTags = group.commonTags ?? {};
+  const patterns = group.patterns ?? [];
 
   return (
     <div className="rounded-lg p-3 bg-slate-700/40">
@@ -40,9 +42,9 @@ export function CompressedGroupCard({ group }: CompressedGroupCardProps) {
       </div>
 
       {/* Common tags */}
-      {Object.keys(group.commonTags).length > 0 && (
+      {Object.keys(commonTags).length > 0 && (
         <div className="flex flex-wrap gap-1 mb-2">
-          {Object.entries(group.commonTags).map(([k, v]) => (
+          {Object.entries(commonTags).map(([k, v]) => (
             <span
               key={k}
               className="text-[10px] px-1.5 py-0.5 bg-slate-600/50 rounded text-slate-300"
@@ -54,8 +56,9 @@ export function CompressedGroupCard({ group }: CompressedGroupCardProps) {
       )}
 
       {/* Patterns */}
-      <div className="space-y-1 mb-2">
-        {group.patterns.map((pattern, i) => (
+      {patterns.length > 0 && (
+        <div className="space-y-1 mb-2">
+          {patterns.map((pattern, i) => (
           <div key={i} className="flex items-center gap-2">
             <code className="text-[11px] text-slate-300 font-mono flex-1 truncate" title={pattern.pattern}>
               {pattern.pattern}
@@ -74,8 +77,9 @@ export function CompressedGroupCard({ group }: CompressedGroupCardProps) {
               />
             </div>
           </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
 
       {/* Time range */}
       {group.firstSeen != null && group.lastUpdated != null && group.firstSeen > 0 && (

--- a/cmd/observer-testbench/ui/src/components/LogView.tsx
+++ b/cmd/observer-testbench/ui/src/components/LogView.tsx
@@ -197,6 +197,11 @@ function LogRateChart({
     const innerWidth = width - m.left - m.right;
     const innerHeight = LOG_CHART_HEIGHT - m.top - m.bottom;
 
+    if (width <= m.left + m.right || innerWidth <= 0 || innerHeight <= 0) {
+      d3.select(svgRef.current).selectAll('*').remove();
+      return;
+    }
+
     d3.select(svgRef.current).selectAll('*').remove();
 
     const svg = d3.select(svgRef.current).attr('width', width).attr('height', LOG_CHART_HEIGHT);
@@ -207,9 +212,13 @@ function LogRateChart({
 
     const g = svg.append('g').attr('transform', `translate(${m.left},${m.top})`);
 
+    const fallbackStart = buckets[0]?.startTs;
+    const fallbackEnd = buckets[buckets.length - 1]?.endTs;
     const xDomain: [number, number] = timeRange
       ? [timeRange.start * 1000, timeRange.end * 1000]
-      : [scenarioStart * 1000, scenarioEnd * 1000];
+      : scenarioStart != null && scenarioEnd != null && scenarioEnd > scenarioStart
+        ? [scenarioStart * 1000, scenarioEnd * 1000]
+        : [fallbackStart! * 1000, fallbackEnd! * 1000];
     const xScale = d3.scaleTime().domain(xDomain).range([0, innerWidth]);
     xScaleRef.current = xScale;
 

--- a/cmd/observer-testbench/ui/src/components/MetricsChart.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsChart.tsx
@@ -217,6 +217,10 @@ export function MetricsChart({
     // Clear previous content
     d3.select(svgRef.current).selectAll('*').remove();
 
+    if (width <= margin.left + margin.right || innerWidth <= 0 || innerHeight <= 0) {
+      return;
+    }
+
     const svg = d3
       .select(svgRef.current)
       .attr('width', width)

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -186,9 +186,8 @@ export function MetricsView({
   useEffect(() => {
     if (!state.activeScenario || state.connectionState !== 'ready') return;
     if (autoSelectedScenario === state.activeScenario) return;
-
-    const telKeys = visibleGroups.filter((g) => g.namespace === 'telemetry').map((g) => g.key);
-    const virtKeys = visibleGroups.filter((g) => g.baseName.startsWith('_virtual.')).map((g) => g.key);
+    const scenarioHasSeries = (state.status?.seriesCount ?? 0) > 0;
+    if (scenarioHasSeries && allSeries.length === 0) return;
 
     const mainGroups = [...visibleGroups]
       .filter((g) => g.namespace !== 'telemetry' && !g.baseName.startsWith('_virtual.'));
@@ -207,9 +206,24 @@ export function MetricsView({
           .map((g) => g.key);
 
     setSelectedGroups(new Set(defaultKeys));
+    setGroupSeriesData(new Map());
     setAutoSelectedScenario(state.activeScenario);
     onTimeRangeChange(null);
-  }, [state.activeScenario, state.connectionState, visibleGroups, anomalyCountByGroup, autoSelectedScenario, onTimeRangeChange]);
+  }, [
+    state.activeScenario,
+    state.connectionState,
+    state.status?.seriesCount,
+    visibleGroups,
+    anomalyCountByGroup,
+    autoSelectedScenario,
+    onTimeRangeChange,
+    allSeries.length,
+  ]);
+
+  useEffect(() => {
+    prevSelectedGroupsRef.current = new Set();
+    setGroupSeriesData(new Map());
+  }, [state.activeScenario]);
 
   const prevSelectedGroupsRef = useRef<Set<string>>(new Set());
   useEffect(() => {
@@ -223,6 +237,7 @@ export function MetricsView({
     if (!selectionChanged) return;
     prevSelectedGroupsRef.current = new Set(selectedGroups);
 
+    let cancelled = false;
     const fetchSeriesData = async () => {
       const next = new Map<string, SeriesData[]>();
       for (const groupKey of selectedGroups) {
@@ -239,10 +254,15 @@ export function MetricsView({
         }
         next.set(groupKey, seriesList);
       }
-      setGroupSeriesData(next);
+      if (!cancelled) {
+        setGroupSeriesData(next);
+      }
     };
 
     fetchSeriesData();
+    return () => {
+      cancelled = true;
+    };
   }, [selectedGroups, state.connectionState, state.activeScenario, groupByKey, groupSeriesData.size]);
 
   const toggleDetector = (name: string) => {


### PR DESCRIPTION
## Summary
- Guard against zero/negative chart dimensions in D3 renders (AnomalySwimlane, LogView, MetricsChart)
- Add null-safe defaults for `commonTags` and `patterns` in CompressedGroupCard
- Fix stale data and race conditions on scenario switch in MetricsView
- Use bucket timestamps as fallback x-domain in LogRateChart when scenario bounds are missing

## Test plan
- [ ] Verify charts render correctly on initial load and resize
- [ ] Switch between scenarios and confirm no stale data appears
- [ ] Confirm CompressedGroupCard renders without errors when backend sends null tags/patterns