### PR TITLE
[observer] Add MinClusterSize threshold to TimeCluster correlator

### DIFF
--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -23,6 +23,12 @@ type TimeClusterConfig struct {
 	// WindowSeconds is how long to keep anomalies before eviction.
 	// Default: 60 seconds.
 	WindowSeconds int64
+
+	// MinClusterSize is the minimum number of anomalies a cluster must contain
+	// to be included in output (ActiveCorrelations, GetClusters).
+	// Clusters below this threshold are still tracked internally but not reported.
+	// Default: 0 (no minimum).
+	MinClusterSize int
 }
 
 // DefaultTimeClusterConfig returns a TimeClusterConfig with default values.
@@ -213,6 +219,9 @@ func (c *TimeClusterCorrelator) GetClusters() []TimeClusterInfo {
 
 	var result []TimeClusterInfo
 	for _, cluster := range c.clusters {
+		if c.config.MinClusterSize > 0 && len(cluster.anomalies) < c.config.MinClusterSize {
+			continue
+		}
 		seen := make(map[observer.SeriesID]bool)
 		for _, a := range cluster.anomalies {
 			seen[a.SourceSeriesID] = true
@@ -257,9 +266,10 @@ func (c *TimeClusterCorrelator) GetStats() map[string]interface{} {
 		"total_clusters":       len(c.clusters),
 		"total_anomalies":      totalAnomalies,
 		"largest_cluster_size": maxClusterSize,
-		"proximity_seconds": c.config.ProximitySeconds,
-		"window_seconds":    c.config.WindowSeconds,
-		"current_data_time": c.currentDataTime,
+		"proximity_seconds":  c.config.ProximitySeconds,
+		"window_seconds":     c.config.WindowSeconds,
+		"min_cluster_size":   c.config.MinClusterSize,
+		"current_data_time":  c.currentDataTime,
 	}
 }
 
@@ -276,6 +286,9 @@ func (c *TimeClusterCorrelator) ActiveCorrelations() []observer.ActiveCorrelatio
 	var result []observer.ActiveCorrelation
 
 	for _, cluster := range c.clusters {
+		if c.config.MinClusterSize > 0 && len(cluster.anomalies) < c.config.MinClusterSize {
+			continue
+		}
 		// Collect unique series IDs
 		seen := make(map[observer.SeriesID]bool)
 		for _, a := range cluster.anomalies {

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -235,6 +235,63 @@ func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 	assert.Len(t, correlations[0].Anomalies, 1)
 }
 
+func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
+	c := NewTimeClusterCorrelator(TimeClusterConfig{
+		ProximitySeconds: 10,
+		WindowSeconds:    60,
+		MinClusterSize:   3,
+	})
+
+	// Create a cluster of 2 and a cluster of 3
+	c.ProcessAnomaly(observer.Anomaly{
+		Source:         "metric.a",
+		SourceSeriesID: "ns|metric.a|",
+		Timestamp:      100,
+	})
+	c.ProcessAnomaly(observer.Anomaly{
+		Source:         "metric.b",
+		SourceSeriesID: "ns|metric.b|",
+		Timestamp:      105,
+	})
+
+	c.ProcessAnomaly(observer.Anomaly{
+		Source:         "metric.c",
+		SourceSeriesID: "ns|metric.c|",
+		Timestamp:      200,
+	})
+	c.ProcessAnomaly(observer.Anomaly{
+		Source:         "metric.d",
+		SourceSeriesID: "ns|metric.d|",
+		Timestamp:      205,
+	})
+	c.ProcessAnomaly(observer.Anomaly{
+		Source:         "metric.e",
+		SourceSeriesID: "ns|metric.e|",
+		Timestamp:      208,
+	})
+
+	// Internally both clusters exist
+	assert.Len(t, c.clusters, 2)
+
+	// Only the cluster with 3 anomalies should appear in output
+	correlations := c.ActiveCorrelations()
+	require.Len(t, correlations, 1)
+	assert.Len(t, correlations[0].Anomalies, 3)
+
+	clusters := c.GetClusters()
+	require.Len(t, clusters, 1)
+	assert.Equal(t, 3, clusters[0].AnomalyCount)
+
+	// Once the small cluster grows to meet threshold, it should appear
+	c.ProcessAnomaly(observer.Anomaly{
+		Source:         "metric.f",
+		SourceSeriesID: "ns|metric.f|",
+		Timestamp:      103,
+	})
+	correlations = c.ActiveCorrelations()
+	assert.Len(t, correlations, 2)
+}
+
 func TestTimeClusterCorrelator_DefaultConfig(t *testing.T) {
 	config := DefaultTimeClusterConfig()
 	assert.Equal(t, int64(10), config.ProximitySeconds)


### PR DESCRIPTION
## Summary

- Adds a `MinClusterSize` field to `TimeClusterConfig` that suppresses clusters with fewer than the configured number of anomalies from output
- Clusters below the threshold are still tracked internally and will appear once they grow to meet it
- Default is `0` (no filtering), preserving existing behavior

## Example configuration

Alongside other observer correlator config in the component catalog:

```go
NewTimeClusterCorrelator(TimeClusterConfig{
    ProximitySeconds: 10,
    WindowSeconds:    120,
    MinClusterSize:   3, // only report clusters with 3+ anomalies
})
```

## Test plan

- [x] New `TestTimeClusterCorrelator_MinClusterSize` covers filtering in both `ActiveCorrelations()` and `GetClusters()`, and verifies clusters appear once they grow past the threshold
- [x] All existing TimeCluster tests pass unchanged