### PR TITLE
fix(review): Fix primary-secondary determination

### DIFF
--- a/tasks/issue.py
+++ b/tasks/issue.py
@@ -50,7 +50,7 @@ def ask_reviews(_, pr_id, action, team_slugs):
     waves = [emoji for emoji in emojis.data['emoji'] if 'wave' in emoji and 'microwave' not in emoji]
 
     # Compute per-team file counts and PR size
-    file_counts = _get_team_file_counts(pr, requested)
+    file_counts = _get_team_file_counts(pr)
     size = get_pr_size(pr)
     max_files = max(file_counts.values()) if file_counts else 0
 
@@ -112,17 +112,15 @@ def _is_revert(pr) -> bool:
     return False
 
 
-def _get_team_file_counts(pr, team_slugs, owners_file='.github/CODEOWNERS'):
+def _get_team_file_counts(pr, owners_file='.github/CODEOWNERS'):
     """Return a dict mapping each team slug to the number of PR files it owns."""
     owners = read_owners(owners_file)
-    counts = {slug: 0 for slug in team_slugs}
+    counts = defaultdict(int)
     for f in pr.get_files():
         file_owners = owners.of(f.filename)
-        for _kind, owner_handle in file_owners:
+        for _, owner_handle in file_owners:
             normalized = owner_handle.casefold().removeprefix("@datadog/")
-            for slug in team_slugs:
-                if slug.casefold() == normalized:
-                    counts[slug] += 1
+            counts[normalized] += 1
     return counts
 
 


### PR DESCRIPTION
### What does this PR do?
Count the ownership of all PR files to properly decide the `primary`/`secondary` role indicator in code review message.

### Motivation
This indicator must help reviewers understand their role in code review. The computation was wrong as only computing the number of files related to the current review_request, thus emitting `primary` nearly all the time.

### Describe how you validated your changes
Local tests on existing PR with modified code:
```
 GITHUB_TOKEN=$(ddtool 
auth github token) inv issue.ask-reviews -p 47890 -a review_request -t agent-log-pipelines
Requested reviewers: ['agent-log-pipelines']
PR size: large lines, 10 files defaultdict(<class 'int'>, {'agent-devx': 9, 'agent-health': 1, 'agent-log-pipelines': 1, 'agent-runtime
s': 2, 'ebpf-platform': 1, 'ndm-integrations': 1, 'network-device-monitoring-core': 1, 'cloud-network-monitoring': 4, 'windows-products
': 1, 'ecs-experiences': 1})
*Pierre-Louis Veyrenc* is asking review for PR <https://github.com/DataDog/datadog-agent/pull/47890/s|[ACIX-1365] refactor(e2e): auto-i
nstall ECR credentials helper in docker.NewManager>.
This is a `large` PR.
agent-log-pipelines has 1 file(s) to review, as a secondary reviewer.
Could you please have a look? Thanks in advance!
 #agent-log-pipelines
```

### Additional Notes


[ACIX-1365]: https://datadoghq.atlassian.net/browse/ACIX-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ