### PR TITLE
[observer] Detectors can emit metrics

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -356,6 +356,8 @@ type DetectionResult struct {
 	Anomalies []Anomaly
 	// Used to debug anomaly detectors
 	Telemetry []ObserverTelemetry
+	// Virtual metrics
+	Metrics []MetricOutput
 }
 
 // SeriesDetector analyzes a time series for anomalies.

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -180,8 +180,9 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 	view := &logView{obs: l}
 	for _, extractor := range e.extractors {
 		metrics := extractor.ProcessLog(view)
+		name := extractor.Name()
 		for _, m := range metrics {
-			e.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
+			e.storage.Add(source, virtualMetricName(name, m.Name), m.Value, l.timestampMs/1000, m.Tags)
 		}
 	}
 	for _, lo := range e.logObservers {
@@ -283,6 +284,10 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 			})
 		}
 		allTelemetry = append(allTelemetry, result.Telemetry...)
+		name := detector.Name()
+		for _, m := range result.Metrics {
+			e.storage.Add("detector", virtualMetricName(name, m.Name), m.Value, upTo, m.Tags)
+		}
 	}
 
 	// Advance correlators so they can update their internal state.
@@ -623,4 +628,9 @@ func (e *engine) ReplayStoredData() advanceResult {
 		anomalies: allAnomalies,
 		telemetry: allTelemetry,
 	}
+}
+
+// Returns the name of a virtual metric for a given detector and metric name.
+func virtualMetricName(detectorName string, metricName string) string {
+	return "_virtual." + detectorName + "." + metricName
 }

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -260,6 +260,11 @@ func (e *engine) advanceWithReason(upToSec int64, reason advanceReason) advanceR
 func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []observerdef.Detector, correlators []observerdef.Correlator) advanceResult {
 	var allAnomalies []observerdef.Anomaly
 	var allTelemetry []observerdef.ObserverTelemetry
+	type metricWithDetector struct {
+		Metric       observerdef.MetricOutput
+		DetectorName string
+	}
+	var allMetrics []metricWithDetector
 
 	for _, detector := range detectors {
 		result := detector.Detect(e.storage, upTo)
@@ -279,10 +284,19 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 			})
 		}
 		allTelemetry = append(allTelemetry, result.Telemetry...)
-		name := detector.Name()
 		for _, m := range result.Metrics {
-			e.storage.Add("detector", virtualMetricName(name, m.Name), m.Value, upTo, m.Tags)
+			allMetrics = append(allMetrics, metricWithDetector{
+				Metric:       m,
+				DetectorName: detector.Name(),
+			})
 		}
+	}
+
+	// *Note about metrics*
+	// When we emit these metrics, they are processed by detectors during the next advance cycle.
+	// This avoids a circular dependency where detectors need to know about each other's metrics.
+	for _, metricWithDetector := range allMetrics {
+		e.storage.Add("detector", virtualMetricName(metricWithDetector.DetectorName, metricWithDetector.Metric.Name), metricWithDetector.Metric.Value, upTo, metricWithDetector.Metric.Tags)
 	}
 
 	// Advance correlators so they can update their internal state.

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -456,6 +456,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 
 	var allAnomalies []observerdef.Anomaly
 	var allTelemetry []observerdef.ObserverTelemetry
+	var allMetrics []observerdef.MetricOutput
 
 	for _, meta := range allSeries {
 		keyStr := seriesKey(meta.Namespace, meta.Name, meta.Tags)
@@ -487,10 +488,11 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 			}
 			allAnomalies = append(allAnomalies, result.Anomalies...)
 			allTelemetry = append(allTelemetry, result.Telemetry...)
+			allMetrics = append(allMetrics, result.Metrics...)
 		}
 	}
 
-	return observerdef.DetectionResult{Anomalies: allAnomalies, Telemetry: allTelemetry}
+	return observerdef.DetectionResult{Anomalies: allAnomalies, Telemetry: allTelemetry, Metrics: allMetrics}
 }
 
 // aggSuffix returns a short suffix for the given aggregation type.

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -683,7 +683,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				telemetryEvent.DetectorName = detectorName
 			}
 			// Save this for UI
-			tb.engine.Storage().Add("telemetry", "telemetry."+telemetryEvent.DetectorName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
+			tb.engine.Storage().Add("telemetry", telemetryMetricName(telemetryEvent.DetectorName, metric.name), metric.value, metric.timestamp, metric.tags)
 		}
 
 		if telemetryEvent.Log != nil {
@@ -796,7 +796,7 @@ func (tb *TestBench) resolveAnomalySeriesIDs(anomalies []observerdef.Anomaly) []
 	for i := range anomalies {
 		a := &anomalies[i]
 		if a.SourceSeriesID == "" && a.Source != "" {
-			telemetryName := "telemetry." + a.DetectorName + "." + string(a.Source)
+			telemetryName := telemetryMetricName(a.DetectorName, string(a.Source))
 			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
 		}
 	}
@@ -1348,4 +1348,8 @@ func getDemoPhaseValueInverse(elapsed, baseline, trough, delay float64) float64 
 	default:
 		return baseline
 	}
+}
+
+func telemetryMetricName(detectorName string, metricName string) string {
+	return "telemetry." + detectorName + "." + metricName
 }


### PR DESCRIPTION
### What does this PR do?

This adds metrics to detector results. The goal is to have a way to emit metrics that are batched, here will be the workflow of log anomaly detection:
1. Extract log patterns -> emit pattern count metric
2. From the detector, compute the rate of each pattern -> emit pattern rate metric
3. From other detectors, do detection on these metrics (this sounds proper than having an instance of a metric detector inside the log AD)

I also refactored how we compute the virtual / telemetry metric names.

### Motivation

### Describe how you validated your changes

### Additional Notes
