### PR TITLE
Use zstd for faster compression in e2e test binaries

### DIFF
--- a/.gitlab/test/e2e/e2e.yml
+++ b/.gitlab/test/e2e/e2e.yml
@@ -180,11 +180,11 @@ go_e2e_test_binaries:
     - go install github.com/DataDog/orchestrion
     - popd
     - dda inv -- -e new-e2e-tests.build-binaries --output-dir test-binaries -p $KUBERNETES_CPU_REQUEST --manifest-file-path manifest.json
-    - tar czf test-binaries.tar.gz test-binaries
+    - tar -cf test-binaries.tar.zst -I "zstd -T0" test-binaries
   artifacts:
     expire_in: 1 week
     paths:
-      - test-binaries.tar.gz
+      - test-binaries.tar.zst
       - manifest.json
   rules:
     - !reference [.except_mergequeue]

--- a/internal/tools/gotest-custom/go.mod
+++ b/internal/tools/gotest-custom/go.mod
@@ -2,4 +2,7 @@ module github.com/DataDog/datadog-agent/internal/tools/gotest-custom
 
 go 1.25.0
 
-require github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+require (
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/klauspost/compress v1.18.4
+)

--- a/internal/tools/gotest-custom/go.sum
+++ b/internal/tools/gotest-custom/go.sum
@@ -1,2 +1,4 @@
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=

--- a/internal/tools/gotest-custom/main.go
+++ b/internal/tools/gotest-custom/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"archive/tar"
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -20,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/google/shlex"
+	"github.com/klauspost/compress/zstd"
 )
 
 func main() {
@@ -148,7 +148,7 @@ type Manifest struct {
 }
 
 func getBinariesFromPackages(packages []string) ([]string, []string, error) {
-	binariesPath := "test-binaries.tar.gz"
+	binariesPath := "test-binaries.tar.zst"
 	manifestPath := "manifest.json"
 	extractPath := "test-binaries"
 
@@ -197,20 +197,19 @@ func getBinariesFromPackages(packages []string) ([]string, []string, error) {
 		}
 	}
 
-	// Open and extract tar.gz file
 	file, err := os.Open(binariesPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open archive: %v", err)
 	}
 	defer file.Close()
 
-	gzr, err := gzip.NewReader(file)
+	zr, err := zstd.NewReader(file)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create gzip reader: %v", err)
+		return nil, nil, fmt.Errorf("failed to create zstd reader: %v", err)
 	}
-	defer gzr.Close()
+	defer zr.Close()
 
-	tr := tar.NewReader(gzr)
+	tr := tar.NewReader(zr)
 
 	// Extract only the targeted binaries
 	for {

--- a/tasks/new_e2e_tests.py
+++ b/tasks/new_e2e_tests.py
@@ -400,9 +400,9 @@ def run(
     # Scrub the test output to avoid leaking API or APP keys when running in the CI
 
     if use_prebuilt_binaries:
-        if not os.path.exists("test-binaries.tar.gz") or not os.path.exists("manifest.json"):
+        if not os.path.exists("test-binaries.tar.zst") or not os.path.exists("manifest.json"):
             print(
-                "WARNING: required artifacts test-binaries.tar.gz and manifest.json not found, disabling use_prebuilt_binaries"
+                "WARNING: required artifacts test-binaries.tar.zst and manifest.json not found, disabling use_prebuilt_binaries"
             )
             use_prebuilt_binaries = False
 


### PR DESCRIPTION
### What does this PR do?

Change compression for pre-build artifacts to zstd. Making compression time from around 10 minutes to 30 seconds
The compressed package is also around 10% smaller

### Motivation

### Describe how you validated your changes

### Additional Notes
