### PR TITLE
feat(discovery): Add /config and /config/by-source endpoints to system-probe-lite

### DIFF
--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -200,3 +200,19 @@ rust_test(
         "@crates//:tempfile",
     ],
 )
+
+rust_test(
+    name = "config_integration_test",
+    srcs = ["tests/config_integration_test.rs"],
+    data = [":system-probe-lite"],
+    edition = "2024",
+    rustc_env = {
+        "CARGO_BIN_EXE_system-probe-lite": "$(rootpath :system-probe-lite)",
+    },
+    deps = [
+        "@crates//:nix",
+        "@crates//:serde_json",
+        "@crates//:tempfile",
+        "@crates//:yaml-rust2",
+    ],
+)

--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -154,6 +154,44 @@ async fn handle_state() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
         .map_err(|e| anyhow!("Failed to build response: {}", e))
 }
 
+async fn handle_config() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
+    // SPL only runs when discovery.enabled and discovery.use_system_probe_lite are both true,
+    // so we can hardcode these values.
+    let yaml_config = "discovery:\n  enabled: true\n  use_system_probe_lite: true\n";
+    Response::builder()
+        .body(
+            Full::new(Bytes::from(yaml_config))
+                .map_err(|e| match e {})
+                .boxed(),
+        )
+        .map_err(|e| anyhow!("Failed to build response: {}", e))
+}
+
+async fn handle_config_by_source() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
+    Response::builder()
+        .header("Content-Type", "application/json")
+        .body(
+            Full::new(
+                serde_json::to_vec(&json!({
+                    "default": {
+                        "discovery": {
+                            "enabled": true,
+                            "use_system_probe_lite": true
+                        }
+                    }
+                }))
+                .unwrap_or_else(|e| {
+                    error!("Failed to serialize response: {e}");
+                    b"Internal server error".to_vec()
+                })
+                .into(),
+            )
+            .map_err(|e| match e {})
+            .boxed(),
+        )
+        .map_err(|e| anyhow!("Failed to build response: {}", e))
+}
+
 async fn handle_debug_stats() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
     Response::builder()
         .header("Content-Type", "application/json")
@@ -195,6 +233,8 @@ async fn handle_request(
             handle_services(req).await
         }
         (&Method::GET, "/discovery/state") => handle_state().await,
+        (&Method::GET, "/config") => handle_config().await,
+        (&Method::GET, "/config/by-source") => handle_config_by_source().await,
         (&Method::GET, "/debug/stats") => handle_debug_stats().await,
         _ => {
             info!(

--- a/pkg/discovery/module/rust/tests/config_integration_test.rs
+++ b/pkg/discovery/module/rust/tests/config_integration_test.rs
@@ -87,20 +87,6 @@ fn test_config_endpoint_returns_yaml() {
         "Expected 200 OK, got: {status_line}"
     );
 
-    // Verify the YAML content
-    assert!(
-        body.contains("discovery:"),
-        "Expected YAML with discovery key, got: {body}"
-    );
-    assert!(
-        body.contains("enabled: true"),
-        "Expected enabled: true in YAML, got: {body}"
-    );
-    assert!(
-        body.contains("use_system_probe_lite: true"),
-        "Expected use_system_probe_lite: true in YAML, got: {body}"
-    );
-
     // Parse as YAML to verify structure
     let docs = yaml_rust2::YamlLoader::load_from_str(&body).expect("Failed to parse YAML");
     assert!(!docs.is_empty(), "Expected at least one YAML document");

--- a/pkg/discovery/module/rust/tests/config_integration_test.rs
+++ b/pkg/discovery/module/rust/tests/config_integration_test.rs
@@ -1,0 +1,163 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::expect_used)]
+#![allow(clippy::cast_possible_wrap)]
+
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
+use tempfile::TempDir;
+
+const SYSTEM_PROBE_LITE_BIN: &str = env!("CARGO_BIN_EXE_system-probe-lite");
+
+fn spawn_spl(temp_dir: &TempDir) -> (std::process::Child, std::path::PathBuf) {
+    let socket_path = temp_dir.path().join("sysprobe.sock");
+    let log_path = temp_dir.path().join("system-probe.log");
+
+    let child = Command::new(SYSTEM_PROBE_LITE_BIN)
+        .arg("run")
+        .arg("--socket")
+        .arg(&socket_path)
+        .arg("--log-file")
+        .arg(&log_path)
+        .spawn()
+        .expect("Failed to spawn system-probe-lite");
+
+    // Give it time to start and bind the socket
+    thread::sleep(Duration::from_millis(500));
+
+    (child, socket_path)
+}
+
+/// Send a GET request over a Unix socket and return (status_line, headers, body).
+fn http_get(socket_path: &std::path::Path, path: &str) -> (String, String, String) {
+    let mut stream = UnixStream::connect(socket_path).expect("Failed to connect to socket");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("Failed to set read timeout");
+
+    let request = format!("GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    stream
+        .write_all(request.as_bytes())
+        .expect("Failed to write request");
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("Failed to read response");
+
+    // Parse HTTP response: status line, headers, body
+    let parts: Vec<&str> = response.splitn(2, "\r\n\r\n").collect();
+    let (header_section, body) = if parts.len() == 2 {
+        (parts[0], parts[1].to_string())
+    } else {
+        (parts[0], String::new())
+    };
+
+    let mut header_lines = header_section.split("\r\n");
+    let status_line = header_lines.next().unwrap_or("").to_string();
+    let headers: String = header_lines.collect::<Vec<&str>>().join("\r\n");
+
+    (status_line, headers, body)
+}
+
+fn kill_child(child: &mut std::process::Child) {
+    use nix::sys::signal::{self, Signal};
+    use nix::unistd::Pid;
+    signal::kill(Pid::from_raw(child.id() as i32), Signal::SIGTERM)
+        .expect("Failed to send SIGTERM");
+    child.wait().expect("Failed to wait on child");
+}
+
+#[test]
+fn test_config_endpoint_returns_yaml() {
+    let temp_dir = TempDir::new().unwrap();
+    let (mut child, socket_path) = spawn_spl(&temp_dir);
+
+    let (status_line, _headers, body) = http_get(&socket_path, "/config");
+
+    assert!(
+        status_line.contains("200"),
+        "Expected 200 OK, got: {status_line}"
+    );
+
+    // Verify the YAML content
+    assert!(
+        body.contains("discovery:"),
+        "Expected YAML with discovery key, got: {body}"
+    );
+    assert!(
+        body.contains("enabled: true"),
+        "Expected enabled: true in YAML, got: {body}"
+    );
+    assert!(
+        body.contains("use_system_probe_lite: true"),
+        "Expected use_system_probe_lite: true in YAML, got: {body}"
+    );
+
+    // Parse as YAML to verify structure
+    let docs = yaml_rust2::YamlLoader::load_from_str(&body).expect("Failed to parse YAML");
+    assert!(!docs.is_empty(), "Expected at least one YAML document");
+    let doc = &docs[0];
+    assert_eq!(
+        doc["discovery"]["enabled"].as_bool(),
+        Some(true),
+        "discovery.enabled should be true"
+    );
+    assert_eq!(
+        doc["discovery"]["use_system_probe_lite"].as_bool(),
+        Some(true),
+        "discovery.use_system_probe_lite should be true"
+    );
+
+    kill_child(&mut child);
+}
+
+#[test]
+fn test_config_by_source_endpoint_returns_json() {
+    let temp_dir = TempDir::new().unwrap();
+    let (mut child, socket_path) = spawn_spl(&temp_dir);
+
+    let (status_line, headers, body) = http_get(&socket_path, "/config/by-source");
+
+    assert!(
+        status_line.contains("200"),
+        "Expected 200 OK, got: {status_line}"
+    );
+
+    // Verify Content-Type header
+    let headers_lower = headers.to_lowercase();
+    assert!(
+        headers_lower.contains("content-type: application/json"),
+        "Expected application/json content type, got headers: {headers}"
+    );
+
+    // Parse as JSON and verify structure
+    let parsed: serde_json::Value =
+        serde_json::from_str(&body).expect("Failed to parse JSON response");
+
+    assert!(
+        parsed.get("default").is_some(),
+        "Expected 'default' key in response, got: {body}"
+    );
+
+    let default = &parsed["default"];
+    assert_eq!(
+        default["discovery"]["enabled"],
+        serde_json::json!(true),
+        "discovery.enabled should be true"
+    );
+    assert_eq!(
+        default["discovery"]["use_system_probe_lite"],
+        serde_json::json!(true),
+        "discovery.use_system_probe_lite should be true"
+    );
+
+    kill_child(&mut child);
+}


### PR DESCRIPTION
### What does this PR do?

Adds two new HTTP endpoints to system-probe-lite (SPL):

- `GET /config` — returns YAML with hardcoded discovery config values (`discovery.enabled: true`, `discovery.use_system_probe_lite: true`)
- `GET /config/by-source` — returns JSON with the same values under the `"default"` source key

SPL doesn't have a full config system, but these endpoints are needed because the core agent queries them and we otherwise print "unknown endpoint" messages from SPL during normal operation (not just flare creation). Since SPL only runs when both config values are true, we hardcode them.

### Motivation

The core agent's `inventoryagent` component fetches system-probe config via `GET /config` (YAML) to populate feature flags like `feature_discovery_enabled`. The `systemprobe` metadata component fetches `GET /config/by-source` (JSON) for config layer reporting. Without these endpoints in SPL, the inventory agent falls back to local config (which may not reflect the running state) and the metadata component logs errors.

Note that we report the source as `"default"` since they will soon be default values and we don't know the exact source. Note that `"default"` key is not included in `layersName` so it won't appear in config layer metadata (this is the same behavior as real system-probe).

### Describe how you validated your changes

CI.

### Additional notes

The tests currently do HTTP client operations without any library to avoid adding new features to hyper, this could be changed in the future.