### PR TITLE
Add explicit `cc_static_library` import for Bazel 9

### DIFF
--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_static_library.bzl", "cc_static_library")
 load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library", "cc_shared_library")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup", "pkg_files")


### PR DESCRIPTION
### What does this PR do?
Adds an explicit `load` for `cc_static_library` from `@rules_cc//cc:cc_static_library.bzl` to `rtloader/BUILD.bazel`.

### Motivation
In Bazel 9, `cc_static_library` is no longer auto-loaded from Bazel's native namespace:
```
ERROR: Traceback (most recent call last):
	File "rtloader/BUILD.bazel", line 77, column 18, in <toplevel>
		cc_static_library(
	File "/virtual_builtins_bzl/bazel/exports.bzl", line 40, column 9, in _removed_rule_failure
Error in fail: 
         This rule has been removed from Bazel. Please add a `load()` statement for it.
         This can also be done automatically by running:
         buildifier --lint=fix <path-to-BUILD-or-bzl-file>
```
The rule was migrated out of Bazel's built-ins into `rules_cc`, but `cc_static_library` was not added to its `defs.bzl`, apparently by omission; it must therefore be loaded explicitly from `@rules_cc//cc:cc_static_library.bzl`.

The `load` is transparent on Bazel 8, where the rule would still be auto-loaded, so this change is safe to land before the Bazel 9 upgrade.

### Describe how you validated your changes
`bazel test //rtloader/...` passes.