### PR TITLE
Fix type conversion: cast SeriesHandle to int for strconv.Itoa

### DIFF
--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -689,7 +689,7 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 	if aggStr != "" {
 		return fmt.Sprintf("%d:%s", numID, aggStr)
 	}
-	return strconv.Itoa(numID)
+	return strconv.Itoa(int(numID))
 }
 
 // FullKeyForNumericID returns the internal storage key for a compact numeric ID.


### PR DESCRIPTION
## Summary
- Fix build error in `comp/observer/impl/storage.go`: cast `observer.SeriesHandle` to `int` before passing to `strconv.Itoa`

## Test plan
- [ ] `go build -o observer-testbench ./cmd/observer-testbench` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)