### PR TITLE
Reintroduce support for Azure Service Principal credentials

### DIFF
--- a/cmd/secret-generic-connector/backend/azure/keyvault.go
+++ b/cmd/secret-generic-connector/backend/azure/keyvault.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -31,33 +32,71 @@ type keyvaultClient interface {
 
 // getKeyvaultClient is a variable that holds the function to create a new keyvaultClient
 // it will be overwritten in tests
-var getKeyvaultClient = func(keyVaultURL, clientID string) (keyvaultClient, error) {
+var getKeyvaultClient = func(cfg KeyVaultBackendConfig) (keyvaultClient, error) {
+	s := cfg.AzureSession
 	var err error
 	var cred azcore.TokenCredential
-	if clientID == "" {
-		cred, err = azidentity.NewDefaultAzureCredential(nil)
+
+	switch {
+	case s.AzureTenantID != "" && s.AzureClientID != "" && s.AzureClientSecret != "":
+		cred, err = azidentity.NewClientSecretCredential(s.AzureTenantID, s.AzureClientID, s.AzureClientSecret, nil)
 		if err != nil {
-			return nil, fmt.Errorf("clientID not provided, could not get credentials: %s", err)
+			return nil, fmt.Errorf("getting client secret credentials: %s", err)
 		}
-	} else {
-		opts := azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID(clientID)}
+	case s.AzureTenantID != "" && s.AzureClientID != "" && s.AzureClientCertificatePath != "":
+		certData, err := os.ReadFile(s.AzureClientCertificatePath)
+		if err != nil {
+			return nil, fmt.Errorf("reading certificate file: %s", err)
+		}
+		var password []byte
+		if s.AzureClientCertificatePassword != "" {
+			password = []byte(s.AzureClientCertificatePassword)
+		}
+		certs, key, err := azidentity.ParseCertificates(certData, password)
+		if err != nil {
+			return nil, fmt.Errorf("parsing certificate: %s", err)
+		}
+		opts := &azidentity.ClientCertificateCredentialOptions{
+			SendCertificateChain: s.AzureClientSendCertificateChain,
+		}
+		cred, err = azidentity.NewClientCertificateCredential(s.AzureTenantID, s.AzureClientID, certs, key, opts)
+		if err != nil {
+			return nil, fmt.Errorf("getting client certificate credentials: %s", err)
+		}
+	case s.AzureClientID != "":
+		opts := azidentity.ManagedIdentityCredentialOptions{ID: azidentity.ClientID(s.AzureClientID)}
 		cred, err = azidentity.NewManagedIdentityCredential(&opts)
 		if err != nil {
 			return nil, fmt.Errorf("getting identity credentials: %s", err)
 		}
+	default:
+		cred, err = azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not get default credentials: %s", err)
+		}
 	}
 
-	client, err := azsecrets.NewClient(keyVaultURL, cred, nil)
+	client, err := azsecrets.NewClient(cfg.KeyVaultURL, cred, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %v", err)
 	}
 	return client, nil
 }
 
+// AzureSessionBackendConfig is the session configuration for Azure (nested under azure_session).
+type AzureSessionBackendConfig struct {
+	AzureClientID                   string `mapstructure:"azure_client_id"`
+	AzureTenantID                   string `mapstructure:"azure_tenant_id"`
+	AzureClientSecret               string `mapstructure:"azure_client_secret"`
+	AzureClientCertificatePath      string `mapstructure:"azure_client_certificate_path"`
+	AzureClientCertificatePassword  string `mapstructure:"azure_client_certificate_password"`
+	AzureClientSendCertificateChain bool   `mapstructure:"azure_client_send_certificate_chain"`
+}
+
 // KeyVaultBackendConfig contains the configuration to connect for Azure backend
 type KeyVaultBackendConfig struct {
-	KeyVaultURL string `mapstructure:"keyvaulturl"`
-	ClientID    string `mapstructure:"clientid"`
+	KeyVaultURL  string                    `mapstructure:"keyvaulturl"`
+	AzureSession AzureSessionBackendConfig `mapstructure:"azure_session"`
 }
 
 // KeyVaultBackend is a backend to fetch secrets from Azure
@@ -66,15 +105,48 @@ type KeyVaultBackend struct {
 	Client keyvaultClient
 }
 
+// normalizeAzureSession returns the azure_session map, normalizing map[interface{}]interface{}
+// (produced by yaml.v2) to map[string]interface{}, and creating it if absent.
+func normalizeAzureSession(bc map[string]interface{}) map[string]interface{} {
+	if bc["azure_session"] == nil {
+		m := make(map[string]interface{})
+		bc["azure_session"] = m
+		return m
+	}
+	if m, ok := bc["azure_session"].(map[string]interface{}); ok {
+		return m
+	}
+	if m, ok := bc["azure_session"].(map[interface{}]interface{}); ok {
+		out := make(map[string]interface{}, len(m))
+		for k, v := range m {
+			if s, ok := k.(string); ok {
+				out[s] = v
+			}
+		}
+		bc["azure_session"] = out
+		return out
+	}
+	return nil
+}
+
 // NewKeyVaultBackend returns a new backend for Azure
 func NewKeyVaultBackend(bc map[string]interface{}) (*KeyVaultBackend, error) {
+	azureSession := normalizeAzureSession(bc)
+
+	// Accept top-level "clientid" as alias for azure_session.azure_client_id
+	if v, ok := bc["clientid"]; ok && azureSession != nil {
+		if _, set := azureSession["azure_client_id"]; !set {
+			azureSession["azure_client_id"] = v
+		}
+	}
+
 	backendConfig := KeyVaultBackendConfig{}
 	err := mapstructure.Decode(bc, &backendConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map backend configuration: %s", err)
 	}
 
-	client, err := getKeyvaultClient(backendConfig.KeyVaultURL, backendConfig.ClientID)
+	client, err := getKeyvaultClient(backendConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/secret-generic-connector/backend/azure/keyvault_test.go
+++ b/cmd/secret-generic-connector/backend/azure/keyvault_test.go
@@ -42,14 +42,17 @@ func TestKeyvaultBackend(t *testing.T) {
 			"key2": "{\"foo\":\"bar\"}",
 		},
 	}
-	getKeyvaultClient = func(_, _ string) (keyvaultClient, error) {
+	getKeyvaultClient = func(_ KeyVaultBackendConfig) (keyvaultClient, error) {
 		return mockClient, nil
 	}
 
+	// v0-style: azure_* nested under azure_session (sibling to keyvaulturl)
 	keyvaultBackendParams := map[string]interface{}{
 		"backend_type": "azure.keyvault",
 		"keyvaulturl":  "https://my-vault.vault.azure.com/",
-		"clientid":     "123abc45-123a-abcd-123a-123abc456def",
+		"azure_session": map[string]interface{}{
+			"azure_client_id": "123abc45-123a-abcd-123a-123abc456def",
+		},
 	}
 	keyvaultSecretsBackend, err := NewKeyVaultBackend(keyvaultBackendParams)
 	assert.NoError(t, err)
@@ -74,7 +77,7 @@ func TestKeyVaultBackend_issue39434(t *testing.T) {
 			"key1": "{\\\"foo\\\":\\\"bar\\\"}",
 		},
 	}
-	getKeyvaultClient = func(_, _ string) (keyvaultClient, error) {
+	getKeyvaultClient = func(_ KeyVaultBackendConfig) (keyvaultClient, error) {
 		return mockClient, nil
 	}
 
@@ -93,4 +96,19 @@ func TestKeyVaultBackend_issue39434(t *testing.T) {
 	// Index into secret json
 	secretOutput = keyvaultSecretsBackend.GetSecretOutput(ctx, "key1;foo")
 	assert.Equal(t, "bar", *secretOutput.Value)
+}
+
+// TestKeyVaultBackend_topLevelClientIDAlias verifies that top-level "clientid" is
+// mapped to azure_session.azure_client_id when azure_session is used.
+func TestKeyVaultBackend_topLevelClientIDAlias(t *testing.T) {
+	getKeyvaultClient = func(cfg KeyVaultBackendConfig) (keyvaultClient, error) {
+		assert.Equal(t, "123abc45-123a-abcd-123a-123abc456def", cfg.AzureSession.AzureClientID)
+		return &keyvaultMockClient{secrets: map[string]interface{}{}}, nil
+	}
+	bc := map[string]interface{}{
+		"keyvaulturl": "https://my-vault.vault.azure.com/",
+		"clientid":    "123abc45-123a-abcd-123a-123abc456def",
+	}
+	_, err := NewKeyVaultBackend(bc)
+	assert.NoError(t, err)
 }

--- a/cmd/secret-generic-connector/backend/azure/keyvault_test.go
+++ b/cmd/secret-generic-connector/backend/azure/keyvault_test.go
@@ -98,6 +98,67 @@ func TestKeyVaultBackend_issue39434(t *testing.T) {
 	assert.Equal(t, "bar", *secretOutput.Value)
 }
 
+// TestKeyVaultBackend_clientSecretCredential verifies that tenant_id + client_id + client_secret
+// are forwarded correctly to the keyvault client factory.
+func TestKeyVaultBackend_clientSecretCredential(t *testing.T) {
+	getKeyvaultClient = func(cfg KeyVaultBackendConfig) (keyvaultClient, error) {
+		s := cfg.AzureSession
+		assert.Equal(t, "my-tenant-id", s.AzureTenantID)
+		assert.Equal(t, "my-client-id", s.AzureClientID)
+		assert.Equal(t, "my-client-secret", s.AzureClientSecret)
+		return &keyvaultMockClient{secrets: map[string]interface{}{}}, nil
+	}
+	bc := map[string]interface{}{
+		"keyvaulturl": "https://my-vault.vault.azure.com/",
+		"azure_session": map[string]interface{}{
+			"azure_tenant_id":     "my-tenant-id",
+			"azure_client_id":     "my-client-id",
+			"azure_client_secret": "my-client-secret",
+		},
+	}
+	_, err := NewKeyVaultBackend(bc)
+	assert.NoError(t, err)
+}
+
+// TestKeyVaultBackend_clientCertificateCredential verifies that tenant_id + client_id + certificate_path
+// are forwarded correctly to the keyvault client factory.
+func TestKeyVaultBackend_clientCertificateCredential(t *testing.T) {
+	getKeyvaultClient = func(cfg KeyVaultBackendConfig) (keyvaultClient, error) {
+		s := cfg.AzureSession
+		assert.Equal(t, "my-tenant-id", s.AzureTenantID)
+		assert.Equal(t, "my-client-id", s.AzureClientID)
+		assert.Equal(t, "/path/to/cert.pem", s.AzureClientCertificatePath)
+		return &keyvaultMockClient{secrets: map[string]interface{}{}}, nil
+	}
+	bc := map[string]interface{}{
+		"keyvaulturl": "https://my-vault.vault.azure.com/",
+		"azure_session": map[string]interface{}{
+			"azure_tenant_id":               "my-tenant-id",
+			"azure_client_id":               "my-client-id",
+			"azure_client_certificate_path": "/path/to/cert.pem",
+		},
+	}
+	_, err := NewKeyVaultBackend(bc)
+	assert.NoError(t, err)
+}
+
+// TestKeyVaultBackend_defaultCredential verifies that omitting all auth fields
+// falls through to the default credential path.
+func TestKeyVaultBackend_defaultCredential(t *testing.T) {
+	getKeyvaultClient = func(cfg KeyVaultBackendConfig) (keyvaultClient, error) {
+		s := cfg.AzureSession
+		assert.Empty(t, s.AzureClientID)
+		assert.Empty(t, s.AzureTenantID)
+		assert.Empty(t, s.AzureClientSecret)
+		return &keyvaultMockClient{secrets: map[string]interface{}{}}, nil
+	}
+	bc := map[string]interface{}{
+		"keyvaulturl": "https://my-vault.vault.azure.com/",
+	}
+	_, err := NewKeyVaultBackend(bc)
+	assert.NoError(t, err)
+}
+
 // TestKeyVaultBackend_topLevelClientIDAlias verifies that top-level "clientid" is
 // mapped to azure_session.azure_client_id when azure_session is used.
 func TestKeyVaultBackend_topLevelClientIDAlias(t *testing.T) {

--- a/releasenotes/notes/azure-keyvault-session-credentials-130ee5e2b6b21f04.yaml
+++ b/releasenotes/notes/azure-keyvault-session-credentials-130ee5e2b6b21f04.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Secret Generic Connector: The Azure Key Vault backend now supports
+    Service Principal authentication with client secret or client certificate,
+    in addition to Managed Identity. Credentials are configured under the
+    ``azure_session`` block (``azure_tenant_id``, ``azure_client_id``,
+    ``azure_client_secret`` or ``azure_client_certificate_path``).


### PR DESCRIPTION
### What does this PR do?

Reintroduce `azure_session` configuration with Secrets Connector

In [secrets backend v1](https://github.com/DataDog/datadog-secret-backend/blob/v1/docs/azure/README.md#example-configuration), we used `azidentity` and lost the ability to set `azure_tenant_id`, `azure_client_secret`, etc  in the secrets configuration - allowing only Managed Identity authentication which requires the resource needing the secret to be in azure.

It is still possible to authenticate using Service Principals (like in [secrets backend v0](https://github.com/DataDog/datadog-secret-backend/blob/main/docs/azure/keyvault.md#configuration-examples)) but only with the use of environment variables AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_*; current logic still works and is able to fetch Azure secrets from a non-Azure host.

### Motivation
- FRAGENT-3486

### Describe how you validated your changes
- config
  ```
  secret_backend_type: azure.keyvault
  secret_backend_config:
      keyvaulturl: https://my-vault.vault.azure.net/
      # clientid: <if set, maps to azure_session.azure_client_id; for backwards compatibility>
      azure_session:
          azure_tenant_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
          azure_client_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
          azure_client_secret: your-client-secret
  ```

- pull the secret from a non-Azure VM without having to set AZURE_* envvars

### Additional Notes
