### PR TITLE
[ABLD-316] Make release.json data available to bazel rules.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,6 +20,11 @@ env_vars(
     ],
 )
 
+# Expose release.json for information about the current release.
+release_json = use_repo_rule("//bazel/repo:release_json.bzl", "release_json")
+
+release_json(name = "dd_release_json")
+
 # package_metadata and rules_license are dependencies of every module in the
 # Bazel ecosystem.  We pin those first to get the versions we require.
 bazel_dep(name = "package_metadata", version = "0.0.7")

--- a/bazel/repo/release_json.bzl
+++ b/bazel/repo/release_json.bzl
@@ -1,0 +1,35 @@
+"""Import release.json so we can use these global constants.
+
+Usage:
+    release_json = use_repo_rule("//bazel/repo:release_json.bzl", "release_json")
+    # Give it a private name so that we don't run the risk of conflicting with a future OSS module.
+    release_json(name = "dd_release_json")
+
+    load("@dd_release_json//:release_json.bzl", "release_json")
+
+    milestone = release_json.get("current_milestone")
+"""
+
+BUILD_FILE_CONTENT = """
+exports_files(
+    ["release_json.bzl"],
+    # We may expand this in the future, but let's limit inventiveness for now.
+    visibility = [
+        "@agent//bazel/rules:__subpackages__",
+        "@agent//packages:__subpackages__",
+    ],
+)
+"""
+
+def _release_json_impl(rctx):
+    rctx.file("BUILD.bazel", BUILD_FILE_CONTENT)
+    release_json = json.decode(rctx.read(rctx.path(rctx.attr._release_json)))
+    rctx.file("release_json.bzl", """release_json = %s\n""" % json.encode_indent(release_json, indent = " "))
+
+release_json = repository_rule(
+    implementation = _release_json_impl,
+    doc = """Import release.json as a .bzl file.""",
+    attrs = {
+        "_release_json": attr.label(default = "//:release.json", allow_single_file = True),
+    },
+)

--- a/bazel/repo/release_json.bzl
+++ b/bazel/repo/release_json.bzl
@@ -24,7 +24,7 @@ exports_files(
 def _release_json_impl(rctx):
     rctx.file("BUILD.bazel", BUILD_FILE_CONTENT)
     release_json = json.decode(rctx.read(rctx.path(rctx.attr._release_json)))
-    rctx.file("release_json.bzl", """release_json = %s\n""" % json.encode_indent(release_json, indent = " "))
+    rctx.file("release_json.bzl", """release_json = %s\n""" % str(release_json))
 
 release_json = repository_rule(
     implementation = _release_json_impl,


### PR DESCRIPTION
Makes the constants in release.json available to rules.

In the short term, this will allow us to pick up values like the base_branch and current_milestone for use in naming the package files in developer builds. (WIP #48018 )

In the current build, we rely on tasks/omnibus.py to compute the PACKAGE_VERSION variable that is used to name the packages in CI.  With this use of release.json and adding some CI_* environment values to env_vars we could reimplement the package naming as a bazel function. That would make it available at analysis time rather than having to call an inv command. This is an intermediate cleanup after we see how the naming applies across all the package types.

A longer term potential is to rewrite the repo rules that use release.json (windows and jmxfetch) to pull from this 
repo, but that may be adding complexity for the sake of saving a few lines.

Alternatives considered:
- keeping a release_json.bzl file in sync with release.json.
  - Human toil. Even with a diff_test rule and auto-update, it is an annoyance.
- reading the json within rules to compute package names
  - That moves computation of the package name from analysis time to build time. That makes it hard to query to see what actually gets built. It also means the packaging rules need to pick up the file name from a file generated by another rule.
 - refactoring invoke tasks to make the package naming aglorithm available as a bazel action.
   - this has the same problem as reading the json file directly.