### PR TITLE
chore: ignore golang Docker image updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -73,6 +73,11 @@
         "matchManagers": ["bazelisk"],
         "matchUpdateTypes": ["major"],
         "enabled": false
+      },
+      {
+        "matchManagers": ["gomod", "dockerfile", "docker-compose"],
+        "matchDepNames": ["golang"],
+        "enabled": false
       }
     ],
     "customManagers" : [


### PR DESCRIPTION
## Summary
- Disable Renovate updates for the `golang` Docker image in `dockerfile` and `docker-compose` managers
- The golang version is managed by the agent-runtimes team to ensure uniform bumps across the entire repo, so Renovate should not create PRs for it (e.g. #47848)

## Test plan
- [ ] Verify Renovate no longer opens PRs for `golang` image updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)