### PR TITLE
remove unneeded tag

### DIFF
--- a/pkg/config/render_config/render_config.go
+++ b/pkg/config/render_config/render_config.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// go:build render_config
+//go:build
 
 package main
 

--- a/pkg/config/render_config/render_config.go
+++ b/pkg/config/render_config/render_config.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build
-
 package main
 
 import (


### PR DESCRIPTION
Remove an unneeded directive on render_config so that gazelle does not keep throwing the rules away.

- Now gazelle doesn't trash the BUILD file.
- `go run pkg/config/render_config/render_config.go` (for the manual users) still works.
- the bazel rule to generate configs still works.  `bazel build //pkg/config:all`