### PR TITLE
[CWS] fix off-by-one out-of-bounds in event handler arrays

### DIFF
--- a/pkg/security/probe/monitors/eventsample/eventsample_monitor.go
+++ b/pkg/security/probe/monitors/eventsample/eventsample_monitor.go
@@ -45,7 +45,7 @@ func (m *Monitor) SendStats() error {
 	buffer := m.stats[1-m.activeStatsBuffer]
 	iterator := buffer.Iterate()
 	statsAcrossAllCPUs := make([]Stats, m.numCPU)
-	statsByEventType := make([]Stats, model.MaxAllEventType)
+	statsByEventType := make([]Stats, model.MaxAllEventType+1)
 
 	var eventType uint32
 	for iterator.Next(&eventType, &statsAcrossAllCPUs) {

--- a/pkg/security/probe/monitors/syscalls/syscalls_monitor.go
+++ b/pkg/security/probe/monitors/syscalls/syscalls_monitor.go
@@ -35,7 +35,7 @@ type Monitor struct {
 func (d *Monitor) SendStats() error {
 	iterator := d.stats.Iterate()
 	statsAcrossAllCPUs := make([][8]byte, d.numCPU)
-	statsByEventType := make([]int32, model.MaxAllEventType)
+	statsByEventType := make([]int32, model.MaxAllEventType+1)
 
 	var eventType uint32
 	for iterator.Next(&eventType, &statsAcrossAllCPUs) {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -122,9 +122,9 @@ type Probe struct {
 
 	// Events section
 	consumers           []*EventConsumer
-	eventHandlers       [model.MaxAllEventType][]EventHandler
-	eventConsumers      [model.MaxAllEventType][]*EventConsumer
-	customEventHandlers [model.MaxAllEventType][]CustomEventHandler
+	eventHandlers       [model.MaxAllEventType + 1][]EventHandler
+	eventConsumers      [model.MaxAllEventType + 1][]*EventConsumer
+	customEventHandlers [model.MaxAllEventType + 1][]CustomEventHandler
 
 	// stats
 	ruleActionStatsLock sync.RWMutex
@@ -329,6 +329,11 @@ func (p *Probe) sendEventToHandlers(event *model.Event) {
 }
 
 func (p *Probe) sendEventToConsumers(event *model.Event) {
+	if t := event.GetEventType(); int(t) >= len(p.eventConsumers) {
+		seclog.Errorf("event type (%d) not allowed", t)
+		return
+	}
+
 	for _, pc := range p.eventConsumers[event.GetEventType()] {
 		if copied := pc.consumer.Copy(event); copied != nil {
 			select {
@@ -374,8 +379,12 @@ func (p *Probe) DispatchCustomEvent(rule *rules.Rule, event *events.CustomEvent)
 
 	// send specific event
 	if event.GetEventType() != model.UnknownEventType {
-		for _, handler := range p.customEventHandlers[event.GetEventType()] {
-			handler.HandleCustomEvent(rule, event)
+		if t := event.GetEventType(); int(t) >= len(p.customEventHandlers) {
+			seclog.Errorf("event type (%d) not allowed", t)
+		} else {
+			for _, handler := range p.customEventHandlers[event.GetEventType()] {
+				handler.HandleCustomEvent(rule, event)
+			}
 		}
 	}
 }

--- a/pkg/security/probe/probe_event_dispatch_test.go
+++ b/pkg/security/probe/probe_event_dispatch_test.go
@@ -1,0 +1,119 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux || windows
+
+// Package probe holds probe related files
+package probe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/security/events"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+// mockCustomEventHandler is a test double for CustomEventHandler
+type mockCustomEventHandler struct {
+	handleCount int
+}
+
+func (m *mockCustomEventHandler) HandleCustomEvent(_ *rules.Rule, _ *events.CustomEvent) {
+	m.handleCount++
+}
+
+// mockEventMarshaler is a no-op EventMarshaler for test CustomEvents
+type mockEventMarshaler struct{}
+
+func (m *mockEventMarshaler) ToJSON() ([]byte, error) {
+	return []byte("{}"), nil
+}
+
+// TestEventHandlerArraySizes verifies that the handler arrays are sized
+// MaxAllEventType+1, so that MaxAllEventType is a valid index.
+func TestEventHandlerArraySizes(t *testing.T) {
+	p := &Probe{}
+
+	assert.Equal(t, int(model.MaxAllEventType)+1, len(p.eventHandlers),
+		"eventHandlers array must have length MaxAllEventType+1")
+	assert.Equal(t, int(model.MaxAllEventType)+1, len(p.eventConsumers),
+		"eventConsumers array must have length MaxAllEventType+1")
+	assert.Equal(t, int(model.MaxAllEventType)+1, len(p.customEventHandlers),
+		"customEventHandlers array must have length MaxAllEventType+1")
+}
+
+// TestEventHandlerArrayMaxIndexAccessible verifies that MaxAllEventType can be
+// used as an index without an out-of-bounds panic (regression for the off-by-one fix).
+func TestEventHandlerArrayMaxIndexAccessible(t *testing.T) {
+	p := &Probe{}
+
+	require.NotPanics(t, func() {
+		_ = p.eventHandlers[model.MaxAllEventType]
+		_ = p.eventConsumers[model.MaxAllEventType]
+		_ = p.customEventHandlers[model.MaxAllEventType]
+	})
+}
+
+// TestSendEventToConsumersOutOfRange verifies that sendEventToConsumers does not
+// panic when given an event whose type exceeds the array bounds.
+func TestSendEventToConsumersOutOfRange(t *testing.T) {
+	p := &Probe{}
+
+	event := &model.Event{}
+	event.Type = uint32(model.MaxAllEventType) + 1
+
+	require.NotPanics(t, func() {
+		p.sendEventToConsumers(event)
+	})
+}
+
+// TestDispatchCustomEventOutOfRange verifies that DispatchCustomEvent does not
+// panic when given an event whose type exceeds the array bounds.
+func TestDispatchCustomEventOutOfRange(t *testing.T) {
+	p := &Probe{}
+
+	outOfRangeType := model.EventType(model.MaxAllEventType) + 1
+	customEvent := events.NewCustomEvent(outOfRangeType, &mockEventMarshaler{})
+
+	require.NotPanics(t, func() {
+		p.DispatchCustomEvent(&rules.Rule{}, customEvent)
+	})
+}
+
+// TestDispatchCustomEventMaxAllEventType verifies that DispatchCustomEvent
+// correctly dispatches to a handler registered at MaxAllEventType-1 (valid boundary).
+func TestDispatchCustomEventMaxAllEventType(t *testing.T) {
+	p := &Probe{}
+
+	handler := &mockCustomEventHandler{}
+	validType := model.EventType(model.MaxAllEventType - 1)
+
+	err := p.AddCustomEventHandler(validType, handler)
+	require.NoError(t, err)
+
+	customEvent := events.NewCustomEvent(validType, &mockEventMarshaler{})
+	p.DispatchCustomEvent(&rules.Rule{}, customEvent)
+
+	assert.Equal(t, 1, handler.handleCount, "handler should have been called once")
+}
+
+// TestDispatchCustomEventWildcard verifies that a wildcard handler registered at
+// UnknownEventType receives all dispatched custom events.
+func TestDispatchCustomEventWildcard(t *testing.T) {
+	p := &Probe{}
+
+	wildcardHandler := &mockCustomEventHandler{}
+	err := p.AddCustomEventHandler(model.UnknownEventType, wildcardHandler)
+	require.NoError(t, err)
+
+	customEvent := events.NewCustomEvent(model.ExecEventType, &mockEventMarshaler{})
+	p.DispatchCustomEvent(&rules.Rule{}, customEvent)
+
+	assert.Equal(t, 1, wildcardHandler.handleCount, "wildcard handler should have been called once")
+}


### PR DESCRIPTION
Arrays sized [model.MaxAllEventType] are too small when MaxAllEventType is used as an index directly, since array indices go from 0 to len-1. Increase size to MaxAllEventType+1 for eventHandlers, eventConsumers, customEventHandlers, and the syscall stats slice.

Also add explicit bounds checks in sendEventToConsumers and DispatchCustomEvent to guard against future out-of-range event types instead of panicking.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
