### PR TITLE
[CNM-5203] Fix missing resolv.conf bug

### DIFF
--- a/pkg/network/containers/container_item_linux.go
+++ b/pkg/network/containers/container_item_linux.go
@@ -66,6 +66,16 @@ type readContainerItemResult struct {
 	noDataReason string
 }
 
+func (r readContainerItemResult) String() string {
+	if r.noDataReason != "" {
+		return fmt.Sprintf("noData(%s)", r.noDataReason)
+	}
+	if r.item.resolvConf == nil {
+		return "empty"
+	}
+	return fmt.Sprintf("resolvConf(%d bytes)", len(r.item.resolvConf.Get()))
+}
+
 func (cr *containerReader) readContainerItem(ctx context.Context, entry *events.Process) (readContainerItemResult, error) {
 	resolvConf, resolvConfErr := cr.readResolvConf(entry)
 	// we must check this last, to guarantee the result of readResolvConf is valid

--- a/pkg/network/containers/container_store_linux.go
+++ b/pkg/network/containers/container_store_linux.go
@@ -34,6 +34,8 @@ const (
 	containerTTL = 10 * time.Minute
 	// cleanerInterval: how often to evict old containers
 	cleanerInterval = 5 * time.Minute
+	// errorRetryInterval: how long to wait before retrying a failed read
+	errorRetryInterval = time.Minute
 )
 
 var containerStoreTelemetry = struct {
@@ -151,9 +153,15 @@ func (cs *ContainerStore) HandleProcessEvent(entry *events.Process) {
 
 func (cs *ContainerStore) addProcess(entry *events.Process) {
 	prevItem, ok := cs.cache.Get(entry.ContainerID)
-	if ok && prevItem.resolvConf != nil {
-		// we already have resolv.conf for this container, no need to re-read
-		return
+	if ok {
+		if prevItem.resolvConf != nil {
+			// we already have resolv.conf for this container, no need to re-read
+			return
+		}
+		// previous read failed (resolvConf is nil); only retry after errorRetryInterval
+		if time.Since(prevItem.timestamp) < errorRetryInterval {
+			return
+		}
 	}
 
 	result, err := cs.readContainerItem(cs.ctx, entry)

--- a/pkg/network/containers/container_store_linux.go
+++ b/pkg/network/containers/container_store_linux.go
@@ -10,6 +10,7 @@ package containers
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
@@ -24,23 +25,23 @@ import (
 const (
 	resolvConfInputMaxSizeBytes = 4096
 	resolvConfMaxSizeBytes      = 1024
-	maxProcessQueueLen          = 100
-	moduleName                  = "network_tracer__containerStore"
+	// the queue is oversized to account for the procfs snapshot when system-probe starts.
+	// these are pointers, so the memory cost is not severe
+	maxProcessQueueLen = 2048
+	moduleName         = "network_tracer__containerStore"
 
-	// containerStaleTime: when to re-fetch a container's resolv.conf
-	containerStaleTime = 10 * time.Minute
-	// containerTTL: when to evict a container
-	containerTTL = 25 * time.Minute
+	// containerTTL: when to evict a container that hasn't been accessed
+	containerTTL = 10 * time.Minute
 	// cleanerInterval: how often to evict old containers
-	cleanerInterval = 15 * time.Minute
+	cleanerInterval = 5 * time.Minute
 )
 
 var containerStoreTelemetry = struct {
-	nonStaleEvictions telemetry.Counter
+	capacityEvictions telemetry.Counter
 	eventsDropped     telemetry.Counter
 	readFailures      telemetry.Counter
 }{
-	telemetry.NewCounter(moduleName, "non_stale_evicts", []string{}, "Counter measuring the number of evictions of non-stale containers in the container store"),
+	telemetry.NewCounter(moduleName, "capacity_evictions", []string{}, "Counter measuring the number of LRU capacity evictions of non-expired containers"),
 	telemetry.NewCounter(moduleName, "events_dropped", []string{}, "Counter measuring the number of dropped process events"),
 	telemetry.NewCounter(moduleName, "read_failures", []string{}, "Counter measuring the number of failures to read container data such as resolv.conf"),
 }
@@ -56,6 +57,9 @@ type ContainerStore struct {
 	ctx       context.Context
 	cancelCtx func()
 
+	// mu protects timestamp updates in GetResolvConf from racing with
+	// expiry checks in cleanMap.
+	mu    sync.Mutex
 	cache *lru.Cache[network.ContainerID, containerStoreItem]
 
 	in chan *events.Process
@@ -69,9 +73,6 @@ type ContainerStore struct {
 	readContainerItem func(ctx context.Context, entry *events.Process) (readContainerItemResult, error)
 }
 
-func (csi containerStoreItem) isStale() bool {
-	return time.Since(csi.timestamp) > containerStaleTime
-}
 func (csi containerStoreItem) isExpired() bool {
 	return time.Since(csi.timestamp) > containerTTL
 }
@@ -80,14 +81,17 @@ func (csi containerStoreItem) isExpired() bool {
 func NewContainerStore(maxContainers int) (*ContainerStore, error) {
 	warnLimit := log.NewLogLimit(5, 10*time.Minute)
 	errorLimit := log.NewLogLimit(5, 10*time.Minute)
-	debugLimit := log.NewLogLimit(5, time.Minute)
+	debugLimit := log.NewLogLimit(10, time.Minute)
 
 	cache, err := lru.NewWithEvict(maxContainers, func(key *intern.Value, item containerStoreItem) {
-		if log.ShouldLog(log.TraceLvl) {
+		if log.ShouldLog(log.DebugLvl) && debugLimit.ShouldLog() {
 			logEvictingID(key)
 		}
-		if !item.isStale() {
-			containerStoreTelemetry.nonStaleEvictions.Add(1)
+		if !item.isExpired() {
+			containerStoreTelemetry.capacityEvictions.Add(1)
+			if warnLimit.ShouldLog() {
+				log.Warnf("CNM ContainerStore capacity eviction of non-expired container %s", containerIDStr(key))
+			}
 		}
 	})
 	if err != nil {
@@ -147,8 +151,8 @@ func (cs *ContainerStore) HandleProcessEvent(entry *events.Process) {
 
 func (cs *ContainerStore) addProcess(entry *events.Process) {
 	prevItem, ok := cs.cache.Get(entry.ContainerID)
-	if ok && !prevItem.isStale() {
-		// we already pulled resolv.conf recently, so skip
+	if ok && prevItem.resolvConf != nil {
+		// we already have resolv.conf for this container, no need to re-read
 		return
 	}
 
@@ -173,48 +177,35 @@ func (cs *ContainerStore) addProcess(entry *events.Process) {
 		return
 	}
 	if result.noDataReason != "" {
-		if log.ShouldLog(log.DebugLvl) && cs.debugLimit.ShouldLog() {
-			logNoData(entry.ContainerID, result.noDataReason)
-		}
 		return
 	}
 
-	item := result.item
+	cs.cache.Add(entry.ContainerID, result.item)
+}
 
-	if log.ShouldLog(log.DebugLvl) && cs.debugLimit.ShouldLog() {
-		logResolvConfRead(len(item.resolvConf.Get()))
+func containerIDStr(containerID network.ContainerID) string {
+	if containerID != nil {
+		if s, ok := containerID.Get().(string); ok {
+			return s
+		}
 	}
-
-	cs.cache.Add(entry.ContainerID, item)
+	return "host"
 }
 
 // logEvictingID logs in a separate function to avoid allocation
 func logEvictingID(containerID network.ContainerID) {
-	containerStr := "host"
-	if containerID != nil {
-		if s, ok := containerID.Get().(string); ok {
-			containerStr = s
-		}
-	}
-	log.Tracef("CNM ContainerStore evicting ID %s", containerStr)
+	log.Debugf("CNM ContainerStore evicting ID %s", containerIDStr(containerID))
 }
 
 // logHandledID logs in a separate function to avoid allocation
 func logHandledID(containerID network.ContainerID, result readContainerItemResult, err error) {
-	log.Debugf("CNM ContainerStore handled ID=%v with result=%v, err=%v", containerID, result, err)
-}
-
-// logNoData logs in a separate function to avoid allocation
-func logNoData(containerID network.ContainerID, reason string) {
-	log.Debugf("CNM ContainerStore read ID=%v and found no data: %s", containerID, reason)
-}
-
-// logResolvConfRead logs in a separate function to avoid allocation
-func logResolvConfRead(size int) {
-	log.Debugf("CNM ContainerStore successfully read resolv.conf of size %d", size)
+	log.Debugf("CNM ContainerStore handled ID=%s with result=%s, err=%v", containerIDStr(containerID), result.String(), err)
 }
 
 func (cs *ContainerStore) cleanMap() {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
 	for _, containerID := range cs.cache.Keys() {
 		item, ok := cs.cache.Get(containerID)
 		if !ok {
@@ -232,11 +223,17 @@ func (cs *ContainerStore) Stop() {
 }
 
 // GetResolvConf returns the resolv.conf for a containerID.
+// Accessing an entry refreshes its timestamp, preventing expiry for active containers.
 func (cs *ContainerStore) GetResolvConf(containerID network.ContainerID) network.ResolvConf {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
 	item, ok := cs.cache.Get(containerID)
-	if !ok {
+	if !ok || item.resolvConf == nil {
 		return nil
 	}
+	item.timestamp = time.Now()
+	cs.cache.Add(containerID, item)
 	return item.resolvConf
 }
 

--- a/pkg/network/containers/container_store_linux_test.go
+++ b/pkg/network/containers/container_store_linux_test.go
@@ -166,6 +166,48 @@ func TestContainerStoreNoData(t *testing.T) {
 	require.True(t, ok, "Container should be in cache")
 	require.Equal(t, resolvConf, item.resolvConf, "ResolvConf should match")
 }
+
+func TestContainerStoreAccessRefreshesTimestamp(t *testing.T) {
+	t.Parallel()
+	cs, err := NewContainerStore(10)
+	require.NoError(t, err)
+	defer cs.Stop()
+
+	containerID := intern.GetByString("container-1")
+	processEvent := &events.Process{
+		Pid:         12345,
+		ContainerID: containerID,
+		StartTime:   time.Now().UnixNano(),
+	}
+
+	resolvConf := stringInterner.GetString("nameserver 8.8.8.8")
+	// mock readContainerItem to return an item with a timestamp far in the past
+	insertTime := time.Now().Add(-containerTTL + time.Minute)
+	cs.readContainerItem = func(_ context.Context, _ *events.Process) (readContainerItemResult, error) {
+		return readContainerItemResult{
+			item: containerStoreItem{
+				timestamp:  insertTime,
+				resolvConf: resolvConf,
+			},
+		}, nil
+	}
+
+	cs.HandleProcessEvent(processEvent)
+
+	require.Eventually(t, func() bool {
+		return cs.cache.Len() == 1
+	}, 2*time.Second, 50*time.Millisecond)
+
+	// verify GetResolvConf refreshes the timestamp
+	result := cs.GetResolvConf(containerID)
+	require.Equal(t, resolvConf, result)
+
+	item, ok := cs.cache.Get(containerID)
+	require.True(t, ok)
+	require.True(t, item.timestamp.After(insertTime),
+		"GetResolvConf should refresh the timestamp to prevent expiry")
+}
+
 func TestContainerStoreDuplicate(t *testing.T) {
 	t.Parallel()
 	// makes sure that nothing weird happens when you repeat a process entry

--- a/pkg/network/containers/container_store_linux_test.go
+++ b/pkg/network/containers/container_store_linux_test.go
@@ -208,6 +208,54 @@ func TestContainerStoreAccessRefreshesTimestamp(t *testing.T) {
 		"GetResolvConf should refresh the timestamp to prevent expiry")
 }
 
+func TestContainerStoreErrorRetry(t *testing.T) {
+	t.Parallel()
+	// verifies that a failed read is retried after errorRetryInterval, but not before
+	cs, err := NewContainerStore(10)
+	require.NoError(t, err)
+	defer cs.Stop()
+
+	containerID := intern.GetByString("container-retry")
+	processEvent := &events.Process{
+		Pid:         12345,
+		ContainerID: containerID,
+		StartTime:   time.Now().UnixNano(),
+	}
+
+	callCount := 0
+	resolvConf := stringInterner.GetString("nameserver 8.8.8.8")
+	cs.readContainerItem = func(_ context.Context, _ *events.Process) (readContainerItemResult, error) {
+		callCount++
+		if callCount == 1 {
+			return readContainerItemResult{}, errors.New("transient procfs error")
+		}
+		return mockReadContainerItemResult(resolvConf), nil
+	}
+
+	// first call: error gets cached
+	cs.addProcess(processEvent)
+	require.Equal(t, 1, callCount)
+	item, ok := cs.cache.Get(containerID)
+	require.True(t, ok)
+	require.Nil(t, item.resolvConf)
+
+	// immediate retry: should be suppressed by errorRetryInterval
+	cs.addProcess(processEvent)
+	require.Equal(t, 1, callCount, "should not retry before errorRetryInterval")
+
+	// backdate the error entry past errorRetryInterval
+	item.timestamp = time.Now().Add(-errorRetryInterval - time.Second)
+	cs.cache.Add(containerID, item)
+
+	// now retry should succeed
+	cs.addProcess(processEvent)
+	require.Equal(t, 2, callCount, "should retry after errorRetryInterval")
+
+	item, ok = cs.cache.Get(containerID)
+	require.True(t, ok)
+	require.Equal(t, resolvConf, item.resolvConf, "should have resolv.conf after successful retry")
+}
+
 func TestContainerStoreDuplicate(t *testing.T) {
 	t.Parallel()
 	// makes sure that nothing weird happens when you repeat a process entry

--- a/pkg/network/tracer/process_cache.go
+++ b/pkg/network/tracer/process_cache.go
@@ -21,7 +21,9 @@ import (
 )
 
 const (
-	maxProcessQueueLen = 100
+	// the queue is oversized to account for the procfs snapshot when system-probe starts.
+	// these are pointers, so the memory cost is not severe
+	maxProcessQueueLen = 2048
 	// maxProcessListSize is the max size of a processList
 	maxProcessListSize     = 3
 	processCacheModuleName = "network_tracer__process_cache"


### PR DESCRIPTION
### What does this PR do?
This fixes missing containerID mappings in ContainerStore which appear as `CNM ContainerStore mapped 5 out of 12 containerIDs`.

There were two issues:
1. CWS does a snapshot of all processes in procfs on system-probe startup. This could easily have more than 100 entries, causing the channel to overflow.  The channel size was increased to account for this.
2. Once a process forks or execs, that's it, no more events from the process stream.  So when you fetch from the store, it needs to update the timestamp, otherwise it will eventually expire.

Additionally, I got rid of the stale/refresh logic since resolv.conf files are expected never to change.

### Motivation

Fix missing resolv.conf data

### Describe how you validated your changes

New test, also going to deploy to a staging cluster