### PR TITLE
Use Bazel hermetic toolchain for `cargo`

### DIFF
--- a/.gitlab/build/lint/technical_linters.yml
+++ b/.gitlab/build/lint/technical_linters.yml
@@ -13,7 +13,7 @@ lint_licenses:
   needs: ["go_deps", "go_tools_deps"]
 
 lint_rust_licenses:
-  extends: .lint
+  extends: [.lint, .bazel:defs:cache:progressive]
   script:
     - dda inv -- -e lint-rust-licenses
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,9 @@
 # Global build settings
 
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@bazel_lib//lib:run_binary.bzl", "run_binary")
 load("@bazel_lib//lib:write_source_files.bzl", "write_source_file")
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-load("@bazel_skylib//rules:run_binary.bzl", "run_binary")
 load("@gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")
 
 package(default_visibility = ["//visibility:public"])
@@ -140,6 +141,15 @@ gazelle_binary(
     languages = DEFAULT_LANGUAGES + [
         "//bazel/rules/go_stringer:gazelle_extension",
     ],
+)
+
+# bazel run //:cargo -- ...
+copy_file(
+    name = "cargo",
+    src = "@rules_rust//rust/toolchain:current_cargo_files",
+    out = "cargo_bin",
+    allow_symlink = True,  # best effort on Windows as of bazel-lib 3.2.2
+    is_executable = True,  #TODO(agent-build): file a PR to have it executable in the first place and make it an `alias`
 )
 
 # bazel run //:go -- ...

--- a/tasks/install_tasks.py
+++ b/tasks/install_tasks.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from invoke import Context, Exit, task
 
+from tasks.libs.build.bazel import bazel
 from tasks.libs.ciproviders.github_api import GithubAPI
 from tasks.libs.common.color import Color, color_message
 from tasks.libs.common.go import download_go_dependencies
@@ -95,8 +96,16 @@ def install_rust_license_tool(ctx):
     Install dd-rust-license-tool and cargo-deny for Rust license verification.
     Required to run the lint-rust-licenses task.
     """
-    ctx.run("cargo install --git https://github.com/DataDog/rust-license-tool dd-rust-license-tool")
-    ctx.run("cargo install cargo-deny --locked")
+    bazel(
+        "run",
+        "//:cargo",
+        "--",
+        "install",
+        "--git",
+        "https://github.com/DataDog/rust-license-tool",
+        "dd-rust-license-tool",
+    )
+    bazel("run", "//:cargo", "--", "install", "cargo-deny", "--locked")
 
 
 @task

--- a/tasks/licenses.py
+++ b/tasks/licenses.py
@@ -355,15 +355,14 @@ def lint_rust_licenses(ctx):
     Checks that the Rust system-probe-lite LICENSE-3rdparty.csv file is up-to-date
     and that all licenses are allowed.
     """
+    from tasks.libs.build.bazel import bazel  # noqa: PLC0415
+
     print("Verify Rust licenses")
 
     rust_dir = 'pkg/discovery/module/rust'
 
     # Check license compliance with cargo deny
-    result = ctx.run(f'cd {rust_dir} && cargo deny check licenses', warn=True)
-    if result.return_code != 0:
-        print("\nCargo-deny found non-allowed licenses.")
-        raise Exit(code=1)
+    bazel("run", "//:cargo", "--", "deny", "--manifest-path", f"{rust_dir}/Cargo.toml", "check", "licenses")
 
     # Check LICENSE-3rdparty.csv is up-to-date
     result = ctx.run(f'cd {rust_dir} && dd-rust-license-tool check', warn=True)


### PR DESCRIPTION
### What does this PR do?
Similar to the `bazel run //:go` alias introduced in #45714, the present changes add support for `bazel run //:cargo`.

The `copy_file` target (a symlink where supported) exposes the `cargo` binary from Bazel's hermetic Rust toolchain as a runnable target.

All remaining `cargo` invocations in `invoke` tasks are routed through `bazel run //:cargo` so they use the same hermetic toolchain.

### Motivation
Ensures reproducibility by using the same Rust/Cargo version that Bazel uses for building Rust code, rather than relying on a host-installed `cargo` that likely differs in distribution or version.

### Describe how you validated your changes
```sh
bazel run //:cargo -- --version
cargo 1.92.0 (344c4567c 2025-10-21)
```

### Additional Notes
#### Why not an `alias`
`rules_rust` exposes `cargo` via `toolchain_files`, which does not set `DefaultInfo.executable` yet and cannot be used directly as a runnable target.
`copy_file` with `is_executable = True` produces a valid `executable` target without requiring a custom rule while remaining lightweight enough to buy us time for filing a PR upstream.

#### Coming next
A follow-up change will replace `cargo`-based license checks with a Bazel `aspect` traversing the dependency graph directly.