### PR TITLE
Fix DownloadFromPod silently dropping single files

### DIFF
--- a/test/e2e-framework/testing/utils/e2e/client/k8s.go
+++ b/test/e2e-framework/testing/utils/e2e/client/k8s.go
@@ -85,7 +85,7 @@ func (k *KubernetesClient) PodExec(namespace, pod, container string, cmd []strin
 	return stdoutSb.String(), suppressGoCoverWarning(stderrSb.String()), nil
 }
 
-// DownloadFromPod downloads a folder from a pod to a local destination
+// DownloadFromPod downloads a file or folder from a pod to a local destination
 func (k *KubernetesClient) DownloadFromPod(namespace, podName, container, srcPath, destPath string) error {
 	reader, outStream := io.Pipe()
 	// Tar from the parent directory to avoid embedding parent folders (e.g., /tmp)
@@ -140,21 +140,40 @@ func (k *KubernetesClient) DownloadFromPod(namespace, podName, container, srcPat
 		return err
 	}
 
-	tarReader := tar.NewReader(reader)
+	if err := extractTar(reader, baseName, destPath); err != nil {
+		cancel()
+		return err
+	}
+	// Reading the tar is complete; cancel the exec stream so it doesn't hang.
+	cancel()
+
+	// Ensure the exec stream completed successfully
+	streamErr := <-streamErrCh
+
+	return streamErr
+}
+
+// extractTar reads a tar stream produced by `tar cf - -C <parent> <baseName>`
+// and writes its contents into destPath. When baseName is a directory the
+// top-level directory entry is stripped so children land directly in destPath.
+// When baseName is a single file it is written into destPath as-is.
+func extractTar(r io.Reader, baseName, destPath string) error {
+	tarReader := tar.NewReader(r)
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
-			// Reading the tar file is complete let's cancel the execution stream, as it is not stopped and will hang otherwise.
-			cancel()
 			break
 		}
 		if err != nil {
 			return err
 		}
-		// Strip the top-level folder (baseName) so contents land directly in destPath
 		entryName := strings.TrimPrefix(header.Name, "./")
-		if entryName == baseName || entryName == baseName+"/" {
-			// Skip the root directory entry
+
+		// When downloading a directory, skip the top-level directory entry and
+		// strip its prefix from children so contents land directly in destPath.
+		// Only skip directory entries here; a single file whose name equals
+		// baseName must be kept, otherwise single-file downloads produce nothing.
+		if (entryName == baseName || entryName == baseName+"/") && header.Typeflag == tar.TypeDir {
 			continue
 		}
 		if after, ok := strings.CutPrefix(entryName, baseName+"/"); ok {
@@ -186,8 +205,5 @@ func (k *KubernetesClient) DownloadFromPod(namespace, podName, container, srcPat
 			}
 		}
 	}
-	// Ensure the exec stream completed successfully
-	streamErr := <-streamErrCh
-
-	return streamErr
+	return nil
 }

--- a/test/e2e-framework/testing/utils/e2e/client/k8s_test.go
+++ b/test/e2e-framework/testing/utils/e2e/client/k8s_test.go
@@ -1,0 +1,107 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package client
+
+import (
+	"archive/tar"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeTarFile adds a regular file entry to a tar writer.
+func writeTarFile(tw *tar.Writer, name string, content []byte) {
+	_ = tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Size:     int64(len(content)),
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+	})
+	_, _ = tw.Write(content)
+}
+
+// writeTarDir adds a directory entry to a tar writer.
+func writeTarDir(tw *tar.Writer, name string) {
+	_ = tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Mode:     0755,
+		Typeflag: tar.TypeDir,
+	})
+}
+
+func TestExtractTar_SingleFile(t *testing.T) {
+	// Simulate: tar cf - -C /tmp myfile.zip
+	// The archive contains a single file entry named "myfile.zip".
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	writeTarFile(tw, "myfile.zip", []byte("file-contents"))
+	tw.Close()
+
+	destPath := t.TempDir()
+	err := extractTar(&buf, "myfile.zip", destPath)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(destPath, "myfile.zip"))
+	require.NoError(t, err)
+	assert.Equal(t, "file-contents", string(content))
+}
+
+func TestExtractTar_Directory(t *testing.T) {
+	// Simulate: tar cf - -C /tmp mydir
+	// The archive contains:
+	//   mydir/
+	//   mydir/a.txt
+	//   mydir/sub/
+	//   mydir/sub/b.txt
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	writeTarDir(tw, "mydir/")
+	writeTarFile(tw, "mydir/a.txt", []byte("aaa"))
+	writeTarDir(tw, "mydir/sub/")
+	writeTarFile(tw, "mydir/sub/b.txt", []byte("bbb"))
+	tw.Close()
+
+	destPath := t.TempDir()
+	err := extractTar(&buf, "mydir", destPath)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(destPath, "a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "aaa", string(content))
+
+	content, err = os.ReadFile(filepath.Join(destPath, "sub", "b.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "bbb", string(content))
+
+	// The top-level "mydir" directory should not appear in destPath
+	_, err = os.Stat(filepath.Join(destPath, "mydir"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestExtractTar_DirectoryWithoutTrailingSlash(t *testing.T) {
+	// Some tar implementations emit directory headers without a trailing slash.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	writeTarDir(tw, "mydir")
+	writeTarFile(tw, "mydir/a.txt", []byte("aaa"))
+	tw.Close()
+
+	destPath := t.TempDir()
+	err := extractTar(&buf, "mydir", destPath)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(destPath, "a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "aaa", string(content))
+
+	_, err = os.Stat(filepath.Join(destPath, "mydir"))
+	assert.True(t, os.IsNotExist(err))
+}
+


### PR DESCRIPTION
### What does this PR do?

Fix `DownloadFromPod` silently dropping single files (like flare zip)

### Motivation

The tar extraction logic in `DownloadFromPod` skipped entries whose name matched baseName in order to strip the top-level directory when downloading directories. However, when downloading a single file (e.g. a flare `.zip`), the sole tar entry also matches baseName exactly, so it was silently discarded. The function created the destination directory but wrote no files into it, and returned nil, so callers had no indication of failure.

This caused E2E test diagnostic flares to be lost: the SBOM Kind test (`TestSBOMKindSuite`) reported: "Downloaded flare: /tmp/datadog-agent- ...zip" but the artifact directories were empty. We discovered this while investigating why the SBOM E2E test had no agent logs available for debugging a pod readiness failure introduced by commit 15b3097d042.

Fix by checking `header.Typeflag == tar.TypeDir` before skipping, so only actual directory entries are stripped. Extract the tar logic into a testable helper and add unit tests covering single-file downloads, directory downloads with trailing slash, and directory downloads without trailing slash.

### Describe how you validated your changes

Artifacts in https://gitlab.ddbuild.io/datadog/datadog-agent/builds/1519860923 now have the agent flares! 🔥 

### Additional Notes

N/A