### PR TITLE
enable CNM direct send by default on Linux

### DIFF
--- a/cmd/agent/subcommands/flare/command_other_test.go
+++ b/cmd/agent/subcommands/flare/command_other_test.go
@@ -21,6 +21,7 @@ func InjectConnectionFailures(mockSysProbeConfig model.Config, _ model.Config) {
 	mockSysProbeConfig.SetWithoutSource("system_probe_config.enabled", true)
 	mockSysProbeConfig.SetWithoutSource("system_probe_config.sysprobe_socket", "/opt/datadog-agent/run/sysprobe-bad.sock")
 	mockSysProbeConfig.SetWithoutSource("network_config.enabled", true)
+	mockSysProbeConfig.SetWithoutSource("network_config.direct_send", false)
 }
 
 // CheckExpectedConnectionFailures checks the expected errors after simulated

--- a/cmd/agent/subcommands/flare/command_test.go
+++ b/cmd/agent/subcommands/flare/command_test.go
@@ -131,6 +131,7 @@ func (c *commandTestSuite) TestReadProfileData() {
 		mockSysProbeConfig.SetWithoutSource("system_probe_config.enabled", true)
 		mockSysProbeConfig.SetWithoutSource("system_probe_config.sysprobe_socket", c.sysprobeSocketPath)
 		mockSysProbeConfig.SetWithoutSource("network_config.enabled", true)
+		mockSysProbeConfig.SetWithoutSource("network_config.direct_send", false)
 	}
 
 	profiler := getProfiler(t)
@@ -201,6 +202,7 @@ func (c *commandTestSuite) TestReadProfileDataNoTraceAgent() {
 		mockSysProbeConfig.SetWithoutSource("system_probe_config.enabled", true)
 		mockSysProbeConfig.SetWithoutSource("system_probe_config.sysprobe_socket", c.sysprobeSocketPath)
 		mockSysProbeConfig.SetWithoutSource("network_config.enabled", true)
+		mockSysProbeConfig.SetWithoutSource("network_config.direct_send", false)
 	}
 
 	profiler := getProfiler(t)

--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -228,6 +228,7 @@ func TestTimeout(t *testing.T) {
 			extraCfgs: map[string]interface{}{},
 			extraSysCfgs: map[string]interface{}{
 				"network_config.enabled":      true,
+				"network_config.direct_send":  false,
 				"system_probe_config.enabled": true,
 			},
 			profileDuration: defaultProfileDuration,
@@ -239,6 +240,7 @@ func TestTimeout(t *testing.T) {
 			extraSysCfgs: map[string]interface{}{
 				"service_monitoring_config.enabled": true,
 				"system_probe_config.enabled":       true,
+				"network_config.direct_send":        false,
 			},
 			profileDuration: defaultProfileDuration,
 			expTimeout:      baseTimeout + 8*defaultProfileDuration,
@@ -248,6 +250,7 @@ func TestTimeout(t *testing.T) {
 			extraCfgs: map[string]interface{}{},
 			extraSysCfgs: map[string]interface{}{
 				"system_probe_config.enabled": true,
+				"network_config.direct_send":  false,
 			},
 			profileDuration: defaultProfileDuration,
 			expTimeout:      baseTimeout + 8*defaultProfileDuration, // config enables NPM, which enables process agent
@@ -261,6 +264,7 @@ func TestTimeout(t *testing.T) {
 			},
 			extraSysCfgs: map[string]interface{}{
 				"system_probe_config.enabled": true,
+				"network_config.direct_send":  false,
 			},
 			profileDuration: defaultProfileDuration,
 			expTimeout:      baseTimeout + 10*defaultProfileDuration,

--- a/comp/process/connectionscheck/impl/check_test.go
+++ b/comp/process/connectionscheck/impl/check_test.go
@@ -10,6 +10,9 @@ package connectionscheckimpl
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/fx"
+
 	"github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	logmock "github.com/DataDog/datadog-agent/comp/core/log/mock"
@@ -23,8 +26,6 @@ import (
 	connectionscheck "github.com/DataDog/datadog-agent/comp/process/connectionscheck/def"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/fx"
 )
 
 func TestConnectionsCheckIsEnabled(t *testing.T) {
@@ -37,7 +38,8 @@ func TestConnectionsCheckIsEnabled(t *testing.T) {
 		{
 			name: "Network check enabled and running on the process-agent",
 			sysprobeConfigs: map[string]interface{}{
-				"network_config.enabled": true,
+				"network_config.enabled":     true,
+				"network_config.direct_send": false,
 			},
 			flavor:  flavor.ProcessAgent,
 			enabled: true,
@@ -46,6 +48,7 @@ func TestConnectionsCheckIsEnabled(t *testing.T) {
 			name: "SysProbe enabled and running on the process-agent",
 			sysprobeConfigs: map[string]interface{}{
 				"system_probe_config.enabled": true,
+				"network_config.direct_send":  false,
 			},
 			flavor:  flavor.ProcessAgent,
 			enabled: true,

--- a/pkg/config/setup/system_probe.go
+++ b/pkg/config/setup/system_probe.go
@@ -407,7 +407,7 @@ func InitSystemProbeConfig(cfg pkgconfigmodel.Setup) {
 	initCWSSystemProbeConfig(cfg)
 	initUSMSystemProbeConfig(cfg)
 
-	cfg.BindEnvAndSetDefault("network_config.direct_send", false)
+	cfg.BindEnvAndSetDefault("network_config.direct_send", runtime.GOOS == "linux")
 }
 
 func suffixHostEtc(suffix string) string {

--- a/pkg/network/sender/event_consumer_linux.go
+++ b/pkg/network/sender/event_consumer_linux.go
@@ -77,12 +77,13 @@ func NewDirectSenderConsumer(em EventConsumerRegistry, log log.Component, syspro
 // NewDirectSenderPoller creates the direct sender consumer using manual process polling
 func NewDirectSenderPoller(log log.Component, sysprobeconfig sysprobeconfig.Component) error {
 	dsc := &directSenderConsumer{
-		log:            log,
-		processes:      make(map[uint32]*process),
-		proxyFilter:    newDockerProxyFilter(log),
-		extractor:      newServiceExtractor(sysprobeconfig),
-		pidAliveFunc:   ddos.PidExists,
-		fetchProcesses: true,
+		log:                  log,
+		processes:            make(map[uint32]*process),
+		proxyFilter:          newDockerProxyFilter(log),
+		extractor:            newServiceExtractor(sysprobeconfig),
+		processNameExtractor: newProcessNameExtractor(),
+		pidAliveFunc:         ddos.PidExists,
+		fetchProcesses:       true,
 	}
 	directSenderConsumerInstance.Store(dsc)
 	return nil

--- a/pkg/system-probe/config/adjust_npm.go
+++ b/pkg/system-probe/config/adjust_npm.go
@@ -52,11 +52,6 @@ func adjustNetwork(cfg model.Config) {
 			}
 			return nil
 		})
-
-		if cfg.GetBool(netNS("direct_send")) {
-			log.Warn("disabling direct send because this feature is not supported on windows")
-			cfg.Set(netNS("direct_send"), false, model.SourceAgentRuntime)
-		}
 	}
 
 	validateInt64(cfg, spNS("max_tracked_connections"), defaultMaxTrackedConnections, func(v int64) error {
@@ -104,6 +99,13 @@ func adjustNetwork(cfg model.Config) {
 			log.Warn("disabling process event monitoring as it is not supported for this kernel version")
 		}
 		cfg.Set(evNS("network_process", "enabled"), false, model.SourceAgentRuntime)
+	}
+
+	if cfg.GetBool(netNS("direct_send")) && !DirectSendSupported() {
+		if flavor.GetFlavor() == flavor.SystemProbe {
+			log.Warn("disabling direct send because this feature is not supported for this platform")
+		}
+		cfg.Set(netNS("direct_send"), false, model.SourceAgentRuntime)
 	}
 
 	// if npm connection rollups are enabled, but usm rollups are not,

--- a/pkg/system-probe/config/config_darwin.go
+++ b/pkg/system-probe/config/config_darwin.go
@@ -19,6 +19,11 @@ func ProcessEventDataStreamSupported() bool {
 	return false
 }
 
+// DirectSendSupported returns true if sending data CNM/USM directly from system-probe is supported
+func DirectSendSupported() bool {
+	return false
+}
+
 // RedisMonitoringSupported returns false on darwin as eBPF is not supported
 func RedisMonitoringSupported() bool {
 	return false

--- a/pkg/system-probe/config/config_linux.go
+++ b/pkg/system-probe/config/config_linux.go
@@ -21,6 +21,11 @@ func ProcessEventDataStreamSupported() bool {
 	return false
 }
 
+// DirectSendSupported returns true if sending data CNM/USM directly from system-probe is supported
+func DirectSendSupported() bool {
+	return true
+}
+
 // RedisMonitoringSupported returns false on linux without BPF
 func RedisMonitoringSupported() bool {
 	return false

--- a/pkg/system-probe/config/config_linux_bpf.go
+++ b/pkg/system-probe/config/config_linux_bpf.go
@@ -49,6 +49,11 @@ func ProcessEventDataStreamSupported() bool {
 	return true
 }
 
+// DirectSendSupported returns true if sending data CNM/USM directly from system-probe is supported
+func DirectSendSupported() bool {
+	return true
+}
+
 // RedisMonitoringSupported returns true if Redis monitoring is supported on the current kernel
 func RedisMonitoringSupported() bool {
 	kernelVersion, err := ebpfkernel.NewKernelVersion()

--- a/pkg/system-probe/config/config_unsupported.go
+++ b/pkg/system-probe/config/config_unsupported.go
@@ -32,6 +32,11 @@ func ProcessEventDataStreamSupported() bool {
 	return false
 }
 
+// DirectSendSupported returns true if sending data CNM/USM directly from system-probe is supported
+func DirectSendSupported() bool {
+	return false
+}
+
 // RedisMonitoringSupported returns false on unsupported platforms
 func RedisMonitoringSupported() bool {
 	return false

--- a/pkg/system-probe/config/config_windows.go
+++ b/pkg/system-probe/config/config_windows.go
@@ -49,6 +49,11 @@ func ProcessEventDataStreamSupported() bool {
 	return true
 }
 
+// DirectSendSupported returns true if sending data CNM/USM directly from system-probe is supported
+func DirectSendSupported() bool {
+	return false
+}
+
 // RedisMonitoringSupported returns false on windows as eBPF is not supported
 func RedisMonitoringSupported() bool {
 	return false

--- a/releasenotes/notes/sysprobe-cnm-direct-send-cd354799143ff83c.yaml
+++ b/releasenotes/notes/sysprobe-cnm-direct-send-cd354799143ff83c.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Send CNM/USM data directly to Datadog from system-probe on Linux.
+    This eliminates the need to run process-agent in certain configurations.

--- a/test/new-e2e/tests/agent-configuration/configrefresh_nix_test.go
+++ b/test/new-e2e/tests/agent-configuration/configrefresh_nix_test.go
@@ -66,7 +66,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefresh() {
 			secretsutils.WithUnixSetupScript(secretResolverPath, true),
 			agentparams.WithAgentConfig(coreconfig),
 			agentparams.WithSecurityAgentConfig(securityAgentConfig),
-			agentparams.WithSystemProbeConfig("network_config:\n  enabled: true"),
+			agentparams.WithSystemProbeConfig("network_config:\n  enabled: true\n  direct_send: false"),
 			agentparams.WithSkipAPIKeyInConfig(), // api_key is already provided in the config
 		)),
 		awshost.WithRunOptions(scenec2.WithAgentClientOptions(
@@ -135,7 +135,7 @@ func (v *configRefreshLinuxSuite) TestConfigRefreshOverSocket() {
 			secretsutils.WithUnixSetupScript(secretResolverPath, true),
 			agentparams.WithAgentConfig(coreconfig),
 			agentparams.WithSecurityAgentConfig(securityAgentConfig),
-			agentparams.WithSystemProbeConfig("network_config:\n  enabled: true"),
+			agentparams.WithSystemProbeConfig("network_config:\n  enabled: true\n  direct_send: false"),
 			agentparams.WithSkipAPIKeyInConfig(), // api_key is already provided in the config
 		)),
 		awshost.WithRunOptions(scenec2.WithAgentClientOptions(

--- a/test/new-e2e/tests/agent-runtimes/ipc_security_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/ipc_security_nix_test.go
@@ -54,7 +54,7 @@ func (v *ipcSecurityLinuxSuite) TestServersideIPCCertUsage() {
 			ec2.WithAgentOptions(
 				agentparams.WithAgentConfig(coreconfig),
 				agentparams.WithSecurityAgentConfig(securityAgentConfig),
-				agentparams.WithSystemProbeConfig("network_config:\n  enabled: true"),
+				agentparams.WithSystemProbeConfig("network_config:\n  enabled: true\n  direct_send: false"),
 			),
 			ec2.WithAgentClientOptions(
 				agentclientparams.WithTraceAgentOnPort(apmReceiverPort),

--- a/test/new-e2e/tests/fips-compliance/fixtures/system-probe.yaml
+++ b/test/new-e2e/tests/fips-compliance/fixtures/system-probe.yaml
@@ -1,4 +1,5 @@
 network_config:
   enabled: true
+  direct_send: false
 runtime_security_config:
   enabled: true

--- a/test/new-e2e/tests/npm/cilium_lb_conntracker_test.go
+++ b/test/new-e2e/tests/npm/cilium_lb_conntracker_test.go
@@ -121,7 +121,7 @@ func (suite *ciliumLBConntrackerTestSuite) TestCiliumConntracker() {
 			assert.NotEmpty(collect, names) {
 			hostname = names[0]
 		}
-	}, time.Minute, time.Second, "timed out getting connection names")
+	}, 2*time.Minute, time.Second, "timed out getting connection names")
 
 	var svcConns []*process.Connection
 	suite.Require().EventuallyWithT(func(collect *assert.CollectT) {

--- a/test/new-e2e/tests/npm/cilium_lb_conntracker_test.go
+++ b/test/new-e2e/tests/npm/cilium_lb_conntracker_test.go
@@ -42,8 +42,8 @@ func TestCiliumLBConntracker(t *testing.T) {
 	// TODO: find a way to update this list dynamically
 	versionsToTest := []string{"1.15.17", "1.16.10", "1.17.4"}
 	for _, v := range versionsToTest {
-		t.Run("version "+v, func(_t *testing.T) {
-			_t.Parallel()
+		t.Run("version "+v, func(t *testing.T) {
+			t.Parallel()
 
 			testCiliumLBConntracker(t, v)
 		})

--- a/test/new-e2e/tests/npm/config/npm-helm-values.yaml
+++ b/test/new-e2e/tests/npm/config/npm-helm-values.yaml
@@ -1,4 +1,5 @@
 datadog:
   networkMonitoring:
     enabled: true
-
+  envDict:
+    DD_NETWORK_CONFIG_DIRECT_SEND: "false"

--- a/test/new-e2e/tests/npm/config/npm-helm-values.yaml
+++ b/test/new-e2e/tests/npm/config/npm-helm-values.yaml
@@ -1,5 +1,3 @@
 datadog:
   networkMonitoring:
     enabled: true
-  envDict:
-    DD_NETWORK_CONFIG_DIRECT_SEND: "false"

--- a/test/new-e2e/tests/npm/config/npm.yaml
+++ b/test/new-e2e/tests/npm/config/npm.yaml
@@ -1,2 +1,3 @@
 network_config:
   enabled: true
+  direct_send: false

--- a/test/new-e2e/tests/process/config/npm.yaml
+++ b/test/new-e2e/tests/process/config/npm.yaml
@@ -1,2 +1,3 @@
 network_config:
   enabled: true
+  direct_send: false

--- a/test/new-e2e/tests/process/docker_test.go
+++ b/test/new-e2e/tests/process/docker_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/dockeragentparams"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/dockeragentparams"
 
 	scendocker "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2docker"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
@@ -136,6 +137,7 @@ func (s *dockerTestSuite) TestProcessChecksWithNPM() {
 	agentOpts := []dockeragentparams.Option{
 		dockeragentparams.WithAgentServiceEnvVariable("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED", pulumi.StringPtr("true")),
 		dockeragentparams.WithAgentServiceEnvVariable("DD_SYSTEM_PROBE_NETWORK_ENABLED", pulumi.StringPtr("true")),
+		dockeragentparams.WithAgentServiceEnvVariable("DD_NETWORK_CONFIG_DIRECT_SEND", pulumi.StringPtr("false")),
 
 		dockeragentparams.WithExtraComposeManifest("fakeProcess", pulumi.String(fakeProcessCompose)),
 	}


### PR DESCRIPTION
### What does this PR do?

enable CNM direct send by default on Linux

### Motivation

Simpler data pathway for CNM/USM data.

### Describe how you validated your changes

Direct send has been enabled on staging for awhile with positive results.

### Additional Notes
