### PR TITLE
Add explicit `py_binary` import for Bazel 9

### DIFF
--- a/deps/openssl_fips.BUILD.bazel
+++ b/deps/openssl_fips.BUILD.bazel
@@ -1,6 +1,7 @@
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_filegroup", "pkg_files")
+load("@rules_python//python:defs.bzl", "py_binary")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
### What does this PR do?
Adds an explicit `load` for `py_binary` from `@rules_python//python:defs.bzl` to `deps/openssl_fips.BUILD.bazel`.

### Motivation
In Bazel 9, `py_binary` is no longer auto-loaded from Bazel's native namespace:
```
ERROR: deps/openssl_fips.BUILD.bazel:140:1:
    name 'py_binary' is not defined (did you mean 'cc_binary'?)
```
The `load` is transparent on Bazel 8, where the rule is still auto-loaded, so this change is safe to land before the Bazel 9 upgrade.

### Describe how you validated your changes
`bazel run -- @openssl_fips//:install --destdir=/tmp/opt/datadog-agent` succeeds.