### PR TITLE
scrubber: broaden credential redaction for secret backends

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -145,18 +145,25 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 		LastUpdated: parseVersion("7.73.1"),
 	}
 	tokenReplacer := matchYAMLKeyEnding(
-		`token`,
-		[]string{"token"},
+		`_?(token|jwt)`,
+		[]string{"token", "jwt"},
 		[]byte(`$1 "********"`),
 	)
-	tokenReplacer.LastUpdated = parseVersion("7.70.2")
+	tokenReplacer.LastUpdated = parseVersion("7.78.0") // https://github.com/DataDog/datadog-agent/pull/48017
 
-	secretReplacer := matchYAMLKey(
-		`(token_secret|consumer_secret)`,
-		[]string{"token_secret", "consumer_secret"},
+	secretReplacer := matchYAMLKeyEnding(
+		`_secret(_id)?`,
+		[]string{"secret", "secret_id"},
 		[]byte(`$1 "********"`),
 	)
-	secretReplacer.LastUpdated = parseVersion("7.70.0") // https://github.com/DataDog/datadog-agent/pull/40345
+	secretReplacer.LastUpdated = parseVersion("7.78.0") // https://github.com/DataDog/datadog-agent/pull/48017
+
+	accessKeyReplacer := matchYAMLKeyEnding(
+		`access_key`,
+		[]string{"access_key"},
+		[]byte(`$1 "********"`),
+	)
+	accessKeyReplacer.LastUpdated = parseVersion("7.78.0") // https://github.com/DataDog/datadog-agent/pull/48017
 
 	// OAuth credentials scrubbers for continuous_ai_netsuite and similar integrations
 	consumerKeyAndTokenIDReplacer := matchYAMLKey(
@@ -300,6 +307,7 @@ func AddDefaultReplacers(scrubber *Scrubber) {
 	scrubber.AddReplacer(SingleLine, tokenReplacer)
 	scrubber.AddReplacer(SingleLine, consumerKeyAndTokenIDReplacer)
 	scrubber.AddReplacer(SingleLine, secretReplacer)
+	scrubber.AddReplacer(SingleLine, accessKeyReplacer)
 	scrubber.AddReplacer(SingleLine, snmpReplacer)
 
 	scrubber.AddReplacer(SingleLine, apiKeyYaml)

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -692,6 +692,34 @@ func TestOAuthCredentials(t *testing.T) {
   token_secret: "********"`)
 }
 
+func TestSecretBackendCredentials(t *testing.T) {
+	// Verifies that all sensitive credential keys used by secret backend integrations
+	// are scrubbed when they appear under a nested session config block.
+	assertClean(t,
+		`secret_backend_config:
+  session:
+    azure_client_secret: my-sp-secret
+    azure_client_certificate_password: my-cert-password
+    aws_secret_access_key: AKIAIOSFODNN7EXAMPLE
+    vault_secret_id: my-vault-secret-id
+    vault_password: my-vault-password
+    vault_ldap_password: my-ldap-password
+    vault_token: s.my-vault-token
+    vault_kubernetes_jwt: eyJhbGciOiJSUzI1NiJ9
+    akeyless_access_key: my-akeyless-key`,
+		`secret_backend_config:
+  session:
+    azure_client_secret: "********"
+    azure_client_certificate_password: "********"
+    aws_secret_access_key: "********"
+    vault_secret_id: "********"
+    vault_password: "********"
+    vault_ldap_password: "********"
+    vault_token: "********"
+    vault_kubernetes_jwt: "********"
+    akeyless_access_key: "********"`)
+}
+
 func TestScrubCommandsEnv(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
### What does this PR do?

  - Extend secretReplacer to match keys ending in `_secret` or `_secret_id`
    (covers `azure_client_secret`, `vault_secret_id`, etc.)
  - Extend tokenReplacer to match keys ending in `_token` or `_jwt`
    (covers `vault_kubernetes_jwt`)
  - Add accessKeyReplacer for keys ending in _access_key
    (covers `aws_secret_access_key`, `akeyless_access_key`)

### Motivation
- Found in but not solely introduced by #47988 

### Describe how you validated your changes

- Configured secret backend
   ```
  secret_backend_type: azure.keyvault
  secret_backend_config:
    keyvaulturl: "https://test.vault.azure.net"
    azure_session:
      azure_tenant_id: "tenantid-abc"
      azure_client_id: "clientid-xyz"
      azure_client_secret: "sensitive_client_secret-123"
      test_password: should_be_masked
   ```
- set `log_level: debug`
- started Agent and grepped for `calling secret_backend_command with payload`
  ```
   2026-03-19 11:06:01 UTC | CORE | DEBUG | (comp/core/secrets/impl/fetch_secret.go:82 in execCommand) | 2026-03-19 11:06:01.482724712 +0000 UTC m=+8.878574526 | calling secret_backend_command with payload: '{
    "config":
      {
          "azure_session":
          {
              "azure_client_id": "clientid-xyz",
              "azure_client_secret": "********",
              "azure_tenant_id": "tenantid-abc",
              "test_password": "********"
          },
          "keyvaulturl": "https://test.vault.azure.net"
      },
      "secret_backend_timeout": 5,
      "secrets":
      [
          "singleval"
      ],
      "type": "azure.keyvault",
      "version": "1.1"
  }'
  ```
    - `"azure_client_secret":"********"`
    - `"test_password":"********"`

### Additional Notes
