### PR TITLE
[observer] ScanMW + ScanWelch Detectors + TP Eval

### DIFF
--- a/cmd/observer-scorer/main.go
+++ b/cmd/observer-scorer/main.go
@@ -4,8 +4,17 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package main provides a standalone scorer for observer eval output.
-// It reads a headless output JSON, resolves ground truth from the scenario's
-// metadata.json, and computes a Gaussian F1 score.
+// It has two mutually exclusive scoring modes:
+//
+//   - Default (F1 scoring): Reads a headless output JSON produced with time_cluster,
+//     resolves ground truth timestamps from the scenario's metadata.json, and computes
+//     a Gaussian F1 score measuring whether the disruption was detected at the right time.
+//
+//   - --score-tp (TP metric scoring): Reads a headless output JSON produced with the
+//     passthrough correlator, loads metric ground truth from ground_truth.json, and
+//     classifies each detected anomaly by metric name match. Measures whether the
+//     right metrics were flagged. Requires passthrough output because it extracts
+//     metric names from each anomaly's Source field.
 package main
 
 import (
@@ -17,19 +26,13 @@ import (
 	observerimpl "github.com/DataDog/datadog-agent/comp/observer/impl"
 )
 
-// combinedResult wraps both timestamp-level and metric-level scoring output.
-type combinedResult struct {
-	TimestampScore *observerimpl.ScoreResult       `json:"timestamp_score"`
-	MetricScore    *observerimpl.MetricScoreResult  `json:"metric_score,omitempty"`
-}
-
 func main() {
 	outputPath := flag.String("input", "", "Path to headless output JSON to score (required)")
 	scenariosDir := flag.String("scenarios-dir", "./comp/observer/scenarios", "Directory containing scenario subdirectories (for metadata.json lookup)")
 	groundTruthTS := flag.Int64("ground-truth-ts", 0, "Ground truth disruption onset timestamp in unix seconds (overrides metadata.json)")
 	sigma := flag.Float64("sigma", 30.0, "Gaussian width in seconds")
 	jsonOutput := flag.Bool("json", false, "Output result as JSON")
-	scoreTP := flag.Bool("score-tp", false, "Score true positive detection using metric ground truth from metadata.json")
+	scoreTP := flag.Bool("score-tp", false, "Score true positive detection using metric ground truth from ground_truth.json. Requires passthrough correlator output.")
 	flag.Parse()
 
 	if *outputPath == "" {
@@ -42,28 +45,34 @@ func main() {
 		gtTimestamps = []int64{*groundTruthTS}
 	}
 
+	// When --score-tp is used, only run metric TP scoring (skip Gaussian F1).
+	if *scoreTP {
+		metricResult, err := scoreMetricTP(*outputPath, *scenariosDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Metric TP scoring failed: %v\n", err)
+			os.Exit(1)
+		}
+		if *jsonOutput {
+			data, err := json.Marshal(metricResult)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "JSON marshal failed: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println(string(data))
+			return
+		}
+		printMetricTPScore(metricResult)
+		return
+	}
+
 	result, err := observerimpl.ScoreOutputFile(*outputPath, gtTimestamps, *scenariosDir, *sigma)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Scoring failed: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Optionally score true positive metric detection.
-	var metricResult *observerimpl.MetricScoreResult
-	if *scoreTP {
-		metricResult, err = scoreMetricTP(*outputPath, *scenariosDir)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Metric TP scoring failed: %v\n", err)
-			os.Exit(1)
-		}
-	}
-
 	if *jsonOutput {
-		out := combinedResult{
-			TimestampScore: result,
-			MetricScore:    metricResult,
-		}
-		data, err := json.Marshal(out)
+		data, err := json.Marshal(result)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "JSON marshal failed: %v\n", err)
 			os.Exit(1)
@@ -83,34 +92,35 @@ func main() {
 	fmt.Printf("  Precision: %.4f\n", result.Precision)
 	fmt.Printf("  Recall:    %.4f\n", result.Recall)
 	fmt.Printf("  TP: %.4f  FP: %.4f  FN: %.4f\n", result.TP, result.FP, result.FN)
+}
 
-	// Text output: metric TP score
-	if metricResult != nil {
+func printMetricTPScore(metricResult *observerimpl.MetricScoreResult) {
+	if metricResult == nil {
+		return
+	}
+	fmt.Printf("Metric TP Score\n")
+	fmt.Printf("  Total anomaly periods: %d\n", metricResult.TotalCount)
+	fmt.Printf("  TP: %d  Unknown: %d\n", metricResult.TPCount, metricResult.UnknownCount)
+	fmt.Println()
+	fmt.Printf("  Metric F1:        %.4f\n", metricResult.MetricF1)
+	fmt.Printf("  Metric Precision: %.4f\n", metricResult.MetricPrecision)
+	fmt.Printf("  Metric Recall:    %.4f\n", metricResult.MetricRecall)
+	fmt.Println()
+	if len(metricResult.TPMetricsFound) > 0 {
+		fmt.Printf("  TP metrics found:  %v\n", metricResult.TPMetricsFound)
+	}
+	if len(metricResult.TPMetricsMissed) > 0 {
+		fmt.Printf("  TP metrics missed: %v\n", metricResult.TPMetricsMissed)
+	}
+	if len(metricResult.Detections) > 0 {
 		fmt.Println()
-		fmt.Printf("Metric TP Score\n")
-		fmt.Printf("  Total anomaly periods: %d\n", metricResult.TotalCount)
-		fmt.Printf("  TP: %d  Unknown: %d\n", metricResult.TPCount, metricResult.UnknownCount)
-		fmt.Println()
-		fmt.Printf("  Metric F1:        %.4f\n", metricResult.MetricF1)
-		fmt.Printf("  Metric Precision: %.4f\n", metricResult.MetricPrecision)
-		fmt.Printf("  Metric Recall:    %.4f\n", metricResult.MetricRecall)
-		fmt.Println()
-		if len(metricResult.TPMetricsFound) > 0 {
-			fmt.Printf("  TP metrics found:  %v\n", metricResult.TPMetricsFound)
-		}
-		if len(metricResult.TPMetricsMissed) > 0 {
-			fmt.Printf("  TP metrics missed: %v\n", metricResult.TPMetricsMissed)
-		}
-		if len(metricResult.Detections) > 0 {
-			fmt.Println()
-			fmt.Printf("  Detections:\n")
-			for _, d := range metricResult.Detections {
-				status := "MISS"
-				if d.Detected {
-					status = fmt.Sprintf("HIT (count=%d, first=%.0fs after disruption)", d.Count, d.DeltaFromDisruption)
-				}
-				fmt.Printf("    [%s] %s/%s: %s\n", d.Classification, d.Service, d.Metric, status)
+		fmt.Printf("  Detections:\n")
+		for _, d := range metricResult.Detections {
+			status := "MISS"
+			if d.Detected {
+				status = fmt.Sprintf("HIT (count=%d, first=%.0fs after disruption)", d.Count, d.DeltaFromDisruption)
 			}
+			fmt.Printf("    [%s] %s/%s: %s\n", d.Classification, d.Service, d.Metric, status)
 		}
 	}
 }

--- a/cmd/observer-scorer/main.go
+++ b/cmd/observer-scorer/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -139,7 +140,7 @@ func scoreMetricTP(outputPath, scenariosDir string) (*observerimpl.MetricScoreRe
 
 	scenarioName := output.Metadata.Scenario
 	if scenarioName == "" {
-		return nil, fmt.Errorf("output file missing metadata.scenario")
+		return nil, errors.New("output file missing metadata.scenario")
 	}
 
 	gt, err := observerimpl.LoadMetricGroundTruth(scenariosDir, scenarioName)

--- a/cmd/observer-scorer/main.go
+++ b/cmd/observer-scorer/main.go
@@ -17,16 +17,23 @@ import (
 	observerimpl "github.com/DataDog/datadog-agent/comp/observer/impl"
 )
 
+// combinedResult wraps both timestamp-level and metric-level scoring output.
+type combinedResult struct {
+	TimestampScore *observerimpl.ScoreResult       `json:"timestamp_score"`
+	MetricScore    *observerimpl.MetricScoreResult  `json:"metric_score,omitempty"`
+}
+
 func main() {
 	outputPath := flag.String("input", "", "Path to headless output JSON to score (required)")
 	scenariosDir := flag.String("scenarios-dir", "./comp/observer/scenarios", "Directory containing scenario subdirectories (for metadata.json lookup)")
 	groundTruthTS := flag.Int64("ground-truth-ts", 0, "Ground truth disruption onset timestamp in unix seconds (overrides metadata.json)")
 	sigma := flag.Float64("sigma", 30.0, "Gaussian width in seconds")
 	jsonOutput := flag.Bool("json", false, "Output result as JSON")
+	scoreTP := flag.Bool("score-tp", false, "Score true positive detection using metric ground truth from metadata.json")
 	flag.Parse()
 
 	if *outputPath == "" {
-		fmt.Fprintf(os.Stderr, "Usage: observer-scorer --input <path> [--scenarios-dir <dir>] [--ground-truth-ts <unix>] [--sigma <seconds>] [--json]\n")
+		fmt.Fprintf(os.Stderr, "Usage: observer-scorer --input <path> [--scenarios-dir <dir>] [--ground-truth-ts <unix>] [--sigma <seconds>] [--score-tp] [--json]\n")
 		os.Exit(1)
 	}
 
@@ -41,8 +48,22 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Optionally score true positive metric detection.
+	var metricResult *observerimpl.MetricScoreResult
+	if *scoreTP {
+		metricResult, err = scoreMetricTP(*outputPath, *scenariosDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Metric TP scoring failed: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
 	if *jsonOutput {
-		data, err := json.Marshal(result)
+		out := combinedResult{
+			TimestampScore: result,
+			MetricScore:    metricResult,
+		}
+		data, err := json.Marshal(out)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "JSON marshal failed: %v\n", err)
 			os.Exit(1)
@@ -51,6 +72,7 @@ func main() {
 		return
 	}
 
+	// Text output: timestamp score
 	fmt.Printf("Gaussian F1 Score\n")
 	fmt.Printf("  Input:       %s\n", *outputPath)
 	fmt.Printf("  Sigma:       %.1fs\n", *sigma)
@@ -61,4 +83,65 @@ func main() {
 	fmt.Printf("  Precision: %.4f\n", result.Precision)
 	fmt.Printf("  Recall:    %.4f\n", result.Recall)
 	fmt.Printf("  TP: %.4f  FP: %.4f  FN: %.4f\n", result.TP, result.FP, result.FN)
+
+	// Text output: metric TP score
+	if metricResult != nil {
+		fmt.Println()
+		fmt.Printf("Metric TP Score\n")
+		fmt.Printf("  Total anomaly periods: %d\n", metricResult.TotalCount)
+		fmt.Printf("  TP: %d  Unknown: %d\n", metricResult.TPCount, metricResult.UnknownCount)
+		fmt.Println()
+		fmt.Printf("  Metric F1:        %.4f\n", metricResult.MetricF1)
+		fmt.Printf("  Metric Precision: %.4f\n", metricResult.MetricPrecision)
+		fmt.Printf("  Metric Recall:    %.4f\n", metricResult.MetricRecall)
+		fmt.Println()
+		if len(metricResult.TPMetricsFound) > 0 {
+			fmt.Printf("  TP metrics found:  %v\n", metricResult.TPMetricsFound)
+		}
+		if len(metricResult.TPMetricsMissed) > 0 {
+			fmt.Printf("  TP metrics missed: %v\n", metricResult.TPMetricsMissed)
+		}
+		if len(metricResult.Detections) > 0 {
+			fmt.Println()
+			fmt.Printf("  Detections:\n")
+			for _, d := range metricResult.Detections {
+				status := "MISS"
+				if d.Detected {
+					status = fmt.Sprintf("HIT (count=%d, first=%.0fs after disruption)", d.Count, d.DeltaFromDisruption)
+				}
+				fmt.Printf("    [%s] %s/%s: %s\n", d.Classification, d.Service, d.Metric, status)
+			}
+		}
+	}
+}
+
+// scoreMetricTP loads the output and ground truth, then runs metric-level TP scoring.
+func scoreMetricTP(outputPath, scenariosDir string) (*observerimpl.MetricScoreResult, error) {
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading output file: %w", err)
+	}
+
+	var output observerimpl.ObserverOutput
+	if err := json.Unmarshal(data, &output); err != nil {
+		return nil, fmt.Errorf("parsing output JSON: %w", err)
+	}
+
+	scenarioName := output.Metadata.Scenario
+	if scenarioName == "" {
+		return nil, fmt.Errorf("output file missing metadata.scenario")
+	}
+
+	gt, err := observerimpl.LoadMetricGroundTruth(scenariosDir, scenarioName)
+	if err != nil {
+		return nil, fmt.Errorf("loading metric ground truth: %w", err)
+	}
+
+	if len(gt.TruePositives) == 0 {
+		return nil, fmt.Errorf("no true_positives in metadata for scenario %q", scenarioName)
+	}
+
+	disruptionStart := observerimpl.LoadDisruptionStartUnix(scenariosDir, scenarioName)
+
+	return observerimpl.ScoreMetrics(&output, gt, disruptionStart), nil
 }

--- a/cmd/observer-testbench/main.go
+++ b/cmd/observer-testbench/main.go
@@ -47,6 +47,7 @@ func main() {
 	httpAddr := flag.String("http", ":8080", "HTTP server address for the API")
 	enableStr := flag.String("enable", "", "Comma-separated components to enable (overrides defaults)")
 	disableStr := flag.String("disable", "", "Comma-separated components to disable (overrides defaults)")
+	onlyStr := flag.String("only", "", "Enable ONLY these components (plus extractors); disable everything else. Mutually exclusive with --enable/--disable.")
 	headless := flag.String("headless", "", "Run scenario in headless mode (no HTTP server) and exit")
 	output := flag.String("output", "", "Path for eval JSON output (headless mode only)")
 	verbose := flag.Bool("verbose", false, "Include full detail in JSON output (headless mode only)")
@@ -54,19 +55,36 @@ func main() {
 	flag.Parse()
 
 	overrides := make(map[string]bool)
-	if *enableStr != "" {
-		for _, name := range strings.Split(*enableStr, ",") {
+	if *onlyStr != "" {
+		// --only: enable listed components + extractors, disable everything else.
+		onlySet := make(map[string]bool)
+		for _, name := range strings.Split(*onlyStr, ",") {
 			name = strings.TrimSpace(name)
 			if name != "" {
-				overrides[name] = true
+				onlySet[name] = true
 			}
 		}
-	}
-	if *disableStr != "" {
-		for _, name := range strings.Split(*disableStr, ",") {
-			name = strings.TrimSpace(name)
-			if name != "" {
-				overrides[name] = false
+		for _, entry := range observerimpl.TestbenchCatalogEntries() {
+			if entry.Kind == "extractor" {
+				continue // extractors always enabled
+			}
+			overrides[entry.Name] = onlySet[entry.Name]
+		}
+	} else {
+		if *enableStr != "" {
+			for _, name := range strings.Split(*enableStr, ",") {
+				name = strings.TrimSpace(name)
+				if name != "" {
+					overrides[name] = true
+				}
+			}
+		}
+		if *disableStr != "" {
+			for _, name := range strings.Split(*disableStr, ",") {
+				name = strings.TrimSpace(name)
+				if name != "" {
+					overrides[name] = false
+				}
 			}
 		}
 	}

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -499,6 +499,17 @@ type StorageReader interface {
 	// set of known series changes. Use this to cache ListSeries results and
 	// refresh them only when new series keys appear.
 	SeriesGeneration() uint64
+
+	// BulkSeriesStatus returns the point count (up to endTime) and write
+	// generation for each handle in a single lock acquisition. This avoids
+	// per-series lock overhead in hot detector loops during replay.
+	BulkSeriesStatus(handles []SeriesHandle, endTime int64) []SeriesStatus
+}
+
+// SeriesStatus holds point count and write generation for a single series.
+type SeriesStatus struct {
+	PointCount      int
+	WriteGeneration int64
 }
 
 // Detector is the flexible detection interface where detectors pull data from storage.

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -499,17 +499,6 @@ type StorageReader interface {
 	// set of known series changes. Use this to cache ListSeries results and
 	// refresh them only when new series keys appear.
 	SeriesGeneration() uint64
-
-	// BulkSeriesStatus returns the point count (up to endTime) and write
-	// generation for each handle in a single lock acquisition. This avoids
-	// per-series lock overhead in hot detector loops during replay.
-	BulkSeriesStatus(handles []SeriesHandle, endTime int64) []SeriesStatus
-}
-
-// SeriesStatus holds point count and write generation for a single series.
-type SeriesStatus struct {
-	PointCount      int
-	WriteGeneration int64
 }
 
 // Detector is the flexible detection interface where detectors pull data from storage.

--- a/comp/observer/impl/anomaly_correlator_passthrough.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// DetectorPassthroughCorrelator passes all anomalies straight through, grouped
+// by detector name. It does no time-clustering or filtering — each detector's
+// anomalies become a separate ActiveCorrelation. This is used for Level 1
+// detector-specific evaluation where we want to score each detector's raw
+// output independently.
+type DetectorPassthroughCorrelator struct {
+	// anomaliesByDetector groups anomalies by DetectorName.
+	anomaliesByDetector map[string][]observer.Anomaly
+	mu                  sync.RWMutex
+}
+
+// NewDetectorPassthroughCorrelator creates a new DetectorPassthroughCorrelator.
+func NewDetectorPassthroughCorrelator() *DetectorPassthroughCorrelator {
+	return &DetectorPassthroughCorrelator{
+		anomaliesByDetector: make(map[string][]observer.Anomaly),
+	}
+}
+
+// Name returns the correlator name.
+func (c *DetectorPassthroughCorrelator) Name() string {
+	return "passthrough_correlator"
+}
+
+// ProcessAnomaly stores the anomaly, grouped by its DetectorName.
+func (c *DetectorPassthroughCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.anomaliesByDetector[anomaly.DetectorName] = append(c.anomaliesByDetector[anomaly.DetectorName], anomaly)
+}
+
+// Advance is a no-op for the passthrough correlator (no windowing).
+func (c *DetectorPassthroughCorrelator) Advance(_ int64) {}
+
+// Reset clears all internal state for reanalysis.
+func (c *DetectorPassthroughCorrelator) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.anomaliesByDetector = make(map[string][]observer.Anomaly)
+}
+
+// ActiveCorrelations returns one ActiveCorrelation per individual anomaly,
+// sorted by detector name then timestamp.
+//
+// Each anomaly becomes its own correlation with:
+//   - Pattern:     "passthrough_{detectorName}_{index}"
+//   - Title:       "Passthrough[{detectorName}]: {anomaly.Source}"
+//   - Anomalies:   single-element slice containing the original anomaly
+//   - FirstSeen/LastUpdated: the anomaly's timestamp
+//
+// When serialized via WriteObserverOutput, each correlation becomes an
+// ObserverCorrelation where period_start == period_end == anomaly.Timestamp.
+// This allows the scorer to evaluate each detection independently
+func (c *DetectorPassthroughCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	// Sort detector names for deterministic ordering
+	detectorNames := make([]string, 0, len(c.anomaliesByDetector))
+	for name := range c.anomaliesByDetector {
+		detectorNames = append(detectorNames, name)
+	}
+	sort.Strings(detectorNames)
+
+	var result []observer.ActiveCorrelation
+	for _, detName := range detectorNames {
+		anomalies := c.anomaliesByDetector[detName]
+
+		// Sort anomalies by timestamp for deterministic output
+		sorted := make([]observer.Anomaly, len(anomalies))
+		copy(sorted, anomalies)
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Timestamp < sorted[j].Timestamp })
+
+		for i, a := range sorted {
+			result = append(result, observer.ActiveCorrelation{
+				Pattern:         fmt.Sprintf("passthrough_%s_%d", detName, i),
+				Title:           fmt.Sprintf("Passthrough[%s]: %s", detName, a.Source),
+				MemberSeriesIDs: []observer.SeriesID{a.SourceSeriesID},
+				MetricNames:     []observer.MetricName{a.Source},
+				Anomalies:       []observer.Anomaly{a},
+				FirstSeen:       a.Timestamp,
+				LastUpdated:     a.Timestamp,
+			})
+		}
+	}
+
+	return result
+}

--- a/comp/observer/impl/anomaly_correlator_passthrough_test.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough_test.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectorPassthroughCorrelator_OnePerAnomaly(t *testing.T) {
+	c := NewDetectorPassthroughCorrelator()
+
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: "redis.cpu.sys", SourceSeriesID: "s1", Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "bocpd", Source: "redis.cpu.sys", SourceSeriesID: "s1", Timestamp: 105})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: "redis.info.latency_ms", SourceSeriesID: "s2", Timestamp: 110})
+
+	corrs := c.ActiveCorrelations()
+	// 3 anomalies = 3 correlations (one per anomaly)
+	require.Len(t, corrs, 3)
+
+	// Sorted by detector name (bocpd before cusum), then by timestamp within detector
+	assert.Equal(t, "passthrough_bocpd_0", corrs[0].Pattern)
+	assert.Equal(t, int64(105), corrs[0].FirstSeen)
+	assert.Len(t, corrs[0].Anomalies, 1)
+
+	assert.Equal(t, "passthrough_cusum_0", corrs[1].Pattern)
+	assert.Equal(t, int64(100), corrs[1].FirstSeen)
+
+	assert.Equal(t, "passthrough_cusum_1", corrs[2].Pattern)
+	assert.Equal(t, int64(110), corrs[2].FirstSeen)
+}
+
+func TestDetectorPassthroughCorrelator_TimestampOrdering(t *testing.T) {
+	c := NewDetectorPassthroughCorrelator()
+
+	// Process out of order
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "pelt", Timestamp: 300})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "pelt", Timestamp: 150})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "pelt", Timestamp: 200})
+
+	corrs := c.ActiveCorrelations()
+	require.Len(t, corrs, 3)
+	// Should be sorted by timestamp within the detector
+	assert.Equal(t, int64(150), corrs[0].FirstSeen)
+	assert.Equal(t, int64(200), corrs[1].FirstSeen)
+	assert.Equal(t, int64(300), corrs[2].FirstSeen)
+}
+
+func TestDetectorPassthroughCorrelator_SeriesIDAndSource(t *testing.T) {
+	c := NewDetectorPassthroughCorrelator()
+
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: "redis.cpu.sys", SourceSeriesID: "s1", Timestamp: 100})
+
+	corrs := c.ActiveCorrelations()
+	require.Len(t, corrs, 1)
+	assert.Equal(t, []observer.SeriesID{"s1"}, corrs[0].MemberSeriesIDs)
+	assert.Equal(t, []observer.MetricName{"redis.cpu.sys"}, corrs[0].MetricNames)
+}
+
+func TestDetectorPassthroughCorrelator_Reset(t *testing.T) {
+	c := NewDetectorPassthroughCorrelator()
+
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Timestamp: 100})
+	require.Len(t, c.ActiveCorrelations(), 1)
+
+	c.Reset()
+	assert.Empty(t, c.ActiveCorrelations())
+}
+
+func TestDetectorPassthroughCorrelator_Empty(t *testing.T) {
+	c := NewDetectorPassthroughCorrelator()
+	assert.Empty(t, c.ActiveCorrelations())
+}
+
+func TestDetectorPassthroughCorrelator_ImplementsCorrelator(t *testing.T) {
+	var _ observer.Correlator = NewDetectorPassthroughCorrelator()
+}

--- a/comp/observer/impl/anomaly_correlator_passthrough_test.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough_test.go
@@ -78,6 +78,6 @@ func TestDetectorPassthroughCorrelator_Empty(t *testing.T) {
 	assert.Empty(t, c.ActiveCorrelations())
 }
 
-func TestDetectorPassthroughCorrelator_ImplementsCorrelator(t *testing.T) {
+func TestDetectorPassthroughCorrelator_ImplementsCorrelator(_ *testing.T) {
 	var _ observer.Correlator = NewDetectorPassthroughCorrelator()
 }

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -142,6 +142,24 @@ func defaultCatalog() *componentCatalog {
 				factory:        func(cfg any) any { return NewRRCFDetector(cfg.(RRCFConfig)) },
 				defaultEnabled: true,
 			},
+			{
+				name:        "scanmw",
+				displayName: "ScanMW",
+				kind:        componentDetector,
+				factory: func() any {
+					return NewScanMWDetector()
+				},
+				defaultEnabled: false,
+			},
+			{
+				name:        "scanwelch",
+				displayName: "ScanWelch",
+				kind:        componentDetector,
+				factory: func() any {
+					return NewScanWelchDetector()
+				},
+				defaultEnabled: false,
+			},
 			// ---- Correlators ----
 			{
 				name:           "cross_signal",
@@ -174,6 +192,15 @@ func defaultCatalog() *componentCatalog {
 				kind:           componentCorrelator,
 				defaultConfig:  DefaultSurpriseConfig(),
 				factory:        func(cfg any) any { return NewSurpriseCorrelator(cfg.(SurpriseConfig)) },
+				defaultEnabled: false,
+			},
+			{
+				name:        "passthrough",
+				displayName: "Passthrough",
+				kind:        componentCorrelator,
+				factory: func() any {
+					return NewDetectorPassthroughCorrelator()
+				},
 				defaultEnabled: false,
 			},
 		},

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -261,6 +261,32 @@ func (c *componentCatalog) Instantiate(settings ComponentSettings) (
 	return detectors, correlators, extractors, components
 }
 
+// CatalogEntry is a public view of a catalog component for CLI use.
+type CatalogEntry struct {
+	Name string
+	Kind string // "detector", "correlator", or "extractor"
+}
+
+// TestbenchCatalogEntries returns all component names and kinds from the testbench catalog.
+// Used by the CLI to implement --only without hardcoding component lists.
+func TestbenchCatalogEntries() []CatalogEntry {
+	cat := testbenchCatalog()
+	result := make([]CatalogEntry, len(cat.entries))
+	for i, e := range cat.entries {
+		kind := "unknown"
+		switch e.kind {
+		case componentDetector:
+			kind = "detector"
+		case componentCorrelator:
+			kind = "correlator"
+		case componentExtractor:
+			kind = "extractor"
+		}
+		result[i] = CatalogEntry{Name: e.name, Kind: kind}
+	}
+	return result
+}
+
 // Entries returns a copy of all catalog entries (for UI/API use).
 func (c *componentCatalog) Entries() []componentEntry {
 	result := make([]componentEntry, len(c.entries))

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -143,21 +143,17 @@ func defaultCatalog() *componentCatalog {
 				defaultEnabled: true,
 			},
 			{
-				name:        "scanmw",
-				displayName: "ScanMW",
-				kind:        componentDetector,
-				factory: func() any {
-					return NewScanMWDetector()
-				},
+				name:           "scanmw",
+				displayName:    "ScanMW",
+				kind:           componentDetector,
+				factory:        func(any) any { return NewScanMWDetector() },
 				defaultEnabled: false,
 			},
 			{
-				name:        "scanwelch",
-				displayName: "ScanWelch",
-				kind:        componentDetector,
-				factory: func() any {
-					return NewScanWelchDetector()
-				},
+				name:           "scanwelch",
+				displayName:    "ScanWelch",
+				kind:           componentDetector,
+				factory:        func(any) any { return NewScanWelchDetector() },
 				defaultEnabled: false,
 			},
 			// ---- Correlators ----
@@ -173,7 +169,7 @@ func defaultCatalog() *componentCatalog {
 				name:           "time_cluster",
 				displayName:    "TimeCluster",
 				kind:           componentCorrelator,
-				defaultConfig:  DefaultTimeClusterConfig(),
+				defaultConfig:  TimeClusterConfig{ProximitySeconds: 10, WindowSeconds: 120, MinClusterSize: 3},
 				factory:        func(cfg any) any { return NewTimeClusterCorrelator(cfg.(TimeClusterConfig)) },
 				defaultEnabled: true,
 				readConfig:     readTimeClusterConfig,
@@ -195,12 +191,10 @@ func defaultCatalog() *componentCatalog {
 				defaultEnabled: false,
 			},
 			{
-				name:        "passthrough",
-				displayName: "Passthrough",
-				kind:        componentCorrelator,
-				factory: func() any {
-					return NewDetectorPassthroughCorrelator()
-				},
+				name:           "passthrough",
+				displayName:    "Passthrough",
+				kind:           componentCorrelator,
+				factory:        func(any) any { return NewDetectorPassthroughCorrelator() },
 				defaultEnabled: false,
 			},
 		},
@@ -270,7 +264,7 @@ type CatalogEntry struct {
 // TestbenchCatalogEntries returns all component names and kinds from the testbench catalog.
 // Used by the CLI to implement --only without hardcoding component lists.
 func TestbenchCatalogEntries() []CatalogEntry {
-	cat := testbenchCatalog()
+	cat := defaultCatalog()
 	result := make([]CatalogEntry, len(cat.entries))
 	for i, e := range cat.entries {
 		kind := "unknown"

--- a/comp/observer/impl/component_catalog.go
+++ b/comp/observer/impl/component_catalog.go
@@ -169,7 +169,7 @@ func defaultCatalog() *componentCatalog {
 				name:           "time_cluster",
 				displayName:    "TimeCluster",
 				kind:           componentCorrelator,
-				defaultConfig:  TimeClusterConfig{ProximitySeconds: 10, WindowSeconds: 120, MinClusterSize: 3},
+				defaultConfig:  DefaultTimeClusterConfig(),
 				factory:        func(cfg any) any { return NewTimeClusterCorrelator(cfg.(TimeClusterConfig)) },
 				defaultEnabled: true,
 				readConfig:     readTimeClusterConfig,

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -1,0 +1,358 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"math"
+	"sort"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// scanmwStateKey identifies per-series state by handle and aggregation.
+type scanmwStateKey struct {
+	handle observer.SeriesHandle
+	agg    observer.Aggregate
+}
+
+// scanmwSeriesState holds per-series streaming state for the ScanMW detector.
+// NOTE: This per-series state struct follows the same pattern used by BOCPD
+// (metrics_detector_bocpd.go). If more scan-based detectors are added,
+// consider extracting a shared scanSeriesState base.
+type scanmwSeriesState struct {
+	// Cursor (same pattern as BOCPD: metrics_detector_bocpd.go:16-22)
+	lastProcessedCount int
+	lastWriteGen       int64
+
+	// Segment tracking: only scan [segmentStartTime, dataTime].
+	// 0 initially (scan full history), advances to changepoint timestamp on fire.
+	segmentStartTime int64
+}
+
+// ScanMWDetector detects changepoints by scanning all possible split points
+// with the Mann-Whitney U test. It picks the split that gives the most
+// significant test result (smallest p-value), making it a non-parametric
+// changepoint detector that's robust to distribution shape.
+//
+// Uses an efficient O(n log n) implementation: ranks are assigned once via
+// sorting, then the rank sum is updated incrementally as the split point moves.
+//
+// Implements Detector (streaming) — after finding a changepoint, advances
+// the segment start so subsequent scans only examine post-change data.
+type ScanMWDetector struct {
+	// MinSegment is the minimum number of points in each segment.
+	// Default: 12
+	MinSegment int
+
+	// MinPoints is the minimum total points before detection runs.
+	// Default: 30
+	MinPoints int
+
+	// SignificanceThreshold is the maximum p-value for the best split to be
+	// considered a changepoint. Default: 1e-8
+	SignificanceThreshold float64
+
+	// MinEffectSize is the minimum |rank-biserial correlation| for reporting.
+	// Default: 0.85
+	MinEffectSize float64
+
+	// MinDeviationMAD is the minimum |post_median - pre_median| / MAD.
+	// Default: 3.0
+	MinDeviationMAD float64
+
+	// Aggregations to run detection on. Default: [Average, Count]
+	Aggregations []observer.Aggregate
+
+	// per-series state keyed by handle+agg
+	series map[scanmwStateKey]*scanmwSeriesState
+
+	// Cache the discovered series list across Detect calls.
+	cachedSeries []observer.SeriesMeta
+	cachedGen    uint64
+}
+
+// NewScanMWDetector creates a ScanMW detector with default settings.
+func NewScanMWDetector() *ScanMWDetector {
+	return &ScanMWDetector{
+		MinSegment:            12,
+		MinPoints:             30,
+		SignificanceThreshold: 1e-8,
+		MinEffectSize:         0.85,
+		MinDeviationMAD:       3.0,
+		Aggregations: []observer.Aggregate{
+			observer.AggregateAverage,
+			observer.AggregateCount,
+		},
+		series: make(map[scanmwStateKey]*scanmwSeriesState),
+	}
+}
+
+// Name returns the detector name.
+func (d *ScanMWDetector) Name() string {
+	return "scanmw"
+}
+
+// Reset clears all per-series state for replay/reanalysis.
+func (d *ScanMWDetector) Reset() {
+	d.series = make(map[scanmwStateKey]*scanmwSeriesState)
+	d.cachedSeries = nil
+	d.cachedGen = 0
+}
+
+// Detect implements Detector. It discovers series, reads segment data,
+// and scans for changepoints. After finding one, the segment start advances
+// so subsequent calls only examine post-change data.
+//
+// Iteration pattern is the same as BOCPD (metrics_detector_bocpd.go:140-221)
+// and ScanWelch — consider dedup if more scan-based detectors are added.
+func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
+	d.ensureDefaults()
+
+	gen := storage.SeriesGeneration()
+	if d.cachedSeries == nil || gen != d.cachedGen {
+		d.cachedSeries = storage.ListSeries(observer.SeriesFilter{})
+		d.cachedGen = gen
+	}
+
+	var allAnomalies []observer.Anomaly
+
+	for _, meta := range d.cachedSeries {
+		for _, agg := range d.Aggregations {
+			sk := scanmwStateKey{handle: meta.Handle, agg: agg}
+
+			state, exists := d.series[sk]
+			if !exists {
+				state = &scanmwSeriesState{}
+				d.series[sk] = state
+			}
+
+			// Check if there are new points.
+			visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
+			currentGen := storage.WriteGeneration(meta.Handle)
+			if visibleCount <= state.lastProcessedCount && currentGen == state.lastWriteGen {
+				continue
+			}
+
+			// Read the active segment.
+			series := storage.GetSeriesRange(meta.Handle, state.segmentStartTime, dataTime, agg)
+			if series == nil || len(series.Points) < d.MinPoints {
+				state.lastProcessedCount = visibleCount
+				state.lastWriteGen = currentGen
+				continue
+			}
+
+			anomaly, changeIdx, found := d.scanMW(series.Points, series, agg)
+			if found {
+				allAnomalies = append(allAnomalies, anomaly)
+				// Advance segment start to the changepoint timestamp.
+				state.segmentStartTime = series.Points[changeIdx].Timestamp
+			}
+
+			state.lastProcessedCount = visibleCount
+			state.lastWriteGen = currentGen
+		}
+	}
+
+	return observer.DetectionResult{Anomalies: allAnomalies}
+}
+
+// scanMW runs the scan algorithm on points within the current segment.
+// Returns (anomaly, changeIndex, found). Pure function over the input data.
+func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series, agg observer.Aggregate) (observer.Anomaly, int, bool) {
+	n := len(points)
+
+	values := make([]float64, n)
+	for i, p := range points {
+		values[i] = p.Value
+	}
+
+	// Efficient O(n log n) scan: assign ranks once, then slide the split point.
+	ranks, tieCorrection := assignRanks(values)
+
+	minSeg := d.MinSegment
+	var R1 float64
+	for i := 0; i < minSeg; i++ {
+		R1 += ranks[i]
+	}
+
+	bestZAbs := 0.0
+	bestK := -1
+	fN := float64(n)
+
+	for k := minSeg; k <= n-minSeg; k++ {
+		if k > minSeg {
+			R1 += ranks[k-1]
+		}
+
+		fk := float64(k)
+		fn_k := float64(n - k)
+
+		U1 := R1 - fk*(fk+1)/2
+		U := math.Min(U1, fk*fn_k-U1)
+
+		meanU := fk * fn_k / 2
+		varU := (fk * fn_k / 12) * (fN + 1 - tieCorrection/(fN*(fN-1)))
+		if varU <= 0 {
+			continue
+		}
+		stdU := math.Sqrt(varU)
+
+		z := (math.Abs(U-meanU) - 0.5) / stdU
+		if z < 0 {
+			z = 0
+		}
+
+		if z > bestZAbs {
+			bestZAbs = z
+			bestK = k
+		}
+	}
+
+	if bestK < 0 {
+		return observer.Anomaly{}, 0, false
+	}
+
+	// Convert best z to p-value.
+	bestPValue := 2 * normalCDFUpper(bestZAbs)
+	if bestPValue > 1.0 {
+		bestPValue = 1.0
+	}
+
+	if bestPValue >= d.SignificanceThreshold {
+		return observer.Anomaly{}, 0, false
+	}
+
+	// Recompute U at bestK for effect size.
+	var bestR1 float64
+	for i := 0; i < bestK; i++ {
+		bestR1 += ranks[i]
+	}
+	bestU1 := bestR1 - float64(bestK)*float64(bestK+1)/2
+	bestU := math.Min(bestU1, float64(bestK)*float64(n-bestK)-bestU1)
+
+	effectSize := rankBiserialCorrelation(bestU, bestK, n-bestK)
+	if math.Abs(effectSize) < d.MinEffectSize {
+		return observer.Anomaly{}, 0, false
+	}
+
+	// Check robust deviation at best split.
+	preVals := values[:bestK]
+	postVals := values[bestK:]
+	preMedian := detectorMedian(preVals)
+	postMedian := detectorMedian(postVals)
+	preMAD := detectorMAD(preVals, preMedian, false)
+
+	denom := preMAD
+	if denom < 1e-10 {
+		denom = math.Max(math.Abs(preMedian)*0.01, 1e-6)
+	}
+	deviation := math.Abs(postMedian-preMedian) / denom
+	if deviation < d.MinDeviationMAD {
+		return observer.Anomaly{}, 0, false
+	}
+
+	changePtTime := points[bestK].Timestamp
+	direction := "increased"
+	if postMedian < preMedian {
+		direction = "decreased"
+	}
+
+	score := -math.Log10(bestPValue)
+	if math.IsInf(score, 1) {
+		score = 300.0
+	}
+
+	seriesName := series.Name + ":" + aggSuffix(agg)
+	anomaly := observer.Anomaly{
+		Type:           observer.AnomalyTypeMetric,
+		Source:         observer.MetricName(seriesName),
+		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
+		DetectorName:   d.Name(),
+		Title:          fmt.Sprintf("ScanMW changepoint: %s", seriesName),
+		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, p=%.2e, effect=%.2f, %.1f MADs)",
+			seriesName, direction, preMedian, postMedian, bestPValue, effectSize, deviation),
+		Tags:      series.Tags,
+		Timestamp: changePtTime,
+		Score:     &score,
+		DebugInfo: &observer.AnomalyDebugInfo{
+			BaselineMedian: preMedian,
+			BaselineMAD:    preMAD,
+			CurrentValue:   postMedian,
+			DeviationSigma: deviation,
+		},
+	}
+
+	return anomaly, bestK, true
+}
+
+// ensureDefaults fills in zero-valued config fields with sensible defaults.
+func (d *ScanMWDetector) ensureDefaults() {
+	if d.MinSegment <= 0 {
+		d.MinSegment = 12
+	}
+	if d.MinPoints <= 0 {
+		d.MinPoints = 30
+	}
+	if d.SignificanceThreshold <= 0 {
+		d.SignificanceThreshold = 1e-8
+	}
+	if d.MinEffectSize <= 0 {
+		d.MinEffectSize = 0.85
+	}
+	if d.MinDeviationMAD <= 0 {
+		d.MinDeviationMAD = 3.0
+	}
+	if d.series == nil {
+		d.series = make(map[scanmwStateKey]*scanmwSeriesState)
+	}
+	if len(d.Aggregations) == 0 {
+		d.Aggregations = []observer.Aggregate{
+			observer.AggregateAverage,
+			observer.AggregateCount,
+		}
+	}
+}
+
+// assignRanks computes the average rank of each value in its original position.
+// Returns (ranks, tieCorrection) where tieCorrection = sum(t^3 - t) for tie groups.
+func assignRanks(values []float64) ([]float64, float64) {
+	n := len(values)
+
+	type indexedValue struct {
+		value float64
+		index int
+	}
+
+	indexed := make([]indexedValue, n)
+	for i, v := range values {
+		indexed[i] = indexedValue{value: v, index: i}
+	}
+
+	sort.Slice(indexed, func(i, j int) bool {
+		return indexed[i].value < indexed[j].value
+	})
+
+	ranks := make([]float64, n)
+	tieCorrection := 0.0
+
+	i := 0
+	for i < n {
+		j := i
+		for j < n && indexed[j].value == indexed[i].value {
+			j++
+		}
+		avgRank := float64(i+1+j) / 2.0
+		tieSize := float64(j - i)
+		for k := i; k < j; k++ {
+			ranks[indexed[k].index] = avgRank
+		}
+		tieCorrection += tieSize*tieSize*tieSize - tieSize
+		i = j
+	}
+
+	return ranks, tieCorrection
+}

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -82,7 +82,7 @@ func NewScanMWDetector() *ScanMWDetector {
 		MinPoints:             30,
 		SignificanceThreshold: 1e-8,
 		MinEffectSize:         0.85,
-		MinDeviationMAD:       3.0,
+		MinDeviationMAD:       15.0,
 		Aggregations: []observer.Aggregate{
 			observer.AggregateAverage,
 			observer.AggregateCount,
@@ -130,10 +130,15 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 				d.series[sk] = state
 			}
 
-			// Check if there are new points.
+			// Replay optimization: skip unless MinSegment new points are visible.
+			// The scan needs MinSegment points per side to evaluate a split, so
+			// fewer new points can't create a new valid split boundary. This cuts
+			// per-series scans from O(timestamps) to O(timestamps/MinSegment).
+			// During live ingestion, writeGen changes on every write so this
+			// condition falls through to the gen check and behaves as before.
 			visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
 			currentGen := storage.WriteGeneration(meta.Handle)
-			if visibleCount <= state.lastProcessedCount && currentGen == state.lastWriteGen {
+			if visibleCount < state.lastProcessedCount+d.MinSegment && currentGen == state.lastWriteGen {
 				continue
 			}
 
@@ -304,7 +309,7 @@ func (d *ScanMWDetector) ensureDefaults() {
 		d.MinEffectSize = 0.85
 	}
 	if d.MinDeviationMAD <= 0 {
-		d.MinDeviationMAD = 3.0
+		d.MinDeviationMAD = 15.0
 	}
 	if d.series == nil {
 		d.series = make(map[scanmwStateKey]*scanmwSeriesState)

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -127,7 +127,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 	for i, meta := range d.cachedSeries {
 		handles[i] = meta.Handle
 	}
-	bulkStatus := storage.BulkSeriesStatus(handles, dataTime)
+	bulkStatus := bulkSeriesStatus(storage, handles, dataTime)
 
 	var allAnomalies []observer.Anomaly
 
@@ -149,7 +149,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 			// per-series scans from O(timestamps) to O(timestamps/MinSegment).
 			// During live ingestion, writeGen changes on every write so this
 			// condition falls through to the gen check and behaves as before.
-			if status.PointCount < state.lastProcessedCount+d.MinSegment && status.WriteGeneration == state.lastWriteGen {
+			if status.pointCount < state.lastProcessedCount+d.MinSegment && status.writeGeneration == state.lastWriteGen {
 				continue
 			}
 
@@ -165,8 +165,8 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 			})
 
 			if seriesMeta == nil || len(state.buf) < d.MinPoints {
-				state.lastProcessedCount = status.PointCount
-				state.lastWriteGen = status.WriteGeneration
+				state.lastProcessedCount = status.pointCount
+				state.lastWriteGen = status.writeGeneration
 				continue
 			}
 
@@ -176,8 +176,8 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 				state.segmentStartTime = state.buf[changeIdx].Timestamp
 			}
 
-			state.lastProcessedCount = status.PointCount
-			state.lastWriteGen = status.WriteGeneration
+			state.lastProcessedCount = status.pointCount
+			state.lastWriteGen = status.writeGeneration
 		}
 	}
 

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -173,7 +173,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 			anomaly, changeIdx, found := d.scanMW(state.buf, seriesMeta, agg)
 			if found {
 				allAnomalies = append(allAnomalies, anomaly)
-				state.segmentStartTime = state.buf[changeIdx].Timestamp
+				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
 			}
 
 			state.lastProcessedCount = status.pointCount

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -31,6 +31,10 @@ type scanmwSeriesState struct {
 	// Segment tracking: only scan [segmentStartTime, dataTime].
 	// 0 initially (scan full history), advances to changepoint timestamp on fire.
 	segmentStartTime int64
+
+	// Reusable point buffer — grows once per series, reused across scans
+	// to avoid per-call allocation from GetSeriesRange.
+	buf []observer.Point
 }
 
 // ScanMWDetector detects changepoints by scanning all possible split points
@@ -118,9 +122,18 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 		d.cachedGen = gen
 	}
 
+	// Bulk-fetch point counts and write generations in a single lock acquisition.
+	handles := make([]observer.SeriesHandle, len(d.cachedSeries))
+	for i, meta := range d.cachedSeries {
+		handles[i] = meta.Handle
+	}
+	bulkStatus := storage.BulkSeriesStatus(handles, dataTime)
+
 	var allAnomalies []observer.Anomaly
 
-	for _, meta := range d.cachedSeries {
+	for i, meta := range d.cachedSeries {
+		status := bulkStatus[i]
+
 		for _, agg := range d.Aggregations {
 			sk := scanmwStateKey{handle: meta.Handle, agg: agg}
 
@@ -136,29 +149,35 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 			// per-series scans from O(timestamps) to O(timestamps/MinSegment).
 			// During live ingestion, writeGen changes on every write so this
 			// condition falls through to the gen check and behaves as before.
-			visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
-			currentGen := storage.WriteGeneration(meta.Handle)
-			if visibleCount < state.lastProcessedCount+d.MinSegment && currentGen == state.lastWriteGen {
+			if status.PointCount < state.lastProcessedCount+d.MinSegment && status.WriteGeneration == state.lastWriteGen {
 				continue
 			}
 
-			// Read the active segment.
-			series := storage.GetSeriesRange(meta.Handle, state.segmentStartTime, dataTime, agg)
-			if series == nil || len(series.Points) < d.MinPoints {
-				state.lastProcessedCount = visibleCount
-				state.lastWriteGen = currentGen
+			// Collect points into reusable buffer to avoid per-call allocation.
+			state.buf = state.buf[:0]
+			var seriesMeta *observer.Series
+			storage.ForEachPoint(meta.Handle, state.segmentStartTime, dataTime, agg, func(s *observer.Series, p observer.Point) {
+				if seriesMeta == nil {
+					sCopy := *s
+					seriesMeta = &sCopy
+				}
+				state.buf = append(state.buf, p)
+			})
+
+			if seriesMeta == nil || len(state.buf) < d.MinPoints {
+				state.lastProcessedCount = status.PointCount
+				state.lastWriteGen = status.WriteGeneration
 				continue
 			}
 
-			anomaly, changeIdx, found := d.scanMW(series.Points, series, agg)
+			anomaly, changeIdx, found := d.scanMW(state.buf, seriesMeta, agg)
 			if found {
 				allAnomalies = append(allAnomalies, anomaly)
-				// Advance segment start to the changepoint timestamp.
-				state.segmentStartTime = series.Points[changeIdx].Timestamp
+				state.segmentStartTime = state.buf[changeIdx].Timestamp
 			}
 
-			state.lastProcessedCount = visibleCount
-			state.lastWriteGen = currentGen
+			state.lastProcessedCount = status.PointCount
+			state.lastWriteGen = status.WriteGeneration
 		}
 	}
 

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -213,13 +213,13 @@ func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series
 		}
 
 		fk := float64(k)
-		fn_k := float64(n - k)
+		fnK := float64(n - k)
 
 		U1 := R1 - fk*(fk+1)/2
-		U := math.Min(U1, fk*fn_k-U1)
+		U := math.Min(U1, fk*fnK-U1)
 
-		meanU := fk * fn_k / 2
-		varU := (fk * fn_k / 12) * (fN + 1 - tieCorrection/(fN*(fN-1)))
+		meanU := fk * fnK / 2
+		varU := (fk * fnK / 12) * (fN + 1 - tieCorrection/(fN*(fN-1)))
 		if varU <= 0 {
 			continue
 		}
@@ -296,7 +296,7 @@ func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series
 		Source:         observer.MetricName(seriesName),
 		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
 		DetectorName:   d.Name(),
-		Title:          fmt.Sprintf("ScanMW changepoint: %s", seriesName),
+		Title:          "ScanMW changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, p=%.2e, effect=%.2f, %.1f MADs)",
 			seriesName, direction, preMedian, postMedian, bestPValue, effectSize, deviation),
 		Tags:      series.Tags,

--- a/comp/observer/impl/metrics_detector_scanmw_test.go
+++ b/comp/observer/impl/metrics_detector_scanmw_test.go
@@ -1,0 +1,162 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testScanMWDetector() *ScanMWDetector {
+	d := NewScanMWDetector()
+	d.Aggregations = []observer.Aggregate{observer.AggregateAverage}
+	return d
+}
+
+func TestScanMW_NotEnoughPoints(t *testing.T) {
+	d := testScanMWDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 10; i++ {
+		storage.Add("ns", "metric", 100, int64(i+1), nil)
+	}
+
+	result := d.Detect(storage, 10)
+	assert.Empty(t, result.Anomalies, "should not fire with fewer than MinPoints")
+}
+
+func TestScanMW_DetectsStepChange(t *testing.T) {
+	d := testScanMWDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	result := d.Detect(storage, 40)
+
+	require.NotEmpty(t, result.Anomalies, "should detect step change")
+	assert.Contains(t, result.Anomalies[0].Title, "ScanMW")
+	// Changepoint should be near the transition at index 20.
+	assert.InDelta(t, 21, result.Anomalies[0].Timestamp, 3)
+}
+
+func TestScanMW_IncrementalAdvance(t *testing.T) {
+	d := testScanMWDetector()
+	storage := newTimeSeriesStorage()
+
+	// First advance: stable data, not enough to fire.
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	r1 := d.Detect(storage, 20)
+	assert.Empty(t, r1.Anomalies, "no anomaly in stable data")
+
+	// Second advance: add shifted data — now has 40 points total.
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+	r2 := d.Detect(storage, 40)
+	require.NotEmpty(t, r2.Anomalies, "should detect step change on second advance")
+
+	// Third advance: no new data — should emit nothing.
+	r3 := d.Detect(storage, 40)
+	assert.Empty(t, r3.Anomalies, "no new data should produce no anomalies")
+}
+
+func TestScanMW_SegmentAdvancement(t *testing.T) {
+	d := testScanMWDetector()
+	storage := newTimeSeriesStorage()
+
+	// Phase 1: baseline at 50, shift to 200.
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 50; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	r1 := d.Detect(storage, 50)
+	require.NotEmpty(t, r1.Anomalies, "should detect first changepoint")
+
+	// After fire, the segment start should have advanced.
+	// Adding more data at 200 (same as post-change) should not re-fire
+	// because the post-change segment is stable.
+	for i := 50; i < 90; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+	r2 := d.Detect(storage, 90)
+	assert.Empty(t, r2.Anomalies, "stable post-change data should not re-fire")
+}
+
+func TestScanMW_TwoSequentialChanges(t *testing.T) {
+	d := testScanMWDetector()
+	storage := newTimeSeriesStorage()
+
+	// Phase 1: 50 → 200
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 50; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	r1 := d.Detect(storage, 50)
+	require.NotEmpty(t, r1.Anomalies, "should detect first changepoint")
+
+	// Phase 2: 200 → 500
+	for i := 50; i < 80; i++ {
+		storage.Add("ns", "metric", 500, int64(i+1), nil)
+	}
+
+	r2 := d.Detect(storage, 80)
+	require.NotEmpty(t, r2.Anomalies, "should detect second changepoint after segment advancement")
+}
+
+func TestScanMW_DeterministicReplay(t *testing.T) {
+	makeDetector := func() *ScanMWDetector { return testScanMWDetector() }
+
+	storage := newTimeSeriesStorage()
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	d1 := makeDetector()
+	r1 := d1.Detect(storage, 40)
+
+	d2 := makeDetector()
+	r2 := d2.Detect(storage, 40)
+
+	require.Equal(t, len(r1.Anomalies), len(r2.Anomalies), "replay should produce same anomaly count")
+	for i := range r1.Anomalies {
+		assert.Equal(t, r1.Anomalies[i].Timestamp, r2.Anomalies[i].Timestamp, "anomaly timestamps should match")
+		assert.Equal(t, r1.Anomalies[i].Source, r2.Anomalies[i].Source, "anomaly sources should match")
+	}
+}
+
+func TestScanMW_Reset(t *testing.T) {
+	d := testScanMWDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 40; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	d.Detect(storage, 40)
+	assert.NotEmpty(t, d.series, "should have state after detection")
+
+	d.Reset()
+	assert.Empty(t, d.series, "reset should clear all state")
+	assert.Nil(t, d.cachedSeries, "reset should clear cached series")
+}

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -166,7 +166,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 			anomaly, changeIdx, found := d.scanWelch(state.buf, seriesMeta, agg)
 			if found {
 				allAnomalies = append(allAnomalies, anomaly)
-				state.segmentStartTime = state.buf[changeIdx].Timestamp
+				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
 			}
 
 			state.lastProcessedCount = status.pointCount

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -26,6 +26,10 @@ type scanwelchSeriesState struct {
 
 	// Segment tracking: only scan [segmentStartTime, dataTime].
 	segmentStartTime int64
+
+	// Reusable point buffer — grows once per series, reused across scans
+	// to avoid per-call allocation from GetSeriesRange.
+	buf []observer.Point
 }
 
 // ScanWelchDetector detects changepoints by scanning all possible split points
@@ -107,9 +111,19 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 		d.cachedGen = gen
 	}
 
+	// Bulk-fetch point counts and write generations in a single lock acquisition.
+	// This avoids 2×len(series) individual RLock/RUnlock calls per Detect() call.
+	handles := make([]observer.SeriesHandle, len(d.cachedSeries))
+	for i, meta := range d.cachedSeries {
+		handles[i] = meta.Handle
+	}
+	bulkStatus := storage.BulkSeriesStatus(handles, dataTime)
+
 	var allAnomalies []observer.Anomaly
 
-	for _, meta := range d.cachedSeries {
+	for i, meta := range d.cachedSeries {
+		status := bulkStatus[i]
+
 		for _, agg := range d.Aggregations {
 			sk := scanwelchStateKey{handle: meta.Handle, agg: agg}
 
@@ -119,33 +133,44 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 				d.series[sk] = state
 			}
 
-			visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
-			currentGen := storage.WriteGeneration(meta.Handle)
 			// Replay optimization: skip unless MinSegment new points are visible.
 			// The scan needs MinSegment points per side to evaluate a split, so
 			// fewer new points can't create a new valid split boundary. This cuts
 			// per-series scans from O(timestamps) to O(timestamps/MinSegment).
 			// During live ingestion, writeGen changes on every write so this
 			// condition falls through to the gen check and behaves as before.
-			if visibleCount < state.lastProcessedCount+d.MinSegment && currentGen == state.lastWriteGen {
+			if status.PointCount < state.lastProcessedCount+d.MinSegment && status.WriteGeneration == state.lastWriteGen {
 				continue
 			}
 
-			series := storage.GetSeriesRange(meta.Handle, state.segmentStartTime, dataTime, agg)
-			if series == nil || len(series.Points) < d.MinPoints {
-				state.lastProcessedCount = visibleCount
-				state.lastWriteGen = currentGen
+			// Collect points into reusable buffer to avoid per-call allocation.
+			// ForEachPoint uses a pooled buffer internally; we append into
+			// state.buf which grows once and is reused across scans.
+			state.buf = state.buf[:0]
+			var seriesMeta *observer.Series
+			storage.ForEachPoint(meta.Handle, state.segmentStartTime, dataTime, agg, func(s *observer.Series, p observer.Point) {
+				if seriesMeta == nil {
+					// Capture series metadata on first point (valid during callback).
+					sCopy := *s
+					seriesMeta = &sCopy
+				}
+				state.buf = append(state.buf, p)
+			})
+
+			if seriesMeta == nil || len(state.buf) < d.MinPoints {
+				state.lastProcessedCount = status.PointCount
+				state.lastWriteGen = status.WriteGeneration
 				continue
 			}
 
-			anomaly, changeIdx, found := d.scanWelch(series.Points, series, agg)
+			anomaly, changeIdx, found := d.scanWelch(state.buf, seriesMeta, agg)
 			if found {
 				allAnomalies = append(allAnomalies, anomaly)
-				state.segmentStartTime = series.Points[changeIdx].Timestamp
+				state.segmentStartTime = state.buf[changeIdx].Timestamp
 			}
 
-			state.lastProcessedCount = visibleCount
-			state.lastWriteGen = currentGen
+			state.lastProcessedCount = status.PointCount
+			state.lastWriteGen = status.WriteGeneration
 		}
 	}
 

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -117,7 +117,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 	for i, meta := range d.cachedSeries {
 		handles[i] = meta.Handle
 	}
-	bulkStatus := storage.BulkSeriesStatus(handles, dataTime)
+	bulkStatus := bulkSeriesStatus(storage, handles, dataTime)
 
 	var allAnomalies []observer.Anomaly
 
@@ -139,7 +139,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 			// per-series scans from O(timestamps) to O(timestamps/MinSegment).
 			// During live ingestion, writeGen changes on every write so this
 			// condition falls through to the gen check and behaves as before.
-			if status.PointCount < state.lastProcessedCount+d.MinSegment && status.WriteGeneration == state.lastWriteGen {
+			if status.pointCount < state.lastProcessedCount+d.MinSegment && status.writeGeneration == state.lastWriteGen {
 				continue
 			}
 
@@ -158,8 +158,8 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 			})
 
 			if seriesMeta == nil || len(state.buf) < d.MinPoints {
-				state.lastProcessedCount = status.PointCount
-				state.lastWriteGen = status.WriteGeneration
+				state.lastProcessedCount = status.pointCount
+				state.lastWriteGen = status.writeGeneration
 				continue
 			}
 
@@ -169,8 +169,8 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 				state.segmentStartTime = state.buf[changeIdx].Timestamp
 			}
 
-			state.lastProcessedCount = status.PointCount
-			state.lastWriteGen = status.WriteGeneration
+			state.lastProcessedCount = status.pointCount
+			state.lastWriteGen = status.writeGeneration
 		}
 	}
 

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -305,7 +305,7 @@ func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.
 		Source:         observer.MetricName(seriesName),
 		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
 		DetectorName:   d.Name(),
-		Title:          fmt.Sprintf("ScanWelch changepoint: %s", seriesName),
+		Title:          "ScanWelch changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, t=%.2f, p=%.2e, effect=%.2f, %.1f MADs)",
 			seriesName, direction, preMedian, postMedian, bestTAbs, pValue, effectSize, deviation),
 		Tags:      series.Tags,

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -1,0 +1,323 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+	"math"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// scanwelchStateKey identifies per-series state by handle and aggregation.
+type scanwelchStateKey struct {
+	handle observer.SeriesHandle
+	agg    observer.Aggregate
+}
+
+// scanwelchSeriesState holds per-series streaming state for the ScanWelch detector.
+// Same pattern as scanmwSeriesState and BOCPD (metrics_detector_bocpd.go).
+type scanwelchSeriesState struct {
+	lastProcessedCount int
+	lastWriteGen       int64
+
+	// Segment tracking: only scan [segmentStartTime, dataTime].
+	segmentStartTime int64
+}
+
+// ScanWelchDetector detects changepoints by scanning all possible split points
+// with Welch's t-test for candidate selection, then verifies each candidate
+// with a Mann-Whitney p-value filter and MAD-based deviation check.
+//
+// This hybrid uses parametric detection (t-test finds mean shifts efficiently)
+// combined with nonparametric verification (MW p-value for selectivity).
+//
+// Implements Detector (streaming) — after finding a changepoint, advances
+// the segment start so subsequent scans only examine post-change data.
+type ScanWelchDetector struct {
+	// MinSegment is the minimum number of points in each segment.
+	MinSegment int
+
+	// MinPoints is the minimum total points before detection runs.
+	MinPoints int
+
+	// MinTStatistic is the minimum |t| for the candidate selection phase.
+	MinTStatistic float64
+
+	// SignificanceThreshold is the maximum MW p-value for reporting.
+	SignificanceThreshold float64
+
+	// MinEffectSize is the minimum |rank-biserial correlation|.
+	MinEffectSize float64
+
+	// MinDeviationMAD is the minimum |post_median - pre_median| / MAD.
+	MinDeviationMAD float64
+
+	// Aggregations to run detection on. Default: [Average, Count]
+	Aggregations []observer.Aggregate
+
+	// per-series state keyed by handle+agg
+	series map[scanwelchStateKey]*scanwelchSeriesState
+
+	// Cache the discovered series list across Detect calls.
+	cachedSeries []observer.SeriesMeta
+	cachedGen    uint64
+}
+
+// NewScanWelchDetector creates a ScanWelch detector with default settings.
+func NewScanWelchDetector() *ScanWelchDetector {
+	return &ScanWelchDetector{
+		MinSegment:            12,
+		MinPoints:             30,
+		MinTStatistic:         8.0,
+		SignificanceThreshold: 1e-8,
+		MinEffectSize:         0.85,
+		MinDeviationMAD:       3.0,
+		Aggregations: []observer.Aggregate{
+			observer.AggregateAverage,
+			observer.AggregateCount,
+		},
+		series: make(map[scanwelchStateKey]*scanwelchSeriesState),
+	}
+}
+
+// Name returns the detector name.
+func (d *ScanWelchDetector) Name() string {
+	return "scanwelch"
+}
+
+// Reset clears all per-series state for replay/reanalysis.
+func (d *ScanWelchDetector) Reset() {
+	d.series = make(map[scanwelchStateKey]*scanwelchSeriesState)
+	d.cachedSeries = nil
+	d.cachedGen = 0
+}
+
+// Detect implements Detector. Same iteration pattern as ScanMW and BOCPD —
+// consider dedup if more scan-based detectors are added.
+func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
+	d.ensureDefaults()
+
+	gen := storage.SeriesGeneration()
+	if d.cachedSeries == nil || gen != d.cachedGen {
+		d.cachedSeries = storage.ListSeries(observer.SeriesFilter{})
+		d.cachedGen = gen
+	}
+
+	var allAnomalies []observer.Anomaly
+
+	for _, meta := range d.cachedSeries {
+		for _, agg := range d.Aggregations {
+			sk := scanwelchStateKey{handle: meta.Handle, agg: agg}
+
+			state, exists := d.series[sk]
+			if !exists {
+				state = &scanwelchSeriesState{}
+				d.series[sk] = state
+			}
+
+			visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
+			currentGen := storage.WriteGeneration(meta.Handle)
+			if visibleCount <= state.lastProcessedCount && currentGen == state.lastWriteGen {
+				continue
+			}
+
+			series := storage.GetSeriesRange(meta.Handle, state.segmentStartTime, dataTime, agg)
+			if series == nil || len(series.Points) < d.MinPoints {
+				state.lastProcessedCount = visibleCount
+				state.lastWriteGen = currentGen
+				continue
+			}
+
+			anomaly, changeIdx, found := d.scanWelch(series.Points, series, agg)
+			if found {
+				allAnomalies = append(allAnomalies, anomaly)
+				state.segmentStartTime = series.Points[changeIdx].Timestamp
+			}
+
+			state.lastProcessedCount = visibleCount
+			state.lastWriteGen = currentGen
+		}
+	}
+
+	return observer.DetectionResult{Anomalies: allAnomalies}
+}
+
+// scanWelch runs the hybrid Welch/MW scan on points within the current segment.
+// Returns (anomaly, changeIndex, found).
+func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.Series, agg observer.Aggregate) (observer.Anomaly, int, bool) {
+	n := len(points)
+
+	values := make([]float64, n)
+	for i, p := range points {
+		values[i] = p.Value
+	}
+
+	// Phase 1: Scan using Welch's t-statistic (fast, O(n) with cumulative sums).
+	cumSum := make([]float64, n+1)
+	cumSumSq := make([]float64, n+1)
+	for i, v := range values {
+		cumSum[i+1] = cumSum[i] + v
+		cumSumSq[i+1] = cumSumSq[i] + v*v
+	}
+
+	bestTAbs := 0.0
+	bestK := -1
+
+	minSeg := d.MinSegment
+	for k := minSeg; k <= n-minSeg; k++ {
+		fk := float64(k)
+		fnk := float64(n - k)
+
+		leftMean := cumSum[k] / fk
+		rightMean := (cumSum[n] - cumSum[k]) / fnk
+
+		leftVar := cumSumSq[k]/fk - leftMean*leftMean
+		rightVar := (cumSumSq[n]-cumSumSq[k])/fnk - rightMean*rightMean
+
+		if leftVar < 1e-12 {
+			leftVar = 1e-12
+		}
+		if rightVar < 1e-12 {
+			rightVar = 1e-12
+		}
+
+		se := math.Sqrt(leftVar/fk + rightVar/fnk)
+		if se < 1e-15 {
+			continue
+		}
+		t := math.Abs(leftMean-rightMean) / se
+
+		if t > bestTAbs {
+			bestTAbs = t
+			bestK = k
+		}
+	}
+
+	if bestK < 0 || bestTAbs < d.MinTStatistic {
+		return observer.Anomaly{}, 0, false
+	}
+
+	// Phase 2: Verify using Mann-Whitney at the best split point.
+	ranks, tieCorrection := assignRanks(values)
+	var R1 float64
+	for i := 0; i < bestK; i++ {
+		R1 += ranks[i]
+	}
+
+	fk := float64(bestK)
+	fnk := float64(n - bestK)
+	fN := float64(n)
+
+	U1 := R1 - fk*(fk+1)/2
+	U := math.Min(U1, fk*fnk-U1)
+
+	meanU := fk * fnk / 2
+	varU := (fk * fnk / 12) * (fN + 1 - tieCorrection/(fN*(fN-1)))
+	if varU <= 0 {
+		return observer.Anomaly{}, 0, false
+	}
+	stdU := math.Sqrt(varU)
+
+	z := (math.Abs(U-meanU) - 0.5) / stdU
+	if z < 0 {
+		z = 0
+	}
+
+	pValue := 2 * normalCDFUpper(z)
+	if pValue > 1.0 {
+		pValue = 1.0
+	}
+	if pValue >= d.SignificanceThreshold {
+		return observer.Anomaly{}, 0, false
+	}
+
+	// Effect size check
+	effectSize := rankBiserialCorrelation(U, bestK, n-bestK)
+	if math.Abs(effectSize) < d.MinEffectSize {
+		return observer.Anomaly{}, 0, false
+	}
+
+	// Phase 3: Robust deviation check
+	preVals := values[:bestK]
+	postVals := values[bestK:]
+	preMedian := detectorMedian(preVals)
+	postMedian := detectorMedian(postVals)
+	preMAD := detectorMAD(preVals, preMedian, false)
+
+	denom := preMAD
+	if denom < 1e-10 {
+		denom = math.Max(math.Abs(preMedian)*0.01, 1e-6)
+	}
+	deviation := math.Abs(postMedian-preMedian) / denom
+	if deviation < d.MinDeviationMAD {
+		return observer.Anomaly{}, 0, false
+	}
+
+	changePtTime := points[bestK].Timestamp
+	direction := "increased"
+	if postMedian < preMedian {
+		direction = "decreased"
+	}
+
+	score := -math.Log10(pValue)
+	if math.IsInf(score, 1) {
+		score = 300.0
+	}
+
+	seriesName := series.Name + ":" + aggSuffix(agg)
+	anomaly := observer.Anomaly{
+		Type:           observer.AnomalyTypeMetric,
+		Source:         observer.MetricName(seriesName),
+		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
+		DetectorName:   d.Name(),
+		Title:          fmt.Sprintf("ScanWelch changepoint: %s", seriesName),
+		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, t=%.2f, p=%.2e, effect=%.2f, %.1f MADs)",
+			seriesName, direction, preMedian, postMedian, bestTAbs, pValue, effectSize, deviation),
+		Tags:      series.Tags,
+		Timestamp: changePtTime,
+		Score:     &score,
+		DebugInfo: &observer.AnomalyDebugInfo{
+			BaselineMedian: preMedian,
+			BaselineMAD:    preMAD,
+			CurrentValue:   postMedian,
+			DeviationSigma: deviation,
+		},
+	}
+
+	return anomaly, bestK, true
+}
+
+// ensureDefaults fills in zero-valued config fields with sensible defaults.
+func (d *ScanWelchDetector) ensureDefaults() {
+	if d.MinSegment <= 0 {
+		d.MinSegment = 12
+	}
+	if d.MinPoints <= 0 {
+		d.MinPoints = 30
+	}
+	if d.MinTStatistic <= 0 {
+		d.MinTStatistic = 8.0
+	}
+	if d.SignificanceThreshold <= 0 {
+		d.SignificanceThreshold = 1e-8
+	}
+	if d.MinEffectSize <= 0 {
+		d.MinEffectSize = 0.85
+	}
+	if d.MinDeviationMAD <= 0 {
+		d.MinDeviationMAD = 3.0
+	}
+	if d.series == nil {
+		d.series = make(map[scanwelchStateKey]*scanwelchSeriesState)
+	}
+	if len(d.Aggregations) == 0 {
+		d.Aggregations = []observer.Aggregate{
+			observer.AggregateAverage,
+			observer.AggregateCount,
+		}
+	}
+}

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -75,7 +75,7 @@ func NewScanWelchDetector() *ScanWelchDetector {
 		MinTStatistic:         8.0,
 		SignificanceThreshold: 1e-8,
 		MinEffectSize:         0.85,
-		MinDeviationMAD:       3.0,
+		MinDeviationMAD:       15.0,
 		Aggregations: []observer.Aggregate{
 			observer.AggregateAverage,
 			observer.AggregateCount,
@@ -121,7 +121,13 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 
 			visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
 			currentGen := storage.WriteGeneration(meta.Handle)
-			if visibleCount <= state.lastProcessedCount && currentGen == state.lastWriteGen {
+			// Replay optimization: skip unless MinSegment new points are visible.
+			// The scan needs MinSegment points per side to evaluate a split, so
+			// fewer new points can't create a new valid split boundary. This cuts
+			// per-series scans from O(timestamps) to O(timestamps/MinSegment).
+			// During live ingestion, writeGen changes on every write so this
+			// condition falls through to the gen check and behaves as before.
+			if visibleCount < state.lastProcessedCount+d.MinSegment && currentGen == state.lastWriteGen {
 				continue
 			}
 
@@ -309,7 +315,7 @@ func (d *ScanWelchDetector) ensureDefaults() {
 		d.MinEffectSize = 0.85
 	}
 	if d.MinDeviationMAD <= 0 {
-		d.MinDeviationMAD = 3.0
+		d.MinDeviationMAD = 15.0
 	}
 	if d.series == nil {
 		d.series = make(map[scanwelchStateKey]*scanwelchSeriesState)

--- a/comp/observer/impl/metrics_detector_scanwelch_test.go
+++ b/comp/observer/impl/metrics_detector_scanwelch_test.go
@@ -1,0 +1,152 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testScanWelchDetector() *ScanWelchDetector {
+	d := NewScanWelchDetector()
+	d.Aggregations = []observer.Aggregate{observer.AggregateAverage}
+	return d
+}
+
+func TestScanWelch_NotEnoughPoints(t *testing.T) {
+	d := testScanWelchDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 10; i++ {
+		storage.Add("ns", "metric", 100, int64(i+1), nil)
+	}
+
+	result := d.Detect(storage, 10)
+	assert.Empty(t, result.Anomalies, "should not fire with fewer than MinPoints")
+}
+
+func TestScanWelch_DetectsStepChange(t *testing.T) {
+	d := testScanWelchDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	result := d.Detect(storage, 40)
+
+	require.NotEmpty(t, result.Anomalies, "should detect step change")
+	assert.Contains(t, result.Anomalies[0].Title, "ScanWelch")
+	assert.InDelta(t, 21, result.Anomalies[0].Timestamp, 3)
+}
+
+func TestScanWelch_IncrementalAdvance(t *testing.T) {
+	d := testScanWelchDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	r1 := d.Detect(storage, 20)
+	assert.Empty(t, r1.Anomalies, "no anomaly in stable data")
+
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+	r2 := d.Detect(storage, 40)
+	require.NotEmpty(t, r2.Anomalies, "should detect step change on second advance")
+
+	r3 := d.Detect(storage, 40)
+	assert.Empty(t, r3.Anomalies, "no new data should produce no anomalies")
+}
+
+func TestScanWelch_SegmentAdvancement(t *testing.T) {
+	d := testScanWelchDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 50; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	r1 := d.Detect(storage, 50)
+	require.NotEmpty(t, r1.Anomalies, "should detect first changepoint")
+
+	for i := 50; i < 90; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+	r2 := d.Detect(storage, 90)
+	assert.Empty(t, r2.Anomalies, "stable post-change data should not re-fire")
+}
+
+func TestScanWelch_TwoSequentialChanges(t *testing.T) {
+	d := testScanWelchDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 50; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	r1 := d.Detect(storage, 50)
+	require.NotEmpty(t, r1.Anomalies, "should detect first changepoint")
+
+	for i := 50; i < 80; i++ {
+		storage.Add("ns", "metric", 500, int64(i+1), nil)
+	}
+
+	r2 := d.Detect(storage, 80)
+	require.NotEmpty(t, r2.Anomalies, "should detect second changepoint after segment advancement")
+}
+
+func TestScanWelch_DeterministicReplay(t *testing.T) {
+	makeDetector := func() *ScanWelchDetector { return testScanWelchDetector() }
+
+	storage := newTimeSeriesStorage()
+	for i := 0; i < 20; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	for i := 20; i < 40; i++ {
+		storage.Add("ns", "metric", 200, int64(i+1), nil)
+	}
+
+	d1 := makeDetector()
+	r1 := d1.Detect(storage, 40)
+
+	d2 := makeDetector()
+	r2 := d2.Detect(storage, 40)
+
+	require.Equal(t, len(r1.Anomalies), len(r2.Anomalies), "replay should produce same anomaly count")
+	for i := range r1.Anomalies {
+		assert.Equal(t, r1.Anomalies[i].Timestamp, r2.Anomalies[i].Timestamp)
+		assert.Equal(t, r1.Anomalies[i].Source, r2.Anomalies[i].Source)
+	}
+}
+
+func TestScanWelch_Reset(t *testing.T) {
+	d := testScanWelchDetector()
+	storage := newTimeSeriesStorage()
+
+	for i := 0; i < 40; i++ {
+		storage.Add("ns", "metric", 50, int64(i+1), nil)
+	}
+	d.Detect(storage, 40)
+	assert.NotEmpty(t, d.series, "should have state after detection")
+
+	d.Reset()
+	assert.Empty(t, d.series, "reset should clear all state")
+	assert.Nil(t, d.cachedSeries, "reset should clear cached series")
+}

--- a/comp/observer/impl/metrics_detector_util.go
+++ b/comp/observer/impl/metrics_detector_util.go
@@ -8,7 +8,41 @@ package observerimpl
 import (
 	"math"
 	"sort"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
+
+// seriesStatus holds point count and write generation for a single series.
+// Used by bulkSeriesStatus and scan-based detectors.
+type seriesStatus struct {
+	pointCount      int
+	writeGeneration int64
+}
+
+// bulkStatusReader is an optional optimization interface for StorageReader
+// implementations that support batch status queries in a single lock acquisition.
+type bulkStatusReader interface {
+	BulkSeriesStatus(handles []observer.SeriesHandle, endTime int64) []seriesStatus
+}
+
+// bulkSeriesStatus returns the point count and write generation for each handle.
+// If storage implements bulkStatusReader (e.g. timeSeriesStorage), it uses a
+// single lock acquisition. Otherwise falls back to individual PointCountUpTo +
+// WriteGeneration calls per handle.
+func bulkSeriesStatus(storage observer.StorageReader, handles []observer.SeriesHandle, endTime int64) []seriesStatus {
+	if br, ok := storage.(bulkStatusReader); ok {
+		return br.BulkSeriesStatus(handles, endTime)
+	}
+	// Fallback: individual calls (2 lock acquisitions per handle).
+	result := make([]seriesStatus, len(handles))
+	for i, h := range handles {
+		result[i] = seriesStatus{
+			pointCount:      storage.PointCountUpTo(h, endTime),
+			writeGeneration: storage.WriteGeneration(h),
+		}
+	}
+	return result
+}
 
 // detectorMedian computes the median of a float64 slice without modifying the input.
 func detectorMedian(vals []float64) float64 {

--- a/comp/observer/impl/metrics_detector_util.go
+++ b/comp/observer/impl/metrics_detector_util.go
@@ -1,0 +1,90 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"math"
+	"sort"
+)
+
+// detectorMedian computes the median of a float64 slice without modifying the input.
+func detectorMedian(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	sorted := make([]float64, len(vals))
+	copy(sorted, vals)
+	sort.Float64s(sorted)
+	n := len(sorted)
+	if n%2 == 0 {
+		return (sorted[n/2-1] + sorted[n/2]) / 2
+	}
+	return sorted[n/2]
+}
+
+// detectorMAD computes the Median Absolute Deviation from a given median.
+// MAD = median(|x_i - median|).
+// When scaleToSigma is true, the result is scaled by 1.4826 to estimate the
+// standard deviation for normally distributed data. Use scaleToSigma=true when
+// comparing against sigma-based thresholds (e.g. Mann-Whitney's deviation check),
+// and false when using raw MAD as a denominator for relative change scores (e.g. TopK).
+func detectorMAD(vals []float64, median float64, scaleToSigma bool) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	absDevs := make([]float64, len(vals))
+	for i, v := range vals {
+		absDevs[i] = math.Abs(v - median)
+	}
+	sort.Float64s(absDevs)
+	n := len(absDevs)
+	var mad float64
+	if n%2 == 0 {
+		mad = (absDevs[n/2-1] + absDevs[n/2]) / 2
+	} else {
+		mad = absDevs[n/2]
+	}
+	if scaleToSigma {
+		mad *= 1.4826
+	}
+	return mad
+}
+
+// rankBiserialCorrelation computes the rank-biserial correlation from a Mann-Whitney U statistic.
+// Used by ScanMW and ScanWelch for effect size verification.
+func rankBiserialCorrelation(u float64, n1, n2 int) float64 {
+	fn1 := float64(n1)
+	fn2 := float64(n2)
+	product := fn1 * fn2
+	if product == 0 {
+		return 0
+	}
+	return 1 - 2*u/product
+}
+
+// normalCDFUpper computes P(Z > z) for z >= 0 using the Abramowitz & Stegun approximation.
+// Used by ScanMW and ScanWelch for p-value computation.
+func normalCDFUpper(z float64) float64 {
+	if z < 0 {
+		return 1 - normalCDFUpper(-z)
+	}
+	// Rational approximation (Abramowitz & Stegun 26.2.17)
+	const (
+		p  = 0.2316419
+		b1 = 0.319381530
+		b2 = -0.356563782
+		b3 = 1.781477937
+		b4 = -1.821255978
+		b5 = 1.330274429
+	)
+	t := 1.0 / (1.0 + p*z)
+	t2 := t * t
+	t3 := t2 * t
+	t4 := t3 * t
+	t5 := t4 * t
+	phi := math.Exp(-z*z/2) / math.Sqrt(2*math.Pi)
+	return phi * (b1*t + b2*t2 + b3*t3 + b4*t4 + b5*t5)
+}

--- a/comp/observer/impl/score_tp.go
+++ b/comp/observer/impl/score_tp.go
@@ -1,0 +1,301 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// MetricGroundTruth holds the TP/FP metric lists from a scenario's metadata.json.
+type MetricGroundTruth struct {
+	TruePositives  []MetricGroundTruthEntry `json:"true_positives"`
+	FalsePositives []MetricGroundTruthEntry `json:"false_positives"`
+}
+
+// MetricGroundTruthEntry is one service's labeled metrics.
+type MetricGroundTruthEntry struct {
+	Service string   `json:"service"`
+	Metrics []string `json:"metrics"`
+}
+
+// MetricDetection records when and how often a specific ground truth metric was detected.
+type MetricDetection struct {
+	Service             string  `json:"service"`
+	Metric              string  `json:"metric"`
+	Classification      string  `json:"classification"` // "tp" or "fp"
+	Detected            bool    `json:"detected"`
+	Count               int     `json:"count"`
+	FirstSeenUnix       int64   `json:"first_seen_unix,omitempty"`
+	DeltaFromDisruption float64 `json:"delta_from_disruption_sec,omitempty"`
+}
+
+// MetricScoreResult contains per-metric TP/FP classification results.
+type MetricScoreResult struct {
+	// Counts of anomaly periods whose metric matched a TP, FP, or neither.
+	TPCount      int `json:"tp_count"`
+	FPCount      int `json:"fp_count"`
+	UnknownCount int `json:"unknown_count"`
+	TotalCount   int `json:"total_count"`
+
+	// Precision = TP / (TP + FP), ignoring unknowns.
+	MetricPrecision float64 `json:"metric_precision"`
+	// Recall = matched TPs / total TP metrics in ground truth.
+	MetricRecall float64 `json:"metric_recall"`
+	// F1 = harmonic mean of MetricPrecision and MetricRecall.
+	MetricF1 float64 `json:"metric_f1"`
+
+	// Which TP metrics were detected and which were missed.
+	TPMetricsFound  []string `json:"tp_metrics_found"`
+	TPMetricsMissed []string `json:"tp_metrics_missed"`
+	FPMetricsFired  []string `json:"fp_metrics_fired"`
+
+	// Per-metric detection timeline (TP and FP entries from ground truth).
+	Detections            []MetricDetection `json:"detections,omitempty"`
+	UnknownMetricCount    int               `json:"unknown_metric_count"`
+	UnknownDetectionCount int               `json:"unknown_detection_count"`
+}
+
+// LoadMetricGroundTruth reads TP/FP metric lists from a scenario's metadata.json.
+func LoadMetricGroundTruth(scenariosDir, scenarioName string) (*MetricGroundTruth, error) {
+	path := filepath.Join(scenariosDir, scenarioName, "metadata.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading metadata %s: %w", path, err)
+	}
+
+	var gt MetricGroundTruth
+	if err := json.Unmarshal(data, &gt); err != nil {
+		return nil, fmt.Errorf("parsing metadata JSON: %w", err)
+	}
+
+	return &gt, nil
+}
+
+// LoadDisruptionStartUnix returns the disruption start timestamp in unix seconds
+// from a scenario's metadata.json, or 0 if unavailable.
+func LoadDisruptionStartUnix(scenariosDir, scenarioName string) int64 {
+	sm, err := loadScoringMetadata(scenariosDir, scenarioName)
+	if err != nil || len(sm.groundTruthTimestamps) == 0 {
+		return 0
+	}
+	return sm.groundTruthTimestamps[0]
+}
+
+// ScoreMetrics classifies each anomaly period's metric as TP, FP, or unknown
+// by matching against the ground truth metric lists.
+//
+// disruptionStartUnix is used to compute delta_from_disruption_sec on detections.
+// Pass 0 if unavailable (deltas will be zero).
+//
+// Matching strategy: metric-only. An anomaly's Source (metric name) is checked
+// against each ground truth entry's metrics list using substring matching with
+// aggregate suffix stripping (e.g., "redis.cpu.sys:avg" matches "redis.cpu.sys").
+func ScoreMetrics(output *ObserverOutput, gt *MetricGroundTruth, disruptionStartUnix int64) *MetricScoreResult {
+	type gtEntry struct {
+		service        string
+		metric         string
+		classification string // "tp" or "fp"
+	}
+	tpSet := make(map[string]gtEntry) // "service:metric" -> entry
+	fpSet := make(map[string]gtEntry)
+	allTPKeys := make(map[string]bool)
+
+	for _, entry := range gt.TruePositives {
+		for _, m := range entry.Metrics {
+			key := entry.Service + ":" + m
+			tpSet[key] = gtEntry{service: entry.Service, metric: m, classification: "tp"}
+			allTPKeys[key] = true
+		}
+	}
+	for _, entry := range gt.FalsePositives {
+		for _, m := range entry.Metrics {
+			key := entry.Service + ":" + m
+			fpSet[key] = gtEntry{service: entry.Service, metric: m, classification: "fp"}
+		}
+	}
+
+	result := &MetricScoreResult{
+		TotalCount: len(output.AnomalyPeriods),
+	}
+
+	type metricHit struct {
+		firstSeen int64
+		count     int
+	}
+	foundTPKeys := make(map[string]*metricHit)
+	firedFPKeys := make(map[string]*metricHit)
+
+	for _, period := range output.AnomalyPeriods {
+		source := period.metricSource()
+		if source == "" {
+			result.UnknownCount++
+			result.UnknownDetectionCount++
+			continue
+		}
+
+		matched := false
+		// Check against TP metrics
+		for key := range tpSet {
+			if metricMatches(source, key) {
+				result.TPCount++
+				if hit, ok := foundTPKeys[key]; ok {
+					hit.count++
+				} else {
+					foundTPKeys[key] = &metricHit{firstSeen: period.PeriodStart, count: 1}
+				}
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+
+		// Check against FP metrics
+		for key := range fpSet {
+			if metricMatches(source, key) {
+				result.FPCount++
+				if hit, ok := firedFPKeys[key]; ok {
+					hit.count++
+				} else {
+					firedFPKeys[key] = &metricHit{firstSeen: period.PeriodStart, count: 1}
+				}
+				matched = true
+				break
+			}
+		}
+		if matched {
+			continue
+		}
+
+		result.UnknownCount++
+		result.UnknownDetectionCount++
+	}
+
+	// Collect found/missed TP metrics
+	for key := range allTPKeys {
+		if _, ok := foundTPKeys[key]; ok {
+			result.TPMetricsFound = append(result.TPMetricsFound, key)
+		} else {
+			result.TPMetricsMissed = append(result.TPMetricsMissed, key)
+		}
+	}
+	for key := range firedFPKeys {
+		result.FPMetricsFired = append(result.FPMetricsFired, key)
+	}
+
+	// Build per-metric detection timeline
+	var detections []MetricDetection
+
+	for key, entry := range tpSet {
+		d := MetricDetection{
+			Service:        entry.service,
+			Metric:         entry.metric,
+			Classification: "tp",
+		}
+		if hit, ok := foundTPKeys[key]; ok {
+			d.Detected = true
+			d.Count = hit.count
+			d.FirstSeenUnix = hit.firstSeen
+			if disruptionStartUnix > 0 {
+				d.DeltaFromDisruption = float64(hit.firstSeen - disruptionStartUnix)
+			}
+		}
+		detections = append(detections, d)
+	}
+
+	for key, entry := range fpSet {
+		d := MetricDetection{
+			Service:        entry.service,
+			Metric:         entry.metric,
+			Classification: "fp",
+		}
+		if hit, ok := firedFPKeys[key]; ok {
+			d.Detected = true
+			d.Count = hit.count
+			d.FirstSeenUnix = hit.firstSeen
+			if disruptionStartUnix > 0 {
+				d.DeltaFromDisruption = float64(hit.firstSeen - disruptionStartUnix)
+			}
+		}
+		detections = append(detections, d)
+	}
+
+	// Stable sort: classification (fp < tp), then service, then metric
+	sort.Slice(detections, func(i, j int) bool {
+		if detections[i].Classification != detections[j].Classification {
+			return detections[i].Classification < detections[j].Classification
+		}
+		if detections[i].Service != detections[j].Service {
+			return detections[i].Service < detections[j].Service
+		}
+		return detections[i].Metric < detections[j].Metric
+	})
+
+	result.Detections = detections
+	result.UnknownMetricCount = result.UnknownDetectionCount
+
+	// Compute precision/recall/F1
+	labeled := result.TPCount + result.FPCount
+	if labeled > 0 {
+		result.MetricPrecision = float64(result.TPCount) / float64(labeled)
+	}
+	if len(allTPKeys) > 0 {
+		result.MetricRecall = float64(len(foundTPKeys)) / float64(len(allTPKeys))
+	}
+	if result.MetricPrecision+result.MetricRecall > 0 {
+		result.MetricF1 = 2 * result.MetricPrecision * result.MetricRecall / (result.MetricPrecision + result.MetricRecall)
+	}
+
+	return result
+}
+
+// metricSource extracts the metric name from an anomaly period.
+// For passthrough correlator output, each period has exactly one anomaly
+// whose Source is the metric name. Falls back to parsing the Title field.
+func (oc *ObserverCorrelation) metricSource() string {
+	// Verbose output: anomalies are populated
+	if len(oc.Anomalies) > 0 {
+		return oc.Anomalies[0].Source
+	}
+	// Non-verbose: Title from passthrough has format "Passthrough[detector]: metric_name"
+	if oc.Title != "" {
+		if idx := strings.Index(oc.Title, "]: "); idx >= 0 {
+			return oc.Title[idx+3:]
+		}
+	}
+	return ""
+}
+
+// metricMatches checks if an anomaly source matches a ground truth key.
+// key format: "service:metric_name" (e.g., "redis:redis.cpu.sys")
+//
+// Matching rules:
+// 1. Strip aggregate suffix from source (e.g., ":avg", ":max")
+// 2. Check if stripped source == metric or contains metric as substring
+func metricMatches(source, key string) bool {
+	parts := strings.SplitN(key, ":", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	metric := parts[1]
+
+	// Strip aggregate suffix (e.g., "redis.cpu.sys:avg" -> "redis.cpu.sys")
+	sourceName := source
+	if colonIdx := strings.LastIndex(source, ":"); colonIdx >= 0 {
+		suffix := source[colonIdx+1:]
+		if len(suffix) <= 5 && !strings.Contains(suffix, ".") {
+			sourceName = source[:colonIdx]
+		}
+	}
+
+	return sourceName == metric || strings.Contains(sourceName, metric)
+}

--- a/comp/observer/impl/score_tp.go
+++ b/comp/observer/impl/score_tp.go
@@ -140,6 +140,19 @@ func ScoreMetrics(output *ObserverOutput, gt *MetricGroundTruth, disruptionStart
 	foundTPKeys := make(map[string]*metricHit)
 	firedFPKeys := make(map[string]*metricHit)
 
+	// Sort keys for deterministic iteration order across runs.
+	sortedTPKeys := make([]string, 0, len(tpSet))
+	for key := range tpSet {
+		sortedTPKeys = append(sortedTPKeys, key)
+	}
+	sort.Strings(sortedTPKeys)
+
+	sortedFPKeys := make([]string, 0, len(fpSet))
+	for key := range fpSet {
+		sortedFPKeys = append(sortedFPKeys, key)
+	}
+	sort.Strings(sortedFPKeys)
+
 	for _, period := range output.AnomalyPeriods {
 		source := period.metricSource()
 		if source == "" {
@@ -149,8 +162,8 @@ func ScoreMetrics(output *ObserverOutput, gt *MetricGroundTruth, disruptionStart
 		}
 
 		matched := false
-		// Check against TP metrics
-		for key := range tpSet {
+		// Check against TP metrics (sorted for determinism)
+		for _, key := range sortedTPKeys {
 			if metricMatches(source, key) {
 				result.TPCount++
 				if hit, ok := foundTPKeys[key]; ok {
@@ -166,8 +179,8 @@ func ScoreMetrics(output *ObserverOutput, gt *MetricGroundTruth, disruptionStart
 			continue
 		}
 
-		// Check against FP metrics
-		for key := range fpSet {
+		// Check against FP metrics (sorted for determinism)
+		for _, key := range sortedFPKeys {
 			if metricMatches(source, key) {
 				result.FPCount++
 				if hit, ok := firedFPKeys[key]; ok {
@@ -187,16 +200,18 @@ func ScoreMetrics(output *ObserverOutput, gt *MetricGroundTruth, disruptionStart
 		result.UnknownDetectionCount++
 	}
 
-	// Collect found/missed TP metrics
-	for key := range allTPKeys {
+	// Collect found/missed TP metrics (use sorted keys for determinism)
+	for _, key := range sortedTPKeys {
 		if _, ok := foundTPKeys[key]; ok {
 			result.TPMetricsFound = append(result.TPMetricsFound, key)
 		} else {
 			result.TPMetricsMissed = append(result.TPMetricsMissed, key)
 		}
 	}
-	for key := range firedFPKeys {
-		result.FPMetricsFired = append(result.FPMetricsFired, key)
+	for _, key := range sortedFPKeys {
+		if _, ok := firedFPKeys[key]; ok {
+			result.FPMetricsFired = append(result.FPMetricsFired, key)
+		}
 	}
 
 	// Build per-metric detection timeline
@@ -287,7 +302,13 @@ func (oc *ObserverCorrelation) metricSource() string {
 //
 // Matching rules:
 // 1. Strip aggregate suffix from source (e.g., ":avg", ":max")
-// 2. Check if stripped source == metric or contains metric as substring
+// 2. Check exact match, then substring containment
+//
+// Substring matching is intentional: "trace.http.request.hits" matches ground
+// truth "trace.http.request" because hits is a derived sub-metric of the same
+// trace endpoint. When multiple ground truth keys could match the same source,
+// the caller must iterate in sorted order for deterministic results — which
+// key wins depends on the full "service:metric" sort order.
 func metricMatches(source, key string) bool {
 	parts := strings.SplitN(key, ":", 2)
 	if len(parts) != 2 {

--- a/comp/observer/impl/score_tp.go
+++ b/comp/observer/impl/score_tp.go
@@ -63,20 +63,27 @@ type MetricScoreResult struct {
 	UnknownDetectionCount int               `json:"unknown_detection_count"`
 }
 
-// LoadMetricGroundTruth reads TP/FP metric lists from a scenario's metadata.json.
+// LoadMetricGroundTruth reads TP metric lists from ground_truth.json in the
+// scenarios directory. This file is committed and keyed by scenario name,
+// separate from metadata.json which is downloaded from S3.
 func LoadMetricGroundTruth(scenariosDir, scenarioName string) (*MetricGroundTruth, error) {
-	path := filepath.Join(scenariosDir, scenarioName, "metadata.json")
+	path := filepath.Join(scenariosDir, "ground_truth.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading metadata %s: %w", path, err)
+		return nil, fmt.Errorf("reading ground truth %s: %w", path, err)
 	}
 
-	var gt MetricGroundTruth
-	if err := json.Unmarshal(data, &gt); err != nil {
-		return nil, fmt.Errorf("parsing metadata JSON: %w", err)
+	var allGT map[string]*MetricGroundTruth
+	if err := json.Unmarshal(data, &allGT); err != nil {
+		return nil, fmt.Errorf("parsing ground truth JSON: %w", err)
 	}
 
-	return &gt, nil
+	gt, ok := allGT[scenarioName]
+	if !ok {
+		return nil, fmt.Errorf("scenario %q not found in ground_truth.json", scenarioName)
+	}
+
+	return gt, nil
 }
 
 // LoadDisruptionStartUnix returns the disruption start timestamp in unix seconds

--- a/comp/observer/impl/score_tp_test.go
+++ b/comp/observer/impl/score_tp_test.go
@@ -1,0 +1,218 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricMatches(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		key    string
+		want   bool
+	}{
+		{"exact", "redis.cpu.sys", "redis:redis.cpu.sys", true},
+		{"with aggregate suffix", "redis.cpu.sys:avg", "redis:redis.cpu.sys", true},
+		{"no match", "redis.mem.used", "redis:redis.cpu.sys", false},
+		{"different service same metric", "trace.http.request.hits", "driver-location-service:trace.http.request.hits", true},
+		{"substring match", "trace.http.request.hits:avg", "driver-location-service:trace.http.request.hits", true},
+		{"partial metric no match", "redis.cpu", "redis:redis.cpu.sys", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, metricMatches(tt.source, tt.key))
+		})
+	}
+}
+
+func TestScoreMetrics_Basic(t *testing.T) {
+	gt := &MetricGroundTruth{
+		TruePositives: []MetricGroundTruthEntry{
+			{Service: "redis", Metrics: []string{"redis.cpu.sys", "redis.info.latency_ms"}},
+			{Service: "driver-location-service", Metrics: []string{"trace.http.request.hits"}},
+		},
+	}
+
+	output := &ObserverOutput{
+		AnomalyPeriods: []ObserverCorrelation{
+			{Anomalies: []ObserverAnomaly{{Source: "redis.cpu.sys"}}},           // TP
+			{Anomalies: []ObserverAnomaly{{Source: "redis.mem.used"}}},          // unknown
+			{Anomalies: []ObserverAnomaly{{Source: "some.other.metric"}}},       // unknown
+			{Anomalies: []ObserverAnomaly{{Source: "trace.http.request.hits"}}}, // TP
+		},
+	}
+
+	result := ScoreMetrics(output, gt, 0)
+
+	assert.Equal(t, 2, result.TPCount)
+	assert.Equal(t, 0, result.FPCount)
+	assert.Equal(t, 2, result.UnknownCount)
+	assert.Equal(t, 4, result.TotalCount)
+
+	// Precision: 2 / (2 + 0) = 1.0
+	assert.InDelta(t, 1.0, result.MetricPrecision, 0.001)
+	// Recall: 2 found / 3 total TP metrics = 0.667
+	assert.InDelta(t, 0.6667, result.MetricRecall, 0.001)
+
+	assert.Len(t, result.TPMetricsFound, 2)
+	assert.Len(t, result.TPMetricsMissed, 1) // redis.info.latency_ms
+}
+
+func TestScoreMetrics_AllTPsFound(t *testing.T) {
+	gt := &MetricGroundTruth{
+		TruePositives: []MetricGroundTruthEntry{
+			{Service: "redis", Metrics: []string{"redis.cpu.sys"}},
+		},
+	}
+
+	output := &ObserverOutput{
+		AnomalyPeriods: []ObserverCorrelation{
+			{Anomalies: []ObserverAnomaly{{Source: "redis.cpu.sys"}}},
+		},
+	}
+
+	result := ScoreMetrics(output, gt, 0)
+	assert.Equal(t, 1, result.TPCount)
+	assert.Equal(t, 0, result.FPCount)
+	assert.InDelta(t, 1.0, result.MetricPrecision, 0.001)
+	assert.InDelta(t, 1.0, result.MetricRecall, 0.001)
+	assert.InDelta(t, 1.0, result.MetricF1, 0.001)
+}
+
+func TestScoreMetrics_Empty(t *testing.T) {
+	gt := &MetricGroundTruth{
+		TruePositives: []MetricGroundTruthEntry{{Service: "redis", Metrics: []string{"redis.cpu.sys"}}},
+	}
+
+	output := &ObserverOutput{AnomalyPeriods: nil}
+
+	result := ScoreMetrics(output, gt, 0)
+	assert.Equal(t, 0, result.TPCount)
+	assert.Equal(t, 0, result.TotalCount)
+	assert.InDelta(t, 0.0, result.MetricRecall, 0.001)
+	assert.Len(t, result.TPMetricsMissed, 1)
+}
+
+func TestScoreMetrics_AggSuffix(t *testing.T) {
+	gt := &MetricGroundTruth{
+		TruePositives: []MetricGroundTruthEntry{
+			{Service: "redis", Metrics: []string{"redis.cpu.sys"}},
+		},
+	}
+
+	output := &ObserverOutput{
+		AnomalyPeriods: []ObserverCorrelation{
+			{Anomalies: []ObserverAnomaly{{Source: "redis.cpu.sys:avg"}}},
+		},
+	}
+
+	result := ScoreMetrics(output, gt, 0)
+	assert.Equal(t, 1, result.TPCount)
+}
+
+func TestScoreMetrics_TitleFallback(t *testing.T) {
+	gt := &MetricGroundTruth{
+		TruePositives: []MetricGroundTruthEntry{
+			{Service: "redis", Metrics: []string{"redis.cpu.sys"}},
+		},
+	}
+
+	// Non-verbose output: no Anomalies, but Title has metric name
+	output := &ObserverOutput{
+		AnomalyPeriods: []ObserverCorrelation{
+			{Title: "Passthrough[cusum]: redis.cpu.sys"},
+		},
+	}
+
+	result := ScoreMetrics(output, gt, 0)
+	assert.Equal(t, 1, result.TPCount)
+}
+
+func TestScoreMetrics_Detections_FirstSeenAndCount(t *testing.T) {
+	gt := &MetricGroundTruth{
+		TruePositives: []MetricGroundTruthEntry{
+			{Service: "redis", Metrics: []string{"redis.cpu.sys", "redis.info.latency_ms"}},
+		},
+	}
+
+	output := &ObserverOutput{
+		AnomalyPeriods: []ObserverCorrelation{
+			{PeriodStart: 1000, Anomalies: []ObserverAnomaly{{Source: "redis.cpu.sys"}}},
+			{PeriodStart: 1100, Anomalies: []ObserverAnomaly{{Source: "redis.cpu.sys"}}},     // second hit
+			{PeriodStart: 1200, Anomalies: []ObserverAnomaly{{Source: "some.other.metric"}}}, // unknown
+		},
+	}
+
+	result := ScoreMetrics(output, gt, 900)
+
+	// 2 ground truth TP entries
+	assert.Len(t, result.Detections, 2)
+
+	byKey := map[string]MetricDetection{}
+	for _, d := range result.Detections {
+		byKey[d.Classification+":"+d.Service+":"+d.Metric] = d
+	}
+
+	// TP: redis.cpu.sys — detected, first at 1000, count=2, delta=100s
+	cpuDet := byKey["tp:redis:redis.cpu.sys"]
+	assert.True(t, cpuDet.Detected)
+	assert.Equal(t, 2, cpuDet.Count)
+	assert.Equal(t, int64(1000), cpuDet.FirstSeenUnix)
+	assert.InDelta(t, 100.0, cpuDet.DeltaFromDisruption, 0.001)
+
+	// TP: redis.info.latency_ms — NOT detected
+	latDet := byKey["tp:redis:redis.info.latency_ms"]
+	assert.False(t, latDet.Detected)
+	assert.Equal(t, 0, latDet.Count)
+	assert.Equal(t, int64(0), latDet.FirstSeenUnix)
+
+	// Unknown counts
+	assert.Equal(t, 1, result.UnknownMetricCount)
+	assert.Equal(t, 1, result.UnknownDetectionCount)
+}
+
+func TestScoreMetrics_Detections_NoDisruptionStart(t *testing.T) {
+	gt := &MetricGroundTruth{
+		TruePositives: []MetricGroundTruthEntry{
+			{Service: "svc", Metrics: []string{"m1"}},
+		},
+	}
+
+	output := &ObserverOutput{
+		AnomalyPeriods: []ObserverCorrelation{
+			{PeriodStart: 500, Anomalies: []ObserverAnomaly{{Source: "m1"}}},
+		},
+	}
+
+	result := ScoreMetrics(output, gt, 0)
+	assert.Len(t, result.Detections, 1)
+	assert.Equal(t, 0.0, result.Detections[0].DeltaFromDisruption)
+	assert.True(t, result.Detections[0].Detected)
+}
+
+func TestScoreMetrics_Detections_SortOrder(t *testing.T) {
+	gt := &MetricGroundTruth{
+		TruePositives: []MetricGroundTruthEntry{
+			{Service: "b-svc", Metrics: []string{"z-metric"}},
+			{Service: "a-svc", Metrics: []string{"a-metric"}},
+		},
+	}
+
+	output := &ObserverOutput{AnomalyPeriods: nil}
+	result := ScoreMetrics(output, gt, 0)
+
+	// Should be sorted by service then metric (all tp)
+	assert.Len(t, result.Detections, 2)
+	assert.Equal(t, "tp", result.Detections[0].Classification)
+	assert.Equal(t, "a-svc", result.Detections[0].Service)
+	assert.Equal(t, "tp", result.Detections[1].Classification)
+	assert.Equal(t, "b-svc", result.Detections[1].Service)
+}

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -777,6 +777,28 @@ func (s *timeSeriesStorage) WriteGeneration(handle observer.SeriesHandle) int64 
 	return 0
 }
 
+// BulkSeriesStatus returns the point count (up to endTime) and write generation
+// for each handle in a single lock acquisition. This avoids the overhead of
+// 2×len(handles) individual RLock/RUnlock calls in hot detector loops.
+func (s *timeSeriesStorage) BulkSeriesStatus(handles []observer.SeriesHandle, endTime int64) []observer.SeriesStatus {
+	result := make([]observer.SeriesStatus, len(handles))
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for i, handle := range handles {
+		stats := s.resolveByID(handle)
+		if stats == nil || stats.pointCount() == 0 {
+			continue
+		}
+		result[i] = observer.SeriesStatus{
+			PointCount:      searchAfter(stats.timestamps, endTime),
+			WriteGeneration: stats.writeGeneration,
+		}
+	}
+	return result
+}
+
 // matchTags checks if tags contain all required key=value pairs.
 func matchTags(tags []string, matchers map[string]string) bool {
 	if len(matchers) == 0 {

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -780,8 +780,9 @@ func (s *timeSeriesStorage) WriteGeneration(handle observer.SeriesHandle) int64 
 // BulkSeriesStatus returns the point count (up to endTime) and write generation
 // for each handle in a single lock acquisition. This avoids the overhead of
 // 2×len(handles) individual RLock/RUnlock calls in hot detector loops.
-func (s *timeSeriesStorage) BulkSeriesStatus(handles []observer.SeriesHandle, endTime int64) []observer.SeriesStatus {
-	result := make([]observer.SeriesStatus, len(handles))
+// Implements bulkStatusReader (metrics_detector_util.go).
+func (s *timeSeriesStorage) BulkSeriesStatus(handles []observer.SeriesHandle, endTime int64) []seriesStatus {
+	result := make([]seriesStatus, len(handles))
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -791,9 +792,9 @@ func (s *timeSeriesStorage) BulkSeriesStatus(handles []observer.SeriesHandle, en
 		if stats == nil || stats.pointCount() == 0 {
 			continue
 		}
-		result[i] = observer.SeriesStatus{
-			PointCount:      searchAfter(stats.timestamps, endTime),
-			WriteGeneration: stats.writeGeneration,
+		result[i] = seriesStatus{
+			pointCount:      searchAfter(stats.timestamps, endTime),
+			writeGeneration: stats.writeGeneration,
 		}
 	}
 	return result

--- a/comp/observer/scenarios/ground_truth.json
+++ b/comp/observer/scenarios/ground_truth.json
@@ -1,0 +1,26 @@
+{
+  "213_pagerduty": {
+    "true_positives": [
+      {"service": "cassandra-cluster", "metrics": ["system.cpu.user"]},
+      {"service": "cassandra-cluster", "metrics": ["cassandra.write_latency.99th_percentile"]},
+      {"service": "notification-pipeline", "metrics": ["trace.notification.delivery.errors"]},
+      {"service": "integration-api", "metrics": ["trace.flask.request.errors"]}
+    ]
+  },
+  "353_postmark": {
+    "true_positives": [
+      {"service": "dns-resolver-service", "metrics": ["trace.dns.lookup.errors"]},
+      {"service": "outbound-delivery-service", "metrics": ["trace.http.request"]},
+      {"service": "queue-manager", "metrics": ["redis.net.commands"]},
+      {"service": "smtp-gateway", "metrics": ["trace.http.request"]}
+    ]
+  },
+  "food_delivery_redis": {
+    "true_positives": [
+      {"service": "redis", "metrics": ["redis.cpu.sys"]},
+      {"service": "order-gateway", "metrics": ["trace.http.request"]},
+      {"service": "driver-location-service", "metrics": ["trace.http.request.hits"]},
+      {"service": "redis", "metrics": ["redis.info.latency_ms"]}
+    ]
+  }
+}

--- a/pkg/config/setup/config.go
+++ b/pkg/config/setup/config.go
@@ -373,11 +373,14 @@ func InitConfig(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("observer.components.cusum.enabled", false)
 	config.BindEnvAndSetDefault("observer.components.bocpd.enabled", true)
 	config.BindEnvAndSetDefault("observer.components.rrcf.enabled", true)
+	config.BindEnvAndSetDefault("observer.components.scanmw.enabled", false)
+	config.BindEnvAndSetDefault("observer.components.scanwelch.enabled", false)
 	config.BindEnvAndSetDefault("observer.components.cross_signal.enabled", false)
 	config.BindEnvAndSetDefault("observer.components.time_cluster.enabled", true)
 	config.BindEnvAndSetDefault("observer.components.time_cluster.min_cluster_size", 0)
 	config.BindEnvAndSetDefault("observer.components.lead_lag.enabled", false)
 	config.BindEnvAndSetDefault("observer.components.surprise.enabled", false)
+	config.BindEnvAndSetDefault("observer.components.passthrough.enabled", false)
 
 	// Auto exit configuration
 	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -142,33 +142,31 @@ def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observe
 @task
 def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, enable: str = ""):
     """
-    Runs observer eval with true positive metric scoring (--score-tp).
+    Runs TP metric scoring: replays scenarios with passthrough correlator and scores
+    each detected anomaly against ground truth metric labels in ground_truth.json.
 
-    Replays scenarios headless, scores both timestamp-level and metric-level TP detection,
-    and prints a summary table with metric precision/recall/F1.
-
-    Only components listed in --enable are active; everything else is disabled.
-    Extractors are always enabled.
+    The passthrough correlator is added automatically — only specify detectors in --enable.
 
     Args:
         scenario: Run a single scenario (e.g. "213_pagerduty"). Default: all scenarios.
         scenarios_dir: Directory containing scenario subdirectories.
         sigma: Gaussian width in seconds for scoring.
-        enable: Comma-separated components to enable (e.g. "scanmw,passthrough"). All others disabled.
+        enable: Comma-separated detectors to enable (e.g. "scanmw").
     """
     if not enable:
-        print(color_message("--enable is required (e.g. --enable scanmw,passthrough)", Color.RED))
+        print(color_message("--enable is required (e.g. --enable scanmw)", Color.RED))
         return
 
-    enabled_set = {name.strip() for name in enable.split(",") if name.strip()}
-    # Extractors are always on; compute disable list for everything else
+    enabled_detectors = {name.strip() for name in enable.split(",") if name.strip()}
     extractors = {"log_metrics_extractor", "connection_error_extractor", "log_pattern_extractor"}
-    disable_set = {c for c in ALL_COMPONENTS if c not in enabled_set and c not in extractors}
-    enable_flag = ",".join(sorted(enabled_set))
+
+    enable_set = enabled_detectors | {"passthrough"}
+    disable_set = {c for c in ALL_COMPONENTS if c not in enable_set and c not in extractors}
+    enable_flag = ",".join(sorted(enable_set))
     disable_flag = ",".join(sorted(disable_set))
 
-    print(color_message(f"Enable:  {enable_flag}", Color.BLUE))
-    print(color_message(f"Disable: {disable_flag}", Color.BLUE))
+    print(color_message(f"Detectors: {','.join(sorted(enabled_detectors))}", Color.BLUE))
+    print(color_message(f"Correlator: passthrough (auto)", Color.BLUE))
 
     print(color_message("Building observer-testbench...", Color.BLUE))
     ctx.run("go build -o bin/observer-testbench ./cmd/observer-testbench", hide=True)
@@ -188,7 +186,7 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
                 print(color_message(f"Skipping {name} — no parquet data at {parquet_dir}", Color.ORANGE))
                 continue
 
-        output_path = f"/tmp/observer-eval-{name}.json"
+        output_path = f"/tmp/observer-eval-{name}-tp.json"
         print(color_message(f"\n{'='*60}", Color.BLUE))
         print(color_message(f"  {name}", Color.BLUE))
         print(color_message(f"{'='*60}", Color.BLUE))
@@ -203,17 +201,10 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
         if not os.path.isfile(output_path):
             print(color_message(f"Testbench did not produce output at {output_path}", Color.RED))
             continue
-        try:
-            with open(output_path) as f:
-                json.load(f)
-        except (json.JSONDecodeError, OSError) as e:
-            print(color_message(f"Testbench output at {output_path} is not valid JSON: {e}", Color.RED))
-            continue
 
         scorer_result = ctx.run(
             f"bin/observer-scorer --input {shlex.quote(output_path)} --scenarios-dir {shlex.quote(scenarios_dir)} --sigma {sigma} --score-tp --json",
-            hide=True,
-            warn=True,
+            hide=True, warn=True,
         )
 
         if scorer_result.failed:
@@ -225,6 +216,7 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
         except json.JSONDecodeError:
             print(color_message(f"Scorer returned invalid JSON for {name}:\n{scorer_result.stdout}", Color.RED))
             continue
+
         results.append({"name": name, **score})
 
     if results:
@@ -232,26 +224,21 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
         print(color_message("  Observer TP Eval Summary", Color.GREEN))
         print(color_message(f"{'='*60}\n", Color.GREEN))
 
-        # Timestamp score header
-        header = f"{'Scenario':<25}  {'TS F1':>6}  {'TS Prec':>7}  {'TS Rec':>6}  {'M F1':>6}  {'M Prec':>7}  {'M Rec':>6}  {'TP':>4}  {'Unk':>4}  {'Found':>5}  {'Missed':>6}"
+        header = f"{'Scenario':<25}  {'M F1':>6}  {'M Prec':>7}  {'M Rec':>6}  {'TP':>4}  {'Unk':>5}  {'Found':>5}  {'Missed':>6}"
         print(header)
         print("-" * len(header))
 
         for r in results:
-            ts = r.get("timestamp_score", {})
-            ms = r.get("metric_score", {})
             print(
                 f"{r['name']:<25}"
-                f"  {ts.get('f1', 0):>6.4f}  {ts.get('precision', 0):>7.4f}  {ts.get('recall', 0):>6.4f}"
-                f"  {ms.get('metric_f1', 0):>6.4f}  {ms.get('metric_precision', 0):>7.4f}  {ms.get('metric_recall', 0):>6.4f}"
-                f"  {ms.get('tp_count', 0):>4}  {ms.get('unknown_count', 0):>4}"
-                f"  {len(ms.get('tp_metrics_found') or []):>5}  {len(ms.get('tp_metrics_missed') or []):>6}"
+                f"  {r.get('metric_f1', 0):>6.4f}  {r.get('metric_precision', 0):>7.4f}  {r.get('metric_recall', 0):>6.4f}"
+                f"  {r.get('tp_count', 0):>4}  {r.get('unknown_count', 0):>5}"
+                f"  {len(r.get('tp_metrics_found') or []):>5}  {len(r.get('tp_metrics_missed') or []):>6}"
             )
 
-        # Print per-scenario metric details
+        # Print per-scenario TP details
         for r in results:
-            ms = r.get("metric_score", {})
-            detections = ms.get("detections", [])
+            detections = r.get("detections", [])
             if not detections:
                 continue
             print(color_message(f"\n  {r['name']} detections:", Color.BLUE))
@@ -262,7 +249,7 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
                     status = "MISS"
                 print(f"    [{d['classification']}] {d['service']}/{d['metric']}: {status}")
 
-        print(f"\nOutput JSONs: /tmp/observer-eval-*.json (sigma={sigma}s)")
+        print(f"\nOutput JSONs: /tmp/observer-eval-*-tp.json")
 
 
 def _ensure_parquets(ctx, name, parquet_dir):

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -12,6 +12,17 @@ from tasks.libs.common.color import Color, color_message
 
 SCENARIOS = ["213_pagerduty", "353_postmark", "food_delivery_redis"]
 
+# All component names from the catalog (component_catalog.go).
+# Used by eval_tp to compute the disable list from an enable list.
+ALL_COMPONENTS = [
+    # extractors
+    "log_metrics_extractor", "connection_error_extractor", "log_pattern_extractor",
+    # detectors
+    "cusum", "bocpd", "rrcf", "scanmw", "scanwelch",
+    # correlators
+    "cross_signal", "time_cluster", "lead_lag", "surprise", "passthrough",
+]
+
 # S3 zip key for each scenario. Update when re-recording.
 SCENARIO_ZIPS = {
     "213_pagerduty": "gensim-results-213_PagerDuty_June_2014_Outage-20260303-1309-78229d.zip",
@@ -124,6 +135,131 @@ def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observe
                 f"{r['name']:<25}  {r['f1']:>6.4f}  {r['precision']:>9.4f}  {r['recall']:>6.4f}"
                 f"  {r['num_predictions']:>6}  {r['num_baseline_fps']:>12}  {r['num_filtered_warmup']:>13}  {r['num_filtered_cascading']:>16}"
             )
+
+        print(f"\nOutput JSONs: /tmp/observer-eval-*.json (sigma={sigma}s)")
+
+
+@task
+def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, enable: str = ""):
+    """
+    Runs observer eval with true positive metric scoring (--score-tp).
+
+    Replays scenarios headless, scores both timestamp-level and metric-level TP detection,
+    and prints a summary table with metric precision/recall/F1.
+
+    Only components listed in --enable are active; everything else is disabled.
+    Extractors are always enabled.
+
+    Args:
+        scenario: Run a single scenario (e.g. "213_pagerduty"). Default: all scenarios.
+        scenarios_dir: Directory containing scenario subdirectories.
+        sigma: Gaussian width in seconds for scoring.
+        enable: Comma-separated components to enable (e.g. "scanmw,passthrough"). All others disabled.
+    """
+    if not enable:
+        print(color_message("--enable is required (e.g. --enable scanmw,passthrough)", Color.RED))
+        return
+
+    enabled_set = {name.strip() for name in enable.split(",") if name.strip()}
+    # Extractors are always on; compute disable list for everything else
+    extractors = {"log_metrics_extractor", "connection_error_extractor", "log_pattern_extractor"}
+    disable_set = {c for c in ALL_COMPONENTS if c not in enabled_set and c not in extractors}
+    enable_flag = ",".join(sorted(enabled_set))
+    disable_flag = ",".join(sorted(disable_set))
+
+    print(color_message(f"Enable:  {enable_flag}", Color.BLUE))
+    print(color_message(f"Disable: {disable_flag}", Color.BLUE))
+
+    print(color_message("Building observer-testbench...", Color.BLUE))
+    ctx.run("go build -o bin/observer-testbench ./cmd/observer-testbench", hide=True)
+    print(color_message("Building observer-scorer...", Color.BLUE))
+    ctx.run("go build -o bin/observer-scorer ./cmd/observer-scorer", hide=True)
+
+    scenarios_to_run = [scenario] if scenario else SCENARIOS
+
+    results = []
+    for name in scenarios_to_run:
+        parquet_dir = os.path.join(scenarios_dir, name, "parquet")
+        scenario_root = os.path.join(scenarios_dir, name)
+        if not os.path.isdir(parquet_dir) or not os.listdir(parquet_dir):
+            _ensure_parquets(ctx, name, parquet_dir)
+        if not os.path.isdir(parquet_dir) or not os.listdir(parquet_dir):
+            if not glob.glob(os.path.join(scenario_root, "*.parquet")):
+                print(color_message(f"Skipping {name} — no parquet data at {parquet_dir}", Color.ORANGE))
+                continue
+
+        output_path = f"/tmp/observer-eval-{name}.json"
+        print(color_message(f"\n{'='*60}", Color.BLUE))
+        print(color_message(f"  {name}", Color.BLUE))
+        print(color_message(f"{'='*60}", Color.BLUE))
+
+        ctx.run(
+            f"bin/observer-testbench --headless {shlex.quote(name)} --output {shlex.quote(output_path)}"
+            f" --scenarios-dir {shlex.quote(scenarios_dir)}"
+            f" --enable {shlex.quote(enable_flag)} --disable {shlex.quote(disable_flag)}"
+        )
+
+        if not os.path.isfile(output_path):
+            print(color_message(f"Testbench did not produce output at {output_path}", Color.RED))
+            continue
+        try:
+            with open(output_path) as f:
+                json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            print(color_message(f"Testbench output at {output_path} is not valid JSON: {e}", Color.RED))
+            continue
+
+        scorer_result = ctx.run(
+            f"bin/observer-scorer --input {shlex.quote(output_path)} --scenarios-dir {shlex.quote(scenarios_dir)} --sigma {sigma} --score-tp --json",
+            hide=True,
+            warn=True,
+        )
+
+        if scorer_result.failed:
+            print(color_message(f"Scorer failed for {name}:\n{scorer_result.stderr}", Color.RED))
+            continue
+
+        try:
+            score = json.loads(scorer_result.stdout.strip())
+        except json.JSONDecodeError:
+            print(color_message(f"Scorer returned invalid JSON for {name}:\n{scorer_result.stdout}", Color.RED))
+            continue
+        results.append({"name": name, **score})
+
+    if results:
+        print(color_message(f"\n{'='*60}", Color.GREEN))
+        print(color_message("  Observer TP Eval Summary", Color.GREEN))
+        print(color_message(f"{'='*60}\n", Color.GREEN))
+
+        # Timestamp score header
+        header = f"{'Scenario':<25}  {'TS F1':>6}  {'TS Prec':>7}  {'TS Rec':>6}  {'M F1':>6}  {'M Prec':>7}  {'M Rec':>6}  {'TP':>4}  {'Unk':>4}  {'Found':>5}  {'Missed':>6}"
+        print(header)
+        print("-" * len(header))
+
+        for r in results:
+            ts = r.get("timestamp_score", {})
+            ms = r.get("metric_score", {})
+            print(
+                f"{r['name']:<25}"
+                f"  {ts.get('f1', 0):>6.4f}  {ts.get('precision', 0):>7.4f}  {ts.get('recall', 0):>6.4f}"
+                f"  {ms.get('metric_f1', 0):>6.4f}  {ms.get('metric_precision', 0):>7.4f}  {ms.get('metric_recall', 0):>6.4f}"
+                f"  {ms.get('tp_count', 0):>4}  {ms.get('unknown_count', 0):>4}"
+                f"  {len(ms.get('tp_metrics_found', [])):>5}  {len(ms.get('tp_metrics_missed', [])):>6}"
+            )
+
+        # Print per-scenario metric details
+        for r in results:
+            ms = r.get("metric_score", {})
+            detections = ms.get("detections", [])
+            if not detections:
+                continue
+            print(color_message(f"\n  {r['name']} detections:", Color.BLUE))
+            for d in detections:
+                if d.get("detected"):
+                    status = f"HIT (count={d['count']}, first={d.get('delta_from_disruption_sec', 0):.0f}s after disruption)"
+                else:
+                    status = "MISS"
+                print(f"    [{d['classification']}] {d['service']}/{d['metric']}: {status}")
 
         print(f"\nOutput JSONs: /tmp/observer-eval-*.json (sigma={sigma}s)")
 

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -12,17 +12,6 @@ from tasks.libs.common.color import Color, color_message
 
 SCENARIOS = ["213_pagerduty", "353_postmark", "food_delivery_redis"]
 
-# All component names from the catalog (component_catalog.go).
-# Used by eval_tp to compute the disable list from an enable list.
-ALL_COMPONENTS = [
-    # extractors
-    "log_metrics_extractor", "connection_error_extractor", "log_pattern_extractor",
-    # detectors
-    "cusum", "bocpd", "rrcf", "scanmw", "scanwelch",
-    # correlators
-    "cross_signal", "time_cluster", "lead_lag", "surprise", "passthrough",
-]
-
 # S3 zip key for each scenario. Update when re-recording.
 SCENARIO_ZIPS = {
     "213_pagerduty": "gensim-results-213_PagerDuty_June_2014_Outage-20260303-1309-78229d.zip",
@@ -53,17 +42,33 @@ def build_scorer(ctx):
 
 # --- Eval ---
 @task
-def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0):
+def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, only: str = ""):
     """
-    Runs the observer eval: builds binaries, replays scenarios headless, scores against ground truth.
+    Runs the observer F1 eval: replays scenarios, scores Gaussian F1.
 
-    Output JSONs are saved to /tmp/observer-eval-<scenario>.json for inspection.
+    Uses testbench --only to control which components are active.
+    Default (no --only): uses testbench defaults (bocpd,rrcf,time_cluster + other default-enabled components).
+    With --only: enables ONLY listed components + extractors, disables everything else.
+      time_cluster is auto-added if not specified.
+
+    Examples:
+        dda inv q.eval-scenarios                            # defaults
+        dda inv q.eval-scenarios --only scanmw              # scanmw + time_cluster (auto)
+        dda inv q.eval-scenarios --only bocpd,time_cluster  # explicit
 
     Args:
         scenario: Run a single scenario (e.g. "213_pagerduty"). Default: all scenarios.
         scenarios_dir: Directory containing scenario subdirectories.
         sigma: Gaussian width in seconds for scoring.
+        only: Comma-separated components to enable (passed as --only to testbench). Auto-adds time_cluster.
     """
+    only_flag = ""
+    if only:
+        components = {name.strip() for name in only.split(",") if name.strip()}
+        components.add("time_cluster")
+        only_flag = ",".join(sorted(components))
+        print(color_message(f"Only: {only_flag}", Color.BLUE))
+
     print(color_message("Building observer-testbench...", Color.BLUE))
     ctx.run("go build -o bin/observer-testbench ./cmd/observer-testbench", hide=True)
     print(color_message("Building observer-scorer...", Color.BLUE))
@@ -88,8 +93,9 @@ def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observe
         print(color_message(f"  {name}", Color.BLUE))
         print(color_message(f"{'='*60}", Color.BLUE))
 
+        only_part = f" --only {shlex.quote(only_flag)}" if only_flag else ""
         ctx.run(
-            f"bin/observer-testbench --headless {shlex.quote(name)} --output {shlex.quote(output_path)} --scenarios-dir {shlex.quote(scenarios_dir)}"
+            f"bin/observer-testbench --headless {shlex.quote(name)} --output {shlex.quote(output_path)} --scenarios-dir {shlex.quote(scenarios_dir)}{only_part}"
         )
 
         if not os.path.isfile(output_path):
@@ -140,33 +146,33 @@ def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observe
 
 
 @task
-def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, enable: str = ""):
+def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, only: str = ""):
     """
     Runs TP metric scoring: replays scenarios with passthrough correlator and scores
     each detected anomaly against ground truth metric labels in ground_truth.json.
 
-    The passthrough correlator is added automatically — only specify detectors in --enable.
+    Uses testbench --only to control which components are active.
+    passthrough correlator is auto-added if not specified (required for TP scoring).
+
+    Examples:
+        dda inv q.eval-tp --only scanmw              # scanmw + passthrough (auto)
+        dda inv q.eval-tp --only bocpd,passthrough    # explicit
 
     Args:
         scenario: Run a single scenario (e.g. "213_pagerduty"). Default: all scenarios.
         scenarios_dir: Directory containing scenario subdirectories.
         sigma: Gaussian width in seconds for scoring.
-        enable: Comma-separated detectors to enable (e.g. "scanmw").
+        only: Comma-separated components to enable (passed as --only to testbench). Auto-adds passthrough.
     """
-    if not enable:
-        print(color_message("--enable is required (e.g. --enable scanmw)", Color.RED))
+    if not only:
+        print(color_message("--only is required (e.g. --only scanmw)", Color.RED))
         return
 
-    enabled_detectors = {name.strip() for name in enable.split(",") if name.strip()}
-    extractors = {"log_metrics_extractor", "connection_error_extractor", "log_pattern_extractor"}
+    components = {name.strip() for name in only.split(",") if name.strip()}
+    components.add("passthrough")
+    only_flag = ",".join(sorted(components))
 
-    enable_set = enabled_detectors | {"passthrough"}
-    disable_set = {c for c in ALL_COMPONENTS if c not in enable_set and c not in extractors}
-    enable_flag = ",".join(sorted(enable_set))
-    disable_flag = ",".join(sorted(disable_set))
-
-    print(color_message(f"Detectors: {','.join(sorted(enabled_detectors))}", Color.BLUE))
-    print(color_message(f"Correlator: passthrough (auto)", Color.BLUE))
+    print(color_message(f"Only: {only_flag}", Color.BLUE))
 
     print(color_message("Building observer-testbench...", Color.BLUE))
     ctx.run("go build -o bin/observer-testbench ./cmd/observer-testbench", hide=True)
@@ -194,7 +200,7 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
         ctx.run(
             f"bin/observer-testbench --headless {shlex.quote(name)} --output {shlex.quote(output_path)}"
             f" --scenarios-dir {shlex.quote(scenarios_dir)}"
-            f" --enable {shlex.quote(enable_flag)} --disable {shlex.quote(disable_flag)}"
+            f" --only {shlex.quote(only_flag)}"
             f" --verbose"
         )
 

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -42,7 +42,9 @@ def build_scorer(ctx):
 
 # --- Eval ---
 @task
-def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, only: str = ""):
+def eval_scenarios(
+    ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, only: str = ""
+):
     """
     Runs the observer F1 eval: replays scenarios, scores Gaussian F1.
 
@@ -146,7 +148,9 @@ def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observe
 
 
 @task
-def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, only: str = ""):
+def eval_tp(
+    ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0, only: str = ""
+):
     """
     Runs TP metric scoring: replays scenarios with passthrough correlator and scores
     each detected anomaly against ground truth metric labels in ground_truth.json.
@@ -210,7 +214,8 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
 
         scorer_result = ctx.run(
             f"bin/observer-scorer --input {shlex.quote(output_path)} --scenarios-dir {shlex.quote(scenarios_dir)} --sigma {sigma} --score-tp --json",
-            hide=True, warn=True,
+            hide=True,
+            warn=True,
         )
 
         if scorer_result.failed:
@@ -250,12 +255,14 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
             print(color_message(f"\n  {r['name']} detections:", Color.BLUE))
             for d in detections:
                 if d.get("detected"):
-                    status = f"HIT (count={d['count']}, first={d.get('delta_from_disruption_sec', 0):.0f}s after disruption)"
+                    status = (
+                        f"HIT (count={d['count']}, first={d.get('delta_from_disruption_sec', 0):.0f}s after disruption)"
+                    )
                 else:
                     status = "MISS"
                 print(f"    [{d['classification']}] {d['service']}/{d['metric']}: {status}")
 
-        print(f"\nOutput JSONs: /tmp/observer-eval-*-tp.json")
+        print("\nOutput JSONs: /tmp/observer-eval-*-tp.json")
 
 
 def _ensure_parquets(ctx, name, parquet_dir):
@@ -335,7 +342,7 @@ def launch_testbench(
     else:
         print("Launching observer-testbench backend and UI, use ^C to exit")
         ctx.run(
-            f"bin/observer-testbench --scenarios-dir {scenarios_dir} & ( cd cmd/observer-testbench/ui && npm install && npm run dev ) &"
+            f"bin/observer-testbench --scenarios-dir {scenarios_dir} --only scanmw,scanwelch,bocpd  & ( cd cmd/observer-testbench/ui && npm install && npm run dev ) &"
         )
 
 

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -197,6 +197,7 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
             f"bin/observer-testbench --headless {shlex.quote(name)} --output {shlex.quote(output_path)}"
             f" --scenarios-dir {shlex.quote(scenarios_dir)}"
             f" --enable {shlex.quote(enable_flag)} --disable {shlex.quote(disable_flag)}"
+            f" --verbose"
         )
 
         if not os.path.isfile(output_path):
@@ -244,7 +245,7 @@ def eval_tp(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scena
                 f"  {ts.get('f1', 0):>6.4f}  {ts.get('precision', 0):>7.4f}  {ts.get('recall', 0):>6.4f}"
                 f"  {ms.get('metric_f1', 0):>6.4f}  {ms.get('metric_precision', 0):>7.4f}  {ms.get('metric_recall', 0):>6.4f}"
                 f"  {ms.get('tp_count', 0):>4}  {ms.get('unknown_count', 0):>4}"
-                f"  {len(ms.get('tp_metrics_found', [])):>5}  {len(ms.get('tp_metrics_missed', [])):>6}"
+                f"  {len(ms.get('tp_metrics_found') or []):>5}  {len(ms.get('tp_metrics_missed') or []):>6}"
             )
 
         # Print per-scenario metric details


### PR DESCRIPTION
## Summary

Add ScanMW and ScanWelch changepoint detectors, a passthrough correlator for detector-level evaluation, metric-level true positive scoring infrastructure, and replay performance optimizations.

### New Detectors

#### ScanMW (Mann-Whitney U scan)

A nonparametric changepoint detector that scans every possible split point in a time series segment. For each candidate split at index k, it divides the data into a pre-change window `[0, k)` and post-change window `[k, n)`, then computes the Mann-Whitney U statistic to test whether the two distributions differ. The candidate with the lowest p-value is selected, subject to three verification gates:

1. **Statistical significance**: MW p-value must be below `SignificanceThreshold` (default 1e-8)
2. **Effect size**: Rank-biserial correlation must exceed `MinEffectSize` (default 0.85), ensuring the shift is large relative to rank overlap
3. **MAD deviation**: `|post_median - pre_median| / MAD` must exceed `MinDeviationMAD` (default 15.0), filtering out statistically significant but operationally small shifts

After detecting a changepoint, the segment start advances past it so subsequent scans only examine post-change data. This allows detection of multiple sequential changepoints in a single series.

#### ScanWelch (Welch's t-test + Mann-Whitney hybrid)

A two-phase detector that combines parametric and nonparametric methods. Phase 1 uses Welch's t-statistic to quickly scan all split points in O(n) time via cumulative sums (running mean and variance). The split with the highest |t| above `MinTStatistic` (default 8.0) is the candidate. Phase 2 verifies the candidate using the same three gates as ScanMW (MW p-value, effect size, MAD deviation).

The hybrid design leverages the t-test's computational efficiency for candidate selection while using the nonparametric MW test for robust verification — the t-test assumes normality which may not hold, but it's effective as a fast pre-filter.

Both detectors share the same segment-advancement strategy, aggregation support (avg, count), and replay optimizations.

### New Correlator

#### DetectorPassthroughCorrelator

A no-op correlator that passes each anomaly through as its own independent correlation. Used for level-1 detector evaluation where we want to score each detector's raw output independently without time-clustering. Each anomaly becomes a correlation with `Title: "Passthrough[detector]: metric_name"`, enabling metric-level TP scoring.

### Scoring Infrastructure

- **Metric TP scoring** (`score_tp.go`): Given ground truth labels of which metrics are true positives, classifies each detected anomaly by substring-matching its source metric against the ground truth list. Computes metric-level precision/recall/F1.
- **`ground_truth.json`**: Committed file with TP metric labels per scenario, keyed by scenario name. Separate from S3-downloaded `metadata.json` so labels persist across data refreshes.

The scorer has two mutually exclusive modes:

| Mode | Flag | Correlator | What it measures |
|---|---|---|---|
| **F1 scoring** | (default) | time_cluster/any | Timestamp-level Gaussian F1 — did we detect the disruption at the right time? |
| **TP scoring** | `--score-tp` | passthrough | Metric-level precision/recall — did we detect the right metrics? |

`--score-tp` requires passthrough correlator output because it extracts metric names from each anomaly's `Source` field (via the `Title: "Passthrough[detector]: metric_name"` format).

Corresponding invoke tasks:

```bash
# F1 scoring (uses BOCPD + time_cluster by default)
dda inv q.eval-scenarios --scenario food_delivery_redis

# TP metric scoring (auto-adds passthrough correlator)
dda inv q.eval-tp --enable scanmw --scenario food_delivery_redis
```


## Eval Results

Evaluated on 3 scenarios with fresh parquet recordings (2026-03-19). Sigma=30s for Gaussian F1 scoring. MinClusterSize=3.

### Time Cluster — Gaussian F1 Scoring

| Scenario | Detector | F1 | Precision | Recall | Predictions |
|---|---|---|---|---|---|
| 213_pagerduty | bocpd | 0.0000 | 0.0000 | 0.0000 | 0 |
| 213_pagerduty | scanmw | 0.0000 | 0.0000 | 0.0000 | 0 |
| 213_pagerduty | scanwelch | 0.0000 | 0.0000 | 0.0000 | 0 |
| 353_postmark | bocpd | 0.4483 | 0.3023 | 0.8666 | 56 |
| 353_postmark | **scanmw** | **0.9286** | **1.0000** | **0.8666** | 3 |
| 353_postmark | **scanwelch** | **0.9286** | **1.0000** | **0.8666** | 3 |
| food_delivery_redis | bocpd | 0.6532 | 1.0000 | 0.4850 | 15 |
| food_delivery_redis | scanmw | 0.0000 | 0.0000 | 0.0000 | 0 |
| food_delivery_redis | **scanwelch** | **0.9138** | **1.0000** | **0.8413** | 1 |

#### Summary (Average F1)

| Detector | Avg F1 |
|---|---|
| bocpd | 0.37 |
| scanmw | 0.31 |
| **scanwelch** | **0.61** |

**Key findings:**
- **ScanWelch is the best detector** — Avg F1=0.61, perfect precision on 353 and food_delivery
- ScanMW and ScanWelch both achieve F1=0.93 on 353_postmark (perfect precision)
- 213_pagerduty scores 0 across all detectors — scan detector anomalies have historical timestamps that cause time_cluster to evict clusters before the accumulator captures them (see Known Issues)
- Same eviction issue affects ScanMW on food_delivery (0.00) but not ScanWelch (0.91) due to different anomaly timing patterns

### Passthrough — TP Metric Scoring

| Scenario | Detector | M F1 | M Prec | M Rec | TP | Unknown | Found |
|---|---|---|---|---|---|---|---|
| 213_pagerduty | bocpd | 0.00 | 0.00 | 0/4 | 0 | 5 | - |
| 213_pagerduty | scanmw | 0.00 | 0.00 | 0/4 | 0 | 104 | - |
| 213_pagerduty | scanwelch | 0.00 | 0.00 | 0/4 | 0 | 97 | - |
| 353_postmark | bocpd | 0.00 | 0.00 | 0/4 | 0 | 1207 | - |
| 353_postmark | scanmw | 0.00 | 0.00 | 0/4 | 0 | 437 | - |
| 353_postmark | **scanwelch** | **0.40** | **1.00** | **1/4** | 6 | 2186 | queue-manager:redis.net.commands |
| food_delivery_redis | bocpd | 0.00 | 0.00 | 0/4 | 0 | 138 | - |
| food_delivery_redis | scanmw | 0.00 | 0.00 | 0/4 | 0 | 529 | - |
| food_delivery_redis | scanwelch | 0.00 | 0.00 | 0/4 | 0 | 401 | - |

**Key findings:**
- TP metric matching is largely 0 because ground truth labels use APM trace metric names (`trace.http.request`, `trace.flask.request.errors`) that don't match the metric names derived by the testbench (`trace.hits`, `trace.duration`, `trace.latency.*`). Ground truth labels need updating.
- ScanWelch found 1/4 TPs on 353_postmark (`redis.net.commands`) — the only infrastructure metric in the TP list.
- The scoring infrastructure works end-to-end; TP labels just need to be aligned with actual metric names.

## Open Issues

1. **353_postmark F1=0**: MAYBE rooted in the fact that `353` is the longest scenario ? 
2. **TP F1~=0**: metrics from gensim `scenario.yaml` are not present in the parquet replay data (?)

## Test plan

- [x] `go test ./comp/observer/impl/ -run "TestScanMW|TestScanWelch"` — 14 detector tests pass
- [x] `go test ./comp/observer/impl/ -run "TestScoreMetrics"` — 8 TP scoring tests pass
- [x] `go test ./comp/observer/impl/ -run "TestMetricMatches"` — 6 matching tests pass
- [x] `go build ./comp/observer/impl/` — compiles
- [x] `go build ./cmd/observer-scorer/` — compiles
- [x] `go build ./cmd/observer-testbench/` — compiles
- [x] Full 18-run eval across 3 scenarios × 3 detectors × 2 correlator modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
