### PR TITLE
[observer] Add ContextProvider for metric origin context

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -841,5 +841,5 @@
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 
-/q_branch/                               @scottopell @val06
+/q_branch/                               @scottopell @lukesteensen
 /tasks/q.py                              @scottopell @lukesteensen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -842,3 +842,4 @@
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 
 /q_branch/                               @scottopell @val06
+/tasks/q.py                              @scottopell @lukesteensen

--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -58,7 +58,7 @@ Aggregation is chosen at **read time**, not write time. Storage always keeps the
 
 The observer is currently **metric-type agnostic** — it does not distinguish between Count, Gauge, Rate, etc. All metrics are treated uniformly as samples to be summarized. This is a bet on a simpler unified model; we'll see over time whether there's a good reason to introduce type-specific logic.
 
-Metrics from logs are stored with a `_virtual.` prefix (e.g. `_virtual.log.field.duration`) to distinguish them from directly observed metrics.
+Metrics from logs are stored under the extractor's component name as the namespace (e.g. `log_metrics_extractor`), distinguishing them from directly observed metrics.
 
 ### 3. Detect
 
@@ -116,7 +116,7 @@ When a log is observed, two things happen:
    ```
    ProcessLog(log LogView) → []MetricOutput
    ```
-   Each returned metric is stored as `_virtual.{name}` and flows through normal detection. Implementations should be stateless and fast.
+   Each returned metric is stored under the extractor's component name as the namespace and flows through normal detection. Implementations should be stateless and fast.
 
 2. **Detectors implementing LogObserver** receive the raw log directly, allowing log-based anomaly detection without the metrics extraction step.
 
@@ -228,7 +228,7 @@ func (m *MyExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
     content := string(log.GetContent())
     // Extract what you need synchronously — don't store the view
     return []observer.MetricOutput{{
-        Name:  "my.metric",    // stored as _virtual.my.metric
+        Name:  "my.metric",    // stored under the extractor's name as namespace
         Value: 1,
         Tags:  log.GetTags(),
     }}

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -445,6 +445,26 @@ const (
 	AggregateMax
 )
 
+// ContextProvider resolves metric keys back to richer context about their
+// origin. Components that synthesize metrics from richer data (e.g. log
+// extractors that turn log patterns into count metrics) can implement this
+// interface so that downstream consumers (detectors, reporters) can produce
+// more descriptive anomaly reports.
+type ContextProvider interface {
+	// GetContext returns contextual information about a metric, if available.
+	GetContext(metricName string) (MetricContext, bool)
+}
+
+// MetricContext describes the origin of a synthesized metric.
+type MetricContext struct {
+	// Pattern is the normalized pattern that generated this metric (e.g. a log signature).
+	Pattern string
+	// Example is a recent raw input that matched the pattern.
+	Example string
+	// Source identifies the originating component or data stream.
+	Source string
+}
+
 // StorageReader provides read access to time series data.
 // Detectors use this to pull whatever data they need.
 //
@@ -499,6 +519,12 @@ type StorageReader interface {
 	// set of known series changes. Use this to cache ListSeries results and
 	// refresh them only when new series keys appear.
 	SeriesGeneration() uint64
+
+	// GetContext returns contextual information about a metric's origin.
+	// For metrics synthesized from richer data (e.g. log pattern counts),
+	// this provides the pattern, an example input, and the source component.
+	// Returns false if no context is available for the given metric name.
+	GetContext(metricName string) (MetricContext, bool)
 }
 
 // Detector is the flexible detection interface where detectors pull data from storage.

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -498,7 +498,7 @@ func AggregateString(agg Aggregate) string {
 // more descriptive anomaly reports.
 type ContextProvider interface {
 	// GetContext returns contextual information about a metric, if available.
-	GetContext(metricName string) (MetricContext, bool)
+	GetContext(metricName string, tags []string) (MetricContext, bool)
 }
 
 // MetricContext describes the origin of a synthesized metric.

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -309,9 +309,12 @@ type Anomaly struct {
 	DetectorName string
 	Title        string
 	Description  string
-	Tags         []string
-	Timestamp    int64    // when the anomaly was detected (unix seconds)
-	Score        *float64 // confidence/severity score (nil if not available)
+	// Context carries optional enrichment about the originating signal, such as
+	// a synthesized pattern and example source data.
+	Context   *MetricContext
+	Tags      []string
+	Timestamp int64    // when the anomaly was detected (unix seconds)
+	Score     *float64 // confidence/severity score (nil if not available)
 	// DebugInfo contains detector-specific debug information explaining the detection.
 	DebugInfo *AnomalyDebugInfo
 }

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -478,7 +478,7 @@ func AggregateString(agg Aggregate) string {
 	case AggregateMax:
 		return "max"
 	default:
-		return "avg"
+		return "unknown"
 	}
 }
 
@@ -556,12 +556,6 @@ type StorageReader interface {
 	// set of known series changes. Use this to cache ListSeries results and
 	// refresh them only when new series keys appear.
 	SeriesGeneration() uint64
-
-	// GetContext returns contextual information about a metric's origin.
-	// The namespace identifies the component that produced the metric;
-	// name is the bare metric name within that namespace.
-	// Returns false if no context is available.
-	GetContext(namespace, name string) (MetricContext, bool)
 }
 
 // Detector is the flexible detection interface where detectors pull data from storage.

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -277,6 +277,9 @@ func (s AnomalySource) String() string {
 	if s.Name == "" {
 		return ""
 	}
+	if s.Aggregate == AggregateNone {
+		return s.Name
+	}
 	return s.Name + ":" + AggregateString(s.Aggregate)
 }
 
@@ -460,7 +463,8 @@ type SeriesMeta struct {
 type Aggregate int
 
 const (
-	AggregateAverage Aggregate = iota
+	AggregateNone Aggregate = iota
+	AggregateAverage
 	AggregateSum
 	AggregateCount
 	AggregateMin
@@ -470,6 +474,8 @@ const (
 // AggregateString returns a short string label for the aggregation type.
 func AggregateString(agg Aggregate) string {
 	switch agg {
+	case AggregateNone:
+		return "none"
 	case AggregateAverage:
 		return "avg"
 	case AggregateSum:

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -259,6 +259,27 @@ type MetricOutput struct {
 // Multiple series can share a MetricName if they differ by tags.
 type MetricName string
 
+// AnomalySource identifies the metric that an anomaly is about using
+// structured fields rather than string concatenation.
+type AnomalySource struct {
+	// Namespace identifies the component that produced this metric
+	// (e.g. an extractor name like "log_metrics_extractor", or "dogstatsd").
+	Namespace string
+	// Name is the base metric name (e.g. "log.pattern.<hash>.count", "cpu.user").
+	Name string
+	// Aggregate is the aggregation applied when reading the series.
+	Aggregate Aggregate
+}
+
+// String returns a human-readable representation (e.g. "cpu.user:avg").
+// Namespace is structural and not included in the display string.
+func (s AnomalySource) String() string {
+	if s.Name == "" {
+		return ""
+	}
+	return s.Name + ":" + AggregateString(s.Aggregate)
+}
+
 // SeriesID uniquely identifies a time series (namespace + name + tags).
 type SeriesID string
 
@@ -279,10 +300,8 @@ type Anomaly struct {
 	// Type distinguishes log-based anomalies from metric-based ones.
 	// Defaults to AnomalyTypeMetric if not set.
 	Type AnomalyType
-	// Source identifies which metric/signal or log source the anomaly is about.
-	// For metric anomalies: the metric name (e.g., "network.retransmits:avg").
-	// For log anomalies: a descriptive source identifier (e.g., "logs").
-	Source MetricName
+	// Source identifies which metric/signal the anomaly is about.
+	Source AnomalySource
 	// SourceSeriesID uniquely identifies the source series (namespace + name + tags).
 	// Empty for log anomalies.
 	SourceSeriesID SeriesID
@@ -445,6 +464,24 @@ const (
 	AggregateMax
 )
 
+// AggregateString returns a short string label for the aggregation type.
+func AggregateString(agg Aggregate) string {
+	switch agg {
+	case AggregateAverage:
+		return "avg"
+	case AggregateSum:
+		return "sum"
+	case AggregateCount:
+		return "count"
+	case AggregateMin:
+		return "min"
+	case AggregateMax:
+		return "max"
+	default:
+		return "avg"
+	}
+}
+
 // ContextProvider resolves metric keys back to richer context about their
 // origin. Components that synthesize metrics from richer data (e.g. log
 // extractors that turn log patterns into count metrics) can implement this
@@ -521,10 +558,10 @@ type StorageReader interface {
 	SeriesGeneration() uint64
 
 	// GetContext returns contextual information about a metric's origin.
-	// For metrics synthesized from richer data (e.g. log pattern counts),
-	// this provides the pattern, an example input, and the source component.
-	// Returns false if no context is available for the given metric name.
-	GetContext(metricName string) (MetricContext, bool)
+	// The namespace identifies the component that produced the metric;
+	// name is the bare metric name within that namespace.
+	// Returns false if no context is available.
+	GetContext(namespace, name string) (MetricContext, bool)
 }
 
 // Detector is the flexible detection interface where detectors pull data from storage.

--- a/comp/observer/impl/agent_internal_logs_test.go
+++ b/comp/observer/impl/agent_internal_logs_test.go
@@ -51,7 +51,7 @@ func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(sig))
 	metricName := "log.pattern." + toHex64(h.Sum64()) + ".count"
-	tags := []string{"source:datadog-agent", "component:core", "level:info"}
+	tags := []string{"component:core", "level:info", "observer_source:agent-internal-logs", "source:datadog-agent"}
 
 	// Poll briefly since observer processes asynchronously.
 	// Namespace is the extractor component name (log_metrics_extractor).

--- a/comp/observer/impl/agent_internal_logs_test.go
+++ b/comp/observer/impl/agent_internal_logs_test.go
@@ -50,13 +50,14 @@ func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
 	sig := logSignature(payload, 4096)
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(sig))
-	metricName := "_virtual.log.pattern." + toHex64(h.Sum64()) + ".count"
+	metricName := "log.pattern." + toHex64(h.Sum64()) + ".count"
 	tags := []string{"source:datadog-agent", "component:core", "level:info"}
 
 	// Poll briefly since observer processes asynchronously.
+	// Namespace is the extractor component name (log_metrics_extractor).
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if s := obs.engine.Storage().GetSeries("agent-internal-logs", metricName, tags, AggregateSum); s != nil && len(s.Points) > 0 {
+		if s := obs.engine.Storage().GetSeries("log_metrics_extractor", metricName, tags, AggregateSum); s != nil && len(s.Points) > 0 {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -21,13 +21,13 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 
 	// Two anomalies with nearby timestamps should cluster together
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
 		Timestamp:      105, // 5 seconds later, within 10s proximity
@@ -48,13 +48,13 @@ func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 
 	// Anomalies within proximity window should cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
 		Timestamp:      108, // 8 seconds later, within 10s proximity
@@ -73,13 +73,13 @@ func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 
 	// Anomalies outside proximity window should form separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
 		Timestamp:      150, // 50 seconds later, outside 10s proximity
@@ -100,13 +100,13 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Create two separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
 		Timestamp:      120, // Far enough to be separate (20s apart)
@@ -117,7 +117,7 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Add anomaly that bridges both clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.c",
+		Source:         observer.AnomalySource{Name: "metric.c"},
 		SourceSeriesID: "ns|metric.c|",
 		Title:          "Anomaly C",
 		Timestamp:      110, // Near both clusters
@@ -138,14 +138,14 @@ func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 
 	// Multiple anomalies from the same series should all be kept
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A v1",
 		Description:    "first",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A v2",
 		Description:    "second",
@@ -168,13 +168,13 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 	// Same metric name, different tags = different SourceSeriesIDs
 	// Both should be separate members in the cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|host:A",
 		Title:          "Anomaly from host A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|host:B",
 		Title:          "Anomaly from host B",
 		Timestamp:      102,
@@ -195,7 +195,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	// Add old anomaly
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.old",
+		Source:         observer.AnomalySource{Name: "metric.old"},
 		SourceSeriesID: "ns|metric.old|",
 		Title:          "Old Anomaly",
 		Timestamp:      100,
@@ -203,7 +203,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	// Add recent anomaly (advances currentDataTime)
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.new",
+		Source:         observer.AnomalySource{Name: "metric.new"},
 		SourceSeriesID: "ns|metric.new|",
 		Title:          "New Anomaly",
 		Timestamp:      200, // 100 seconds later, old one should be evicted
@@ -225,7 +225,7 @@ func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 
 	// A single anomaly should form a cluster of one
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Timestamp:      100,
 	})
@@ -244,28 +244,28 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Create a cluster of 2 and a cluster of 3
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Timestamp:      105,
 	})
 
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.c",
+		Source:         observer.AnomalySource{Name: "metric.c"},
 		SourceSeriesID: "ns|metric.c|",
 		Timestamp:      200,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.d",
+		Source:         observer.AnomalySource{Name: "metric.d"},
 		SourceSeriesID: "ns|metric.d|",
 		Timestamp:      205,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.e",
+		Source:         observer.AnomalySource{Name: "metric.e"},
 		SourceSeriesID: "ns|metric.e|",
 		Timestamp:      208,
 	})
@@ -284,7 +284,7 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Once the small cluster grows to meet threshold, it should appear
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.f",
+		Source:         observer.AnomalySource{Name: "metric.f"},
 		SourceSeriesID: "ns|metric.f|",
 		Timestamp:      103,
 	})

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -139,10 +139,10 @@ func (c *CrossSignalCorrelator) Advance(dataTime int64) {
 	// Evict old entries before checking patterns
 	c.evictOldEntries()
 
-	// Extract unique signal sources from anomalies
+	// Extract unique signal sources from anomalies (display names for pattern matching)
 	sourceSet := make(map[observer.MetricName]struct{})
 	for _, entry := range c.buffer {
-		sourceSet[entry.anomaly.Source] = struct{}{}
+		sourceSet[observer.MetricName(entry.anomaly.Source.String())] = struct{}{}
 	}
 
 	// Track which patterns are currently active
@@ -209,8 +209,9 @@ func (c *CrossSignalCorrelator) collectMatchingAnomalies(pattern correlationPatt
 	bySource := make(map[observer.MetricName]observer.Anomaly)
 
 	for _, entry := range c.buffer {
+		display := observer.MetricName(entry.anomaly.Source.String())
 		for _, src := range pattern.requiredSources {
-			if entry.anomaly.Source == src {
+			if display == src {
 				existing, exists := bySource[src]
 				// Keep the one with the later timestamp (more recent)
 				if !exists || entry.anomaly.Timestamp > existing.Timestamp {

--- a/comp/observer/impl/anomaly_processor_correlator_test.go
+++ b/comp/observer/impl/anomaly_processor_correlator_test.go
@@ -17,7 +17,7 @@ func TestCorrelator_SingleAnomalyNoReport(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 	})
@@ -32,12 +32,12 @@ func TestCorrelator_TwoAnomaliesSameSignalNoReport(t *testing.T) {
 
 	// Add two anomalies from the same signal
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits 1",
 		Description: "First occurrence",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits 2",
 		Description: "Second occurrence",
 	})
@@ -53,17 +53,17 @@ func TestCorrelator_ThreeRequiredSignalsProduceReport(t *testing.T) {
 	// Add anomalies from all three required signals for kernel bottleneck pattern
 	// Note: Source names now include aggregation suffix (avg for value, count for frequency)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Title:       "Lock contention",
 		Description: "High lock contention detected",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Title:       "Connection errors",
 		Description: "Connection error rate elevated",
 	})
@@ -100,7 +100,7 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 
 	// Add first anomaly at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 		Timestamp:   1000,
@@ -108,13 +108,13 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 
 	// Add remaining anomalies at data time 1031 (31 seconds later, beyond window)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Title:       "Lock contention",
 		Description: "High lock contention detected",
 		Timestamp:   1031,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Title:       "Connection errors",
 		Description: "Connection error rate elevated",
 		Timestamp:   1031,
@@ -130,9 +130,9 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -153,9 +153,9 @@ func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -170,9 +170,9 @@ func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
 func TestCorrelator_BufferNotClearedAfterAdvance(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
 
 	// First flush should create active correlations
 	correlator.Advance(0)
@@ -202,8 +202,8 @@ func TestCorrelator_PartialPatternNoActiveCorrelation(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Only two of three required signals
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -214,10 +214,10 @@ func TestCorrelator_ExtraSignalsStillMatch(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// All required signals plus an extra one
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "extra.signal:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "extra.signal"}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -240,15 +240,15 @@ func TestCorrelator_ActiveCorrelationTimestamps(t *testing.T) {
 
 	// Add all required signals at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "network.retransmits:avg",
+		Source:    observer.AnomalySource{Name: "network.retransmits"},
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "ebpf.lock_contention_ns:avg",
+		Source:    observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "connection.errors:count",
+		Source:    observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Timestamp: 1000,
 	})
 
@@ -266,7 +266,7 @@ func TestCorrelator_ActiveCorrelationTimestamps(t *testing.T) {
 
 	// Add new anomalies at data time 1010
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "network.retransmits:avg",
+		Source:    observer.AnomalySource{Name: "network.retransmits"},
 		Timestamp: 1010,
 	})
 
@@ -291,15 +291,15 @@ func TestCorrelator_ActiveCorrelationCleared(t *testing.T) {
 
 	// Add all required signals at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "network.retransmits:avg",
+		Source:    observer.AnomalySource{Name: "network.retransmits"},
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "ebpf.lock_contention_ns:avg",
+		Source:    observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "connection.errors:count",
+		Source:    observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Timestamp: 1000,
 	})
 
@@ -310,7 +310,7 @@ func TestCorrelator_ActiveCorrelationCleared(t *testing.T) {
 	// Add an anomaly at data time 1035 (35 seconds later), which advances currentDataTime
 	// and causes all previous signals to expire (1000 < 1035 - 30 = 1005)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "some.other.signal:avg",
+		Source:    observer.AnomalySource{Name: "some.other.signal"},
 		Timestamp: 1035,
 	})
 	correlator.Advance(0)
@@ -323,17 +323,17 @@ func TestCorrelator_ActiveCorrelationContainsAnomalies(t *testing.T) {
 
 	// Add anomalies with descriptions for all required signals
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits",
 		Description: "network.retransmits:avg elevated: recent avg 100 vs baseline 10 (>3 stddev)",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Title:       "Lock contention",
 		Description: "ebpf.lock_contention_ns:avg elevated: recent avg 500 vs baseline 50 (>3 stddev)",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Title:       "Connection errors",
 		Description: "connection.errors:count elevated: recent avg 25 vs baseline 2 (>3 stddev)",
 	})
@@ -365,17 +365,17 @@ func TestCorrelator_AnomaliesUpdatedOnAdvance(t *testing.T) {
 
 	// Add initial anomalies - all within 30 second window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "first retransmits anomaly",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Description: "first lock contention anomaly",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Description: "first connection errors anomaly",
 		Timestamp:   1010,
 	})
@@ -390,7 +390,7 @@ func TestCorrelator_AnomaliesUpdatedOnAdvance(t *testing.T) {
 
 	// Add another anomaly for one of the signals with later timestamp (still within 30s window)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "second retransmits anomaly",
 		Timestamp:   1020, // later but within window
 	})
@@ -411,29 +411,29 @@ func TestCorrelator_DedupesBySourceKeepingMostRecent(t *testing.T) {
 	// Add multiple anomalies for the same source with different timestamps
 	// All timestamps within the 30-second window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "oldest retransmits",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "newest retransmits", // should be kept
 		Timestamp:   1025,                 // latest timestamp
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "middle retransmits",
 		Timestamp:   1015,
 	})
 
 	// Add other required signals - all within window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Description: "lock contention",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Description: "connection errors",
 		Timestamp:   1010,
 	})
@@ -451,7 +451,7 @@ func TestCorrelator_DedupesBySourceKeepingMostRecent(t *testing.T) {
 
 	// Find the network.retransmits anomaly and verify it's the newest one
 	for _, a := range anomalies {
-		if string(a.Source) == "network.retransmits:avg" {
+		if a.Source.String() == "network.retransmits:avg" {
 			assert.Equal(t, "newest retransmits", a.Description, "should keep anomaly with latest timestamp")
 			assert.Equal(t, int64(1025), a.Timestamp, "should have latest timestamp")
 		}
@@ -463,19 +463,19 @@ func TestCorrelator_AnomaliesOnlyIncludesMatchingSignals(t *testing.T) {
 
 	// Add all required signals plus an extra one
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "retransmits anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Description: "lock contention anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Description: "connection errors anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "extra.signal:avg",
+		Source:      observer.AnomalySource{Name: "extra.signal"},
 		Description: "extra signal anomaly",
 	})
 
@@ -493,6 +493,6 @@ func TestCorrelator_AnomaliesOnlyIncludesMatchingSignals(t *testing.T) {
 
 	// Verify extra signal is not included
 	for _, a := range anomalies {
-		assert.NotEqual(t, "extra.signal:avg", string(a.Source), "extra signal should not be in anomalies")
+		assert.NotEqual(t, "extra.signal:avg", a.Source.String(), "extra signal should not be in anomalies")
 	}
 }

--- a/comp/observer/impl/consumer_memory.go
+++ b/comp/observer/impl/consumer_memory.go
@@ -80,9 +80,9 @@ func (r *StdoutReporter) reportNewAnomalies(anomalies []observer.Anomaly) {
 	}
 
 	for _, anomaly := range anomalies {
-		key := string(anomaly.Source) + "|" + anomaly.DetectorName
+		key := anomaly.Source.String() + "|" + anomaly.DetectorName
 		if !r.seenRawAnomalies[key] {
-			fmt.Printf("[observer] [%s] ANOMALY: %s\n", anomaly.DetectorName, anomaly.Source)
+			fmt.Printf("[observer] [%s] ANOMALY: %s\n", anomaly.DetectorName, anomaly.Source.String())
 			fmt.Printf("           %s\n", anomaly.Description)
 			r.seenRawAnomalies[key] = true
 		}

--- a/comp/observer/impl/context_provider.go
+++ b/comp/observer/impl/context_provider.go
@@ -25,8 +25,9 @@ func collectContextProviders(extractors []observer.LogMetricsExtractor) map[stri
 
 // truncate shortens s to maxLen, appending "..." if truncated.
 func truncate(s string, maxLen int) string {
-	if len(s) <= maxLen {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
 		return s
 	}
-	return s[:maxLen] + "..."
+	return string(runes[:maxLen]) + "..."
 }

--- a/comp/observer/impl/context_provider.go
+++ b/comp/observer/impl/context_provider.go
@@ -9,32 +9,34 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-// contextAwareStorage wraps a StorageReader with a set of ContextProviders,
+// contextAwareStorage wraps a StorageReader with namespace-keyed ContextProviders,
 // adding GetContext resolution to the storage interface. Detectors receive
-// this instead of bare storage so they can enrich anomalies with origin info.
+// this instead of bare storage so they can query context by namespace + name.
 type contextAwareStorage struct {
 	observer.StorageReader
-	providers []observer.ContextProvider
+	providers map[string]observer.ContextProvider // namespace → provider
 }
 
-// GetContext queries registered ContextProviders in order, returning the first match.
-func (s *contextAwareStorage) GetContext(metricName string) (observer.MetricContext, bool) {
-	for _, cp := range s.providers {
-		if info, ok := cp.GetContext(metricName); ok {
-			return info, true
-		}
+// GetContext looks up the provider for the given namespace, then queries it
+// with the bare metric name. Returns false if no provider exists for the
+// namespace or if the provider has no context for the name.
+func (s *contextAwareStorage) GetContext(namespace, name string) (observer.MetricContext, bool) {
+	cp, ok := s.providers[namespace]
+	if !ok {
+		return observer.MetricContext{}, false
 	}
-	return observer.MetricContext{}, false
+	return cp.GetContext(name)
 }
 
 // collectContextProviders discovers ContextProvider implementations among
-// instantiated extractors via type assertion. This is called during catalog
-// instantiation so the engine receives providers without any schema changes.
-func collectContextProviders(extractors []observer.LogMetricsExtractor) []observer.ContextProvider {
-	var providers []observer.ContextProvider
+// instantiated extractors via type assertion. Returns a map keyed by the
+// extractor's component name (which is used as the storage namespace for
+// its metrics), enabling O(1) lookup during anomaly enrichment.
+func collectContextProviders(extractors []observer.LogMetricsExtractor) map[string]observer.ContextProvider {
+	providers := make(map[string]observer.ContextProvider)
 	for _, ext := range extractors {
 		if cp, ok := ext.(observer.ContextProvider); ok {
-			providers = append(providers, cp)
+			providers[ext.Name()] = cp
 		}
 	}
 	return providers

--- a/comp/observer/impl/context_provider.go
+++ b/comp/observer/impl/context_provider.go
@@ -9,25 +9,6 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-// contextAwareStorage wraps a StorageReader with namespace-keyed ContextProviders,
-// adding GetContext resolution to the storage interface. Detectors receive
-// this instead of bare storage so they can query context by namespace + name.
-type contextAwareStorage struct {
-	observer.StorageReader
-	providers map[string]observer.ContextProvider // namespace → provider
-}
-
-// GetContext looks up the provider for the given namespace, then queries it
-// with the bare metric name. Returns false if no provider exists for the
-// namespace or if the provider has no context for the name.
-func (s *contextAwareStorage) GetContext(namespace, name string) (observer.MetricContext, bool) {
-	cp, ok := s.providers[namespace]
-	if !ok {
-		return observer.MetricContext{}, false
-	}
-	return cp.GetContext(name)
-}
-
 // collectContextProviders discovers ContextProvider implementations among
 // instantiated extractors via type assertion. Returns a map keyed by the
 // extractor's component name (which is used as the storage namespace for

--- a/comp/observer/impl/context_provider.go
+++ b/comp/observer/impl/context_provider.go
@@ -6,8 +6,23 @@
 package observerimpl
 
 import (
+	"fmt"
+
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
+
+// validateUniqueExtractorNames rejects duplicate runtime extractor names since
+// they are used as namespaces in storage and context lookup.
+func validateUniqueExtractorNames(extractors []observer.LogMetricsExtractor) {
+	seen := make(map[string]struct{}, len(extractors))
+	for _, ext := range extractors {
+		name := ext.Name()
+		if _, ok := seen[name]; ok {
+			panic(fmt.Sprintf("duplicate log extractor name: %q", name))
+		}
+		seen[name] = struct{}{}
+	}
+}
 
 // collectContextProviders discovers ContextProvider implementations among
 // instantiated extractors via type assertion. Returns a map keyed by the

--- a/comp/observer/impl/context_provider.go
+++ b/comp/observer/impl/context_provider.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// contextAwareStorage wraps a StorageReader with a set of ContextProviders,
+// adding GetContext resolution to the storage interface. Detectors receive
+// this instead of bare storage so they can enrich anomalies with origin info.
+type contextAwareStorage struct {
+	observer.StorageReader
+	providers []observer.ContextProvider
+}
+
+// GetContext queries registered ContextProviders in order, returning the first match.
+func (s *contextAwareStorage) GetContext(metricName string) (observer.MetricContext, bool) {
+	for _, cp := range s.providers {
+		if info, ok := cp.GetContext(metricName); ok {
+			return info, true
+		}
+	}
+	return observer.MetricContext{}, false
+}
+
+// collectContextProviders discovers ContextProvider implementations among
+// instantiated extractors via type assertion. This is called during catalog
+// instantiation so the engine receives providers without any schema changes.
+func collectContextProviders(extractors []observer.LogMetricsExtractor) []observer.ContextProvider {
+	var providers []observer.ContextProvider
+	for _, ext := range extractors {
+		if cp, ok := ext.(observer.ContextProvider); ok {
+			providers = append(providers, cp)
+		}
+	}
+	return providers
+}

--- a/comp/observer/impl/context_provider.go
+++ b/comp/observer/impl/context_provider.go
@@ -39,3 +39,11 @@ func collectContextProviders(extractors []observer.LogMetricsExtractor) []observ
 	}
 	return providers
 }
+
+// truncate shortens s to maxLen, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/comp/observer/impl/correlation_identity.go
+++ b/comp/observer/impl/correlation_identity.go
@@ -14,10 +14,11 @@ import (
 func sortedUniqueMetricNames(anomalies []observer.Anomaly) []observer.MetricName {
 	seen := make(map[observer.MetricName]struct{})
 	for _, a := range anomalies {
-		if a.Source == "" {
+		display := observer.MetricName(a.Source.String())
+		if display == "" {
 			continue
 		}
-		seen[a.Source] = struct{}{}
+		seen[display] = struct{}{}
 	}
 	names := make([]observer.MetricName, 0, len(seen))
 	for n := range seen {

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -185,7 +185,7 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 	for _, extractor := range e.extractors {
 		metrics := extractor.ProcessLog(view)
 		for _, m := range metrics {
-			tags := append(m.Tags, sourceTag)
+			tags := append(copyTags(m.Tags), sourceTag)
 			e.storage.Add(extractor.Name(), m.Name, m.Value, l.timestampMs/1000, tags)
 		}
 	}
@@ -326,9 +326,11 @@ func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
 	if !ok {
 		return
 	}
-	ctxCopy := ctx
-	ctxCopy.Example = truncate(ctxCopy.Example, 120)
-	a.Context = &ctxCopy
+	a.Context = &observerdef.MetricContext{
+		Pattern: ctx.Pattern,
+		Example: truncate(ctx.Example, 120),
+		Source:  ctx.Source,
+	}
 }
 
 // processAnomaly sends an anomaly to all registered correlators.

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -275,6 +276,7 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	for _, detector := range detectors {
 		result := detector.Detect(storage, upTo)
 		for _, anomaly := range result.Anomalies {
+			e.enrichAnomaly(storage, &anomaly)
 			if !e.captureRawAnomaly(anomaly) {
 				continue // duplicate — skip correlators, events, and reporters
 			}
@@ -315,6 +317,20 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	return advanceResult{
 		anomalies: allAnomalies,
 		telemetry: allTelemetry,
+	}
+}
+
+// enrichAnomaly decorates an anomaly with context from the originating
+// extractor, if available. This runs automatically on every anomaly so
+// detectors don't need to be aware of context providers.
+func (e *engine) enrichAnomaly(storage observerdef.StorageReader, a *observerdef.Anomaly) {
+	ctx, ok := storage.GetContext(string(a.Source))
+	if !ok {
+		return
+	}
+	if a.Description == "" {
+		a.Description = fmt.Sprintf("Pattern %q from %s (e.g. %q)",
+			ctx.Pattern, ctx.Source, truncate(ctx.Example, 120))
 	}
 }
 

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -264,17 +264,8 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	var allAnomalies []observerdef.Anomaly
 	var allTelemetry []observerdef.ObserverTelemetry
 
-	// Wrap storage with context providers so detectors can call GetContext.
-	var storage observerdef.StorageReader = e.storage
-	if len(e.contextProviders) > 0 {
-		storage = &contextAwareStorage{
-			StorageReader: e.storage,
-			providers:     e.contextProviders,
-		}
-	}
-
 	for _, detector := range detectors {
-		result := detector.Detect(storage, upTo)
+		result := detector.Detect(e.storage, upTo)
 		for _, anomaly := range result.Anomalies {
 			e.enrichAnomaly(&anomaly)
 			if !e.captureRawAnomaly(anomaly) {

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -111,6 +111,7 @@ func newEngine(cfg engineConfig) *engine {
 	if sched == nil {
 		sched = &currentBehaviorPolicy{}
 	}
+	validateUniqueExtractorNames(cfg.extractors)
 
 	e := &engine{
 		storage:          cfg.storage,
@@ -322,7 +323,7 @@ func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
 	if !ok {
 		return
 	}
-	ctx, ok := provider.GetContext(a.Source.Name)
+	ctx, ok := provider.GetContext(a.Source.Name, a.Tags)
 	if !ok {
 		return
 	}
@@ -517,7 +518,9 @@ func (e *engine) SetExtractors(extractors []observerdef.LogMetricsExtractor) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	validateUniqueExtractorNames(extractors)
 	e.extractors = extractors
+	e.contextProviders = collectContextProviders(extractors)
 }
 
 // Reset clears analysis state so detectors will re-analyze from scratch.
@@ -537,6 +540,12 @@ func (e *engine) Reset() {
 
 	for _, correlator := range e.correlators {
 		correlator.Reset()
+	}
+
+	for _, extractor := range e.extractors {
+		if resetter, ok := extractor.(interface{ Reset() }); ok {
+			resetter.Reset()
+		}
 	}
 }
 

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -6,7 +6,6 @@
 package observerimpl
 
 import (
-	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -61,10 +60,10 @@ type engine struct {
 	rawAnomalies         []observerdef.Anomaly
 	rawAnomalyIndex      map[anomalyDedupKey]int // O(1) dedup lookup
 	rawAnomalyMu         sync.RWMutex
-	rawAnomalyWindow     int64                           // seconds to keep (0 = unlimited)
-	maxRawAnomalies      int                             // max count to keep (0 = unlimited)
-	currentDataTime      int64                           // latest anomaly timestamp seen
-	totalAnomalyCount    int                                  // total count ever (no cap)
+	rawAnomalyWindow     int64                              // seconds to keep (0 = unlimited)
+	maxRawAnomalies      int                                // max count to keep (0 = unlimited)
+	currentDataTime      int64                              // latest anomaly timestamp seen
+	totalAnomalyCount    int                                // total count ever (no cap)
 	uniqueAnomalySources map[observerdef.AnomalySource]bool // unique sources that had anomalies
 
 	// Accumulated correlations from all advance cycles.
@@ -327,10 +326,9 @@ func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
 	if !ok {
 		return
 	}
-	if a.Description == "" {
-		a.Description = fmt.Sprintf("Pattern %q from %s (e.g. %q)",
-			ctx.Pattern, ctx.Source, truncate(ctx.Example, 120))
-	}
+	ctxCopy := ctx
+	ctxCopy.Example = truncate(ctxCopy.Example, 120)
+	a.Context = &ctxCopy
 }
 
 // processAnomaly sends an anomaly to all registered correlators.

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -42,7 +42,7 @@ type engine struct {
 	extractors       []observerdef.LogMetricsExtractor
 	detectors        []observerdef.Detector
 	correlators      []observerdef.Correlator
-	contextProviders []observerdef.ContextProvider
+	contextProviders map[string]observerdef.ContextProvider // namespace → provider
 
 	// scheduler decides when the engine should advance analysis.
 	scheduler schedulerPolicy
@@ -64,8 +64,8 @@ type engine struct {
 	rawAnomalyWindow     int64                           // seconds to keep (0 = unlimited)
 	maxRawAnomalies      int                             // max count to keep (0 = unlimited)
 	currentDataTime      int64                           // latest anomaly timestamp seen
-	totalAnomalyCount    int                             // total count ever (no cap)
-	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
+	totalAnomalyCount    int                                  // total count ever (no cap)
+	uniqueAnomalySources map[observerdef.AnomalySource]bool // unique sources that had anomalies
 
 	// Accumulated correlations from all advance cycles.
 	// Correlators maintain sliding windows that evict old state, but for
@@ -97,7 +97,7 @@ type engineConfig struct {
 	extractors       []observerdef.LogMetricsExtractor
 	detectors        []observerdef.Detector
 	correlators      []observerdef.Correlator
-	contextProviders []observerdef.ContextProvider
+	contextProviders map[string]observerdef.ContextProvider // namespace → provider
 
 	// scheduler is the scheduling policy. If nil, defaults to currentBehaviorPolicy.
 	scheduler schedulerPolicy
@@ -185,7 +185,7 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 	for _, extractor := range e.extractors {
 		metrics := extractor.ProcessLog(view)
 		for _, m := range metrics {
-			e.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
+			e.storage.Add(extractor.Name(), m.Name, m.Value, l.timestampMs/1000, m.Tags)
 		}
 	}
 	for _, lo := range e.logObservers {
@@ -276,7 +276,7 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	for _, detector := range detectors {
 		result := detector.Detect(storage, upTo)
 		for _, anomaly := range result.Anomalies {
-			e.enrichAnomaly(storage, &anomaly)
+			e.enrichAnomaly(&anomaly)
 			if !e.captureRawAnomaly(anomaly) {
 				continue // duplicate — skip correlators, events, and reporters
 			}
@@ -323,8 +323,14 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 // enrichAnomaly decorates an anomaly with context from the originating
 // extractor, if available. This runs automatically on every anomaly so
 // detectors don't need to be aware of context providers.
-func (e *engine) enrichAnomaly(storage observerdef.StorageReader, a *observerdef.Anomaly) {
-	ctx, ok := storage.GetContext(string(a.Source))
+// Lookup is keyed by the anomaly's namespace (= extractor component name),
+// so there's no string munging — the namespace is a direct map key.
+func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
+	provider, ok := e.contextProviders[a.Source.Namespace]
+	if !ok {
+		return
+	}
+	ctx, ok := provider.GetContext(a.Source.Name)
 	if !ok {
 		return
 	}
@@ -351,7 +357,7 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 	e.totalAnomalyCount++
 
 	if e.uniqueAnomalySources == nil {
-		e.uniqueAnomalySources = make(map[observerdef.MetricName]bool)
+		e.uniqueAnomalySources = make(map[observerdef.AnomalySource]bool)
 	}
 	const maxUniqueSources = 500
 	if len(e.uniqueAnomalySources) < maxUniqueSources {

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -37,10 +37,11 @@ type engine struct {
 	// take a write lock; readers (stateView methods) take a read lock.
 	mu sync.RWMutex
 
-	storage     *timeSeriesStorage
-	extractors  []observerdef.LogMetricsExtractor
-	detectors   []observerdef.Detector
-	correlators []observerdef.Correlator
+	storage          *timeSeriesStorage
+	extractors       []observerdef.LogMetricsExtractor
+	detectors        []observerdef.Detector
+	correlators      []observerdef.Correlator
+	contextProviders []observerdef.ContextProvider
 
 	// scheduler decides when the engine should advance analysis.
 	scheduler schedulerPolicy
@@ -91,10 +92,11 @@ type engine struct {
 
 // engineConfig holds the parameters for constructing an engine.
 type engineConfig struct {
-	storage     *timeSeriesStorage
-	extractors  []observerdef.LogMetricsExtractor
-	detectors   []observerdef.Detector
-	correlators []observerdef.Correlator
+	storage          *timeSeriesStorage
+	extractors       []observerdef.LogMetricsExtractor
+	detectors        []observerdef.Detector
+	correlators      []observerdef.Correlator
+	contextProviders []observerdef.ContextProvider
 
 	// scheduler is the scheduling policy. If nil, defaults to currentBehaviorPolicy.
 	scheduler schedulerPolicy
@@ -111,11 +113,12 @@ func newEngine(cfg engineConfig) *engine {
 	}
 
 	e := &engine{
-		storage:     cfg.storage,
-		extractors:  cfg.extractors,
-		detectors:   cfg.detectors,
-		correlators: cfg.correlators,
-		scheduler:   sched,
+		storage:          cfg.storage,
+		extractors:       cfg.extractors,
+		detectors:        cfg.detectors,
+		correlators:      cfg.correlators,
+		contextProviders: cfg.contextProviders,
+		scheduler:        sched,
 
 		rawAnomalyWindow: cfg.rawAnomalyWindow,
 		maxRawAnomalies:  cfg.maxRawAnomalies,
@@ -260,8 +263,17 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	var allAnomalies []observerdef.Anomaly
 	var allTelemetry []observerdef.ObserverTelemetry
 
+	// Wrap storage with context providers so detectors can call GetContext.
+	var storage observerdef.StorageReader = e.storage
+	if len(e.contextProviders) > 0 {
+		storage = &contextAwareStorage{
+			StorageReader: e.storage,
+			providers:     e.contextProviders,
+		}
+	}
+
 	for _, detector := range detectors {
-		result := detector.Detect(e.storage, upTo)
+		result := detector.Detect(storage, upTo)
 		for _, anomaly := range result.Anomalies {
 			if !e.captureRawAnomaly(anomaly) {
 				continue // duplicate — skip correlators, events, and reporters

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -182,10 +182,12 @@ func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
 // detectors should advance. Returns advance requests that the caller should execute.
 func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 	view := &logView{obs: l}
+	sourceTag := "observer_source:" + source
 	for _, extractor := range e.extractors {
 		metrics := extractor.ProcessLog(view)
 		for _, m := range metrics {
-			e.storage.Add(extractor.Name(), m.Name, m.Value, l.timestampMs/1000, m.Tags)
+			tags := append(m.Tags, sourceTag)
+			e.storage.Add(extractor.Name(), m.Name, m.Value, l.timestampMs/1000, tags)
 		}
 	}
 	for _, lo := range e.logObservers {

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -114,12 +114,37 @@ func (d *anomalyDetector) Detect(_ observerdef.StorageReader, _ int64) observerd
 }
 
 type stubContextProvider struct {
-	context observerdef.MetricContext
-	ok      bool
+	context             observerdef.MetricContext
+	ok                  bool
+	requestedMetricName string
+	requestedTags       []string
 }
 
-func (p *stubContextProvider) GetContext(_ string) (observerdef.MetricContext, bool) {
+func (p *stubContextProvider) GetContext(metricName string, tags []string) (observerdef.MetricContext, bool) {
+	p.requestedMetricName = metricName
+	p.requestedTags = copyTags(tags)
 	return p.context, p.ok
+}
+
+type stubExtractor struct {
+	name            string
+	contextBySeries map[string]observerdef.MetricContext
+	resetCount      int
+}
+
+func (e *stubExtractor) Name() string { return e.name }
+
+func (e *stubExtractor) ProcessLog(_ observerdef.LogView) []observerdef.MetricOutput {
+	return nil
+}
+
+func (e *stubExtractor) GetContext(metricName string, tags []string) (observerdef.MetricContext, bool) {
+	ctx, ok := e.contextBySeries[logMetricContextKey(metricName, tags)]
+	return ctx, ok
+}
+
+func (e *stubExtractor) Reset() {
+	e.resetCount++
 }
 
 type resettableDetector struct {
@@ -190,6 +215,14 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 }
 
 func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T) {
+	provider := &stubContextProvider{
+		context: observerdef.MetricContext{
+			Pattern: "error <*> timeout",
+			Example: "very long example line that should still be attached as context without replacing the detector description",
+			Source:  "log_metrics_extractor",
+		},
+		ok: true,
+	}
 	anomalies := []observerdef.Anomaly{{
 		Source: observerdef.AnomalySource{
 			Namespace: "log_metrics_extractor",
@@ -198,6 +231,7 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 		},
 		DetectorName:   "test",
 		Description:    "detector-authored description",
+		Tags:           []string{"observer_source:source-a", "service:api"},
 		Timestamp:      99,
 		SourceSeriesID: "ns|log.pattern.abc.count|",
 	}}
@@ -208,14 +242,7 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 			&anomalyDetector{name: "test", anomalies: anomalies},
 		},
 		contextProviders: map[string]observerdef.ContextProvider{
-			"log_metrics_extractor": &stubContextProvider{
-				context: observerdef.MetricContext{
-					Pattern: "error <*> timeout",
-					Example: "very long example line that should still be attached as context without replacing the detector description",
-					Source:  "log_metrics_extractor",
-				},
-				ok: true,
-			},
+			"log_metrics_extractor": provider,
 		},
 	})
 
@@ -232,6 +259,53 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 	assert.Equal(t, "error <*> timeout", got.Context.Pattern)
 	assert.Equal(t, "log_metrics_extractor", got.Context.Source)
 	assert.Contains(t, got.Context.Example, "very long example line")
+	assert.Equal(t, "log.pattern.abc.count", provider.requestedMetricName)
+	assert.Equal(t, []string{"observer_source:source-a", "service:api"}, provider.requestedTags)
+}
+
+func TestSetExtractorsRefreshesContextProviders(t *testing.T) {
+	first := &stubExtractor{name: "first", contextBySeries: map[string]observerdef.MetricContext{}}
+	second := &stubExtractor{name: "second", contextBySeries: map[string]observerdef.MetricContext{
+		logMetricContextKey("metric", []string{"service:api"}): {Pattern: "p2", Example: "e2", Source: "second"},
+	}}
+	e := newEngine(engineConfig{
+		storage:          newTimeSeriesStorage(),
+		extractors:       []observerdef.LogMetricsExtractor{first},
+		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{first}),
+		detectors: []observerdef.Detector{&anomalyDetector{name: "test", anomalies: []observerdef.Anomaly{{
+			Source:    observerdef.AnomalySource{Namespace: "second", Name: "metric"},
+			Tags:      []string{"service:api"},
+			Timestamp: 1,
+		}}}},
+	})
+
+	e.SetExtractors([]observerdef.LogMetricsExtractor{second})
+	result := e.Advance(2)
+	require.Len(t, result.anomalies, 1)
+	require.NotNil(t, result.anomalies[0].Context)
+	assert.Equal(t, "second", result.anomalies[0].Context.Source)
+}
+
+func TestNewEnginePanicsOnDuplicateExtractorNames(t *testing.T) {
+	first := &stubExtractor{name: "dup", contextBySeries: map[string]observerdef.MetricContext{}}
+	second := &stubExtractor{name: "dup", contextBySeries: map[string]observerdef.MetricContext{}}
+
+	assert.PanicsWithValue(t, `duplicate log extractor name: "dup"`, func() {
+		_ = newEngine(engineConfig{
+			storage:    newTimeSeriesStorage(),
+			extractors: []observerdef.LogMetricsExtractor{first, second},
+		})
+	})
+}
+
+func TestSetExtractorsPanicsOnDuplicateExtractorNames(t *testing.T) {
+	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	first := &stubExtractor{name: "dup", contextBySeries: map[string]observerdef.MetricContext{}}
+	second := &stubExtractor{name: "dup", contextBySeries: map[string]observerdef.MetricContext{}}
+
+	assert.PanicsWithValue(t, `duplicate log extractor name: "dup"`, func() {
+		e.SetExtractors([]observerdef.LogMetricsExtractor{first, second})
+	})
 }
 
 func TestTruncatePreservesUTF8RuneBoundaries(t *testing.T) {
@@ -314,16 +388,19 @@ func TestReplayStoredDataEmitsEventsViaScheduler(t *testing.T) {
 func TestEngineResetResetsDetectorsAndCorrelators(t *testing.T) {
 	detector := &resettableDetector{name: "detector"}
 	correlator := &resettableCorrelator{name: "correlator"}
+	extractor := &stubExtractor{name: "extractor", contextBySeries: map[string]observerdef.MetricContext{}}
 	e := newEngine(engineConfig{
 		storage:     newTimeSeriesStorage(),
 		detectors:   []observerdef.Detector{detector},
 		correlators: []observerdef.Correlator{correlator},
+		extractors:  []observerdef.LogMetricsExtractor{extractor},
 	})
 
 	e.Reset()
 
 	assert.Equal(t, 1, detector.resetCount)
 	assert.Equal(t, 1, correlator.resetCount)
+	assert.Equal(t, 1, extractor.resetCount)
 }
 
 func TestReporterEventSink(t *testing.T) {

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -157,8 +157,8 @@ func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
 
 func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
-		{Source: "cpu", DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|cpu|"},
-		{Source: "mem", DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|mem|"},
+		{Source: observerdef.AnomalySource{Name: "cpu"}, DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|cpu|"},
+		{Source: observerdef.AnomalySource{Name: "mem"}, DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|mem|"},
 	}
 
 	e := newEngine(engineConfig{
@@ -175,8 +175,8 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 
 	anomalyEvents := sink.eventsOfKind(eventAnomalyCreated)
 	assert.Len(t, anomalyEvents, 2)
-	assert.Equal(t, "cpu", string(anomalyEvents[0].anomalyCreated.anomaly.Source))
-	assert.Equal(t, "mem", string(anomalyEvents[1].anomalyCreated.anomaly.Source))
+	assert.Equal(t, "cpu:avg", anomalyEvents[0].anomalyCreated.anomaly.Source.String())
+	assert.Equal(t, "mem:avg", anomalyEvents[1].anomalyCreated.anomaly.Source.String())
 }
 
 func TestAdvanceEmitsCorrelationUpdatedEvents(t *testing.T) {
@@ -286,7 +286,7 @@ func TestReporterEventSink(t *testing.T) {
 		kind:      eventAnomalyCreated,
 		timestamp: 100,
 		anomalyCreated: &anomalyCreatedEvent{
-			anomaly: observerdef.Anomaly{Source: "cpu"},
+			anomaly: observerdef.Anomaly{Source: observerdef.AnomalySource{Name: "cpu"}},
 		},
 	})
 	assert.Equal(t, 1, reported, "anomaly events should not trigger reporter")
@@ -303,7 +303,7 @@ func (r *countingReporter) Report(_ observerdef.ReportOutput) { *r.count++ }
 func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:         "cpu",
+			Source:         observerdef.AnomalySource{Name: "cpu"},
 			SourceSeriesID: "ns|cpu:avg|",
 			DetectorName:   "test_detector",
 			Title:          "Spike detected",
@@ -311,7 +311,7 @@ func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 			Timestamp:      100,
 		},
 		{
-			Source:         "cpu",
+			Source:         observerdef.AnomalySource{Name: "cpu"},
 			SourceSeriesID: "ns|cpu:avg|",
 			DetectorName:   "test_detector",
 			Title:          "Trend change detected",
@@ -339,7 +339,7 @@ func TestFindingM2_EmptySourceSeriesIDCollision(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
 		{
 			Type:           observerdef.AnomalyTypeLog,
-			Source:         "logs",
+			Source:         observerdef.AnomalySource{Name: "logs"},
 			SourceSeriesID: "", // empty for log anomalies
 			DetectorName:   "log_detector",
 			Title:          "Error pattern A detected",
@@ -348,7 +348,7 @@ func TestFindingM2_EmptySourceSeriesIDCollision(t *testing.T) {
 		},
 		{
 			Type:           observerdef.AnomalyTypeLog,
-			Source:         "logs",
+			Source:         observerdef.AnomalySource{Name: "logs"},
 			SourceSeriesID: "", // empty for log anomalies
 			DetectorName:   "log_detector",
 			Title:          "Error pattern B detected",
@@ -376,14 +376,14 @@ func TestFindingM3_DedupAsymmetry(t *testing.T) {
 	// Two identical anomalies (same dedup key) -- one will be deduped from rawAnomalies.
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:         "cpu",
+			Source:         observerdef.AnomalySource{Name: "cpu"},
 			SourceSeriesID: "ns|cpu:avg|",
 			DetectorName:   "test_detector",
 			Title:          "Spike",
 			Timestamp:      100,
 		},
 		{
-			Source:         "cpu",
+			Source:         observerdef.AnomalySource{Name: "cpu"},
 			SourceSeriesID: "ns|cpu:avg|",
 			DetectorName:   "test_detector",
 			Title:          "Spike",

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -185,8 +185,8 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 
 	anomalyEvents := sink.eventsOfKind(eventAnomalyCreated)
 	assert.Len(t, anomalyEvents, 2)
-	assert.Equal(t, "cpu:avg", anomalyEvents[0].anomalyCreated.anomaly.Source.String())
-	assert.Equal(t, "mem:avg", anomalyEvents[1].anomalyCreated.anomaly.Source.String())
+	assert.Equal(t, "cpu", anomalyEvents[0].anomalyCreated.anomaly.Source.String())
+	assert.Equal(t, "mem", anomalyEvents[1].anomalyCreated.anomaly.Source.String())
 }
 
 func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T) {

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -112,6 +112,15 @@ func (d *anomalyDetector) Detect(_ observerdef.StorageReader, _ int64) observerd
 	}
 }
 
+type stubContextProvider struct {
+	context observerdef.MetricContext
+	ok      bool
+}
+
+func (p *stubContextProvider) GetContext(_ string) (observerdef.MetricContext, bool) {
+	return p.context, p.ok
+}
+
 type resettableDetector struct {
 	name       string
 	resetCount int
@@ -177,6 +186,51 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 	assert.Len(t, anomalyEvents, 2)
 	assert.Equal(t, "cpu:avg", anomalyEvents[0].anomalyCreated.anomaly.Source.String())
 	assert.Equal(t, "mem:avg", anomalyEvents[1].anomalyCreated.anomaly.Source.String())
+}
+
+func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T) {
+	anomalies := []observerdef.Anomaly{{
+		Source: observerdef.AnomalySource{
+			Namespace: "log_metrics_extractor",
+			Name:      "log.pattern.abc.count",
+			Aggregate: observerdef.AggregateCount,
+		},
+		DetectorName:   "test",
+		Description:    "detector-authored description",
+		Timestamp:      99,
+		SourceSeriesID: "ns|log.pattern.abc.count|",
+	}}
+
+	e := newEngine(engineConfig{
+		storage: newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{
+			&anomalyDetector{name: "test", anomalies: anomalies},
+		},
+		contextProviders: map[string]observerdef.ContextProvider{
+			"log_metrics_extractor": &stubContextProvider{
+				context: observerdef.MetricContext{
+					Pattern: "error <*> timeout",
+					Example: "very long example line that should still be attached as context without replacing the detector description",
+					Source:  "log_metrics_extractor",
+				},
+				ok: true,
+			},
+		},
+	})
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+
+	e.Advance(100)
+
+	anomalyEvents := sink.eventsOfKind(eventAnomalyCreated)
+	require.Len(t, anomalyEvents, 1)
+	got := anomalyEvents[0].anomalyCreated.anomaly
+	assert.Equal(t, "detector-authored description", got.Description)
+	require.NotNil(t, got.Context)
+	assert.Equal(t, "error <*> timeout", got.Context.Pattern)
+	assert.Equal(t, "log_metrics_extractor", got.Context.Source)
+	assert.Contains(t, got.Context.Example, "very long example line")
 }
 
 func TestAdvanceEmitsCorrelationUpdatedEvents(t *testing.T) {

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
@@ -231,6 +232,12 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 	assert.Equal(t, "error <*> timeout", got.Context.Pattern)
 	assert.Equal(t, "log_metrics_extractor", got.Context.Source)
 	assert.Contains(t, got.Context.Example, "very long example line")
+}
+
+func TestTruncatePreservesUTF8RuneBoundaries(t *testing.T) {
+	got := truncate("hello世界", 6)
+	assert.Equal(t, "hello世...", got)
+	assert.True(t, utf8.ValidString(got))
 }
 
 func TestAdvanceEmitsCorrelationUpdatedEvents(t *testing.T) {
@@ -718,4 +725,27 @@ func TestFindingM12_LogOnlyTimestampsSkippedInReplay(t *testing.T) {
 	assert.True(t, has103,
 		"DataTimestamps() should include timestamp 103 from the log observation, "+
 			"but it only returns metric timestamps: %v", dataTS)
+}
+
+func TestIngestLogCopiesMetricTagsBeforeInjectingObserverSource(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	e := newEngine(engineConfig{
+		storage:    storage,
+		extractors: []observerdef.LogMetricsExtractor{&sharedTagsExtractor{}},
+	})
+
+	e.IngestLog("source-a", &logObs{
+		content:     []byte("hello"),
+		tags:        []string{"env:test"},
+		timestampMs: 1000,
+	})
+
+	seriesA := storage.GetSeries("shared_tags_extractor", "metric.a", []string{"env:test", "observer_source:source-a"}, AggregateAverage)
+	require.NotNil(t, seriesA)
+
+	seriesB := storage.GetSeries("shared_tags_extractor", "metric.b", []string{"env:test", "observer_source:source-a"}, AggregateAverage)
+	require.NotNil(t, seriesB)
+
+	assert.Nil(t, storage.GetSeries("shared_tags_extractor", "metric.a", []string{"env:test", "observer_source:source-a", "observer_source:source-a"}, AggregateAverage))
+	assert.Nil(t, storage.GetSeries("shared_tags_extractor", "metric.b", []string{"env:test", "observer_source:source-a", "observer_source:source-a"}, AggregateAverage))
 }

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -36,19 +36,26 @@ type LogMetricsExtractor struct {
 	ExcludeFields map[string]struct{}
 
 	// patternContext tracks the signature and a recent example for each
-	// pattern metric key. Populated during ProcessLog, read via GetContext.
+	// pattern metric series key (metric name + canonicalized tags). Populated
+	// during ProcessLog, read via GetContext.
 	patternContext map[string]observer.MetricContext
 }
 
 func (a *LogMetricsExtractor) Name() string { return "log_metrics_extractor" }
 
+// Reset clears cached per-series context so replay/reanalysis starts from the
+// currently observed data instead of reusing stale examples.
+func (a *LogMetricsExtractor) Reset() {
+	a.patternContext = nil
+}
+
 // GetContext implements observer.ContextProvider. It returns the pattern
 // signature and a recent example log line for metrics emitted by this extractor.
-func (a *LogMetricsExtractor) GetContext(metricName string) (observer.MetricContext, bool) {
+func (a *LogMetricsExtractor) GetContext(metricName string, tags []string) (observer.MetricContext, bool) {
 	if a.patternContext == nil {
 		return observer.MetricContext{}, false
 	}
-	ctx, ok := a.patternContext[metricName]
+	ctx, ok := a.patternContext[logMetricContextKey(metricName, tags)]
 	return ctx, ok
 }
 
@@ -68,7 +75,7 @@ func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.Metric
 	if a.patternContext == nil {
 		a.patternContext = make(map[string]observer.MetricContext)
 	}
-	a.patternContext[metricName] = observer.MetricContext{
+	a.patternContext[logMetricContextKey(metricName, tags)] = observer.MetricContext{
 		Pattern: patternSig,
 		Example: string(content),
 		Source:  "log_metrics_extractor",
@@ -157,6 +164,10 @@ func coerceNumber(v any) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+func logMetricContextKey(metricName string, tags []string) string {
+	return seriesKey("", metricName, tags)
 }
 
 func patternCountMetricName(signature string) string {

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -21,6 +21,11 @@ import (
 // - Unstructured logs: pattern frequency -> Sum aggregation
 //
 // This is intentionally minimal; cardinality controls live in the observer storage (Step 5).
+//
+// LogMetricsExtractor also implements observer.ContextProvider, tracking the
+// pattern signature and a recent example log line for each pattern metric it
+// emits. Detectors can query this via StorageReader.GetContext to produce
+// richer anomaly descriptions.
 type LogMetricsExtractor struct {
 	// MaxEvalBytes caps how many bytes we evaluate for unstructured signature generation (0 = no cap).
 	MaxEvalBytes int
@@ -29,9 +34,23 @@ type LogMetricsExtractor struct {
 	IncludeFields map[string]struct{}
 	// ExcludeFields always excludes JSON fields from numeric extraction.
 	ExcludeFields map[string]struct{}
+
+	// patternContext tracks the signature and a recent example for each
+	// pattern metric key. Populated during ProcessLog, read via GetContext.
+	patternContext map[string]observer.MetricContext
 }
 
 func (a *LogMetricsExtractor) Name() string { return "log_metrics_extractor" }
+
+// GetContext implements observer.ContextProvider. It returns the pattern
+// signature and a recent example log line for metrics emitted by this extractor.
+func (a *LogMetricsExtractor) GetContext(metricName string) (observer.MetricContext, bool) {
+	if a.patternContext == nil {
+		return observer.MetricContext{}, false
+	}
+	ctx, ok := a.patternContext[metricName]
+	return ctx, ok
+}
 
 func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
 	content := log.GetContent()
@@ -43,8 +62,20 @@ func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.Metric
 		return nil
 	}
 
+	metricName := patternCountMetricName(patternSig)
+
+	// Track context for this pattern metric so detectors can enrich anomalies.
+	if a.patternContext == nil {
+		a.patternContext = make(map[string]observer.MetricContext)
+	}
+	a.patternContext[metricName] = observer.MetricContext{
+		Pattern: patternSig,
+		Example: string(content),
+		Source:  "log_metrics_extractor",
+	}
+
 	metrics := []observer.MetricOutput{{
-		Name:  patternCountMetricName(patternSig),
+		Name:  metricName,
 		Value: 1,
 		Tags:  tags,
 	}}

--- a/comp/observer/impl/log_metrics_extractor_test.go
+++ b/comp/observer/impl/log_metrics_extractor_test.go
@@ -125,3 +125,46 @@ func TestLogMetricsExtractor_InvalidJSONFallsBackToUnstructured(t *testing.T) {
 	_, _ = h.Write([]byte(sig))
 	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res[0].Name)
 }
+
+func TestLogMetricsExtractor_GetContextUsesCanonicalizedTags(t *testing.T) {
+	a := &LogMetricsExtractor{}
+	log := &mockLogView{
+		content: []byte("Request completed in 45ms"),
+		tags:    []string{"service:web", "env:prod"},
+	}
+
+	res := a.ProcessLog(log)
+	require.Len(t, res, 1)
+
+	ctx, ok := a.GetContext(res[0].Name, []string{"env:prod", "service:web"})
+	require.True(t, ok)
+	assert.Equal(t, "log_metrics_extractor", ctx.Source)
+	assert.Equal(t, "Request completed in 45ms", ctx.Example)
+}
+
+func TestLogMetricsExtractor_ContextSeparatesSameMetricByTags(t *testing.T) {
+	a := &LogMetricsExtractor{}
+	logA := &mockLogView{
+		content: []byte("Request completed in 45ms"),
+		tags:    []string{"service:api"},
+	}
+	logB := &mockLogView{
+		content: []byte("Request completed in 45ms"),
+		tags:    []string{"service:worker"},
+	}
+
+	resA := a.ProcessLog(logA)
+	resB := a.ProcessLog(logB)
+	require.Len(t, resA, 1)
+	require.Len(t, resB, 1)
+	require.Equal(t, resA[0].Name, resB[0].Name)
+
+	ctxA, ok := a.GetContext(resA[0].Name, []string{"service:api"})
+	require.True(t, ok)
+	ctxB, ok := a.GetContext(resB[0].Name, []string{"service:worker"})
+	require.True(t, ok)
+
+	assert.Equal(t, "Request completed in 45ms", ctxA.Example)
+	assert.Equal(t, "Request completed in 45ms", ctxB.Example)
+	assert.Equal(t, ctxA.Pattern, ctxB.Pattern)
+}

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -351,7 +351,11 @@ func (b *BOCPDDetector) updatePosterior(state *bocpdSeriesState, x float64) (boo
 
 // makeAnomaly constructs an Anomaly for a new alert onset.
 func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, cpProb, shortRunMass float64) *observer.Anomaly {
-	seriesName := series.Name + ":" + aggSuffix(agg)
+	source := observer.AnomalySource{
+		Namespace: series.Namespace,
+		Name:      series.Name,
+		Aggregate: agg,
+	}
 	deviation := (p.Value - state.baselineMean) / state.baselineStddev
 
 	triggerType := "short-run posterior mass"
@@ -363,14 +367,15 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 		triggerThreshold = b.CPThreshold
 	}
 
+	displayName := source.String()
 	return &observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
-		Source:         observer.MetricName(seriesName),
-		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
+		Source:         source,
+		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, series.Name+":"+aggSuffix(agg), series.Tags)),
 		DetectorName:   b.Name(),
-		Title:          "BOCPD changepoint detected: " + seriesName,
+		Title:          "BOCPD changepoint detected: " + displayName,
 		Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",
-			seriesName, triggerType, triggerValue, triggerThreshold, cpProb, b.ShortRunLength, shortRunMass),
+			displayName, triggerType, triggerValue, triggerThreshold, cpProb, b.ShortRunLength, shortRunMass),
 		Tags:      series.Tags,
 		Timestamp: p.Timestamp,
 		DebugInfo: &observer.AnomalyDebugInfo{

--- a/comp/observer/impl/metrics_detector_bocpd_test.go
+++ b/comp/observer/impl/metrics_detector_bocpd_test.go
@@ -125,7 +125,7 @@ func TestBOCPDDetector_SustainedIncidentEmitsOnce(t *testing.T) {
 	// Should emit at most one anomaly per series/agg despite sustained shift.
 	anomalyCount := 0
 	for _, a := range result.Anomalies {
-		if a.Source == "test.metric:avg" {
+		if a.Source.String() == "test.metric:avg" {
 			anomalyCount++
 		}
 	}
@@ -189,7 +189,7 @@ func TestBOCPDDetector_RecoveryAndReAlert(t *testing.T) {
 	// Count total anomalies for m:avg across r3 and r4.
 	avgAnomalies := 0
 	for _, a := range append(r3.Anomalies, r4.Anomalies...) {
-		if a.Source == "m:avg" {
+		if a.Source.String() == "m:avg" {
 			avgAnomalies++
 		}
 	}

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
@@ -138,6 +139,7 @@ func (c *CUSUMDetector) Detect(series observer.Series) observer.DetectionResult 
 func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64, debugInfo *observer.AnomalyDebugInfo) *observer.Anomaly {
 	var sHigh, sLow float64
 	cusumValues := make([]float64, 0, len(series.Points))
+	source := anomalySourceFromSeriesName(series.Name)
 
 	for i, p := range series.Points {
 		// Upper CUSUM: detect increases
@@ -164,7 +166,7 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 				debugInfo.CUSUMValues = cusumValues
 			}
 			return &observer.Anomaly{
-				Source: observer.AnomalySource{Name: series.Name},
+				Source: source,
 				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ above baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
@@ -185,7 +187,7 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 				debugInfo.CUSUMValues = cusumValues
 			}
 			return &observer.Anomaly{
-				Source: observer.AnomalySource{Name: series.Name},
+				Source: source,
 				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ below baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
@@ -197,6 +199,35 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 	}
 
 	return nil
+}
+
+func anomalySourceFromSeriesName(name string) observer.AnomalySource {
+	if idx := strings.LastIndex(name, ":"); idx != -1 {
+		if agg, ok := parseAggregateSuffix(name[idx+1:]); ok {
+			return observer.AnomalySource{
+				Name:      name[:idx],
+				Aggregate: agg,
+			}
+		}
+	}
+	return observer.AnomalySource{Name: name}
+}
+
+func parseAggregateSuffix(s string) (observer.Aggregate, bool) {
+	switch s {
+	case "avg":
+		return observer.AggregateAverage, true
+	case "sum":
+		return observer.AggregateSum, true
+	case "count":
+		return observer.AggregateCount, true
+	case "min":
+		return observer.AggregateMin, true
+	case "max":
+		return observer.AggregateMax, true
+	default:
+		return 0, false
+	}
 }
 
 // mean calculates the arithmetic mean of points.

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -164,7 +164,7 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 				debugInfo.CUSUMValues = cusumValues
 			}
 			return &observer.Anomaly{
-				Source: observer.MetricName(series.Name),
+				Source: observer.AnomalySource{Name: series.Name},
 				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ above baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
@@ -185,7 +185,7 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 				debugInfo.CUSUMValues = cusumValues
 			}
 			return &observer.Anomaly{
-				Source: observer.MetricName(series.Name),
+				Source: observer.AnomalySource{Name: series.Name},
 				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ below baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),

--- a/comp/observer/impl/metrics_detector_cusum_test.go
+++ b/comp/observer/impl/metrics_detector_cusum_test.go
@@ -209,7 +209,9 @@ func TestCUSUMDetector_SourceAndTags(t *testing.T) {
 	require.Len(t, result.Anomalies, 1)
 
 	anomaly := result.Anomalies[0]
-	assert.Equal(t, "my.metric:avg", anomaly.Source.Name, "Source name should match series name")
+	assert.Equal(t, "my.metric", anomaly.Source.Name, "Source name should exclude the aggregate suffix")
+	assert.Equal(t, observer.AggregateAverage, anomaly.Source.Aggregate, "Source aggregate should be parsed from the series name")
+	assert.Equal(t, "my.metric:avg", anomaly.Source.String(), "Source display should round-trip to the original series name")
 	assert.Equal(t, []string{"env:prod", "service:api"}, anomaly.Tags, "Tags should be preserved")
 }
 

--- a/comp/observer/impl/metrics_detector_cusum_test.go
+++ b/comp/observer/impl/metrics_detector_cusum_test.go
@@ -84,7 +84,7 @@ func TestCUSUMDetector_DetectsShift(t *testing.T) {
 	require.Len(t, result.Anomalies, 1, "should detect the shift")
 
 	anomaly := result.Anomalies[0]
-	assert.Equal(t, "shifted_metric:avg", anomaly.Source.String())
+	assert.Equal(t, "shifted_metric", anomaly.Source.String())
 	assert.Contains(t, anomaly.Title, "CUSUM")
 	assert.Contains(t, anomaly.Description, "shifted")
 

--- a/comp/observer/impl/metrics_detector_cusum_test.go
+++ b/comp/observer/impl/metrics_detector_cusum_test.go
@@ -84,7 +84,7 @@ func TestCUSUMDetector_DetectsShift(t *testing.T) {
 	require.Len(t, result.Anomalies, 1, "should detect the shift")
 
 	anomaly := result.Anomalies[0]
-	assert.Equal(t, "shifted_metric", string(anomaly.Source))
+	assert.Equal(t, "shifted_metric:avg", anomaly.Source.String())
 	assert.Contains(t, anomaly.Title, "CUSUM")
 	assert.Contains(t, anomaly.Description, "shifted")
 
@@ -209,7 +209,7 @@ func TestCUSUMDetector_SourceAndTags(t *testing.T) {
 	require.Len(t, result.Anomalies, 1)
 
 	anomaly := result.Anomalies[0]
-	assert.Equal(t, "my.metric:avg", string(anomaly.Source), "Source should match series name")
+	assert.Equal(t, "my.metric:avg", anomaly.Source.Name, "Source name should match series name")
 	assert.Equal(t, []string{"env:prod", "service:api"}, anomaly.Tags, "Tags should be preserved")
 }
 

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -487,7 +487,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 
 		if r.config.ThresholdSigma > 0 && threshold > 0 && score > threshold {
 			anomaly := observer.Anomaly{
-				Source:       "score",
+				Source:       observer.AnomalySource{Namespace: "rrcf", Name: "score"},
 				DetectorName: r.Name(),
 				Title:        "RRCF multivariate anomaly",
 				Description:  fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -198,11 +198,12 @@ func NewComponent(deps Requires) Provides {
 	detectors, correlators, extractors, _ := catalog.Instantiate(correlatorOverrides)
 
 	eng := newEngine(engineConfig{
-		storage:     newTimeSeriesStorage(),
-		extractors:  extractors,
-		detectors:   detectors,
-		correlators: correlators,
-		scheduler:   &currentBehaviorPolicy{},
+		storage:          newTimeSeriesStorage(),
+		extractors:       extractors,
+		detectors:        detectors,
+		correlators:      correlators,
+		contextProviders: collectContextProviders(extractors),
+		scheduler:        &currentBehaviorPolicy{},
 	})
 
 	// Wire reporters via event subscription.

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -483,7 +483,11 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 			for j := range result.Anomalies {
 				result.Anomalies[j].Type = observerdef.AnomalyTypeMetric
 				result.Anomalies[j].DetectorName = a.detector.Name()
-				result.Anomalies[j].Source = observerdef.MetricName(seriesWithAgg.Name)
+				result.Anomalies[j].Source = observerdef.AnomalySource{
+					Namespace: series.Namespace,
+					Name:      series.Name,
+					Aggregate: agg,
+				}
 				result.Anomalies[j].SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
 			}
 			allAnomalies = append(allAnomalies, result.Anomalies...)
@@ -496,20 +500,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 
 // aggSuffix returns a short suffix for the given aggregation type.
 func aggSuffix(agg observerdef.Aggregate) string {
-	switch agg {
-	case observerdef.AggregateAverage:
-		return "avg"
-	case observerdef.AggregateSum:
-		return "sum"
-	case observerdef.AggregateCount:
-		return "count"
-	case observerdef.AggregateMin:
-		return "min"
-	case observerdef.AggregateMax:
-		return "max"
-	default:
-		return "unknown"
-	}
+	return observerdef.AggregateString(agg)
 }
 
 // RawAnomalies returns a copy of currently tracked raw anomalies.

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -105,7 +105,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			for j, a := range corr.Anomalies {
 				oc.Anomalies[j] = ObserverAnomaly{
 					Timestamp:      a.Timestamp,
-					Source:         string(a.Source),
+					Source:         a.Source.String(),
 					SourceSeriesID: string(a.SourceSeriesID),
 					Detector:       a.DetectorName,
 				}

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -51,14 +51,14 @@ func testCorrelation() observerdef.ActiveCorrelation {
 		Anomalies: []observerdef.Anomaly{
 			{
 				Timestamp:      1000,
-				Source:         "cpu.user:avg",
+				Source:         observerdef.AnomalySource{Name: "cpu.user"},
 				SourceSeriesID: "parquet|cpu.user:avg|host:a",
 				DetectorName:   "cusum",
 				Description:    "CUSUM detected shift in cpu.user:avg",
 			},
 			{
 				Timestamp:      1200,
-				Source:         "mem.used:avg",
+				Source:         observerdef.AnomalySource{Name: "mem.used"},
 				SourceSeriesID: "parquet|mem.used:avg|host:a",
 				DetectorName:   "cusum",
 				Description:    "CUSUM detected shift in mem.used:avg",
@@ -213,7 +213,7 @@ func TestWriteObserverOutput_ValidJSON(t *testing.T) {
 			Anomalies: []observerdef.Anomaly{
 				{
 					Timestamp:      100,
-					Source:         "metric:avg",
+					Source:         observerdef.AnomalySource{Name: "metric"},
 					SourceSeriesID: "s1",
 					DetectorName:   "cusum",
 				},

--- a/comp/observer/impl/reporter_html.go
+++ b/comp/observer/impl/reporter_html.go
@@ -1127,7 +1127,7 @@ func (r *HTMLReporter) handleAPICorrelations(w http.ResponseWriter, _ *http.Requ
 			anomalies := make([]anomalyOutput, len(ac.Anomalies))
 			for j, a := range ac.Anomalies {
 				anomalies[j] = anomalyOutput{
-					Source:      string(a.Source),
+					Source:      a.Source.String(),
 					Title:       a.Title,
 					Description: a.Description,
 					Tags:        a.Tags,
@@ -1175,7 +1175,7 @@ func (r *HTMLReporter) handleAPIRawAnomalies(w http.ResponseWriter, _ *http.Requ
 		anomalies = make([]rawAnomalyOutput, len(raw))
 		for i, a := range raw {
 			anomalies[i] = rawAnomalyOutput{
-				Source:       string(a.Source),
+				Source:       a.Source.String(),
 				DetectorName: a.DetectorName,
 				Title:        a.Title,
 				Description:  a.Description,

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -435,7 +435,7 @@ func TestHTMLReporter_APICorrelations_ReturnsJSON(t *testing.T) {
 	assert.Equal(t, "test_pattern", correlations[0].Pattern)
 	assert.Equal(t, "Test Correlation", correlations[0].Title)
 	require.Len(t, correlations[0].Anomalies, 1)
-	assert.Equal(t, "signal1:avg", correlations[0].Anomalies[0].Source)
+	assert.Equal(t, "signal1", correlations[0].Anomalies[0].Source)
 }
 
 func TestHTMLReporter_APICorrelations_NoState(t *testing.T) {

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -28,7 +28,7 @@ func TestHTMLReporter_Report_AddsToBuffer(t *testing.T) {
 	r.Report(observer.ReportOutput{
 		AdvancedToSec: 100,
 		NewAnomalies: []observer.Anomaly{
-			{Source: "cpu", DetectorName: "test"},
+			{Source: observer.AnomalySource{Name: "cpu"}, DetectorName: "test"},
 		},
 		ActiveCorrelations: []observer.ActiveCorrelation{
 			{Pattern: "p1", Title: "Correlation 1"},
@@ -151,7 +151,7 @@ func TestHTMLReporter_APIReports_ReturnsJSON(t *testing.T) {
 	r.Report(observer.ReportOutput{
 		AdvancedToSec: 42,
 		NewAnomalies: []observer.Anomaly{
-			{Source: "cpu"},
+			{Source: observer.AnomalySource{Name: "cpu"}},
 		},
 	})
 
@@ -413,7 +413,7 @@ func TestHTMLReporter_APICorrelations_ReturnsJSON(t *testing.T) {
 					observer.SeriesID("series|signal2|"),
 				},
 				Anomalies: []observer.Anomaly{
-					{Source: "signal1", Title: "Anomaly 1", Description: "Description 1"},
+					{Source: observer.AnomalySource{Name: "signal1"}, Title: "Anomaly 1", Description: "Description 1"},
 				},
 			},
 		},
@@ -435,7 +435,7 @@ func TestHTMLReporter_APICorrelations_ReturnsJSON(t *testing.T) {
 	assert.Equal(t, "test_pattern", correlations[0].Pattern)
 	assert.Equal(t, "Test Correlation", correlations[0].Title)
 	require.Len(t, correlations[0].Anomalies, 1)
-	assert.Equal(t, "signal1", string(correlations[0].Anomalies[0].Source))
+	assert.Equal(t, "signal1:avg", correlations[0].Anomalies[0].Source)
 }
 
 func TestHTMLReporter_APICorrelations_NoState(t *testing.T) {

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -69,12 +69,12 @@ func TestStateView_Anomalies(t *testing.T) {
 
 	// Add some anomalies via the engine
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:       "cpu",
+		Source:       observerdef.AnomalySource{Name: "cpu"},
 		DetectorName: "cusum",
 		Timestamp:    100,
 	})
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:       "mem",
+		Source:       observerdef.AnomalySource{Name: "mem"},
 		DetectorName: "bocpd",
 		Timestamp:    101,
 	})
@@ -112,7 +112,7 @@ func TestStateView_Anomalies(t *testing.T) {
 
 	// AnomaliesForSeries filters by SourceSeriesID
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:         "disk",
+		Source:         observerdef.AnomalySource{Name: "disk"},
 		DetectorName:   "cusum",
 		Timestamp:      102,
 		SourceSeriesID: "ns|disk:avg|",
@@ -121,8 +121,8 @@ func TestStateView_Anomalies(t *testing.T) {
 	if len(diskAnomalies) != 1 {
 		t.Fatalf("expected 1 disk anomaly, got %d", len(diskAnomalies))
 	}
-	if diskAnomalies[0].Source != "disk" {
-		t.Fatalf("expected disk source, got %s", diskAnomalies[0].Source)
+	if diskAnomalies[0].Source.Name != "disk" {
+		t.Fatalf("expected disk source, got %s", diskAnomalies[0].Source.Name)
 	}
 	// Empty SourceSeriesID should not match
 	emptyAnomalies := sv.AnomaliesForSeries("")

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -779,7 +779,7 @@ func (s *timeSeriesStorage) WriteGeneration(handle observer.SeriesHandle) int64 
 
 // GetContext on bare storage always returns false — context comes from
 // the contextAwareStorage wrapper that layers ContextProviders on top.
-func (s *timeSeriesStorage) GetContext(_ string) (observer.MetricContext, bool) {
+func (s *timeSeriesStorage) GetContext(_, _ string) (observer.MetricContext, bool) {
 	return observer.MetricContext{}, false
 }
 

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -777,6 +777,12 @@ func (s *timeSeriesStorage) WriteGeneration(handle observer.SeriesHandle) int64 
 	return 0
 }
 
+// GetContext on bare storage always returns false — context comes from
+// the contextAwareStorage wrapper that layers ContextProviders on top.
+func (s *timeSeriesStorage) GetContext(_ string) (observer.MetricContext, bool) {
+	return observer.MetricContext{}, false
+}
+
 // matchTags checks if tags contain all required key=value pairs.
 func matchTags(tags []string, matchers map[string]string) bool {
 	if len(matchers) == 0 {

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -777,12 +777,6 @@ func (s *timeSeriesStorage) WriteGeneration(handle observer.SeriesHandle) int64 
 	return 0
 }
 
-// GetContext on bare storage always returns false — context comes from
-// the contextAwareStorage wrapper that layers ContextProviders on top.
-func (s *timeSeriesStorage) GetContext(_, _ string) (observer.MetricContext, bool) {
-	return observer.MetricContext{}, false
-}
-
 // matchTags checks if tags contain all required key=value pairs.
 func matchTags(tags []string, matchers map[string]string) bool {
 	if len(matchers) == 0 {

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -212,8 +212,8 @@ func TestAggSuffix(t *testing.T) {
 	assert.Equal(t, "min", aggSuffix(AggregateMin))
 	assert.Equal(t, "max", aggSuffix(AggregateMax))
 
-	// Unknown aggregation type defaults to "avg"
-	assert.Equal(t, "avg", aggSuffix(Aggregate(999)))
+	// Unknown aggregation type
+	assert.Equal(t, "unknown", aggSuffix(Aggregate(999)))
 }
 
 func TestTimeSeriesStorage_DropsNonFiniteValuesWithStats(t *testing.T) {

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -212,8 +212,8 @@ func TestAggSuffix(t *testing.T) {
 	assert.Equal(t, "min", aggSuffix(AggregateMin))
 	assert.Equal(t, "max", aggSuffix(AggregateMax))
 
-	// Test unknown aggregation type
-	assert.Equal(t, "unknown", aggSuffix(Aggregate(999)))
+	// Unknown aggregation type defaults to "avg"
+	assert.Equal(t, "avg", aggSuffix(Aggregate(999)))
 }
 
 func TestTimeSeriesStorage_DropsNonFiniteValuesWithStats(t *testing.T) {

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -38,7 +38,7 @@ func (d *dynamicAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime in
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{
 			{
-				Source:         observerdef.MetricName(fmt.Sprintf("%s%d", d.prefix, d.currentIndex)),
+				Source:         observerdef.AnomalySource{Name: fmt.Sprintf("%s%d", d.prefix, d.currentIndex)},
 				SourceSeriesID: observerdef.SeriesID(fmt.Sprintf("ns|%s%d|", d.prefix, d.currentIndex)),
 				DetectorName:   d.Name(),
 				Title:          fmt.Sprintf("anomaly_%d", d.currentIndex),

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -76,3 +76,14 @@ func (e *noopLogExtractor) Name() string { return "noop_extractor" }
 func (e *noopLogExtractor) ProcessLog(_ observerdef.LogView) []observerdef.MetricOutput {
 	return nil
 }
+
+type sharedTagsExtractor struct{}
+
+func (e *sharedTagsExtractor) Name() string { return "shared_tags_extractor" }
+func (e *sharedTagsExtractor) ProcessLog(log observerdef.LogView) []observerdef.MetricOutput {
+	tags := log.GetTags()
+	return []observerdef.MetricOutput{
+		{Name: "metric.a", Value: 1, Tags: tags},
+		{Name: "metric.b", Value: 1, Tags: tags},
+	}
+}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -796,8 +796,8 @@ func (tb *TestBench) GetMetricsAnomaliesForSeries(seriesID observerdef.SeriesID)
 func (tb *TestBench) resolveAnomalySeriesIDs(anomalies []observerdef.Anomaly) []observerdef.Anomaly {
 	for i := range anomalies {
 		a := &anomalies[i]
-		if a.SourceSeriesID == "" && a.Source != "" {
-			telemetryName := "telemetry." + a.DetectorName + "." + string(a.Source)
+		if a.SourceSeriesID == "" && a.Source.Name != "" {
+			telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
 			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
 		}
 	}
@@ -1194,7 +1194,7 @@ func (tb *TestBench) loadDemoScenario() error {
 	for _, a := range demoAnomalies {
 		anomaly := observerdef.Anomaly{
 			Type:         observerdef.AnomalyTypeLog,
-			Source:       "logs",
+			Source:       observerdef.AnomalySource{Name: "logs"},
 			DetectorName: a.detectorName,
 			Title:        a.title,
 			Description:  a.description,

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -182,11 +182,12 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 	detectors, correlators, extractors, components := catalog.Instantiate(config.EnableOverrides)
 
 	eng := newEngine(engineConfig{
-		storage:     newTimeSeriesStorage(),
-		extractors:  extractors,
-		detectors:   detectors,
-		correlators: correlators,
-		scheduler:   &currentBehaviorPolicy{},
+		storage:          newTimeSeriesStorage(),
+		extractors:       extractors,
+		detectors:        detectors,
+		correlators:      correlators,
+		contextProviders: collectContextProviders(extractors),
+		scheduler:        &currentBehaviorPolicy{},
 	})
 
 	hub := newSSEHub()

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -727,7 +727,7 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 			sourceSeriesID = storage.CompactSeriesID(sourceSeriesID)
 		}
 		resp := anomalyResponse{
-			Source:            string(a.Source),
+			Source:            a.Source.String(),
 			SourceSeriesID:    sourceSeriesID,
 			DetectorName:      a.DetectorName,
 			DetectorComponent: detectorComponentMap[a.DetectorName],
@@ -763,7 +763,7 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 			for _, a := range anomalies {
 				if a.DetectorName == "" || a.Timestamp == 0 {
 					log.Printf("skipping malformed anomaly response: detector=%q source=%q ts=%d",
-						a.DetectorName, a.Source, a.Timestamp)
+						a.DetectorName, a.Source.String(), a.Timestamp)
 					continue
 				}
 				response = append(response, toResponse(a))
@@ -775,7 +775,7 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 		for _, a := range anomalies {
 			if a.DetectorName == "" || a.Timestamp == 0 {
 				log.Printf("skipping malformed anomaly response: detector=%q source=%q ts=%d",
-					a.DetectorName, a.Source, a.Timestamp)
+					a.DetectorName, a.Source.String(), a.Timestamp)
 				continue
 			}
 			response = append(response, toResponse(a))
@@ -810,7 +810,7 @@ func (api *TestBenchAPI) handleLogAnomalies(w http.ResponseWriter, r *http.Reque
 	response := make([]logAnomalyResponse, 0, len(anomalies))
 	for _, a := range anomalies {
 		response = append(response, logAnomalyResponse{
-			Source:       string(a.Source),
+			Source:       a.Source.String(),
 			DetectorName: a.DetectorName,
 			Title:        a.Title,
 			Description:  a.Description,
@@ -984,7 +984,7 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 				tags = []string{}
 			}
 			anomalies[j] = anomalyOutput{
-				Source:      string(a.Source),
+				Source:      a.Source.String(),
 				Title:       a.Title,
 				Description: a.Description,
 				Timestamp:   a.Timestamp,

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -463,7 +463,7 @@ func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Req
 
 // handleNumericSeriesData resolves a compact numeric ID to series data.
 func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID observerdef.SeriesHandle, aggStr string, originalID string) {
-	var agg Aggregate
+	agg := AggregateAverage
 	switch aggStr {
 	case "avg":
 		agg = AggregateAverage

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -12,11 +12,12 @@ from tasks.libs.common.color import Color, color_message
 
 SCENARIOS = ["213_pagerduty", "353_postmark", "food_delivery_redis"]
 
-# S3 zip key for each scenario. Update when re-recording.
-SCENARIO_ZIPS = {
-    "213_pagerduty": "gensim-results-213_PagerDuty_June_2014_Outage-20260303-1309-78229d.zip",
-    "353_postmark": "gensim-results-353_postmark_upstream_cloud_provider_outage-20260303-1333-ad0bba.zip",
-    "food_delivery_redis": "gensim-results-food-delivery-redis-cpu-saturation-20260303-1314-5f7194.zip",
+
+# Maps short scenario names to episode names used in runs.jsonl
+SCENARIO_EPISODE_NAMES = {
+    "213_pagerduty": "213_PagerDuty_June_2014_Outage",
+    "353_postmark": "353_postmark_upstream_cloud_provider_outage",
+    "food_delivery_redis": "food-delivery-redis-cpu-saturation",
 }
 
 S3_BUCKET = "qbranch-gensim-recordings"
@@ -42,7 +43,12 @@ def build_scorer(ctx):
 
 # --- Eval ---
 @task
-def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios", sigma: float = 30.0):
+def eval_scenarios(
+    ctx,
+    scenario: str = "",
+    scenarios_dir: str = "./comp/observer/scenarios",
+    sigma: float = 30.0,
+):
     """
     Runs the observer eval: builds binaries, replays scenarios headless, scores against ground truth.
 
@@ -128,13 +134,65 @@ def eval_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observe
         print(f"\nOutput JSONs: /tmp/observer-eval-*.json (sigma={sigma}s)")
 
 
+def _resolve_zip_from_runs_jsonl(ctx, name):
+    """Resolve the latest zip key for a scenario from runs.jsonl in S3."""
+    episode_name = SCENARIO_EPISODE_NAMES.get(name)
+    if not episode_name:
+        return None
+
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as tmp:
+        tmp_path = tmp.name
+
+    try:
+        result = ctx.run(
+            f"aws-vault exec {AWS_PROFILE} -- aws s3 cp s3://{S3_BUCKET}/runs.jsonl {shlex.quote(tmp_path)}",
+            warn=True,
+            hide=True,
+        )
+        if result is None or result.failed:
+            return None
+
+        with open(tmp_path) as f:
+            lines = []
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    lines.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue  # skip malformed records
+
+        # Find the latest entry matching this episode
+        matches = [entry for entry in lines if entry.get("episode") == episode_name]
+        if not matches:
+            return None
+
+        latest = matches[-1]
+        zip_key = latest.get("zip")
+        if zip_key:
+            print(
+                color_message(
+                    f"Resolved '{name}' from runs.jsonl: {zip_key} "
+                    f"(image: {latest.get('image', '?')}, {latest.get('timestamp', '?')})",
+                    Color.BLUE,
+                )
+            )
+        return zip_key
+    except (OSError, json.JSONDecodeError):
+        return None
+    finally:
+        os.unlink(tmp_path)
+
+
 def _ensure_parquets(ctx, name, parquet_dir):
-    """Download and extract parquet files from S3 if not present locally."""
-    zip_key = SCENARIO_ZIPS.get(name)
+    """Download and extract parquet files from S3 via runs.jsonl."""
+    zip_key = _resolve_zip_from_runs_jsonl(ctx, name)
     if not zip_key:
         print(
             color_message(
-                f"No S3 zip configured for '{name}' — add it to SCENARIO_ZIPS to enable auto-download", Color.ORANGE
+                f"No recording found for '{name}' in runs.jsonl. " f"Run a gensim-eks episode to produce one.",
+                Color.RED,
             )
         )
         return
@@ -172,6 +230,39 @@ def _ensure_parquets(ctx, name, parquet_dir):
         print(color_message(f"Extracted parquet files to {parquet_dir}", Color.GREEN))
     finally:
         os.unlink(tmp_path)
+
+
+@task
+def download_scenarios(ctx, scenario: str = "", scenarios_dir: str = "./comp/observer/scenarios"):
+    """
+    Download scenario parquet data from S3.
+
+    Resolves the latest recording for each scenario from runs.jsonl in the S3 bucket.
+
+    Args:
+        scenario: Download a single scenario (e.g. "food_delivery_redis"). Default: all.
+        scenarios_dir: Directory containing scenario subdirectories.
+
+    Examples:
+        inv q.download-scenarios
+        inv q.download-scenarios --scenario=food_delivery_redis
+    """
+    scenarios_to_download = [scenario] if scenario else SCENARIOS
+    for name in scenarios_to_download:
+        parquet_dir = os.path.join(scenarios_dir, name, "parquet")
+        # Download to a temp dir first, then swap -- preserves existing data if download fails.
+        tmp_parquet_dir = parquet_dir + ".new"
+        if os.path.isdir(tmp_parquet_dir):
+            shutil.rmtree(tmp_parquet_dir)
+        _ensure_parquets(ctx, name, tmp_parquet_dir)
+        if os.path.isdir(tmp_parquet_dir) and os.listdir(tmp_parquet_dir):
+            if os.path.isdir(parquet_dir):
+                shutil.rmtree(parquet_dir)
+            os.rename(tmp_parquet_dir, parquet_dir)
+        else:
+            # Download failed -- clean up temp dir, keep existing data
+            shutil.rmtree(tmp_parquet_dir, ignore_errors=True)
+            print(color_message(f"Download failed for '{name}', keeping existing data", Color.ORANGE))
 
 
 @task


### PR DESCRIPTION
## Summary

This PR adds `ContextProvider` support so anomaly reports can be enriched with context about the originating metric source.

It also replaces the old stringly-typed `_virtual.` metric prefix approach with a structured metric namespace model:
- synthesized metrics are now stored under the extractor's `Name()`
- anomaly sources now carry structured fields for `Namespace`, `Name`, and `Aggregate`
- the extractor name is the namespace, rather than being encoded into the metric name

This makes the source model more explicit and avoids overloading metric names with transport details.

## What Changed

- Added `ContextProvider` to let components map synthesized metrics back to richer source context.
- Added structured `AnomalySource` with:
  - `Namespace`
  - `Name`
  - `Aggregate`
- Updated anomaly generation to use structured sources instead of plain metric-name strings.
- Changed log-derived metric ingestion to write metrics under the extractor name as namespace, instead of using the old `_virtual.` metric-name prefix.
- Added anomaly enrichment in the engine using registered context providers.
- Made context lookup tag-aware so enrichment matches the specific anomalous series rather than only the metric name.
- Made extractors participate in `Reset()` when they support it.
- Added duplicate extractor-name validation so namespace collisions fail fast.

## Why

Previously, synthesized metrics encoded origin information into metric names using conventions like `_virtual.<name>`. That made the system harder to reason about and made it awkward to recover source context later.

This PR moves that origin information into structured fields:
- namespace identifies the producing component
- metric name remains the metric name
- aggregate is tracked explicitly

That in turn makes it possible to enrich anomalies with source-specific context in a cleaner way.

## Notes

- For log-derived metrics, context lookup is now based on metric name plus tags, so two different tagged series with the same synthesized metric name do not overwrite each other's context.
- Extractor names are now semantically important because they define the namespace for synthesized metrics.

## Validation

Targeted observer tests were run for:
- anomaly context enrichment
- extractor replacement refreshing providers
- canonicalized tag-aware context lookup
- separation of same metric name across different tag sets
- duplicate extractor-name rejection
- extractor reset participation
