### PR TITLE
[cluster-agent/kubernetes_metadata_stream] Fix stream unsubscribe race when node reconnects

### DIFF
--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_stream.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_stream.go
@@ -95,10 +95,10 @@ func (srv *KubeMetadataStreamServer) StreamKubeMetadata(req *pb.KubeMetadataStre
 	nodeName := req.GetNodeName()
 
 	podServicesNotifyCh := srv.store.Subscribe(nodeName)
-	defer srv.store.Unsubscribe(nodeName)
+	defer srv.store.Unsubscribe(nodeName, podServicesNotifyCh)
 
 	namespacesNotifyCh := srv.subscribeToNamespaceEvents(nodeName)
-	defer srv.unsubscribeFromNamespaceEvents(nodeName)
+	defer srv.unsubscribeFromNamespaceEvents(nodeName, namespacesNotifyCh)
 
 	// Send initial full state
 	lastSentPodServicesState := srv.buildPodServiceMappingsSnapshot(nodeName)
@@ -219,11 +219,13 @@ func (srv *KubeMetadataStreamServer) subscribeToNamespaceEvents(nodeName string)
 	return ch
 }
 
-func (srv *KubeMetadataStreamServer) unsubscribeFromNamespaceEvents(nodeName string) {
+func (srv *KubeMetadataStreamServer) unsubscribeFromNamespaceEvents(nodeName string, ch <-chan struct{}) {
 	srv.namespacesMutex.Lock()
 	defer srv.namespacesMutex.Unlock()
 
-	delete(srv.namespaceSubscribers, nodeName)
+	if srv.namespaceSubscribers[nodeName] == ch {
+		delete(srv.namespaceSubscribers, nodeName)
+	}
 }
 
 func (srv *KubeMetadataStreamServer) buildNamespacesSnapshot() map[string]namespaceEntry {

--- a/cmd/cluster-agent/api/v1/kubernetes_metadata_stream_test.go
+++ b/cmd/cluster-agent/api/v1/kubernetes_metadata_stream_test.go
@@ -92,6 +92,36 @@ func TestStart(t *testing.T) {
 	assert.Empty(t, srv.buildNamespacesSnapshot())
 }
 
+func TestUnsubscribeFromNamespaceEvents(t *testing.T) {
+	srv := NewKubeMetadataStreamServer(nil, nil)
+
+	// First connection subscribes, then new connection subscribes
+	// (overwriting), then old connection's deferred unsubscribe runs.
+	oldCh := srv.subscribeToNamespaceEvents("node1")
+	newCh := srv.subscribeToNamespaceEvents("node1")
+	srv.unsubscribeFromNamespaceEvents("node1", oldCh)
+
+	// The new subscriber should still be registered and receive notifications.
+	srv.processNamespaceEvents([]workloadmeta.Event{
+		{
+			Type: workloadmeta.EventTypeSet,
+			Entity: &workloadmeta.KubernetesMetadata{
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:   "ns1",
+					Labels: map[string]string{"l1": "v1"},
+				},
+			},
+		},
+	})
+
+	select {
+	case <-newCh:
+		// expected
+	case <-time.After(1 * time.Second):
+		t.Fatal("new subscriber was not notified after old unsubscribe")
+	}
+}
+
 func TestBundleToPodServiceMappingsSnapshot(t *testing.T) {
 	bundle := apiserver.NewMetadataMapperBundle()
 	bundle.Services.Set("ns1", "pod1", "svc1", "svc2")

--- a/pkg/util/kubernetes/apiserver/controllers/store.go
+++ b/pkg/util/kubernetes/apiserver/controllers/store.go
@@ -127,11 +127,13 @@ func (m *MetaBundleStore) Subscribe(nodeName string) <-chan struct{} {
 }
 
 // Unsubscribe removes a subscriber.
-func (m *MetaBundleStore) Unsubscribe(nodeName string) {
+func (m *MetaBundleStore) Unsubscribe(nodeName string, ch <-chan struct{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	delete(m.subscribers, nodeName)
+	if m.subscribers[nodeName] == ch {
+		delete(m.subscribers, nodeName)
+	}
 }
 
 // notifyLocked signals the subscriber for the given node.

--- a/pkg/util/kubernetes/apiserver/controllers/store_test.go
+++ b/pkg/util/kubernetes/apiserver/controllers/store_test.go
@@ -21,7 +21,7 @@ func TestSubscribe(t *testing.T) {
 	store := newTestStore()
 
 	ch := store.Subscribe("node1")
-	defer store.Unsubscribe("node1")
+	defer store.Unsubscribe("node1", ch)
 
 	bundle := apiserver.NewMetadataMapperBundle()
 	bundle.Services.Set("default", "pod1", "svc1")
@@ -49,7 +49,7 @@ func TestSubscribe_WithDelete(t *testing.T) {
 	store.set("node1", bundle)
 
 	ch := store.Subscribe("node1")
-	defer store.Unsubscribe("node1")
+	defer store.Unsubscribe("node1", ch)
 
 	store.delete("node1")
 
@@ -68,9 +68,9 @@ func TestSubscribe_OtherNodes(t *testing.T) {
 	store := newTestStore()
 
 	ch := store.Subscribe("node1")
-	defer store.Unsubscribe("node1")
-	store.Subscribe("node2")
-	defer store.Unsubscribe("node2")
+	defer store.Unsubscribe("node1", ch)
+	ch2 := store.Subscribe("node2")
+	defer store.Unsubscribe("node2", ch2)
 
 	bundle := apiserver.NewMetadataMapperBundle()
 	store.set("node2", bundle)
@@ -86,8 +86,8 @@ func TestSubscribe_OtherNodes(t *testing.T) {
 func TestUnsubscribe(_ *testing.T) {
 	store := newTestStore()
 
-	store.Subscribe("node1")
-	store.Unsubscribe("node1")
+	ch := store.Subscribe("node1")
+	store.Unsubscribe("node1", ch)
 
 	bundle := apiserver.NewMetadataMapperBundle()
 	bundle.Services.Set("default", "pod1", "svc1")
@@ -95,6 +95,28 @@ func TestUnsubscribe(_ *testing.T) {
 
 	// No subscriber for node1, so this shouldn't do anything. Just testing that
 	// this doesn't panic or block.
+}
+
+func TestUnsubscribe_DoesNotRemoveNewerSubscriber(t *testing.T) {
+	store := newTestStore()
+
+	// First connection subscribes, then new connection subscribes
+	// (overwriting), then old connection's deferred unsubscribe runs.
+	oldCh := store.Subscribe("node1")
+	newCh := store.Subscribe("node1")
+	store.Unsubscribe("node1", oldCh)
+
+	// The new subscriber should still be registered and receive notifications.
+	bundle := apiserver.NewMetadataMapperBundle()
+	bundle.Services.Set("default", "pod1", "svc1")
+	store.set("node1", bundle)
+
+	select {
+	case <-newCh:
+		// expected
+	case <-time.After(1 * time.Second):
+		t.Fatal("new subscriber was not notified after old unsubscribe")
+	}
 }
 
 func newTestStore() *MetaBundleStore {


### PR DESCRIPTION
### What does this PR do?

This PR fixes a race in the kubernetes metadata streaming endpoint of the Cluster Agent.

More specifically, this PR fixes a bug where a reconnecting node's new subscription channel could be removed by the old connection's deferred cleanup, causing the new connection to never receive notifications.

The bug only exists in the main branch. Reported by @gabedos 

### Describe how you validated your changes

New unit tests.
