### PR TITLE
Increase SBOM testUpAndRunning timeout from 1m to 2m

### DIFF
--- a/test/new-e2e/tests/sbom/k8s_test.go
+++ b/test/new-e2e/tests/sbom/k8s_test.go
@@ -94,7 +94,7 @@ func (suite *k8sSuite) Test00UpAndRunning() {
 // Inside a testify test suite, tests are executed in alphabetical order.
 // The ZZ in TestZZUpAndRunning is here to guarantee that this test, is run last.
 func (suite *k8sSuite) TestZZUpAndRunning() {
-	suite.testUpAndRunning(1 * time.Minute)
+	suite.testUpAndRunning(2 * time.Minute)
 }
 
 func (suite *k8sSuite) testUpAndRunning(waitFor time.Duration) {
@@ -259,7 +259,7 @@ func (suite *k8sSuite) TestSBOM() {
 					suite.UpdateEnv(provisioner)
 
 					// Wait for agent pods to restart and stabilize before checking SBOMs
-					suite.testUpAndRunning(1 * time.Minute)
+					suite.testUpAndRunning(2 * time.Minute)
 				}
 
 				suite.EventuallyWithTf(func(collect *assert.CollectT) {


### PR DESCRIPTION
### What does this PR do?

Increase SBOM testUpAndRunning timeout from 1m to 2m

### Motivation

The agent takes ~60s to pass readiness probes after a helm upgrade in the SBOM Kind test. The bulk of this time is spent in process check Init() where retryGetNetworkID makes 4 attempts to reach the EC2 IMDS endpoint, each timing out after ~5s. In a Kind-on-EC2 environment the IMDS is unreachable from inside the Kind container so these retries always fail.

Combined with the readiness probe configuration (initialDelaySeconds=15, periodSeconds=15) and the time for collector queues to register their first health pings, the agent consistently needs 4 probe cycles (60s) to become ready. This left zero margin with the 1-minute timeout, causing the test to flap depending on exact container start timing.

2 minutes provides enough buffer for infrastructure variance while keeping the test fast enough to detect real readiness issues.

### Describe how you validated your changes

The failing `dd-gitlab/new-e2e-sbom: [--run "TestSBOMKindSuite"]` now passed with the new duration.

### Additional Notes

N/A