### PR TITLE
fix(discovery): Open /proc/<pid>/exe directly for Go language detection

### DIFF
--- a/pkg/discovery/module/impl_services_test.go
+++ b/pkg/discovery/module/impl_services_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/http/testutil"
 	"github.com/DataDog/datadog-agent/pkg/network/protocols/tls/nodejs"
 	fileopener "github.com/DataDog/datadog-agent/pkg/network/usm/sharedlibraries/testutil"
+	usmtestutil "github.com/DataDog/datadog-agent/pkg/network/usm/testutil"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	globalutils "github.com/DataDog/datadog-agent/pkg/util/testutil"
 	dockerutils "github.com/DataDog/datadog-agent/pkg/util/testutil/docker"
@@ -420,6 +421,57 @@ func (s *discoveryTestSuite) TestServicesLogsWithoutPorts() {
 		}
 	}
 	assert.True(t, found, "expected to find log file %s in LogFiles: %v", logFileName, svc.LogFiles)
+}
+
+// TestServicesGoDetectionMovedExe tests that Go language detection works even
+// when the binary has been moved after the process started. This simulates
+// the container case where /proc/<pid>/exe points to a path inside the
+// container's filesystem that doesn't exist on the host — resolving the
+// symlink separately won't work, but opening /proc/<pid>/exe directly does.
+func (s *discoveryTestSuite) TestServicesGoDetectionMovedExe() {
+	t := s.T()
+	discovery := s.discovery
+
+	curDir, err := testutil.CurDir()
+	require.NoError(t, err)
+
+	serverBin, err := usmtestutil.BuildGoBinaryWrapper(filepath.Join(curDir, "testutil"), "fake_server")
+	require.NoError(t, err)
+
+	// Copy the Go binary to a temp directory so we can move it
+	tmpDir := t.TempDir()
+	tmpBin := filepath.Join(tmpDir, "fake_server")
+	data, err := os.ReadFile(serverBin)
+	require.NoError(t, err)
+	err = os.WriteFile(tmpBin, data, 0755)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel() })
+
+	cmd := exec.CommandContext(ctx, tmpBin)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Start()
+	require.NoError(t, err)
+
+	pid := cmd.Process.Pid
+
+	// Move the binary so that the original path no longer exists.
+	// /proc/<pid>/exe still works (the kernel follows the inode), but
+	// resolving the symlink target gives a "(deleted)" path.
+	movedBin := filepath.Join(tmpDir, "fake_server_moved")
+	err = os.Rename(tmpBin, movedBin)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		resp := getServices(collect, discovery)
+		svc := findService(pid, resp.Services)
+		require.NotNilf(collect, svc, "could not find service for pid %v", pid)
+
+		assert.Equal(collect, string(language.Go), svc.Language,
+			"Go binary should be detected as Go even after the exe has been moved")
+	}, 30*time.Second, 100*time.Millisecond)
 }
 
 func (s *discoveryTestSuite) TestServicesAPMInstrumentationProvided() {

--- a/pkg/discovery/module/impl_services_test.go
+++ b/pkg/discovery/module/impl_services_test.go
@@ -423,12 +423,12 @@ func (s *discoveryTestSuite) TestServicesLogsWithoutPorts() {
 	assert.True(t, found, "expected to find log file %s in LogFiles: %v", logFileName, svc.LogFiles)
 }
 
-// TestServicesGoDetectionMovedExe tests that Go language detection works even
-// when the binary has been moved after the process started. This simulates
+// TestServicesGoDetectionDeletedExe tests that Go language detection works even
+// when the binary has been deleted after the process started. This simulates
 // the container case where /proc/<pid>/exe points to a path inside the
 // container's filesystem that doesn't exist on the host — resolving the
 // symlink separately won't work, but opening /proc/<pid>/exe directly does.
-func (s *discoveryTestSuite) TestServicesGoDetectionMovedExe() {
+func (s *discoveryTestSuite) TestServicesGoDetectionDeletedExe() {
 	t := s.T()
 	discovery := s.discovery
 
@@ -438,7 +438,7 @@ func (s *discoveryTestSuite) TestServicesGoDetectionMovedExe() {
 	serverBin, err := usmtestutil.BuildGoBinaryWrapper(filepath.Join(curDir, "testutil"), "fake_server")
 	require.NoError(t, err)
 
-	// Copy the Go binary to a temp directory so we can move it
+	// Copy the Go binary to a temp directory so we can delete it
 	tmpDir := t.TempDir()
 	tmpBin := filepath.Join(tmpDir, "fake_server")
 	data, err := os.ReadFile(serverBin)
@@ -457,11 +457,10 @@ func (s *discoveryTestSuite) TestServicesGoDetectionMovedExe() {
 
 	pid := cmd.Process.Pid
 
-	// Move the binary so that the original path no longer exists.
-	// /proc/<pid>/exe still works (the kernel follows the inode), but
-	// resolving the symlink target gives a "(deleted)" path.
-	movedBin := filepath.Join(tmpDir, "fake_server_moved")
-	err = os.Rename(tmpBin, movedBin)
+	// Delete the binary so that the original path no longer exists.
+	// /proc/<pid>/exe still works (the kernel keeps the inode alive), but
+	// resolving the symlink target gives a path with " (deleted)" appended.
+	err = os.Remove(tmpBin)
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -470,7 +469,7 @@ func (s *discoveryTestSuite) TestServicesGoDetectionMovedExe() {
 		require.NotNilf(collect, svc, "could not find service for pid %v", pid)
 
 		assert.Equal(collect, string(language.Go), svc.Language,
-			"Go binary should be detected as Go even after the exe has been moved")
+			"Go binary should be detected as Go even after the exe has been deleted")
 	}, 30*time.Second, 100*time.Millisecond)
 }
 

--- a/pkg/discovery/module/rust/src/language.rs
+++ b/pkg/discovery/module/rust/src/language.rs
@@ -193,8 +193,8 @@ impl Language {
         const BUILD_INFO_SIZE: usize = 32;
         const BUILD_INFO_ALIGN: usize = 16;
 
-        let exe = Exe::get(pid).ok()?;
-        let mut elf_file = File::open(&exe.0).ok()?;
+        let exe_path = crate::procfs::root_path().join(pid.to_string()).join("exe");
+        let mut elf_file = File::open(&exe_path).ok()?;
         let mut elf = elf::ElfStream::<AnyEndian, _>::open_stream(&mut elf_file).ok()?;
 
         // First, try to find .go.buildinfo section.
@@ -214,7 +214,7 @@ impl Language {
         let read_size = std::cmp::min(data_phdr.p_filesz as usize, ELF_READ_LIMIT);
 
         // Reopen file for manual read (elf consumes the original file)
-        let mut file = File::open(&exe.0).ok()?;
+        let mut file = File::open(&exe_path).ok()?;
         file.seek(SeekFrom::Start(data_phdr.p_offset)).ok()?;
         file.read_exact(segment_buffer.get_mut(..read_size)?).ok()?;
 


### PR DESCRIPTION
### What does this PR do?

Fixes Go language detection in system-probe-lite for processes whose binary has been deleted or is inaccessible at the resolved symlink path (e.g. in containers). Changes `from_go()` to open `/proc/<pid>/exe` directly instead of first resolving the symlink via `Exe::get()` and then opening the resolved path.

Adds an integration test (`TestServicesGoDetectionDeletedExe`) that deletes a Go binary after starting it and verifies that Go detection still works. The test runs on both the Go and Rust discovery implementations.

### Motivation

In containers, `/proc/<pid>/exe` points to a path inside the container's filesystem (e.g. `/app/myserver`). From the host, this resolved path doesn't exist. The previous code resolved the symlink first via `Exe::get()` then tried to open the resolved path, which failed. Opening `/proc/<pid>/exe` directly works because the kernel handles the indirection — it follows the inode, not the path.

### Describe how you validated your changes

- Verified the test **fails** without the fix (Rust reports `"unknown"` instead of `"go"`)
- Verified the test **passes** with the fix on both Go and Rust implementations
- Ran `bazel build --config=lint //pkg/discovery/module/rust/...` with no errors

### Additional Notes

Deleting the binary (rather than renaming it) is key for the test — renaming preserves the directory entry and the kernel updates the symlink target, so it doesn't reproduce the container scenario. Deleting causes the symlink to show `" (deleted)"`, which properly simulates an inaccessible resolved path.