### PR TITLE
Update process-agent shouldStayAlive check in Kubernetes environments

### DIFF
--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -65,6 +65,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/metadata/workloadmeta/collector"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/process/util/coreagent"
 	"github.com/DataDog/datadog-agent/pkg/util/coredump"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -323,7 +324,7 @@ func initMisc(deps miscDeps) error {
 // TODO: remove this once the Helm chart no longer deploys the process-agent container when
 // runInCoreAgent is enabled (the chart's doNotCheckTag logic prevents automatic detection).
 func shouldStayAlive() bool {
-	if env.IsKubernetes() {
+	if env.IsKubernetes() && coreagent.ProcessChecksRunInCoreAgent() {
 		log.Error("The process-agent is idle: process checks run in the core agent. Update your Helm chart or Datadog Operator to the latest version to prevent this (https://docs.datadoghq.com/containers/kubernetes/installation/).")
 		return true
 	}


### PR DESCRIPTION
### What does this PR do?

Reduces the scope of `shouldStayAlive` so that only Linux on K8s could be affected using the `coreagent.ProcessChecksRunInCoreAgent` function which only returns true on Linux. In theory, this function shouldn't even be reached in a Windows K8s scenario since the process-agent container will be deployed any relevant check (NPM/Process). However, it seems appropriate to reduce potential scope since if this occurs, it signals a bigger problem since the checks won't run anywhere else.

### Motivation
Do not potentially keep agents on Windows K8s alive.

### Describe how you validated your changes
e2e

### Additional Notes
