### PR TITLE
Neutralize `GOROOT`/`GOPATH` when running `gopatch`

### DIFF
--- a/bazel/rules/go_sdk_overrides/repo.bzl
+++ b/bazel/rules/go_sdk_overrides/repo.bzl
@@ -19,7 +19,7 @@ def _impl(rctx):
                 rctx,
                 op = "gopatch {}".format(p),
                 arguments = [go, "-C", rctx.path(rctx.attr._gopatch).dirname, "run", ".", "-p", p, rctx.path(".")],
-                environment = {"GOWORK": "off"},
+                environment = {"GOPATH": None, "GOROOT": None, "GOWORK": "off"},
             )
         else:
             rctx.patch(p, strip = 1)


### PR DESCRIPTION
### Motivation
Ambient `GOROOT` or `GOPATH` leak into `rctx.execute` calls because Bazel repository rules inherit the full environment by default.

### What does this PR do?
Setting those variables to `None` in the environment dict removes them from the subprocess, letting Go derive its own `GOROOT` from the hermetic SDK binary path and ignore any stale `GOPATH`.

### Describe how you validated your changes
All credits to @chouquette: https://github.com/DataDog/datadog-agent/pull/48032#pullrequestreview-3974199551.

### Additional Notes
This is a stopgap until `--experimental_strict_repo_env` is enabled project-wide and can be kept should the latter be reverted or disabled locally.