### PR TITLE
fix(process): prepare tests for default discovery.enabled=true

### DIFF
--- a/cmd/agent/subcommands/processchecks/command_test.go
+++ b/cmd/agent/subcommands/processchecks/command_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestCommand(t *testing.T) {
+	t.Setenv("DD_DISCOVERY_ENABLED", "false")
 	testDir := t.TempDir()
 
 	configPath := path.Join(testDir, "datadog.yaml")

--- a/cmd/agent/subcommands/processchecks/command_test.go
+++ b/cmd/agent/subcommands/processchecks/command_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestCommand(t *testing.T) {
-	t.Setenv("DD_DISCOVERY_ENABLED", "false")
 	testDir := t.TempDir()
 
 	configPath := path.Join(testDir, "datadog.yaml")

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -123,6 +123,7 @@ func TestBundleOneShot(t *testing.T) {
 		fx.Provide(func(ipcComp ipc.Component) ipc.HTTPClient { return ipcComp.GetClient() }),
 		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
 		sysprobeconfigimpl.MockModule(),
+		fx.Replace(sysprobeconfigimpl.MockParams{Overrides: map[string]interface{}{"discovery.enabled": false}}),
 		telemetryimpl.MockModule(),
 		hostnameimpl.MockModule(),
 		fx.Provide(func() delegatedauth.Component { return delegatedauthmock.New(t) }),

--- a/comp/process/bundle_test.go
+++ b/comp/process/bundle_test.go
@@ -31,6 +31,8 @@ import (
 	tagger "github.com/DataDog/datadog-agent/comp/core/tagger/def"
 	taggerfxmock "github.com/DataDog/datadog-agent/comp/core/tagger/fx-mock"
 	"github.com/DataDog/datadog-agent/comp/core/telemetry/telemetryimpl"
+	workloadfilter "github.com/DataDog/datadog-agent/comp/core/workloadfilter/def"
+	workloadfilterfxmock "github.com/DataDog/datadog-agent/comp/core/workloadfilter/fx-mock"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
 	workloadmetafxmock "github.com/DataDog/datadog-agent/comp/core/workloadmeta/fx-mock"
 	"github.com/DataDog/datadog-agent/comp/dogstatsd/statsd"
@@ -43,6 +45,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process/types"
 	rdnsquerier "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx-mock"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
+	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
 )
 
@@ -123,7 +126,10 @@ func TestBundleOneShot(t *testing.T) {
 		fx.Provide(func(ipcComp ipc.Component) ipc.HTTPClient { return ipcComp.GetClient() }),
 		fx.Provide(func() secrets.Component { return secretsmock.New(t) }),
 		sysprobeconfigimpl.MockModule(),
-		fx.Replace(sysprobeconfigimpl.MockParams{Overrides: map[string]interface{}{"discovery.enabled": false}}),
+		workloadfilterfxmock.MockModule(),
+		fx.Invoke(func(wmeta workloadmeta.Component, tagger tagger.Component, filterStore workloadfilter.Component) {
+			proccontainers.InitSharedContainerProvider(wmeta, tagger, filterStore)
+		}),
 		telemetryimpl.MockModule(),
 		hostnameimpl.MockModule(),
 		fx.Provide(func() delegatedauth.Component { return delegatedauthmock.New(t) }),

--- a/comp/process/containercheck/containercheckimpl/check_test.go
+++ b/comp/process/containercheck/containercheckimpl/check_test.go
@@ -38,8 +38,11 @@ func TestContainerCheckIsEnabled(t *testing.T) {
 	}{
 		{
 			// the container collection is enabled by default in containerized environments
-			name:             "empty config - container collection is enabled",
-			configs:          nil,
+			name:    "empty config - container collection is enabled",
+			configs: nil,
+			sysProbeConfigs: map[string]interface{}{
+				"discovery.enabled": false,
+			},
 			containerizedEnv: true,
 			enabled:          true,
 		},
@@ -57,6 +60,9 @@ func TestContainerCheckIsEnabled(t *testing.T) {
 			configs: map[string]interface{}{
 				"process_config.process_collection.enabled":   false,
 				"process_config.container_collection.enabled": true,
+			},
+			sysProbeConfigs: map[string]interface{}{
+				"discovery.enabled": false,
 			},
 			containerizedEnv: true,
 			enabled:          true,
@@ -98,7 +104,9 @@ func TestContainerCheckIsEnabled(t *testing.T) {
 				"process_config.process_collection.enabled":   false,
 				"process_config.container_collection.enabled": true,
 			},
-
+			sysProbeConfigs: map[string]interface{}{
+				"discovery.enabled": false,
+			},
 			containerizedEnv: true,
 			flavor:           flavor.DefaultAgent,
 			enabled:          true,

--- a/comp/process/processdiscoverycheck/processdiscoverycheckimpl/check_test.go
+++ b/comp/process/processdiscoverycheck/processdiscoverycheckimpl/check_test.go
@@ -29,8 +29,10 @@ func TestProcessDiscoveryIsEnabled(t *testing.T) {
 			configs: map[string]interface{}{
 				"process_config.process_discovery.enabled": true,
 			},
-			sysProbeConfigs: map[string]interface{}{},
-			enabled:         true,
+			sysProbeConfigs: map[string]interface{}{
+				"discovery.enabled": false,
+			},
+			enabled: true,
 		},
 		{
 			name: "disabled",

--- a/comp/process/rtcontainercheck/rtcontainercheckimpl/check_test.go
+++ b/comp/process/rtcontainercheck/rtcontainercheckimpl/check_test.go
@@ -37,8 +37,11 @@ func TestRTContainerCheckIsEnabled(t *testing.T) {
 	}{
 		{
 			// the container collection is enabled by default in containerized environments
-			name:             "empty config - container collection is enabled",
-			configs:          nil,
+			name:    "empty config - container collection is enabled",
+			configs: nil,
+			sysProbeConfigs: map[string]interface{}{
+				"discovery.enabled": false,
+			},
 			containerizedEnv: true,
 			enabled:          true,
 		},
@@ -56,6 +59,9 @@ func TestRTContainerCheckIsEnabled(t *testing.T) {
 			configs: map[string]interface{}{
 				"process_config.process_collection.enabled":   false,
 				"process_config.container_collection.enabled": true,
+			},
+			sysProbeConfigs: map[string]interface{}{
+				"discovery.enabled": false,
 			},
 			containerizedEnv: true,
 			enabled:          true,
@@ -107,7 +113,9 @@ func TestRTContainerCheckIsEnabled(t *testing.T) {
 				"process_config.process_collection.enabled":   false,
 				"process_config.container_collection.enabled": true,
 			},
-
+			sysProbeConfigs: map[string]interface{}{
+				"discovery.enabled": false,
+			},
 			containerizedEnv: true,
 			flavor:           flavor.DefaultAgent,
 			enabled:          true,

--- a/pkg/process/checks/process_discovery_check_linux_test.go
+++ b/pkg/process/checks/process_discovery_check_linux_test.go
@@ -24,7 +24,6 @@ func TestProcessDiscoveryLinuxRunsInCoreAgent(t *testing.T) {
 	sysCfg := configmock.NewSystemProbe(t)
 	cfg.SetWithoutSource("process_config.process_collection.enabled", false)
 	cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
-	cfg.SetWithoutSource("process_config.run_in_core_agent.enabled", true)
 	sysCfg.SetWithoutSource("discovery.enabled", false)
 
 	tests := []struct {

--- a/pkg/process/checks/process_discovery_check_linux_test.go
+++ b/pkg/process/checks/process_discovery_check_linux_test.go
@@ -24,6 +24,8 @@ func TestProcessDiscoveryLinuxRunsInCoreAgent(t *testing.T) {
 	sysCfg := configmock.NewSystemProbe(t)
 	cfg.SetWithoutSource("process_config.process_collection.enabled", false)
 	cfg.SetWithoutSource("process_config.process_discovery.enabled", true)
+	cfg.SetWithoutSource("process_config.run_in_core_agent.enabled", true)
+	sysCfg.SetWithoutSource("discovery.enabled", false)
 
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### What does this PR do?

Fixes process-related tests that break when `discovery.enabled` defaults to
true. When discovery is enabled, `isProcessCheckEnabled()` returns true, which
makes `canEnableContainerChecks()` return false (process and container checks
are mutually exclusive) and `ProcessDiscoveryCheck.IsEnabled()` return false
(process check and process discovery check are mutually exclusive). This breaks test
cases that don't intend to test discovery behavior.

Changes per test file:
- **ContainerCheck / RTContainerCheck tests**: Add `"discovery.enabled": false`
  to `sysProbeConfigs` in test cases that expect container checks to be enabled.
  Existing "service discovery disables the container check" test cases already
  cover the `discovery.enabled=true` scenario.
- **ProcessDiscoveryCheck test**: Pin `discovery.enabled=false` in the "enabled"
  test case which tests process_discovery without process_collection, not
  discovery behavior.
- **process_discovery_check_linux_test**: Pin `discovery.enabled=false` since
  the test is about run-in-core-agent behavior, not discovery.
- **TestBundleOneShot (comp/process)**: Instead of disabling discovery, add the
  missing `InitSharedContainerProvider` wiring and `workloadfilter` mock to
  match production initialization. This ensures the test exercises the bundle
  with discovery enabled.

### Motivation

Preparing for `discovery.enabled` to default to true. These tests don't test
discovery behavior and should not be affected by the default change.

### Describe how you validated your changes

`dda inv test --targets=./comp/process/` — all 81 tests pass.
`dda inv test --targets=./cmd/agent/subcommands/processchecks/` — passes.