### PR TITLE
ci: add dd-octo-sts trust policy for integrations-core days-since-last-pin

### DIFF
--- a/.github/chainguard/integrations-core.github.read-release-json.schedule.sts.yaml
+++ b/.github/chainguard/integrations-core.github.read-release-json.schedule.sts.yaml
@@ -1,0 +1,12 @@
+# Policy for: .github/workflows/days-since-last-pin.yml in DataDog/integrations-core
+issuer: https://token.actions.githubusercontent.com
+subject: repo:DataDog/integrations-core:ref:refs/heads/master
+
+claim_pattern:
+  event_name: (schedule|workflow_dispatch)
+  job_workflow_ref: DataDog/integrations-core/\.github/workflows/days-since-last-pin\.yml@refs/heads/master
+  ref: refs/heads/master
+  repository: DataDog/integrations-core
+
+permissions:
+  contents: read


### PR DESCRIPTION
## Summary

Adds a dd-octo-sts trust policy authorizing `DataDog/integrations-core`'s daily `days-since-last-pin` workflow to read `release.json` from this repo.

Needed for https://github.com/DataDog/integrations-core/pull/22951

## Context

The `days-since-last-pin.yml` workflow in `integrations-core` (Jira: AI-6462) computes how many days it has been since `INTEGRATIONS_CORE_VERSION` was last updated in this repo's `release.json`, and posts a gauge metric to Datadog for CI dashboard alerting (turns red when > 4 days).

## Policy

**File:** `.github/chainguard/integrations-core.github.read-release-json.schedule.sts.yaml`

- **Source:** `DataDog/integrations-core` (scheduled + workflow_dispatch, runs on `master`)
- **Permission:** `contents: read` on this repo (to read `release.json` at historical SHAs and query the commits API)
- Restricted to the exact workflow file and default branch via `claim_pattern`

## Related PR

DataDog/integrations-core#22951