### PR TITLE
[Backport 7.77.x][CWS] skip empty hostname check when running as a Fargate sidecar

### DIFF
--- a/cmd/system-probe/modules/eventmonitor.go
+++ b/cmd/system-probe/modules/eventmonitor.go
@@ -22,6 +22,7 @@ import (
 	secmodule "github.com/DataDog/datadog-agent/pkg/security/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
+	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -53,7 +54,9 @@ func createEventMonitorModule(_ *sysconfigtypes.Config, deps module.FactoryDepen
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hostname: %w", err)
 	}
-	if hostname == "" {
+
+	// there is no hostname on Fargate instance
+	if !fargate.IsSidecar() && hostname == "" {
 		return nil, errors.New("hostname from core agent is empty")
 	}
 


### PR DESCRIPTION
On Fargate, the agent runs as a sidecar container and does not have a traditional hostname. The previous check unconditionally returned an error when the hostname was empty, preventing the event monitor from initializing in Fargate environments.

Skip the empty hostname validation when `fargate.IsSidecar()` returns true so CWS can start correctly on Fargate.

(cherry picked from commit a9bbb48db5ab31006350cfb5d43047c1cc9f9ce8)

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
