### PR TITLE
[workloadmeta/kubemetadata] Extract metadataProvider strategy

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go
@@ -10,18 +10,13 @@ package kubemetadata
 
 import (
 	"context"
-	stderrors "errors"
-	"fmt"
-	"strings"
 	"time"
 
 	"go.uber.org/fx"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/DataDog/datadog-agent/comp/core/workloadmeta/collectors/util"
 	workloadmeta "github.com/DataDog/datadog-agent/comp/core/workloadmeta/def"
-	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	configutils "github.com/DataDog/datadog-agent/pkg/config/utils"
@@ -53,6 +48,7 @@ type collector struct {
 	lastUpdate                  time.Time
 	collectNamespaceLabels      bool
 	collectNamespaceAnnotations bool
+	ignoreServiceReadiness      bool
 
 	// stream is the gRPC streaming client for pod-to-service and namespace
 	// metadata. nil if streaming is disabled or the DCA is not enabled.
@@ -129,6 +125,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 	metadataAsTags := configutils.GetMetadataAsTags(pkgconfigsetup.Datadog())
 	c.collectNamespaceLabels = len(metadataAsTags.GetNamespaceLabelsAsTags()) > 0
 	c.collectNamespaceAnnotations = len(metadataAsTags.GetNamespaceAnnotationsAsTags()) > 0
+	c.ignoreServiceReadiness = pkgconfigsetup.Datadog().GetBool("kubernetes_kube_service_ignore_readiness")
 
 	if c.dcaEnabled && pkgconfigsetup.Datadog().GetBool("kubernetes_metadata_streaming") {
 		nodeName, nodeNameErr := c.kubeUtil.GetNodename(ctx)
@@ -163,14 +160,6 @@ func (c *collector) Pull(ctx context.Context) error {
 	pods, err := c.kubeUtil.GetLocalPodList(ctx)
 	if err != nil {
 		return err
-	}
-
-	if !c.isDCAEnabled() {
-		// If the DCA is not used, each agent stores a local cache of the MetadataMap.
-		err = c.addToCacheMetadataMapping(pods)
-		if err != nil {
-			log.Debugf("Cannot add the metadataMapping to cache: %v", err)
-		}
 	}
 
 	seen := make(map[workloadmeta.EntityID]struct{})
@@ -267,33 +256,20 @@ func (c *collector) parsePods(
 	pods []*kubelet.Pod,
 	seen map[workloadmeta.EntityID]struct{},
 ) ([]workloadmeta.CollectorEvent, error) {
-	events := []workloadmeta.CollectorEvent{}
-
-	var err error
-	var metadataByNsPods apiv1.NamespacesPodsStringsSet
-
-	streamActive := c.stream != nil && c.stream.isActive()
-
-	if !streamActive && c.isDCAEnabled() {
-		dcaVersion := c.dcaClient.Version(false)
-		if dcaVersion.Major >= 1 && dcaVersion.Minor >= 3 {
-			var nodeName string
-			nodeName, err = c.kubeUtil.GetNodename(ctx)
-			if err != nil {
-				log.Errorf("Could not retrieve the Nodename, err: %v", err)
-				return events, err
-			}
-
-			metadataByNsPods, err = c.dcaClient.GetPodsMetadataForNode(nodeName)
-			if err != nil {
-				log.Debugf("Could not pull the metadata map of pods on node %s from the Datadog Cluster Agent: %s", nodeName, err.Error())
-				return events, err
-			}
-		}
+	// selectProvider is called on every pull (instead of Start) because:
+	// 1. The stream provider can fall back to another one if the DCA returns
+	// "unimplemented" after Start.
+	// 2. Providers have a per-pull namespace cache.
+	provider, err := c.selectProvider(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	// To get metadata/labels once per namespace.
-	metadataByNS := make(map[string]*clusteragent.Metadata)
+	if err := provider.prepare(pods); err != nil {
+		return nil, err
+	}
+
+	events := []workloadmeta.CollectorEvent{}
 
 	for _, pod := range pods {
 		if pod.Metadata.UID == "" {
@@ -301,97 +277,13 @@ func (c *collector) parsePods(
 		}
 
 		services := []string{}
-
-		// collectService if new kube_service bahavior is active
-		// or if not active, use old condition IsPodReady
-		collectService := pkgconfigsetup.Datadog().GetBool("kubernetes_kube_service_ignore_readiness") || kubelet.IsPodReady(pod)
-
-		if collectService {
-			if streamActive {
-				if svcList, ok := c.stream.getServices(pod.Metadata.Namespace, pod.Metadata.Name); ok {
-					services = svcList
-				}
-			} else {
-				metadata, metaErr := c.getMetadata(apiserver.GetPodMetadataNames, metadataByNsPods, pod)
-				if metaErr != nil {
-					log.Debugf("Could not fetch metadata for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, metaErr)
-				}
-				for _, data := range metadata {
-					d := strings.Split(data, ":")
-					switch len(d) {
-					case 1:
-						// c.dcaClient.GetPodsMetadataForNode returns only a list of services without tag key
-						services = append(services, d[0])
-					case 2:
-						services = append(services, d[1])
-					default:
-						continue
-					}
-				}
+		if c.shouldCollectServices(pod) {
+			if s := provider.getKubernetesServices(pod); s != nil {
+				services = s
 			}
 		}
 
-		var nsLabels, nsAnnotations map[string]string
-
-		if streamActive {
-			if labels, annotations, ok := c.stream.getNamespaceMetadata(pod.Metadata.Namespace); ok {
-				if c.collectNamespaceLabels {
-					nsLabels = labels
-				}
-				if c.collectNamespaceAnnotations {
-					nsAnnotations = annotations
-				}
-				if c.collectNamespaceLabels || c.collectNamespaceAnnotations {
-					metadataByNS[pod.Metadata.Namespace] = &clusteragent.Metadata{
-						Labels:      labels,
-						Annotations: annotations,
-					}
-				}
-			}
-		} else if c.isDCAEnabled() && c.dcaClient.SupportsNamespaceMetadataCollection() {
-			// Cluster agent with version 7.55+
-			nsMetadata, ok := metadataByNS[pod.Metadata.Namespace]
-			if !ok {
-				nsMetadata, err = c.getNamespaceMetadata(pod.Metadata.Namespace)
-				if err == nil {
-					metadataByNS[pod.Metadata.Namespace] = nsMetadata
-				} else {
-					log.Errorf("Could not fetch namespace metadata for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
-				}
-			}
-
-			if nsMetadata != nil {
-				if c.collectNamespaceAnnotations {
-					nsAnnotations = nsMetadata.Annotations
-				}
-
-				if c.collectNamespaceLabels {
-					nsLabels = nsMetadata.Labels
-				}
-			}
-		} else {
-			// Cluster agent with version older than 7.55
-			nsMetadata, ok := metadataByNS[pod.Metadata.Namespace]
-			if !ok {
-				nsLabels, err = c.getNamespaceLabels(pod.Metadata.Namespace)
-				if err == nil {
-					nsMetadata = &clusteragent.Metadata{
-						Labels: nsLabels,
-					}
-					metadataByNS[pod.Metadata.Namespace] = nsMetadata
-				} else {
-					log.Errorf("Could not fetch namespace labels for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
-				}
-			}
-
-			if nsMetadata != nil {
-				nsLabels = nsMetadata.Labels
-			}
-
-			if c.collectNamespaceAnnotations {
-				log.Errorf("Could not fetch namespace annotations for pod %s/%s: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent", pod.Metadata.Namespace, pod.Metadata.Name)
-			}
-		}
+		nsLabels, nsAnnotations := provider.getNamespaceMetadata(pod.Metadata.Namespace)
 
 		entityID := workloadmeta.EntityID{
 			Kind: workloadmeta.KindKubernetesPod,
@@ -421,7 +313,7 @@ func (c *collector) parsePods(
 	}
 
 	// Save kubernetes namespace metadata entities for caching
-	for ns, nsMetadata := range metadataByNS {
+	for ns, nsMetadata := range provider.getCollectedNamespaces() {
 		nsEntity := createNamespaceEntity(ns, nsMetadata)
 		nsEntityID := nsEntity.GetID()
 
@@ -438,54 +330,6 @@ func (c *collector) parsePods(
 	return events, nil
 }
 
-// getMetadata returns the cluster level metadata (kube service only currently).
-func (c *collector) getMetadata(getPodMetaDataFromAPIServerFunc func(string, string, string) ([]string, error), metadataByNsPods apiv1.NamespacesPodsStringsSet, po *kubelet.Pod) ([]string, error) {
-	if !c.isDCAEnabled() {
-		metadataNames, err := getPodMetaDataFromAPIServerFunc(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
-		if err != nil {
-			err = fmt.Errorf("could not fetch cluster level tags of pod: %s, %v", po.Metadata.Name, err)
-		}
-		return metadataNames, err
-	}
-
-	if metadataByNsPods != nil {
-		if data, ok := metadataByNsPods[po.Metadata.Namespace][po.Metadata.Name]; ok && data != nil {
-			return sets.List(data), nil
-		}
-		return nil, nil
-	}
-
-	metadataNames, err := c.dcaClient.GetKubernetesMetadataNames(po.Spec.NodeName, po.Metadata.Namespace, po.Metadata.Name)
-	if err != nil {
-		err = fmt.Errorf("could not pull the metadata map of pod %s on node %s, %v", po.Metadata.Name, po.Spec.NodeName, err)
-	}
-
-	return metadataNames, err
-}
-
-// getNamespaceLabels returns the namespace labels, fast return if namespace labels as tags is disabled.
-func (c *collector) getNamespaceLabels(ns string) (map[string]string, error) {
-	if !c.collectNamespaceLabels || !c.isDCAEnabled() {
-		return nil, nil
-	}
-
-	return c.dcaClient.GetNamespaceLabels(ns)
-}
-
-// getNamespaceMetadata returns the namespace metadata
-// fast return if both namespace annotations and labels as tags are disabled, or if cluster agent is disabled
-// This endpoint is supported for cluster agents with version 7.55+
-func (c *collector) getNamespaceMetadata(ns string) (*clusteragent.Metadata, error) {
-	if !c.collectNamespaceAnnotations && !c.collectNamespaceLabels {
-		return nil, nil
-	}
-
-	if !c.isDCAEnabled() {
-		return nil, stderrors.New("cluster agent should be enabled in order to allow fetching namespace metadata")
-	}
-	return c.dcaClient.GetNamespaceMetadata(ns)
-}
-
 func (c *collector) isDCAEnabled() bool {
 	if c.dcaEnabled && c.dcaClient != nil {
 		v := c.dcaClient.Version(false)
@@ -497,18 +341,42 @@ func (c *collector) isDCAEnabled() bool {
 	return false
 }
 
+func (c *collector) selectProvider(ctx context.Context) (metadataProvider, error) {
+	if c.stream != nil && !c.stream.isUnimplemented() {
+		return newStreamProvider(c.stream, c.collectNamespaceLabels, c.collectNamespaceAnnotations), nil
+	}
+
+	if !c.isDCAEnabled() {
+		return newLocalAPIServerProvider(c.apiClient), nil
+	}
+
+	dcaVersion := c.dcaClient.Version(false)
+	if supportsPerNodePodMetadata(dcaVersion) {
+		nodeName, err := c.kubeUtil.GetNodename(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if c.dcaClient.SupportsNamespaceMetadataCollection() {
+			return newDCAFullProvider(nodeName, c.dcaClient, c.collectNamespaceLabels, c.collectNamespaceAnnotations), nil
+		}
+
+		return newDCAPerNodeProvider(nodeName, c.dcaClient, c.collectNamespaceLabels, c.collectNamespaceAnnotations), nil
+	}
+
+	return newDCAPerPodProvider(c.dcaClient, c.collectNamespaceLabels, c.collectNamespaceAnnotations), nil
+}
+
 // createNamespaceEntity creates a KubernetesMetadata entity for a namespace
-func createNamespaceEntity(namespaceName string, metadata *clusteragent.Metadata) *workloadmeta.KubernetesMetadata {
+func createNamespaceEntity(namespaceName string, metadata namespaceMetadata) *workloadmeta.KubernetesMetadata {
 	labels := make(map[string]string)
 	annotations := make(map[string]string)
 
-	if metadata != nil {
-		if metadata.Labels != nil {
-			labels = metadata.Labels
-		}
-		if metadata.Annotations != nil {
-			annotations = metadata.Annotations
-		}
+	if metadata.labels != nil {
+		labels = metadata.labels
+	}
+	if metadata.annotations != nil {
+		annotations = metadata.annotations
 	}
 
 	return &workloadmeta.KubernetesMetadata{
@@ -529,24 +397,6 @@ func createNamespaceEntity(namespaceName string, metadata *clusteragent.Metadata
 	}
 }
 
-// addToCacheMetadataMapping is acting like the DCA at the node level.
-func (c *collector) addToCacheMetadataMapping(kubeletPodList []*kubelet.Pod) error {
-	if len(kubeletPodList) == 0 {
-		log.Debug("Empty kubelet pod list")
-		return nil
-	}
-
-	reachablePods := make([]*kubelet.Pod, 0)
-	nodeName := ""
-	for _, p := range kubeletPodList {
-		if p.Status.PodIP == "" {
-			continue
-		}
-		if nodeName == "" && p.Spec.NodeName != "" {
-			nodeName = p.Spec.NodeName
-		}
-		reachablePods = append(reachablePods, p)
-	}
-
-	return c.apiClient.NodeMetadataMapping(nodeName, reachablePods)
+func (c *collector) shouldCollectServices(pod *kubelet.Pod) bool {
+	return c.ignoreServiceReadiness || kubelet.IsPodReady(pod)
 }

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata_test.go
@@ -9,8 +9,6 @@ package kubemetadata
 
 import (
 	"context"
-	"errors"
-	"reflect"
 	"testing"
 	"time"
 
@@ -29,6 +27,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
+
+type fakeKubeUtil struct {
+	kubelet.KubeUtil
+	nodeName string
+}
+
+func (f *fakeKubeUtil) GetNodename(_ context.Context) (string, error) { return f.nodeName, nil }
 
 type FakeDCAClient struct {
 	LocalVersion                 version.Version
@@ -136,6 +141,85 @@ func (f *FakeDCAClient) PostLanguageMetadata(_ context.Context, _ *pbgo.ParentLa
 
 func (f *FakeDCAClient) SupportsNamespaceMetadataCollection() bool {
 	return f.LocalVersion.Major >= 7 && f.LocalVersion.Minor >= 55
+}
+
+func TestCollector_selectProvider(t *testing.T) {
+	tests := []struct {
+		name      string
+		collector collector
+		wantType  interface{}
+	}{
+		{
+			name: "local apiserver provider when DCA is disabled",
+			collector: collector{
+				dcaClient: nil,
+			},
+			wantType: &localAPIServerProvider{},
+		},
+		{
+			name: "per-pod provider for DCA < 1.3",
+			collector: collector{
+				dcaEnabled: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion: version.Version{Major: 1, Minor: 2},
+				},
+			},
+			wantType: &dcaPerPodProvider{},
+		},
+		{
+			name: "per-node provider for DCA >= 1.3 and < 7.55",
+			collector: collector{
+				dcaEnabled: true,
+				kubeUtil:   &fakeKubeUtil{nodeName: "node-a"},
+				dcaClient: &FakeDCAClient{
+					LocalVersion: version.Version{Major: 7, Minor: 54},
+				},
+			},
+			wantType: &dcaPerNodeProvider{},
+		},
+		{
+			name: "full provider for DCA >= 7.55",
+			collector: collector{
+				dcaEnabled: true,
+				kubeUtil:   &fakeKubeUtil{nodeName: "node-a"},
+				dcaClient: &FakeDCAClient{
+					LocalVersion: version.Version{Major: 7, Minor: 55},
+				},
+			},
+			wantType: &dcaFullProvider{},
+		},
+		{
+			name: "stream provider initialized and did not return unimplemented",
+			collector: collector{
+				dcaEnabled: true,
+				dcaClient: &FakeDCAClient{
+					LocalVersion: version.Version{Major: 7, Minor: 58},
+				},
+				stream: &streamClient{unimplemented: false},
+			},
+			wantType: &streamProvider{},
+		},
+		{
+			name: "selects full provider when stream provider is initialized but returned unimplemented",
+			collector: collector{
+				dcaEnabled: true,
+				kubeUtil:   &fakeKubeUtil{nodeName: "node-a"},
+				dcaClient: &FakeDCAClient{
+					LocalVersion: version.Version{Major: 7, Minor: 58},
+				},
+				stream: &streamClient{unimplemented: true},
+			},
+			wantType: &dcaFullProvider{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := tt.collector.selectProvider(context.TODO())
+			assert.NoError(t, err)
+			assert.IsType(t, tt.wantType, provider)
+		})
+	}
 }
 
 func TestCollector_detectExpiredNamespace(t *testing.T) {
@@ -264,275 +348,6 @@ func TestCollector_createUnsetEvent(t *testing.T) {
 	}
 }
 
-func TestKubeMetadataCollector_getMetadata(t *testing.T) {
-	type fields struct {
-		dcaClient           clusteragent.DCAClientInterface
-		clusterAgentEnabled bool
-	}
-	type args struct {
-		getPodMetaDataFromAPIServerFunc func(string, string, string) ([]string, error)
-		metadataByNsPods                apiv1.NamespacesPodsStringsSet
-		po                              *kubelet.Pod
-	}
-
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    []string
-		wantErr bool
-	}{
-		{
-			name: "clusterAgentEnabled not enable",
-			args: args{
-				getPodMetaDataFromAPIServerFunc: func(string, string, string) ([]string, error) {
-					return []string{"foo=bar"}, nil
-				},
-				po: &kubelet.Pod{},
-			},
-			fields: fields{
-				clusterAgentEnabled: false,
-				dcaClient:           &FakeDCAClient{},
-			},
-			want:    []string{"foo=bar"},
-			wantErr: false,
-		},
-
-		{
-			name: "clusterAgentEnabled not enable, APIserver return error",
-			args: args{
-				getPodMetaDataFromAPIServerFunc: func(string, string, string) ([]string, error) {
-					return nil, errors.New("fake error")
-				},
-				po: &kubelet.Pod{},
-			},
-			fields: fields{
-				clusterAgentEnabled: false,
-				dcaClient:           &FakeDCAClient{},
-			},
-			want:    nil,
-			wantErr: true,
-		},
-
-		{
-			name: "clusterAgentEnabled enable, but old version",
-			args: args{
-				getPodMetaDataFromAPIServerFunc: func(string, string, string) ([]string, error) {
-					return []string{"foo=bar"}, nil
-				},
-				po: &kubelet.Pod{},
-			},
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion:            version.Version{Major: 1, Minor: 2},
-					KubernetesMetadataNames: []string{"foo=bar"},
-				},
-			},
-			want:    []string{"foo=bar"},
-			wantErr: false,
-		},
-
-		{
-			name: "clusterAgentEnabled enable, but old version",
-			args: args{
-				getPodMetaDataFromAPIServerFunc: func(string, string, string) ([]string, error) {
-					return []string{"foo=bar"}, nil
-				},
-				po: &kubelet.Pod{},
-			},
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient:           &clusteragent.DCAClient{},
-			},
-			want:    []string{"foo=bar"},
-			wantErr: false,
-		},
-
-		{
-			name: "clusterAgentEnabled enable, but old version, DCS return error",
-			args: args{
-				getPodMetaDataFromAPIServerFunc: func(string, string, string) ([]string, error) {
-					return []string{"foo=bar"}, nil
-				},
-				po: &kubelet.Pod{},
-			},
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion:               version.Version{Major: 1, Minor: 2},
-					KubernetesMetadataNamesErr: errors.New("fake error"),
-				},
-			},
-			want:    nil,
-			wantErr: true,
-		},
-
-		{
-			name: "clusterAgentEnabled enable with new version",
-			args: args{
-				getPodMetaDataFromAPIServerFunc: func(string, string, string) ([]string, error) {
-					return []string{"foo=bar"}, nil
-				},
-				po: &kubelet.Pod{Metadata: kubelet.PodMetadata{
-					Namespace: "test",
-					Name:      "pod-bar",
-				}},
-				metadataByNsPods: apiv1.NamespacesPodsStringsSet{
-					"test": apiv1.MapStringSet{
-						"pod-bar": sets.New("foo=bar"),
-					},
-				},
-			},
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion: version.Version{Major: 1, Minor: 3},
-				},
-			},
-			want:    []string{"foo=bar"},
-			wantErr: false,
-		},
-		{
-			name: "clusterAgentEnabled enable with new version (error case, pod not exist)",
-			args: args{
-				getPodMetaDataFromAPIServerFunc: func(string, string, string) ([]string, error) {
-					return []string{"foo=bar"}, nil
-				},
-				po: &kubelet.Pod{Metadata: kubelet.PodMetadata{
-					Namespace: "test",
-					Name:      "pod-bar",
-				}},
-				metadataByNsPods: apiv1.NamespacesPodsStringsSet{
-					"test": apiv1.MapStringSet{},
-				},
-			},
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion: version.Version{Major: 1, Minor: 3},
-				},
-			},
-			want:    nil,
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &collector{
-				dcaClient:  tt.fields.dcaClient,
-				dcaEnabled: tt.fields.clusterAgentEnabled,
-			}
-			got, err := c.getMetadata(tt.args.getPodMetaDataFromAPIServerFunc, tt.args.metadataByNsPods, tt.args.po)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("KubeMetadataCollector.getMetadaNames() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("KubeMetadataCollector.getMetadaNames() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestKubeMetadataCollector_getNamespaceMetadata(t *testing.T) {
-	type fields struct {
-		dcaClient           clusteragent.DCAClientInterface
-		clusterAgentEnabled bool
-	}
-
-	tests := []struct {
-		name                       string
-		fields                     fields
-		namespaceAnnotationsAsTags map[string]string
-		namespaceLabelsAsTags      map[string]string
-		want                       *workloadmeta.EntityMeta
-		wantErr                    bool
-	}{
-		{
-			name:    "no namespace annotations as tags and no namespace labels as tags",
-			want:    nil,
-			wantErr: false,
-		},
-		{
-			name: "cluster agent not enabled",
-			fields: fields{
-				clusterAgentEnabled: false,
-				dcaClient:           &FakeDCAClient{},
-			},
-			namespaceAnnotationsAsTags: map[string]string{
-				"annot-key": "annot-tag",
-			},
-			namespaceLabelsAsTags: map[string]string{
-				"label-key": "label-tag",
-			},
-			want:    nil,
-			wantErr: true,
-		},
-		{
-			name: "cluster agent enabled",
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion: version.Version{Major: 1, Minor: 12},
-					NamespaceMetadata: clusteragent.Metadata{
-						Annotations: map[string]string{
-							"annot-key": "value",
-						},
-						Labels: map[string]string{
-							"label-key": "value",
-						},
-					},
-				},
-			},
-			namespaceAnnotationsAsTags: map[string]string{
-				"annot-key": "annot-tag",
-			},
-			namespaceLabelsAsTags: map[string]string{
-				"label-key": "label-tag",
-			},
-			want: &workloadmeta.EntityMeta{
-				Labels:      map[string]string{"label-key": "value"},
-				Annotations: map[string]string{"annot-key": "value"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "cluster agent enabled and failed to get namespace metadata",
-			fields: fields{
-				clusterAgentEnabled: true,
-				dcaClient: &FakeDCAClient{
-					LocalVersion:         version.Version{Major: 1, Minor: 12},
-					NamespaceMetadataErr: errors.New("failed to get namespace metadata"),
-				},
-			},
-			namespaceAnnotationsAsTags: map[string]string{
-				"key": "tag",
-			},
-			namespaceLabelsAsTags: map[string]string{
-				"key": "tag",
-			},
-			want:    nil,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := &collector{
-				dcaClient:                   tt.fields.dcaClient,
-				dcaEnabled:                  tt.fields.clusterAgentEnabled,
-				collectNamespaceAnnotations: len(tt.namespaceAnnotationsAsTags) > 0,
-				collectNamespaceLabels:      len(tt.namespaceLabelsAsTags) > 0,
-			}
-
-			metadata, err := c.getNamespaceMetadata("foo")
-			assert.True(t, (err != nil) == tt.wantErr)
-			assert.EqualValues(&testing.T{}, tt.want, metadata)
-		})
-	}
-}
-
 func TestKubeMetadataCollector_parsePods(t *testing.T) {
 	pods := []*kubelet.Pod{{
 		Metadata: kubelet.PodMetadata{
@@ -555,6 +370,11 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 	}}
 	podsCache := kubelet.PodList{
 		Items: pods,
+	}
+	podMetadata := apiv1.NamespacesPodsStringsSet{
+		"default": apiv1.MapStringSet{
+			"foo": sets.New("svc1", "svc2"),
+		},
 	}
 
 	type fields struct {
@@ -587,8 +407,8 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 				dcaEnabled:             true,
 				collectNamespaceLabels: true,
 				dcaClient: &FakeDCAClient{
-					LocalVersion:            version.Version{Major: 1, Minor: 3},
-					KubernetesMetadataNames: []string{"svc1", "svc2"},
+					LocalVersion:       version.Version{Major: 1, Minor: 3},
+					PodMetadataForNode: podMetadata,
 					NamespaceLabels: map[string]string{
 						"label": "value",
 					},
@@ -709,8 +529,8 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 				collectNamespaceLabels:      true,
 				collectNamespaceAnnotations: true,
 				dcaClient: &FakeDCAClient{
-					LocalVersion:            version.Version{Major: 1, Minor: 3},
-					KubernetesMetadataNames: []string{"svc1", "svc2"},
+					LocalVersion:       version.Version{Major: 1, Minor: 3},
+					PodMetadataForNode: podMetadata,
 					NamespaceLabels: map[string]string{
 						"label": "value",
 					},
@@ -777,8 +597,8 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 				collectNamespaceLabels:      true,
 				collectNamespaceAnnotations: true,
 				dcaClient: &FakeDCAClient{
-					LocalVersion:            version.Version{Major: 7, Minor: 55},
-					KubernetesMetadataNames: []string{"svc1", "svc2"},
+					LocalVersion:       version.Version{Major: 7, Minor: 55},
+					PodMetadataForNode: podMetadata,
 					NamespaceLabels: map[string]string{
 						"label": "value",
 					},
@@ -858,8 +678,8 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 				collectNamespaceLabels:      true,
 				collectNamespaceAnnotations: false,
 				dcaClient: &FakeDCAClient{
-					LocalVersion:            version.Version{Major: 7, Minor: 55},
-					KubernetesMetadataNames: []string{"svc1", "svc2"},
+					LocalVersion:       version.Version{Major: 7, Minor: 55},
+					PodMetadataForNode: podMetadata,
 					NamespaceLabels: map[string]string{
 						"label": "value",
 					},
@@ -935,8 +755,8 @@ func TestKubeMetadataCollector_parsePods(t *testing.T) {
 				dcaEnabled:             true,
 				collectNamespaceLabels: false,
 				dcaClient: &FakeDCAClient{
-					LocalVersion:            version.Version{Major: 1, Minor: 3},
-					KubernetesMetadataNames: []string{"svc1", "svc2"},
+					LocalVersion:       version.Version{Major: 1, Minor: 3},
+					PodMetadataForNode: podMetadata,
 					NamespaceLabels: map[string]string{
 						"label": "value",
 					},

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/metadata_provider.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/metadata_provider.go
@@ -1,0 +1,402 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && kubelet
+
+package kubemetadata
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+// The collector supports multiple metadata providers because kube metadata can
+// come from different sources depending on deployment mode and DCA version:
+//
+// - localAPIServerProvider: no DCA. The node Agent calls the kubernetes API server
+// - dcaPerPodProvider:      DCA < 1.3, uses per-pod service mappings endpoint
+// - dcaPerNodeProvider:     DCA >= 1.3, uses per-node service mappings endpoint
+// - dcaFullProvider:        DCA >= 7.55, adds namespace metadata endpoint
+// - streamProvider:         uses streaming endpoint (DCA >= 7.78 and opt-in)
+
+// metadataProvider abstracts how pod services and namespace metadata are
+// fetched.
+type metadataProvider interface {
+	// prepare is called once before iterating pods.
+	prepare(pods []*kubelet.Pod) error
+	// getKubernetesServices returns the kube services for a pod.
+	getKubernetesServices(pod *kubelet.Pod) []string
+	// getNamespaceMetadata returns namespace labels/annotations.
+	getNamespaceMetadata(ns string) (labels, annotations map[string]string)
+	// getCollectedNamespaces returns the namespaces collected while parsing pods.
+	getCollectedNamespaces() map[string]namespaceMetadata
+}
+
+type namespaceMetadata struct {
+	labels      map[string]string
+	annotations map[string]string
+}
+
+type namespaceCache struct {
+	collected map[string]namespaceMetadata
+}
+
+func newNamespaceCache() namespaceCache {
+	return namespaceCache{
+		collected: make(map[string]namespaceMetadata),
+	}
+}
+
+func (c *namespaceCache) getCollectedNamespaces() map[string]namespaceMetadata {
+	return c.collected
+}
+
+func (c *namespaceCache) get(ns string) (namespaceMetadata, bool) {
+	metadata, found := c.collected[ns]
+	return metadata, found
+}
+
+func (c *namespaceCache) set(ns string, metadata namespaceMetadata) namespaceMetadata {
+	c.collected[ns] = metadata
+	return metadata
+}
+
+// localAPIServerProvider is used when the node agent is not using the DCA and
+// must resolve pod services from the local apiserver metadata mapper.
+type localAPIServerProvider struct {
+	apiClient *apiserver.APIClient
+	nsCache   namespaceCache
+}
+
+func newLocalAPIServerProvider(apiClient *apiserver.APIClient) *localAPIServerProvider {
+	return &localAPIServerProvider{
+		apiClient: apiClient,
+		nsCache:   newNamespaceCache(),
+	}
+}
+
+func (p *localAPIServerProvider) prepare(pods []*kubelet.Pod) error {
+	return addToCacheMetadataMapping(p.apiClient, pods)
+}
+
+func (p *localAPIServerProvider) getKubernetesServices(pod *kubelet.Pod) []string {
+	metadata, err := apiserver.GetPodMetadataNames(pod.Spec.NodeName, pod.Metadata.Namespace, pod.Metadata.Name)
+	if err != nil {
+		log.Debugf("Could not fetch metadata for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
+		return nil
+	}
+
+	return metadataNamesToServices(metadata)
+}
+
+func (p *localAPIServerProvider) getNamespaceMetadata(ns string) (labels, annotations map[string]string) {
+	if _, found := p.nsCache.get(ns); !found {
+		p.nsCache.set(ns, namespaceMetadata{})
+	}
+	return nil, nil
+}
+
+func (p *localAPIServerProvider) getCollectedNamespaces() map[string]namespaceMetadata {
+	return p.nsCache.getCollectedNamespaces()
+}
+
+// dcaPerPodProvider is used with older DCA versions that do not expose the
+// per-node metadata endpoint and use the per-pod endpoint instead.
+type dcaPerPodProvider struct {
+	dcaClient                   clusteragent.DCAClientInterface
+	collectNamespaceLabels      bool
+	collectNamespaceAnnotations bool
+	nsCache                     namespaceCache
+}
+
+func newDCAPerPodProvider(
+	dcaClient clusteragent.DCAClientInterface,
+	collectNamespaceLabels bool,
+	collectNamespaceAnnotations bool,
+) *dcaPerPodProvider {
+	return &dcaPerPodProvider{
+		dcaClient:                   dcaClient,
+		collectNamespaceLabels:      collectNamespaceLabels,
+		collectNamespaceAnnotations: collectNamespaceAnnotations,
+		nsCache:                     newNamespaceCache(),
+	}
+}
+
+func (p *dcaPerPodProvider) prepare(_ []*kubelet.Pod) error {
+	return nil
+}
+
+func (p *dcaPerPodProvider) getKubernetesServices(pod *kubelet.Pod) []string {
+	metadata, err := p.dcaClient.GetKubernetesMetadataNames(pod.Spec.NodeName, pod.Metadata.Namespace, pod.Metadata.Name)
+	if err != nil {
+		log.Debugf("Could not fetch metadata for pod %s/%s: %v", pod.Metadata.Namespace, pod.Metadata.Name, err)
+		return nil
+	}
+
+	return metadataNamesToServices(metadata)
+}
+
+func (p *dcaPerPodProvider) getNamespaceMetadata(ns string) (labels, annotations map[string]string) {
+	return getNamespaceLabelsOnly(&p.nsCache, p.dcaClient, ns, p.collectNamespaceLabels, p.collectNamespaceAnnotations)
+}
+
+func (p *dcaPerPodProvider) getCollectedNamespaces() map[string]namespaceMetadata {
+	return p.nsCache.getCollectedNamespaces()
+}
+
+// dcaPerNodeProvider is used with DCA versions that support per-node pod metadata
+// but do not support the namespace metadata endpoint.
+type dcaPerNodeProvider struct {
+	nodeName                    string
+	dcaClient                   clusteragent.DCAClientInterface
+	collectNamespaceLabels      bool
+	collectNamespaceAnnotations bool
+	metadataByNsPods            apiv1.NamespacesPodsStringsSet
+	nsCache                     namespaceCache
+}
+
+func newDCAPerNodeProvider(
+	nodeName string,
+	dcaClient clusteragent.DCAClientInterface,
+	collectNamespaceLabels bool,
+	collectNamespaceAnnotations bool,
+) *dcaPerNodeProvider {
+	return &dcaPerNodeProvider{
+		nodeName:                    nodeName,
+		dcaClient:                   dcaClient,
+		collectNamespaceLabels:      collectNamespaceLabels,
+		collectNamespaceAnnotations: collectNamespaceAnnotations,
+		nsCache:                     newNamespaceCache(),
+	}
+}
+
+func (p *dcaPerNodeProvider) prepare(_ []*kubelet.Pod) error {
+	var err error
+	p.metadataByNsPods, err = p.dcaClient.GetPodsMetadataForNode(p.nodeName)
+	if err != nil {
+		return fmt.Errorf("could not pull the metadata map of pods on node %s from the Datadog Cluster Agent: %w", p.nodeName, err)
+	}
+
+	return nil
+}
+
+func (p *dcaPerNodeProvider) getKubernetesServices(pod *kubelet.Pod) []string {
+	if p.metadataByNsPods == nil {
+		return nil
+	}
+
+	podsByNamespace, found := p.metadataByNsPods[pod.Metadata.Namespace]
+	if !found {
+		return nil
+	}
+
+	metadata, found := podsByNamespace[pod.Metadata.Name]
+	if !found || metadata == nil {
+		return nil
+	}
+
+	return metadataNamesToServices(sets.List(metadata))
+}
+
+func (p *dcaPerNodeProvider) getNamespaceMetadata(ns string) (labels, annotations map[string]string) {
+	return getNamespaceLabelsOnly(&p.nsCache, p.dcaClient, ns, p.collectNamespaceLabels, p.collectNamespaceAnnotations)
+}
+
+func (p *dcaPerNodeProvider) getCollectedNamespaces() map[string]namespaceMetadata {
+	return p.nsCache.getCollectedNamespaces()
+}
+
+// dcaFullProvider is used with DCA versions that support both per-node pod
+// metadata and the namespace metadata endpoint for labels and annotations.
+type dcaFullProvider struct {
+	*dcaPerNodeProvider
+}
+
+func newDCAFullProvider(
+	nodeName string,
+	dcaClient clusteragent.DCAClientInterface,
+	collectNamespaceLabels bool,
+	collectNamespaceAnnotations bool,
+) *dcaFullProvider {
+	return &dcaFullProvider{
+		dcaPerNodeProvider: newDCAPerNodeProvider(nodeName, dcaClient, collectNamespaceLabels, collectNamespaceAnnotations),
+	}
+}
+
+func (p *dcaFullProvider) getNamespaceMetadata(ns string) (labels, annotations map[string]string) {
+	if metadata, found := p.nsCache.get(ns); found {
+		return selectNamespaceMetadata(metadata, p.collectNamespaceLabels, p.collectNamespaceAnnotations)
+	}
+
+	if !p.collectNamespaceLabels && !p.collectNamespaceAnnotations {
+		p.nsCache.set(ns, namespaceMetadata{})
+		return nil, nil
+	}
+
+	metadata, err := p.dcaClient.GetNamespaceMetadata(ns)
+	if err != nil {
+		log.Errorf("Could not fetch namespace metadata for namespace %s: %v", ns, err)
+		return nil, nil
+	}
+
+	collected := p.nsCache.set(ns, fromClusterAgentMetadata(metadata))
+	return selectNamespaceMetadata(collected, p.collectNamespaceLabels, p.collectNamespaceAnnotations)
+}
+
+// streamProvider is used when the streaming endpoint is enabled and exposed in
+// the DCA.
+type streamProvider struct {
+	stream                      *streamClient
+	collectNamespaceLabels      bool
+	collectNamespaceAnnotations bool
+	nsCache                     namespaceCache
+}
+
+func newStreamProvider(
+	stream *streamClient,
+	collectNamespaceLabels bool,
+	collectNamespaceAnnotations bool,
+) *streamProvider {
+	return &streamProvider{
+		stream:                      stream,
+		collectNamespaceLabels:      collectNamespaceLabels,
+		collectNamespaceAnnotations: collectNamespaceAnnotations,
+		nsCache:                     newNamespaceCache(),
+	}
+}
+
+func (p *streamProvider) prepare(_ []*kubelet.Pod) error {
+	return nil
+}
+
+func (p *streamProvider) getKubernetesServices(pod *kubelet.Pod) []string {
+	services, found := p.stream.getServices(pod.Metadata.Namespace, pod.Metadata.Name)
+	if !found {
+		return nil
+	}
+
+	return services
+}
+
+func (p *streamProvider) getNamespaceMetadata(ns string) (labels, annotations map[string]string) {
+	if metadata, found := p.nsCache.get(ns); found {
+		return selectNamespaceMetadata(metadata, p.collectNamespaceLabels, p.collectNamespaceAnnotations)
+	}
+
+	nsLabels, nsAnnotations, found := p.stream.getNamespaceMetadata(ns)
+	if !found {
+		return nil, nil
+	}
+
+	metadata := namespaceMetadata{
+		labels:      nsLabels,
+		annotations: nsAnnotations,
+	}
+	p.nsCache.set(ns, metadata)
+	return selectNamespaceMetadata(metadata, p.collectNamespaceLabels, p.collectNamespaceAnnotations)
+}
+
+func (p *streamProvider) getCollectedNamespaces() map[string]namespaceMetadata {
+	return p.nsCache.getCollectedNamespaces()
+}
+
+func metadataNamesToServices(metadata []string) []string {
+	services := make([]string, 0, len(metadata))
+	for _, data := range metadata {
+		parts := strings.Split(data, ":")
+		switch len(parts) {
+		case 1:
+			services = append(services, parts[0])
+		case 2:
+			services = append(services, parts[1])
+		}
+	}
+	return services
+}
+
+func selectNamespaceMetadata(metadata namespaceMetadata, includeLabels, includeAnnotations bool) (labels, annotations map[string]string) {
+	if includeLabels {
+		labels = metadata.labels
+	}
+	if includeAnnotations {
+		annotations = metadata.annotations
+	}
+
+	return labels, annotations
+}
+
+func fromClusterAgentMetadata(metadata *clusteragent.Metadata) namespaceMetadata {
+	if metadata == nil {
+		return namespaceMetadata{}
+	}
+
+	return namespaceMetadata{
+		labels:      metadata.Labels,
+		annotations: metadata.Annotations,
+	}
+}
+
+// getNamespaceLabelsOnly fetches namespace labels via the DCA labels-only
+// endpoint.
+func getNamespaceLabelsOnly(cache *namespaceCache, dcaClient clusteragent.DCAClientInterface, ns string, collectLabels, collectAnnotations bool) (map[string]string, map[string]string) {
+	if metadata, found := cache.get(ns); found {
+		return metadata.labels, nil
+	}
+
+	metadata := namespaceMetadata{}
+	if collectLabels {
+		var err error
+		metadata.labels, err = dcaClient.GetNamespaceLabels(ns)
+		if err != nil {
+			log.Errorf("Could not fetch namespace labels for namespace %s: %v", ns, err)
+			return nil, nil
+		}
+	}
+
+	if collectAnnotations {
+		log.Errorf("Could not fetch namespace annotations for namespace %s: kubernetes_namespace_annotations_as_tags requires version 7.55 or later of the cluster agent", ns)
+	}
+
+	cache.set(ns, metadata)
+	return metadata.labels, nil
+}
+
+func addToCacheMetadataMapping(apiClient *apiserver.APIClient, kubeletPodList []*kubelet.Pod) error {
+	if apiClient == nil {
+		return nil
+	}
+
+	if len(kubeletPodList) == 0 {
+		log.Debug("Empty kubelet pod list")
+		return nil
+	}
+
+	reachablePods := make([]*kubelet.Pod, 0)
+	nodeName := ""
+	for _, p := range kubeletPodList {
+		if p.Status.PodIP == "" {
+			continue
+		}
+		if nodeName == "" && p.Spec.NodeName != "" {
+			nodeName = p.Spec.NodeName
+		}
+		reachablePods = append(reachablePods, p)
+	}
+
+	return apiClient.NodeMetadataMapping(nodeName, reachablePods)
+}
+
+func supportsPerNodePodMetadata(dcaVersion version.Version) bool {
+	return dcaVersion.Major > 1 || (dcaVersion.Major == 1 && dcaVersion.Minor >= 3)
+}

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/metadata_provider_test.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/metadata_provider_test.go
@@ -1,0 +1,339 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver && kubelet
+
+package kubemetadata
+
+import (
+	"errors"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
+	"github.com/DataDog/datadog-agent/pkg/util/clusteragent"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+func TestDCAPerPodProvider(t *testing.T) {
+	pod := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: kubelet.Spec{NodeName: "node-1"},
+	}
+
+	t.Run("getKubernetesServices returns services", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			KubernetesMetadataNames: []string{"kube_service:service-1", "kube_service:service-2"},
+		}
+		provider := newDCAPerPodProvider(dcaClient, false, false)
+
+		services := provider.getKubernetesServices(pod)
+		assert.ElementsMatch(t, []string{"service-1", "service-2"}, services)
+	})
+
+	t.Run("getKubernetesServices returns empty on error", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			KubernetesMetadataNamesErr: errors.New("some error"),
+		}
+		provider := newDCAPerPodProvider(dcaClient, false, false)
+
+		services := provider.getKubernetesServices(pod)
+		assert.Empty(t, services)
+	})
+
+	t.Run("getNamespaceMetadata returns labels when enabled", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			NamespaceLabels: map[string]string{"label-1": "a"},
+		}
+		provider := newDCAPerPodProvider(dcaClient, true, false)
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Equal(t, map[string]string{"label-1": "a"}, labels)
+		assert.Empty(t, annotations) // Not supported in this provider
+	})
+
+	t.Run("getNamespaceMetadata returns no labels when their collection is disabled", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{}
+		provider := newDCAPerPodProvider(dcaClient, false, false)
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Empty(t, labels)
+		assert.Empty(t, annotations) // Not supported in this provider
+	})
+
+	t.Run("getNamespaceMetadata returns empty annotations even when their collection is enabled", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{}
+		provider := newDCAPerPodProvider(dcaClient, false, true)
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Empty(t, labels)
+		assert.Empty(t, annotations) // Not supported in this provider
+	})
+
+	t.Run("getCollectedNamespaces returns namespaces seen via getNamespaceMetadata", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			NamespaceLabels: map[string]string{"label-1": "a"},
+		}
+		provider := newDCAPerPodProvider(dcaClient, true, false)
+
+		assert.Empty(t, provider.getCollectedNamespaces())
+
+		provider.getNamespaceMetadata("default")
+		provider.getNamespaceMetadata("kube-system")
+
+		collectedNamespaces := slices.Collect(maps.Keys(provider.getCollectedNamespaces()))
+		assert.ElementsMatch(t, []string{"default", "kube-system"}, collectedNamespaces)
+	})
+}
+
+func TestDCAPerNodeProvider(t *testing.T) {
+	pod := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: kubelet.Spec{NodeName: "node-1"},
+	}
+
+	t.Run("getKubernetesServices returns services", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			PodMetadataForNode: apiv1.NamespacesPodsStringsSet{
+				"default": apiv1.MapStringSet{
+					"foo": sets.New("service-1", "service-2"),
+				},
+			},
+		}
+		provider := newDCAPerNodeProvider("node-1", dcaClient, false, false)
+		require.NoError(t, provider.prepare(nil))
+
+		services := provider.getKubernetesServices(pod)
+		assert.ElementsMatch(t, []string{"service-1", "service-2"}, services)
+	})
+
+	t.Run("getNamespaceMetadata returns labels when enabled", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			PodMetadataForNode: apiv1.NamespacesPodsStringsSet{},
+			NamespaceLabels:    map[string]string{"label-1": "a"},
+		}
+		provider := newDCAPerNodeProvider("node-1", dcaClient, true, false)
+		require.NoError(t, provider.prepare(nil))
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Equal(t, map[string]string{"label-1": "a"}, labels)
+		assert.Empty(t, annotations) // Not supported in this provider
+	})
+
+	t.Run("getNamespaceMetadata returns no labels when their collection is disabled", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			PodMetadataForNode: apiv1.NamespacesPodsStringsSet{},
+		}
+		provider := newDCAPerNodeProvider("node-1", dcaClient, false, false)
+		require.NoError(t, provider.prepare(nil))
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Empty(t, labels)
+		assert.Empty(t, annotations) // Not supported in this provider
+	})
+
+	t.Run("getNamespaceMetadata returns empty annotations even when their collection is enabled", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			PodMetadataForNode: apiv1.NamespacesPodsStringsSet{},
+		}
+		provider := newDCAPerNodeProvider("node-1", dcaClient, false, true)
+		require.NoError(t, provider.prepare(nil))
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Empty(t, labels)
+		assert.Empty(t, annotations) // Not supported in this provider
+	})
+
+	t.Run("getCollectedNamespaces returns namespaces seen via getNamespaceMetadata", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			PodMetadataForNode: apiv1.NamespacesPodsStringsSet{},
+			NamespaceLabels:    map[string]string{"label-1": "a"},
+		}
+		provider := newDCAPerNodeProvider("node-1", dcaClient, true, false)
+		require.NoError(t, provider.prepare(nil))
+
+		assert.Empty(t, provider.getCollectedNamespaces())
+
+		provider.getNamespaceMetadata("default")
+		provider.getNamespaceMetadata("kube-system")
+
+		collectedNamespaces := slices.Collect(maps.Keys(provider.getCollectedNamespaces()))
+		assert.ElementsMatch(t, []string{"default", "kube-system"}, collectedNamespaces)
+	})
+}
+
+func TestDCAFullProvider(t *testing.T) {
+	// First version that supports this provider
+	dcaVersion := version.Version{Major: 7, Minor: 55}
+
+	t.Run("getKubernetesServices returns services", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			LocalVersion: dcaVersion,
+			PodMetadataForNode: apiv1.NamespacesPodsStringsSet{
+				"default": apiv1.MapStringSet{
+					"foo": sets.New("service-1"),
+				},
+			},
+		}
+		provider := newDCAFullProvider("node-1", dcaClient, false, false)
+		require.NoError(t, provider.prepare(nil))
+
+		pod := &kubelet.Pod{
+			Metadata: kubelet.PodMetadata{Name: "foo", Namespace: "default"},
+		}
+		services := provider.getKubernetesServices(pod)
+		assert.ElementsMatch(t, []string{"service-1"}, services)
+	})
+
+	t.Run("getNamespaceMetadata returns labels and annotations", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			LocalVersion: dcaVersion,
+			NamespaceMetadata: clusteragent.Metadata{
+				Labels:      map[string]string{"label-1": "a"},
+				Annotations: map[string]string{"annotation-1": "a"},
+			},
+		}
+		provider := newDCAFullProvider("node-1", dcaClient, true, true)
+		require.NoError(t, provider.prepare(nil))
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Equal(t, map[string]string{"label-1": "a"}, labels)
+		assert.Equal(t, map[string]string{"annotation-1": "a"}, annotations)
+	})
+
+	t.Run("getNamespaceMetadata returns empty labels/annotations when collection is disabled", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			LocalVersion: dcaVersion,
+		}
+		provider := newDCAFullProvider("node-1", dcaClient, false, false)
+		require.NoError(t, provider.prepare(nil))
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Empty(t, labels)
+		assert.Empty(t, annotations)
+	})
+
+	t.Run("getCollectedNamespaces returns namespaces seen via getNamespaceMetadata", func(t *testing.T) {
+		dcaClient := &FakeDCAClient{
+			LocalVersion: dcaVersion,
+			NamespaceMetadata: clusteragent.Metadata{
+				Labels:      map[string]string{"label-1": "a"},
+				Annotations: map[string]string{"annotation-1": "a"},
+			},
+		}
+		provider := newDCAFullProvider("node-1", dcaClient, true, true)
+		require.NoError(t, provider.prepare(nil))
+
+		assert.Empty(t, provider.getCollectedNamespaces())
+
+		provider.getNamespaceMetadata("default")
+		provider.getNamespaceMetadata("kube-system")
+
+		collectedNamespaces := slices.Collect(maps.Keys(provider.getCollectedNamespaces()))
+		assert.ElementsMatch(t, []string{"default", "kube-system"}, collectedNamespaces)
+	})
+}
+
+func TestStreamProvider(t *testing.T) {
+	pod := &kubelet.Pod{
+		Metadata: kubelet.PodMetadata{
+			Name:      "foo",
+			Namespace: "default",
+		},
+	}
+
+	t.Run("getKubernetesServices returns services", func(t *testing.T) {
+		stream := &streamClient{
+			podServices: map[string][]string{"default/foo": {"service-1", "service-2"}},
+			namespaces:  make(map[string]namespaceMetadata),
+		}
+		provider := newStreamProvider(stream, false, false)
+
+		services := provider.getKubernetesServices(pod)
+		assert.ElementsMatch(t, []string{"service-1", "service-2"}, services)
+	})
+
+	t.Run("getKubernetesServices returns empty for unknown pod", func(t *testing.T) {
+		stream := &streamClient{
+			podServices: map[string][]string{},
+			namespaces:  make(map[string]namespaceMetadata),
+		}
+		provider := newStreamProvider(stream, false, false)
+
+		services := provider.getKubernetesServices(pod)
+		assert.Empty(t, services)
+	})
+
+	t.Run("getNamespaceMetadata returns labels and annotations from stream", func(t *testing.T) {
+		stream := &streamClient{
+			podServices: make(map[string][]string),
+			namespaces: map[string]namespaceMetadata{
+				"default": {
+					labels:      map[string]string{"label-1": "a"},
+					annotations: map[string]string{"annotation-1": "a"},
+				},
+			},
+		}
+		provider := newStreamProvider(stream, true, true)
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Equal(t, map[string]string{"label-1": "a"}, labels)
+		assert.Equal(t, map[string]string{"annotation-1": "a"}, annotations)
+	})
+
+	t.Run("getNamespaceMetadata returns empty annotations when their collection is disabled", func(t *testing.T) {
+		stream := &streamClient{
+			podServices: make(map[string][]string),
+			namespaces: map[string]namespaceMetadata{
+				"default": {
+					labels:      map[string]string{"label-1": "a"},
+					annotations: map[string]string{"annotation-1": "a"},
+				},
+			},
+		}
+		provider := newStreamProvider(stream, true, false)
+
+		labels, annotations := provider.getNamespaceMetadata("default")
+		assert.Equal(t, map[string]string{"label-1": "a"}, labels)
+		assert.Empty(t, annotations)
+	})
+
+	t.Run("getCollectedNamespaces returns namespaces seen via getNamespaceMetadata", func(t *testing.T) {
+		stream := &streamClient{
+			podServices: make(map[string][]string),
+			namespaces: map[string]namespaceMetadata{
+				"default": {
+					labels:      map[string]string{"label-1": "a"},
+					annotations: map[string]string{"annotation-1": "a"},
+				},
+				"kube-system": {
+					labels:      map[string]string{"label-1": "b"},
+					annotations: map[string]string{"annotation-1": "b"},
+				},
+			},
+		}
+		provider := newStreamProvider(stream, true, true)
+
+		assert.Empty(t, provider.getCollectedNamespaces())
+
+		provider.getNamespaceMetadata("default")
+		provider.getNamespaceMetadata("kube-system")
+
+		collectedNamespaces := slices.Collect(maps.Keys(provider.getCollectedNamespaces()))
+		assert.ElementsMatch(t, []string{"default", "kube-system"}, collectedNamespaces)
+	})
+}

--- a/comp/core/workloadmeta/collectors/internal/kubemetadata/stream.go
+++ b/comp/core/workloadmeta/collectors/internal/kubemetadata/stream.go
@@ -36,21 +36,17 @@ const (
 	streamRecvTimeout     = 10 * time.Minute
 )
 
-type namespaceMetadata struct {
-	labels      map[string]string
-	annotations map[string]string
-}
-
 // streamClient manages a gRPC streaming connection to the DCA for
 // pod-to-service and namespace metadata. It keeps a local cache.
 type streamClient struct {
 	nodeName string
 	cfg      configmodel.Reader
 
-	mu          sync.RWMutex
-	podServices map[string][]string          // "namespace/podName" -> services
-	namespaces  map[string]namespaceMetadata // namespace name -> labels/annotations
-	active      bool
+	mu            sync.RWMutex
+	podServices   map[string][]string          // "namespace/podName" -> services
+	namespaces    map[string]namespaceMetadata // namespace name -> labels/annotations
+	active        bool
+	unimplemented bool
 }
 
 func newStreamClient(nodeName string, cfg configmodel.Reader) *streamClient {
@@ -75,7 +71,7 @@ func (sc *streamClient) run(ctx context.Context) {
 		if statusWithErr, ok := status.FromError(err); ok && statusWithErr.Code() == codes.Unimplemented {
 			log.Infof("DCA does not support kube metadata streaming")
 			sc.mu.Lock()
-			sc.active = false
+			sc.unimplemented = true
 			sc.mu.Unlock()
 			return
 		}
@@ -105,10 +101,6 @@ func (sc *streamClient) getServices(namespace, podName string) ([]string, bool) 
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
 
-	if !sc.active {
-		return nil, false
-	}
-
 	key := namespace + "/" + podName
 	svcs, ok := sc.podServices[key]
 	return svcs, ok
@@ -118,10 +110,6 @@ func (sc *streamClient) getNamespaceMetadata(namespace string) (labels, annotati
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
 
-	if !sc.active {
-		return nil, nil, false
-	}
-
 	ns, ok := sc.namespaces[namespace]
 	if !ok {
 		return nil, nil, false
@@ -129,10 +117,10 @@ func (sc *streamClient) getNamespaceMetadata(namespace string) (labels, annotati
 	return ns.labels, ns.annotations, true
 }
 
-func (sc *streamClient) isActive() bool {
+func (sc *streamClient) isUnimplemented() bool {
 	sc.mu.RLock()
 	defer sc.mu.RUnlock()
-	return sc.active
+	return sc.unimplemented
 }
 
 // streamOnce establishes a single gRPC streaming connection and processes


### PR DESCRIPTION
### What does this PR do?

This PR refactors the kubemetadata workloadmeta collector to extract a `metadataProvider` strategy interface.

I need to add proper support for the streaming endpoint introduced in previous PRs (https://github.com/DataDog/datadog-agent/pull/47025, https://github.com/DataDog/datadog-agent/pull/47314), but the kubemetadata collector is already fairly complex, so I wanted to clean it up before adding more complexity on top.

The collector is hard to follow because depending on the Cluster Agent version, it uses different endpoints to fetch pod-to-service mappings and namespace metadata.

This PR extracts each code path into its own provider implementation behind a common interface, so they can be understood and tested independently. It's a refactor with no intentional behavior change, apart from minor improvements (logging, error handling). To achieve this, the PR extracts a lot of the code in `comp/core/workloadmeta/collectors/internal/kubemetadata/kubemetadata.go` to a new `comp/core/workloadmeta/collectors/internal/kubemetadata/metadata_provider.go` that contains the different implementations.

### Describe how you validated your changes

New unit tests plus tested locally with kind different Cluster Agent versions. I deployed specifying `DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS` and `DD_KUBERNETES_NAMESPACE_ANNOTATIONS_AS_TAGS`. Also deployed an example pod behind a kubernetes service. Then, for the different Cluster Agent versions, I checked that the expected `kube_service` and the tags specified in namespaces labels/annotations as tags are present.
