### PR TITLE
NDMC-235: SNMP Autodiscovery - register cached devices immediately upon agent restart 

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -139,7 +139,7 @@ func (l *SNMPListener) loadCache(subnet *snmpSubnet) {
 			entityID := subnet.config.Digest(deviceIP.String())
 			deviceInfo := l.checkDeviceInfo(subnet.config.Authentications[0], subnet.config.Port, deviceIP.String())
 
-			l.createService(entityID, subnet, deviceIP.String(), deviceInfo, 0, 0, false)
+			l.createService(entityID, subnet, deviceIP.String(), deviceInfo, 0, 0, true)
 		}
 		return
 	}
@@ -154,7 +154,7 @@ func (l *SNMPListener) loadCache(subnet *snmpSubnet) {
 		entityID := subnet.config.Digest(device.IP.String())
 		deviceInfo := l.checkDeviceInfo(subnet.config.Authentications[device.AuthIndex], subnet.config.Port, device.IP.String())
 
-		l.createService(entityID, subnet, device.IP.String(), deviceInfo, device.AuthIndex, device.Failures, false)
+		l.createService(entityID, subnet, device.IP.String(), deviceInfo, device.AuthIndex, device.Failures, true)
 	}
 }
 
@@ -214,7 +214,7 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 		}
 
 		deviceInfo := l.checkDeviceInfo(authentication, job.subnet.config.Port, deviceIP)
-		l.createService(entityID, job.subnet, deviceIP, deviceInfo, authIndex, 0, true)
+		l.createService(entityID, job.subnet, deviceIP, deviceInfo, authIndex, 0, false)
 
 		break
 	}
@@ -460,7 +460,7 @@ func (l *SNMPListener) createService(
 	deviceInfo devicededuper.DeviceInfo,
 	authIndex int,
 	deviceFailures int,
-	writeCache bool,
+	addedFromCache bool,
 ) {
 	l.Lock()
 	defer l.Unlock()
@@ -498,17 +498,21 @@ func (l *SNMPListener) createService(
 	l.services[entityID] = &svc
 
 	pendingDevice := devicededuper.PendingDevice{
-		Config:     config,
-		Info:       deviceInfo,
-		AuthIndex:  authIndex,
-		WriteCache: writeCache,
-		IP:         deviceIP,
-		Failures:   deviceFailures,
+		Config:         config,
+		Info:           deviceInfo,
+		AuthIndex:      authIndex,
+		AddedFromCache: addedFromCache,
+		IP:             deviceIP,
+		Failures:       deviceFailures,
 	}
 
 	if deviceInfo == (devicededuper.DeviceInfo{}) {
 		l.registerService(pendingDevice)
 		return
+	}
+
+	if addedFromCache {
+		l.registerService(pendingDevice)
 	}
 
 	l.deviceDeduper.AddPendingDevice(pendingDevice)
@@ -537,7 +541,7 @@ func (l *SNMPListener) registerService(pendingDevice devicededuper.PendingDevice
 		AuthIndex: pendingDevice.AuthIndex,
 		Failures:  pendingDevice.Failures,
 	}
-	if pendingDevice.WriteCache {
+	if !pendingDevice.AddedFromCache {
 		l.writeCache(svc.subnet)
 	}
 	l.newService <- svc

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -18,6 +18,7 @@ import (
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/persistentcache"
 	"github.com/DataDog/datadog-agent/pkg/snmp"
+	"github.com/DataDog/datadog-agent/pkg/snmp/devicededuper"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 )
 
@@ -541,6 +542,60 @@ func TestSubnetIndex(t *testing.T) {
 	for i, subnet := range subnets {
 		assert.Equal(t, i, subnet.index)
 	}
+}
+
+func TestCreateServiceFromCacheRegistersImmediately(t *testing.T) {
+	testDir := t.TempDir()
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("run_path", testDir)
+	mockConfig.SetWithoutSource("network_devices.autodiscovery.configs", []interface{}{
+		map[string]interface{}{
+			"network":   "192.168.0.0/30",
+			"community": "public",
+		},
+	})
+
+	listener, err := NewSNMPListener(ServiceListernerDeps{})
+	assert.NoError(t, err)
+	l := listener.(*SNMPListener)
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.newService = newSvc
+	l.delService = delSvc
+
+	_, ipNet, err := net.ParseCIDR("192.168.0.0/30")
+	assert.NoError(t, err)
+
+	subnet := &snmpSubnet{
+		adIdentifier: "snmp",
+		config:       l.config.Configs[0],
+		network:      *ipNet,
+		cacheKey:     "snmp:test123",
+		devices:      map[string]deviceCache{},
+	}
+
+	deviceInfo := devicededuper.DeviceInfo{
+		Name:        "router-1",
+		Description: "Test Router",
+		BootTimeMs:  1000000,
+		SysObjectID: "1.3.6.1.4.1.9.1.1",
+	}
+
+	// Simulate loading 192.168.0.1 from cache — should register immediately
+	entityID1 := subnet.config.Digest("192.168.0.1")
+	l.createService(entityID1, subnet, "192.168.0.1", deviceInfo, 0, 0, true)
+
+	assert.Equal(t, 1, len(newSvc))
+	svc := (<-newSvc).(*SNMPService)
+	assert.Equal(t, "192.168.0.1", svc.deviceIP)
+	assert.False(t, svc.pending)
+
+	// Simulate scan discovering 192.168.0.2 — same physical device, should NOT register
+	entityID2 := subnet.config.Digest("192.168.0.2")
+	l.createService(entityID2, subnet, "192.168.0.2", deviceInfo, 0, 0, false)
+
+	assert.Equal(t, 0, len(newSvc), "second IP for same device should not be registered")
 }
 
 func TestBuildCacheKey(t *testing.T) {

--- a/pkg/snmp/devicededuper/device_deduper.go
+++ b/pkg/snmp/devicededuper/device_deduper.go
@@ -29,12 +29,12 @@ type DeviceInfo struct {
 
 // PendingDevice represents a device pending deduplication
 type PendingDevice struct {
-	Config     snmp.Config
-	Info       DeviceInfo
-	AuthIndex  int
-	WriteCache bool
-	IP         string
-	Failures   int
+	Config         snmp.Config
+	Info           DeviceInfo
+	AuthIndex      int
+	AddedFromCache bool
+	IP             string
+	Failures       int
 }
 
 func (d DeviceInfo) equal(other DeviceInfo) bool {

--- a/pkg/snmp/devicededuper/device_deduper_test.go
+++ b/pkg/snmp/devicededuper/device_deduper_test.go
@@ -294,9 +294,9 @@ func TestDeviceDeduper_AddPendingDevice(t *testing.T) {
 			BootTimeMs:  now,
 			SysObjectID: "1.3.6.1.4.1.9.1.1",
 		},
-		AuthIndex:  0,
-		WriteCache: true,
-		IP:         "192.168.1.2",
+		AuthIndex:      0,
+		AddedFromCache: false,
+		IP:             "192.168.1.2",
 	}
 
 	pendingDevice2 := PendingDevice{
@@ -312,9 +312,9 @@ func TestDeviceDeduper_AddPendingDevice(t *testing.T) {
 			BootTimeMs:  now,
 			SysObjectID: "1.3.6.1.4.1.9.1.2",
 		},
-		AuthIndex:  0,
-		WriteCache: true,
-		IP:         "192.168.1.3",
+		AuthIndex:      0,
+		AddedFromCache: false,
+		IP:             "192.168.1.3",
 	}
 
 	deduper.AddPendingDevice(pendingDevice1)
@@ -337,9 +337,9 @@ func TestDeviceDeduper_AddPendingDevice(t *testing.T) {
 			BootTimeMs:  now,
 			SysObjectID: "1.3.6.1.4.1.9.1.1",
 		},
-		AuthIndex:  0,
-		WriteCache: true,
-		IP:         "192.168.1.1",
+		AuthIndex:      0,
+		AddedFromCache: false,
+		IP:             "192.168.1.1",
 	}
 
 	deduper.AddPendingDevice(pendingDevice3)
@@ -363,9 +363,9 @@ func TestDeviceDeduper_AddPendingDevice(t *testing.T) {
 			BootTimeMs:  now,
 			SysObjectID: "1.3.6.1.4.1.9.1.2",
 		},
-		AuthIndex:  0,
-		WriteCache: true,
-		IP:         "192.168.1.4",
+		AuthIndex:      0,
+		AddedFromCache: false,
+		IP:             "192.168.1.4",
 	}
 
 	deduper.AddPendingDevice(pendingDevice4)
@@ -405,10 +405,10 @@ func TestDeviceDeduper_GetDedupedDevices(t *testing.T) {
 				{Community: "public"},
 			},
 		},
-		Info:       device1,
-		AuthIndex:  0,
-		WriteCache: true,
-		IP:         "192.168.1.1",
+		Info:           device1,
+		AuthIndex:      0,
+		AddedFromCache: false,
+		IP:             "192.168.1.1",
 	}
 
 	pendingDevice2 := PendingDevice{
@@ -418,10 +418,10 @@ func TestDeviceDeduper_GetDedupedDevices(t *testing.T) {
 				{Community: "public"},
 			},
 		},
-		Info:       device2,
-		AuthIndex:  0,
-		WriteCache: true,
-		IP:         "192.168.1.3",
+		Info:           device2,
+		AuthIndex:      0,
+		AddedFromCache: false,
+		IP:             "192.168.1.3",
 	}
 
 	deduper.AddPendingDevice(pendingDevice1)

--- a/releasenotes/notes/register-cached-devices-startup-cdfa86407695b4ad.yaml
+++ b/releasenotes/notes/register-cached-devices-startup-cdfa86407695b4ad.yaml
@@ -1,0 +1,7 @@
+fixes:
+  - |
+    Fixed a bug (only present when deduplication is enabled) where SNMP devices loaded
+    from the cache on agent restart were not registered immediately, causing them to be
+    temporarily unavailable until the next discovery cycle completed. Cached
+    devices are now registered right away and tracked for deduplication so that
+    subsequent scans for the same physical device are correctly deduplicated.


### PR DESCRIPTION
### What does this PR do?
When the SNMP listener restarts, devices previously discovered and written to the cache are loaded back as PendingDevice entries with WriteCache: false. Previously these cached devices would go through the normal pending queue and wait for the next deduplication cycle before being registered, introducing an unnecessary delay. This PR ensures that cached devices (writeCache == false) are registered immediately upon startup.                                                             

### Motivation
After an agent restart, previously-discovered SNMP devices were not being monitored until the next full scan cycle completed. Registering cached devices immediately on restart restores monitoring without waiting for a scan, reducing gaps in SNMP coverage after agent restarts.

### Describe how you validated your changes
- Added a test which verifies that a cached device (WriteCache: false) does not enter the pending queue (i.e. is registered immediately), and its DeviceInfo is recorded so a subsequent scan for the same physical device is deduplicated.                                                     
- Existing unit tests in should continue to pass. 
- When testing locally, cached devices should immediately show up as discovered when the status of the agent is returned on the terminal.

### Additional Notes
This PR assumes that the cached devices are already the minimum IP for the device. It also leverages the writeCache flag to signify that a device IP came from cache