### PR TITLE
Fix datadogextension hostname check in OTel e2e tests

### DIFF
--- a/test/new-e2e/tests/otel/utils/config_utils.go
+++ b/test/new-e2e/tests/otel/utils/config_utils.go
@@ -252,6 +252,27 @@ func validateConfigs(t *testing.T, expectedCfg string, actualCfg string) {
 		delete(lcfg, "endpoint")
 	}
 
+	// The hostname in the datadog extension is resolved at runtime and varies per cluster node.
+	// Validate it is non-empty, then remove it from both sides so YAMLEq is not hostname-dependent.
+	exts, _ := actualConfRaw["extensions"].(map[string]any)
+	if ddExt, ok := exts["datadog/dd-autoconfigured"]; ok {
+		ddExtMap := ddExt.(map[string]any)
+		actualHostname, _ := ddExtMap["hostname"].(string)
+		assert.NotEmpty(t, actualHostname, "hostname in datadog/dd-autoconfigured extension should be resolved at runtime")
+		delete(ddExtMap, "hostname")
+	}
+
+	// Also remove hostname from the expected config so the structural comparison is not affected
+	var expectedConfRaw map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(expectedCfg), &expectedConfRaw))
+	expsExpected, _ := expectedConfRaw["extensions"].(map[string]any)
+	if ddExtExpected, ok := expsExpected["datadog/dd-autoconfigured"]; ok {
+		delete(ddExtExpected.(map[string]any), "hostname")
+	}
+	expectedCfgBytes, err := yaml.Marshal(expectedConfRaw)
+	require.NoError(t, err)
+	expectedCfg = string(expectedCfgBytes)
+
 	actualCfgBytes, err := yaml.Marshal(actualConfRaw)
 	require.NoError(t, err)
 	actualCfg = string(actualCfgBytes)


### PR DESCRIPTION
### What does this PR do?
Fixes datadogextension hostname check in the OTel e2e tests, from change https://github.com/DataDog/datadog-agent/pull/47937.

### Motivation
#incident-51351

### Describe how you validated your changes

### Additional Notes
