### PR TITLE
[procmgrd] Add E2E smoke tests for process manager and DDOT lifecycle

### DIFF
--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
@@ -111,13 +111,20 @@ func (s *procmgrLinuxSuite) SetupSuite() {
 }
 
 func (s *procmgrLinuxSuite) installRealDDOT() bool {
+	// Check whether the package exists before attempting to install.
+	// Only skip DDOT tests when the package is genuinely unavailable;
+	// a real install failure should fail the suite, not silently skip.
 	_, err := s.Env().RemoteHost.Execute(
-		"(sudo apt-get update -qq && sudo apt-get install -y datadog-agent-ddot) || " +
-			"sudo yum install -y datadog-agent-ddot")
+		"(sudo apt-get update -qq && apt-cache show datadog-agent-ddot >/dev/null 2>&1) || " +
+			"yum info datadog-agent-ddot >/dev/null 2>&1")
 	if err != nil {
-		s.T().Logf("datadog-agent-ddot package not available; DDOT tests will be skipped: %v", err)
+		s.T().Logf("datadog-agent-ddot package not found in repos; DDOT tests will be skipped")
 		return false
 	}
+
+	s.Env().RemoteHost.MustExecute(
+		"(sudo apt-get install -y datadog-agent-ddot) || " +
+			"(sudo yum install -y datadog-agent-ddot)")
 
 	s.Env().RemoteHost.Execute("sudo systemctl stop datadog-agent-ddot.service || true")
 	s.Env().RemoteHost.Execute("sudo systemctl reset-failed datadog-agent-ddot.service || true")

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
@@ -104,7 +104,7 @@ func (s *procmgrLinuxSuite) SetupSuite() {
 
 	if s.hasCLI {
 		require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
-			_, err := s.Env().RemoteHost.Execute(fmt.Sprintf("sudo chmod 0777 %s", procmgrSocket))
+			_, err := s.Env().RemoteHost.Execute("sudo chmod 0777 " + procmgrSocket)
 			assert.NoError(t, err, "socket not yet available")
 		}, 30*time.Second, 2*time.Second)
 	}
@@ -214,7 +214,7 @@ func (s *procmgrLinuxSuite) TestDDOTProcessRunning() {
 	pid := fieldValue(out, "PID")
 	require.NotEmpty(s.T(), pid, "PID should be reported for a Running process")
 	require.NotEqual(s.T(), "-", pid, "PID should not be '-' for a Running process")
-	s.Env().RemoteHost.MustExecute(fmt.Sprintf("test -d /proc/%s", pid))
+	s.Env().RemoteHost.MustExecute("test -d /proc/" + pid)
 
 	pidFileContent := strings.TrimSpace(
 		s.Env().RemoteHost.MustExecute("cat /opt/datadog-agent/run/otel-agent.pid"))

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
@@ -3,11 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// Package procmgr provides e2e tests for the Datadog Process Manager (dd-procmgrd)
 package procmgr
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +29,9 @@ const (
 	procmgrCLI    = "/opt/datadog-agent/embedded/bin/dd-procmgr"
 	procmgrSocket = "/var/run/datadog-procmgrd/dd-procmgrd.sock"
 
+	ddotPkgBinaryPath = "/opt/datadog-agent/embedded/bin/otel-agent"
+	ddotExtBinaryPath = "/opt/datadog-agent/ext/ddot/embedded/bin/otel-agent"
+
 	testProcessConfig = `command: /bin/sleep
 args:
   - "3600"
@@ -34,20 +39,49 @@ auto_start: true
 restart: always
 description: E2E test process
 `
+
+	missingBinaryConfig = `command: /nonexistent/binary
+condition_path_exists: /nonexistent/binary
+auto_start: true
+restart: never
+description: should not start
+`
+
+	ddotConfigRepoPath = "pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot.yaml"
 )
+
+func repoRoot() string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("cannot determine test file path")
+	}
+	// thisFile is test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..", "..")
+}
+
+func readDDOTProcessConfig(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoRoot(), ddotConfigRepoPath))
+	require.NoError(t, err, "failed to read DDOT process config from %s", ddotConfigRepoPath)
+	return string(data)
+}
 
 type procmgrLinuxSuite struct {
 	e2e.BaseSuite[environments.Host]
-	hasCLI bool
+	hasCLI  bool
+	hasDDOT bool
 }
 
 func TestProcmgrSmokeLinuxSuite(t *testing.T) {
 	t.Parallel()
+	ddotProcessConfig := readDDOTProcessConfig(t)
 	e2e.Run(t, &procmgrLinuxSuite{}, e2e.WithProvisioner(
 		awshost.ProvisionerNoFakeIntake(
 			awshost.WithRunOptions(
 				scenec2.WithAgentOptions(
 					agentparams.WithFile("/etc/datadog-agent/processes.d/test-sleep.yaml", testProcessConfig, true),
+					agentparams.WithFile("/etc/datadog-agent/processes.d/datadog-agent-ddot.yaml", ddotProcessConfig, true),
+					agentparams.WithFile("/etc/datadog-agent/processes.d/missing-binary.yaml", missingBinaryConfig, true),
 				),
 			),
 		),
@@ -66,15 +100,40 @@ func (s *procmgrLinuxSuite) SetupSuite() {
 	_, err = s.Env().RemoteHost.Execute("test -f " + procmgrCLI)
 	s.hasCLI = err == nil
 
+	s.hasDDOT = s.installRealDDOT()
+
 	if s.hasCLI {
-		// Make the socket accessible to the SSH user so the CLI can connect without sudo.
-		// The socket is owned by dd-agent; sudo with full paths outside secure_path
-		// requires a TTY that SSH non-interactive sessions don't provide.
 		require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
 			_, err := s.Env().RemoteHost.Execute(fmt.Sprintf("sudo chmod 0777 %s", procmgrSocket))
 			assert.NoError(t, err, "socket not yet available")
 		}, 30*time.Second, 2*time.Second)
 	}
+}
+
+func (s *procmgrLinuxSuite) installRealDDOT() bool {
+	_, err := s.Env().RemoteHost.Execute(
+		"(sudo apt-get update -qq && sudo apt-get install -y datadog-agent-ddot) || " +
+			"sudo yum install -y datadog-agent-ddot")
+	if err != nil {
+		s.T().Logf("datadog-agent-ddot package not available; DDOT tests will be skipped: %v", err)
+		return false
+	}
+
+	s.Env().RemoteHost.Execute("sudo systemctl stop datadog-agent-ddot.service || true")
+	s.Env().RemoteHost.Execute("sudo systemctl reset-failed datadog-agent-ddot.service || true")
+	s.Env().RemoteHost.Execute("sudo systemctl disable datadog-agent-ddot.service || true")
+
+	s.Env().RemoteHost.MustExecute("sudo mkdir -p /opt/datadog-agent/ext/ddot/embedded/bin")
+	s.Env().RemoteHost.MustExecute(fmt.Sprintf("sudo cp %s %s", ddotPkgBinaryPath, ddotExtBinaryPath))
+
+	s.Env().RemoteHost.MustExecute(`sudo sh -c "printf 'otelcollector:\n  enabled: true\n' >> /etc/datadog-agent/datadog.yaml"`)
+	s.Env().RemoteHost.MustExecute(`sudo sh -c "sed -e 's/\${env:DD_API_KEY}/aaaaaaaaaaaaaaaa/' -e 's/\${env:DD_SITE}/datadoghq.com/' /etc/datadog-agent/otel-config.yaml.example > /etc/datadog-agent/otel-config.yaml"`)
+	s.Env().RemoteHost.MustExecute("sudo chown dd-agent:dd-agent /etc/datadog-agent/otel-config.yaml && sudo chmod 640 /etc/datadog-agent/otel-config.yaml")
+
+	s.Env().RemoteHost.MustExecute("sudo systemctl restart datadog-agent.service")
+	s.Env().RemoteHost.MustExecute("sudo systemctl restart datadog-agent-procmgrd")
+
+	return true
 }
 
 func (s *procmgrLinuxSuite) TestBinariesExist() {
@@ -97,8 +156,8 @@ func (s *procmgrLinuxSuite) TestCLIStatus() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
 		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " status")
-		assert.Contains(t, out, "Version")
-		assert.Contains(t, out, "Uptime")
+		assertHasField(t, out, "Version")
+		assertHasField(t, out, "Uptime")
 	}, 30*time.Second, 2*time.Second)
 }
 
@@ -106,8 +165,10 @@ func (s *procmgrLinuxSuite) TestCLIListShowsConfiguredProcess() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
 		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " list")
-		assert.Contains(t, out, "test-sleep")
-		assert.Contains(t, out, "Running")
+		assertTableRow(t, out, "test-sleep", map[string]string{
+			"STATE":   "Running",
+			"COMMAND": "/bin/sleep",
+		})
 	}, 30*time.Second, 2*time.Second)
 }
 
@@ -115,9 +176,178 @@ func (s *procmgrLinuxSuite) TestCLIDescribe() {
 	s.requireCLI()
 	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
 		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " describe test-sleep")
-		assert.Contains(t, out, "test-sleep")
-		assert.Contains(t, out, "/bin/sleep")
+		assertField(t, out, "Name", "test-sleep")
+		assertField(t, out, "State", "Running")
+		assertField(t, out, "Command", "/bin/sleep")
 	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *procmgrLinuxSuite) TestConditionPathExistsSkipsMissingBinary() {
+	s.requireCLI()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " list")
+		assertTableRow(t, out, "missing-binary", map[string]string{
+			"STATE": "Created",
+			"PID":   "-",
+		})
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *procmgrLinuxSuite) TestDDOTProcessRunning() {
+	s.requireDDOT()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " list")
+		assertTableRow(t, out, "datadog-agent-ddot", map[string]string{
+			"STATE":   "Running",
+			"COMMAND": ddotExtBinaryPath,
+		})
+	}, 60*time.Second, 2*time.Second)
+
+	out := s.Env().RemoteHost.MustExecute(procmgrCLI + " describe datadog-agent-ddot")
+	pid := fieldValue(out, "PID")
+	require.NotEmpty(s.T(), pid, "PID should be reported for a Running process")
+	require.NotEqual(s.T(), "-", pid, "PID should not be '-' for a Running process")
+	s.Env().RemoteHost.MustExecute(fmt.Sprintf("test -d /proc/%s", pid))
+
+	pidFileContent := strings.TrimSpace(
+		s.Env().RemoteHost.MustExecute("cat /opt/datadog-agent/run/otel-agent.pid"))
+	assert.Equal(s.T(), pid, pidFileContent, "PID file should match procmgrd-reported PID")
+
+	unitState := strings.TrimSpace(
+		s.Env().RemoteHost.MustExecute("systemctl is-active datadog-agent-ddot.service || true"))
+	assert.NotEqual(s.T(), "active", unitState, "systemd unit should not be active; procmgrd manages DDOT")
+}
+
+func (s *procmgrLinuxSuite) TestDDOTProcessDescribe() {
+	s.requireDDOT()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " describe datadog-agent-ddot")
+		assertField(t, out, "Name", "datadog-agent-ddot")
+		assertField(t, out, "State", "Running")
+		assertField(t, out, "Command", ddotExtBinaryPath)
+		assertField(t, out, "Restart Policy", "on-failure")
+		assertHasField(t, out, "PID")
+		assertHasField(t, out, "UUID")
+	}, 60*time.Second, 2*time.Second)
+}
+
+func fieldValue(output, label string) string {
+	needle := label + ":"
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, needle) {
+			return strings.TrimSpace(trimmed[len(needle):])
+		}
+	}
+	return ""
+}
+
+func assertField(t assert.TestingT, output, label, expected string) {
+	needle := label + ":"
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, needle) {
+			actual := strings.TrimSpace(trimmed[len(needle):])
+			assert.Equal(t, expected, actual, "field %q", label)
+			return
+		}
+	}
+	assert.Fail(t, fmt.Sprintf("field %q not found in output:\n%s", label, output))
+}
+
+func assertHasField(t assert.TestingT, output, label string) {
+	needle := label + ":"
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), needle) {
+			return
+		}
+	}
+	assert.Fail(t, fmt.Sprintf("field %q not found in output:\n%s", label, output))
+}
+
+func assertTableRow(t assert.TestingT, output, rowName string, expected map[string]string) {
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+	if !assert.GreaterOrEqual(t, len(lines), 2, "list output should have header + at least one row") {
+		return
+	}
+	header := lines[0]
+	columns := parseTableColumns(header)
+
+	for _, line := range lines[1:] {
+		name := extractColumn(line, 0, columns)
+		if name != rowName {
+			continue
+		}
+		for col, want := range expected {
+			idx := -1
+			for i, c := range columns {
+				if c.name == col {
+					idx = i
+					break
+				}
+			}
+			if !assert.NotEqual(t, -1, idx, "column %q not in header: %s", col, header) {
+				continue
+			}
+			got := extractColumn(line, idx, columns)
+			assert.Equal(t, want, got, "row %q column %q", rowName, col)
+		}
+		return
+	}
+	assert.Fail(t, fmt.Sprintf("row %q not found in table output:\n%s", rowName, output))
+}
+
+type tableColumn struct {
+	name  string
+	start int
+}
+
+func parseTableColumns(header string) []tableColumn {
+	var cols []tableColumn
+	i := 0
+	for i < len(header) {
+		for i < len(header) && header[i] == ' ' {
+			i++
+		}
+		if i >= len(header) {
+			break
+		}
+		start := i
+		for i < len(header) {
+			if header[i] == ' ' {
+				j := i
+				for j < len(header) && header[j] == ' ' {
+					j++
+				}
+				if j >= len(header) || (j-i >= 2) {
+					break
+				}
+				i = j
+			} else {
+				i++
+			}
+		}
+		cols = append(cols, tableColumn{name: header[start:i], start: start})
+	}
+	return cols
+}
+
+func extractColumn(line string, idx int, columns []tableColumn) string {
+	if idx >= len(columns) {
+		return ""
+	}
+	start := columns[idx].start
+	end := len(line)
+	if idx+1 < len(columns) {
+		end = columns[idx+1].start
+	}
+	if start >= len(line) {
+		return ""
+	}
+	if end > len(line) {
+		end = len(line)
+	}
+	return strings.TrimSpace(line[start:end])
 }
 
 func (s *procmgrLinuxSuite) requireCLI() {
@@ -125,4 +355,12 @@ func (s *procmgrLinuxSuite) requireCLI() {
 	if !s.hasCLI {
 		s.T().Skip("dd-procmgr CLI not included in this agent package")
 	}
+}
+
+func (s *procmgrLinuxSuite) requireDDOT() {
+	s.T().Helper()
+	if !s.hasDDOT {
+		s.T().Skip("datadog-agent-ddot package not available")
+	}
+	s.requireCLI()
 }

--- a/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
+++ b/test/new-e2e/tests/agent-runtimes/procmgr/procmgr_nix_test.go
@@ -1,0 +1,128 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package procmgr provides e2e tests for the Datadog Process Manager (dd-procmgrd)
+package procmgr
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/agentparams"
+	scenec2 "github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/ec2"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/e2e"
+	"github.com/DataDog/datadog-agent/test/e2e-framework/testing/environments"
+	awshost "github.com/DataDog/datadog-agent/test/e2e-framework/testing/provisioners/aws/host"
+)
+
+const (
+	procmgrdBin   = "/opt/datadog-agent/embedded/bin/dd-procmgrd"
+	procmgrCLI    = "/opt/datadog-agent/embedded/bin/dd-procmgr"
+	procmgrSocket = "/var/run/datadog-procmgrd/dd-procmgrd.sock"
+
+	testProcessConfig = `command: /bin/sleep
+args:
+  - "3600"
+auto_start: true
+restart: always
+description: E2E test process
+`
+)
+
+type procmgrLinuxSuite struct {
+	e2e.BaseSuite[environments.Host]
+	hasCLI bool
+}
+
+func TestProcmgrSmokeLinuxSuite(t *testing.T) {
+	t.Parallel()
+	e2e.Run(t, &procmgrLinuxSuite{}, e2e.WithProvisioner(
+		awshost.ProvisionerNoFakeIntake(
+			awshost.WithRunOptions(
+				scenec2.WithAgentOptions(
+					agentparams.WithFile("/etc/datadog-agent/processes.d/test-sleep.yaml", testProcessConfig, true),
+				),
+			),
+		),
+	))
+}
+
+func (s *procmgrLinuxSuite) SetupSuite() {
+	s.BaseSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+
+	_, err := s.Env().RemoteHost.Execute("test -f " + procmgrdBin)
+	if err != nil {
+		s.T().Skip("dd-procmgrd not included in this agent package; skipping process manager tests")
+	}
+
+	_, err = s.Env().RemoteHost.Execute("test -f " + procmgrCLI)
+	s.hasCLI = err == nil
+
+	if s.hasCLI {
+		// Make the socket accessible to the SSH user so the CLI can connect without sudo.
+		// The socket is owned by dd-agent; sudo with full paths outside secure_path
+		// requires a TTY that SSH non-interactive sessions don't provide.
+		require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+			_, err := s.Env().RemoteHost.Execute(fmt.Sprintf("sudo chmod 0777 %s", procmgrSocket))
+			assert.NoError(t, err, "socket not yet available")
+		}, 30*time.Second, 2*time.Second)
+	}
+}
+
+func (s *procmgrLinuxSuite) TestBinariesExist() {
+	s.Env().RemoteHost.MustExecute("test -f " + procmgrdBin)
+
+	if !s.hasCLI {
+		s.T().Skip("dd-procmgr CLI not included in this agent package")
+	}
+	s.Env().RemoteHost.MustExecute("test -f " + procmgrCLI)
+}
+
+func (s *procmgrLinuxSuite) TestServiceRunning() {
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute("systemctl is-active datadog-agent-procmgrd")
+		assert.Equal(t, "active", strings.TrimSpace(out))
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *procmgrLinuxSuite) TestCLIStatus() {
+	s.requireCLI()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " status")
+		assert.Contains(t, out, "Version")
+		assert.Contains(t, out, "Uptime")
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *procmgrLinuxSuite) TestCLIListShowsConfiguredProcess() {
+	s.requireCLI()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " list")
+		assert.Contains(t, out, "test-sleep")
+		assert.Contains(t, out, "Running")
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *procmgrLinuxSuite) TestCLIDescribe() {
+	s.requireCLI()
+	require.EventuallyWithT(s.T(), func(t *assert.CollectT) {
+		out := s.Env().RemoteHost.MustExecute(procmgrCLI + " describe test-sleep")
+		assert.Contains(t, out, "test-sleep")
+		assert.Contains(t, out, "/bin/sleep")
+	}, 30*time.Second, 2*time.Second)
+}
+
+func (s *procmgrLinuxSuite) requireCLI() {
+	s.T().Helper()
+	if !s.hasCLI {
+		s.T().Skip("dd-procmgr CLI not included in this agent package")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a new E2E test suite (`TestProcmgrSmokeLinuxSuite`) for `dd-procmgrd` under `test/new-e2e/tests/agent-runtimes/procmgr/`. The suite provisions an AWS EC2 host with the Datadog Agent and exercises the process manager daemon and CLI end-to-end.

**Tests included:**
- **TestBinariesExist** — `dd-procmgrd` and `dd-procmgr` are installed at expected paths.
- **TestServiceRunning** — `datadog-agent-procmgrd` systemd unit is active.
- **TestCLIStatus / TestCLIListShowsConfiguredProcess / TestCLIDescribe** — CLI commands return correct structured output for a managed `sleep` process.
- **TestConditionPathExistsSkipsMissingBinary** — a process whose `condition_path_exists` binary is absent stays in `Created` state and is never started.
- **TestDDOTProcessRunning** — installs the real `datadog-agent-ddot` package, disables its systemd unit, and verifies procmgrd spawns and manages the otel-agent. Checks include: procmgrd list/describe output, daemon spawn log in journalctl, PID liveness via `/proc`, PID file consistency, and systemd unit is inactive.
- **TestDDOTProcessDescribe** — verifies describe output fields (name, state, command, restart policy, PID, UUID) for the DDOT process.

The DDOT process config is read directly from `pkg/fleet/installer/packages/embedded/tmpl/gen/debrpm/datadog-agent-ddot.yaml` so the test automatically reflects any future config changes.

### Motivation

The process manager had no Go E2E coverage in the new-e2e framework. The existing Rust E2E tests (`pkg/procmgr/rust/tests/e2e.rs`) validate the daemon in isolation, but don't exercise the full installed agent package with procmgrd managing real processes like DDOT on an actual VM. This suite closes that gap and runs automatically in CI via the `agent-runtimes` test path.

### Describe how you validated your changes

Ran the full suite against a real AWS EC2 host

### Additional Notes

- Tests gracefully skip when `dd-procmgrd` or `dd-procmgr` binaries are absent (requires a pipeline build that includes the process manager).
- DDOT tests skip when the `datadog-agent-ddot` package is not available in the configured repos.
- CLI assertion helpers (`assertField`, `assertTableRow`, `assertHasField`) mirror the patterns from the Rust E2E tests in `pkg/procmgr/rust/tests/helpers/mod.rs`.