### PR TITLE
Remove agent onboarding codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -147,7 +147,7 @@
 
 /.gitlab/.pre/deps_build/                                 @DataDog/ebpf-platform @DataDog/agent-build @DataDog/windows-products
 
-/.gitlab/windows/test/e2e_install_packages/windows.yml   @DataDog/agent-onboarding @DataDog/windows-products
+/.gitlab/windows/test/e2e_install_packages/windows.yml   @DataDog/windows-products
 
 /.gitlab/.pre/common/                                     @DataDog/agent-devx
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,7 +39,7 @@
 
 /CHANGELOG.rst                          @DataDog/agent-delivery
 /CHANGELOG-DCA.rst                      @DataDog/container-integrations @DataDog/container-platform
-/CHANGELOG-INSTALLSCRIPT.rst            @DataDog/agent-delivery @DataDog/agent-onboarding
+/CHANGELOG-INSTALLSCRIPT.rst            @DataDog/agent-delivery
 
 /*.md                                   @DataDog/agent-devx
 /NOTICE                                 @DataDog/agent-delivery
@@ -96,7 +96,6 @@
 /.gitlab/.pre/deps_fetch/*                                @DataDog/agent-devx
 /.gitlab/test/e2e/*                                       @DataDog/agent-devx
 /.gitlab/deploy/e2e_testing_deploy/*                        @DataDog/agent-devx
-/.gitlab/test/e2e_install_packages/*                      @DataDog/agent-onboarding
 /.gitlab/test/e2e_pre_test/*                              @DataDog/agent-devx
 /.gitlab/test/kernel_matrix_testing/*                     @DataDog/agent-devx @DataDog/ebpf-platform
 /.gitlab/build/lint/*                                      @DataDog/agent-devx
@@ -110,7 +109,7 @@
 /.gitlab/build/binary_build/cws_instrumentation.yml        @DataDog/agent-devx @DataDog/agent-security
 /.gitlab/build/binary_build/linux.yml                      @DataDog/agent-devx @DataDog/agent-build
 /.gitlab/test/functional_test/static_quality_gate.yml     @DataDog/agent-build
-/.gitlab/test/install_script_testing/install_script_testing.yml          @DataDog/agent-build @DataDog/agent-onboarding
+/.gitlab/test/install_script_testing/install_script_testing.yml          @DataDog/agent-build
 /.gitlab/test/integration_test/dogstatsd.yml              @DataDog/agent-devx @DataDog/agent-metric-pipelines
 /.gitlab/test/integration_test/linux.yml                  @DataDog/agent-devx
 /.gitlab/test/integration_test/otel.yml                   @DataDog/agent-devx @DataDog/opentelemetry-agent
@@ -232,7 +231,7 @@
 /cmd/agent/dist/conf.d/snmp.d/          @DataDog/network-device-monitoring-core
 /cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-products
 /cmd/agent/dist/conf.d/windows_certificate.d/ @DataDog/windows-products
-/cmd/agent/install*.sh                  @DataDog/agent-onboarding @DataDog/agent-build
+/cmd/agent/install*.sh                  @DataDog/agent-build
 /cmd/cluster-agent/                     @DataDog/container-platform
 /cmd/cluster-agent/subcommands/autoscalerlist   @DataDog/container-autoscaling @DataDog/container-integrations
 /cmd/cluster-agent-cloudfoundry/        @DataDog/agent-integrations
@@ -541,7 +540,6 @@
 /pkg/eventmonitor/                      @DataDog/ebpf-platform @DataDog/agent-security
 /pkg/dyninst/                           @DataDog/debugger-go
 /pkg/flare/                             @DataDog/agent-configuration
-/pkg/flare/clusteragent/manifests.go    @DataDog/agent-onboarding @DataDog/agent-configuration
 /pkg/flare/*_win.go                     @DataDog/windows-products @DataDog/agent-configuration
 /pkg/flare/*_windows.go                 @DataDog/windows-products @DataDog/agent-configuration
 /pkg/flare/*_windows_test.go            @DataDog/windows-products @DataDog/agent-configuration
@@ -796,7 +794,7 @@
 /test/new-e2e/system-probe                    @DataDog/ebpf-platform
 /test/new-e2e/system-probe/config/vmconfig-security-agent.json @DataDog/ebpf-platform @DataDog/agent-security
 /test/new-e2e/scenarios/system-probe          @DataDog/ebpf-platform
-/test/new-e2e/tests/agent-platform            @DataDog/agent-onboarding @DataDog/agent-devx
+/test/new-e2e/tests/agent-platform            @DataDog/agent-devx
 /test/new-e2e/tests/agent-platform/common/agent_integration.go @DataDog/agent-integrations
 /test/new-e2e/tests/agent-runtimes            @DataDog/agent-runtimes
 /test/new-e2e/tests/agent-configuration       @DataDog/agent-configuration


### PR DESCRIPTION
### What does this PR do?

* Removes agent-onboarding from codeowners

### Motivation

Agent-onboarding team does not exist anymore following org change

### Describe how you validated your changes

### Additional Notes
