### PR TITLE
[FA] Fix agent_config edge case

### DIFF
--- a/pkg/remoteconfig/state/agent_config.go
+++ b/pkg/remoteconfig/state/agent_config.go
@@ -142,15 +142,21 @@ func MergeRCAgentConfig(applyStatus func(cfgPath string, status ApplyStatus), up
 	// Go through all the layers that were sent, and apply them one by one to the merged structure
 	mergedConfig := ConfigContent{}
 	for i := len(orderFile.Config.Order) - 1; i >= 0; i-- {
-		if layer, found := parsedLayers[orderFile.Config.Order[i]]; found {
-			mergedConfig.LogLevel = layer.Config.Config.LogLevel
+		id := orderFile.Config.Order[i]
+		layer, found := parsedLayers[id]
+		if !found {
+			return ConfigContent{}, fmt.Errorf("config '%s' referenced in order is not yet available", id)
 		}
+		mergedConfig.LogLevel = layer.Config.Config.LogLevel
 	}
 	// Same for internal config
 	for i := len(orderFile.Config.InternalOrder) - 1; i >= 0; i-- {
-		if layer, found := parsedLayers[orderFile.Config.InternalOrder[i]]; found {
-			mergedConfig.LogLevel = layer.Config.Config.LogLevel
+		id := orderFile.Config.InternalOrder[i]
+		layer, found := parsedLayers[id]
+		if !found {
+			return ConfigContent{}, fmt.Errorf("config '%s' referenced in internal_order is not yet available", id)
 		}
+		mergedConfig.LogLevel = layer.Config.Config.LogLevel
 	}
 
 	return mergedConfig, nil

--- a/pkg/remoteconfig/state/agent_config_test.go
+++ b/pkg/remoteconfig/state/agent_config_test.go
@@ -6,8 +6,10 @@
 package state
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMergeRCConfigWithEmptyData(t *testing.T) {
@@ -16,4 +18,44 @@ func TestMergeRCConfigWithEmptyData(t *testing.T) {
 	content, err := MergeRCAgentConfig(emptyUpdateStatus, make(map[string]RawConfig))
 	assert.NoError(t, err)
 	assert.Equal(t, ConfigContent{}, content)
+}
+
+// TestMergeRCConfigOrderArrivesBeforeConfig reproduces the race where the
+// configuration_order file arrives in one poll but the referenced config file
+// has not been stored in state yet. The previous behaviour silently returned an
+// empty ConfigContent (log_level ""), causing a spurious log and an early-return
+// that never acknowledged the configs.  The fix returns an explicit error so the
+// callback treats it as a transient failure and the RC backend retries.
+func TestMergeRCConfigOrderArrivesBeforeConfig(t *testing.T) {
+	emptyUpdateStatus := func(_ string, _ ApplyStatus) {}
+
+	// Only the order file is present; the referenced config is missing.
+	updates := map[string]RawConfig{
+		"datadog/2/AGENT_CONFIG/configuration_order/configuration_order": {
+			Config: []byte(`{"order":["flare-log-level-abc123"],"internal_order":[]}`),
+		},
+	}
+
+	_, err := MergeRCAgentConfig(emptyUpdateStatus, updates)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "flare-log-level-abc123")
+}
+
+// TestMergeRCConfigBothArriveTogether verifies that when both the order file and
+// the referenced config are present in the same update the log level is returned.
+func TestMergeRCConfigBothArriveTogether(t *testing.T) {
+	emptyUpdateStatus := func(_ string, _ ApplyStatus) {}
+
+	updates := map[string]RawConfig{
+		"datadog/2/AGENT_CONFIG/configuration_order/configuration_order": {
+			Config: []byte(`{"order":["flare-log-level-abc123"],"internal_order":[]}`),
+		},
+		"datadog/2/AGENT_CONFIG/flare-log-level-abc123/flare-log-level-abc123": {
+			Config: []byte(`{"name":"flare-log-level-abc123","config":{"log_level":"debug"}}`),
+		},
+	}
+
+	content, err := MergeRCAgentConfig(emptyUpdateStatus, updates)
+	require.NoError(t, err)
+	assert.Equal(t, "debug", content.LogLevel)
 }


### PR DESCRIPTION
### What does this PR do?

This pull request improves the robustness of the remote config merging logic by ensuring that missing configuration files referenced in the order are explicitly handled as errors, rather than silently ignored. It also adds targeted tests to verify the new error handling and correct merging behavior.

**Error handling improvements:**

* Updated `MergeRCAgentConfig` in `agent_config.go` to return an explicit error if a config referenced in the `order` or `internal_order` is missing, instead of silently proceeding with incomplete data. This prevents unnoticed misconfigurations and ensures that missing files trigger retries.

**Testing enhancements:**

* Added `TestMergeRCConfigOrderArrivesBeforeConfig` to verify that the function returns an error when the order file references a config that hasn't arrived yet. This reproduces and guards against a previous race condition.
* Added `TestMergeRCConfigBothArriveTogether` to confirm that when both the order file and the referenced config are present, the merging logic works correctly and the expected log level is set.
* Improved imports in `agent_config_test.go` to include `require` for better assertion handling.

### Motivation

### Describe how you validated your changes

### Additional Notes
