### PR TITLE
Remove outdated diagnostics from `tools/bazel.bat`

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -29,9 +29,20 @@ if [ -n "${XDG_CACHE_HOME:-}" ]; then
   unset GOCACHE                               # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
   export GOMODCACHE="$XDG_CACHE_HOME"/go/mod  # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
   unset PIP_CACHE_DIR                         # https://pip.pypa.io/en/stable/topics/caching/#default-paths
-  if [[ -n "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then
-    exec "$BAZEL_REAL" ${1:+"$1" --config=ci} "${@:2}"
-  fi
+fi
+
+# "--startup cmd ..." -> "--startup cmd --config=ci ..."
+if [[ $# -gt 0 && -n "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then
+  args=()
+  cmd=
+  for arg in "$@"; do
+    args+=("$arg")
+    if [[ -z "$cmd" && "$arg" != -* ]]; then
+      cmd=$arg
+      args+=(--config=ci)
+    fi
+  done
+  set -- "${args[@]}"
 fi
 
 exec "$BAZEL_REAL" "$@"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -54,10 +54,27 @@ if not exist "!more_than_260_chars!" (
   )
 )
 
-set "bazel_args=%*"
-if defined bazel_args if defined CI if not defined GITHUB_ACTIONS (
-  :: In CI except GitHub: "$@" -> "$1" --config=ci "${@:2}"
-  call set "bazel_args=%1 --config=ci%%bazel_args:*%1=%%"
-)
-"%BAZEL_REAL%" !bazel_home_startup_option! !bazel_args!
+set "args=%*"
+if defined args if defined CI if not defined GITHUB_ACTIONS call :inject_ci_args
+"%BAZEL_REAL%" !bazel_home_startup_option! !args!
 exit /b !errorlevel!
+
+:: "--startup cmd ..." -> "--startup cmd --config=ci ..."
+:inject_ci_args
+set "startup_args="
+set "next_args=!args!"
+:parse_next_arg
+set "cmd="
+for /f "tokens=1* delims= " %%i in ("!next_args!") do (
+  set "arg=%%~i"
+  if "!arg:~0,1!" equ "-" (
+    set "startup_args=!startup_args! %%i"
+    set "next_args=%%j"
+  ) else (
+    if defined startup_args set "startup_args=!startup_args:~1! "
+    set "cmd=%%i"
+    set "args=!startup_args!!cmd! --config=ci %%j"
+  )
+)
+if not defined cmd if defined next_args goto :parse_next_arg
+exit /b

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -54,50 +54,10 @@ if not exist "!more_than_260_chars!" (
   )
 )
 
-:: Not in CI nor GitHub Actions: simply execute `bazel` - done
-if defined CI if not defined GITHUB_ACTIONS goto :ci_config
-"%BAZEL_REAL%" !bazel_home_startup_option! %*
-exit /b !errorlevel!
-:ci_config
-
-:: Pass CI-specific options through `.user.bazelrc` so any nested `bazel run` and next `bazel shutdown` also honor them
-(
-  echo startup --connect_timeout_secs=5  # instead of 30s, for quicker iterations in diagnostics
-  echo startup --local_startup_timeout_secs=30  # instead of 120s, to fail faster for diagnostics
-  echo startup !bazel_home_startup_option:\=/!  # forward slashes: https://github.com/bazelbuild/bazel/issues/3275
-  echo common --config=ci
-) >"%~dp0..\user.bazelrc"
-
-:: Diagnostics: print any stalled client/server before `bazel` execution
->&2 powershell -NoProfile -Command "Get-Process bazel,java -ErrorAction SilentlyContinue | Select-Object 🟡,ProcessName,StartTime"
-
-:: Payload: execute `bazel` and remember exit status
-"%BAZEL_REAL%" %*
-set bazel_exit=!errorlevel!
-
-:: Diagnostics: dump logs on non-trivial failures (https://bazel.build/run/scripts#exit-codes)
-:: TODO(regis): adjust (probably `== 37`) next time a `cannot connect to Bazel server` error happens (#incident-42947)
-set should_diagnose=1
-for %%c in (0 1 3 34 36 48) do if !bazel_exit!==%%c set should_diagnose=0
-if !should_diagnose!==1 (
-  >&2 echo 🔴 Bazel failed [!bazel_exit!], dumping available info in !bazel_home! ^(excluding junctions^):
-  for /f "delims=" %%d in ('dir /a:d-l /b "!bazel_home!"') do (
-    >&2 echo 🟡 [%%d]
-    for %%f in ("!bazel_home!\%%d\java.log.*" "!bazel_home!\%%d\server\*") do (
-      if exist "%%f" (
-        >&2 echo 🟡 %%f:
-        >&2 type "%%f"
-        >&2 echo.
-      ) else (
-        >&2 echo 🟡 %%f doesn't exist
-      )
-    )
-  )
+set "bazel_args=%*"
+if defined bazel_args if defined CI if not defined GITHUB_ACTIONS (
+  :: In CI except GitHub: "$@" -> "$1" --config=ci "${@:2}"
+  call set "bazel_args=%1 --config=ci%%bazel_args:*%1=%%"
 )
-
-:: Stop `bazel` (if still running) to close files and proceed with cleanup
->&2 "%BAZEL_REAL%" shutdown --ui_event_filters=-info
->&2 del /f /q "%~dp0..\user.bazelrc"
-
-:: Done
-exit /b !bazel_exit!
+"%BAZEL_REAL%" !bazel_home_startup_option! !bazel_args!
+exit /b !errorlevel!


### PR DESCRIPTION
### What does this PR do?
- remove the diagnostics instrumentation: pre-execution stalled process dump, post-execution log dump, diagnostic timeouts, `bazel shutdown`,
- drop `user.bazelrc` in favor of passing `--config=ci` directly to the command line,
- unify the CI and non-CI paths into a single `bazel` invocation.

### Motivation
No `cannot connect to Bazel server` error happened over the past months since #incident-42947, indicating the problems we used to face were indeed strictly infrastructure-related: insufficient container resources, anti-virus exclusions whose syntax was ineffective (incorrectly transposed from Ruby to PowerShell), anti-virus eventually disabled.

Juggling with `bazel`-related variables (flags, paths) has therefore become an unnecessary burden strengthened by the need for tuning the repository content cache (another flag) with upcoming Bazel 9.

### Describe how you validated your changes
- run all combinations on my Windows VM,
- the fewer the code paths, the fewer the points of failure.