### PR TITLE
[KMT] Fix stale AWS account name in SSH key config log message

### DIFF
--- a/tasks/kmt.py
+++ b/tasks/kmt.py
@@ -558,7 +558,7 @@ def config_ssh_key(ctx: Context):
 
         info("[+] KMT needs this SSH key to be loaded in AWS so that it can be used to access the instances")
         info(
-            "[+] If you haven't loaded it yet, go to https://dtdg.co/aws-sso-prod -> DataDog Sandbox -> EC2 -> Network & Security -> Key Pairs"
+            "[+] If you haven't loaded it yet, go to https://dtdg.co/aws-sso-prod -> Agent Sandbox -> EC2 -> Network & Security -> Key Pairs"
         )
         aws_key_name = ask(
             f"Enter the key name configured in AWS for this key (leave blank to set the same as the local key name '{ssh_key['name']}'): "


### PR DESCRIPTION
The migration to agent-sandbox (#43626) missed updating the log message in kmt.config-ssh-key, which still referenced "DataDog Sandbox".

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
