### PR TITLE
fix(discovery): Downgrade unknown endpoint log to debug level

### DIFF
--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -237,7 +237,7 @@ async fn handle_request(
         (&Method::GET, "/config/by-source") => handle_config_by_source().await,
         (&Method::GET, "/debug/stats") => handle_debug_stats().await,
         _ => {
-            info!(
+            debug!(
                 "{} Request to unknown endpoint: {}",
                 req.method(),
                 req.uri().path()


### PR DESCRIPTION
Change the log level for requests to unknown endpoints in the discovery module's Rust service from `info!` to `debug!`. Some unknown endpoints are hit during flare creation (handled gracefully in the core agent), but the information is only useful for debugging.