### PR TITLE
Treat Datadog Installer as disabled in FIPS service tests

### DIFF
--- a/.gitlab/windows/test/e2e/windows.yml
+++ b/.gitlab/windows/test/e2e/windows.yml
@@ -87,6 +87,7 @@ new-e2e-windows-service-test:
       - EXTRA_PARAMS: --run TestServiceBehaviorWhenDisabledProcessAgent
       - EXTRA_PARAMS: --run TestServiceBehaviorWhenDisabledTraceAgent
       - EXTRA_PARAMS: --run TestServiceBehaviorWhenDisabledInstaller
+      - EXTRA_PARAMS: --run TestServiceBehaviorInstallerWithRemoteConfig
       - EXTRA_PARAMS: --run TestDriverVerifierOnServiceBehaviorAgentCommand
       - EXTRA_PARAMS: --run TestDriverVerifierOnServiceBehaviorPowerShell
       - EXTRA_PARAMS: --run TestDriverVerifierOnServiceBehaviorWhenDisabledSystemProbe

--- a/test/new-e2e/tests/windows/service-test/fixtures/datadog-rc-enabled.yaml
+++ b/test/new-e2e/tests/windows/service-test/fixtures/datadog-rc-enabled.yaml
@@ -1,0 +1,17 @@
+# enable logs agent
+logs_enabled: true
+
+# enable process agent
+process_config:
+  # live process
+  process_collection:
+    enabled: true
+
+# enable the datadog-installer, needs an API KEY
+remote_updates: true
+
+# enable remote configuration so the installer runs in FIPS mode
+remote_configuration:
+  enabled: true
+
+# trace-agent is running by default

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -337,6 +337,11 @@ func (s *agentServiceDisabledSuite) SetupSuite() {
 	// SetupSuite needs to defer CleanupOnSetupFailure() if what comes after BaseSuite.SetupSuite() can fail.
 	defer s.CleanupOnSetupFailure()
 
+	// TODO: This service is not supported in FIPS mode yet
+	if s.Env().Agent.FIPSEnabled && !slices.Contains(s.disabledServices, "Datadog Installer") {
+		s.disabledServices = append(s.disabledServices, "Datadog Installer")
+	}
+
 	// set up the expected services before calling the base setup
 	s.runningUserServices = func() []string {
 		runningServices := []string{}
@@ -557,10 +562,24 @@ func (s *baseStartStopSuite) SetupSuite() {
 
 	// Setup default expected services
 	s.runningUserServices = func() []string {
-		return s.getInstalledUserServices()
+		services := s.getInstalledUserServices()
+		if s.Env().Agent.FIPSEnabled {
+			// TODO: This service is not supported in FIPS mode yet
+			services = slices.DeleteFunc(services, func(svc string) bool {
+				return svc == "Datadog Installer"
+			})
+		}
+		return services
 	}
 	s.runningServices = func() []string {
-		return s.getInstalledServices()
+		services := s.getInstalledServices()
+		if s.Env().Agent.FIPSEnabled {
+			// TODO: This service is not supported in FIPS mode yet
+			services = slices.DeleteFunc(services, func(svc string) bool {
+				return svc == "Datadog Installer"
+			})
+		}
+		return services
 	}
 
 	// By default driver verifier is disabled.

--- a/test/new-e2e/tests/windows/service-test/startstop_test.go
+++ b/test/new-e2e/tests/windows/service-test/startstop_test.go
@@ -46,6 +46,9 @@ var agentConfigTADisabled string
 //go:embed fixtures/datadog-di-disabled.yaml
 var agentConfigDIDisabled string
 
+//go:embed fixtures/datadog-rc-enabled.yaml
+var agentConfigRCEnabled string
+
 //go:embed fixtures/system-probe.yaml
 var systemProbeConfig string
 
@@ -77,6 +80,31 @@ const defaultTimeoutScale = 1
 const driverVerifierTimeoutScale = 10
 
 type onServiceStateMismatch func(host *components.RemoteHost, serviceName, actual string)
+
+// TestServiceBehaviorInstallerWithRemoteConfig tests that the installer runs
+// when remote_configuration is explicitly enabled, which is required in FIPS mode.
+// TODO: remove this test when installer runs fully in FIPS mode.
+func TestServiceBehaviorInstallerWithRemoteConfig(t *testing.T) {
+	s := &installerWithRemoteConfigSuite{}
+	run(t, s, systemProbeConfig, agentConfigRCEnabled, securityAgentConfig)
+}
+
+type installerWithRemoteConfigSuite struct {
+	powerShellServiceCommandSuite
+}
+
+func (s *installerWithRemoteConfigSuite) SetupSuite() {
+	s.powerShellServiceCommandSuite.SetupSuite()
+	defer s.CleanupOnSetupFailure()
+
+	// With remote_configuration enabled, the installer should run even in FIPS mode
+	s.runningUserServices = func() []string {
+		return s.getInstalledUserServices()
+	}
+	s.runningServices = func() []string {
+		return s.getInstalledServices()
+	}
+}
 
 // TestServiceBehaviorAgentCommandNoFIM tests the service behavior when controlled by Agent commands
 func TestNoFIMServiceBehaviorAgentCommand(t *testing.T) {
@@ -390,6 +418,15 @@ func (s *agentServiceDisabledSuite) TestStartingDisabledService() {
 
 		// verify that we only try user services
 		if !slices.Contains(kernel, service) {
+			// In FIPS builds the installer does not start correctly
+			// when remote configuration is disabled and Start-Service fails.
+			// TODO: remove this when installer runs fully in FIPS mode.
+			if s.Env().Agent.FIPSEnabled && service == "Datadog Installer" {
+				err := windowsCommon.StartService(s.Env().RemoteHost, service)
+				s.Require().Error(err, "should fail to start "+service+" in FIPS mode")
+				continue
+			}
+
 			// try and start it and verify that it does correctly outputs to event log
 			err := windowsCommon.StartService(s.Env().RemoteHost, service)
 			s.Require().NoError(err, "should start "+service)


### PR DESCRIPTION
### What does this PR do?
Excludes the Datadog Installer service from the expected running services in the Windows service start/stop tests when FIPS mode is enabled. The installer is still installed but acts as disabled in FIPS builds.

### Motivation
These tests were written for the regular Agent package but are now also run with the FIPS package, where the Datadog Installer service should not be running.

### Describe how you validated your changes
Test-only change. The FIPS service test pipeline will validate.
manual run
```
pwsh.exe -Command { $env:E2E_PIPELINE_ID="102586157"; $env:E2E_FIPS="true"; go test -v -timeout 30m -tags test .\test\new-e2e\tests\windows\service-test -run 'TestServiceBehaviorAgentCommand' }
```