### PR TITLE
Update cacerts to 2026-03-19

### DIFF
--- a/omnibus/config/software/cacerts.rb
+++ b/omnibus/config/software/cacerts.rb
@@ -29,9 +29,9 @@ name "cacerts"
 # cacerts bundle changes.
 # This allows us to always use up-to-date cacerts, without breaking all builds
 # when they change.
-default_version "2025-12-02"
+default_version "2026-03-19"
 source url: "https://curl.se/ca/cacert-#{version}.pem",
-       sha256: "f1407d974c5ed87d544bd931a278232e13925177e239fca370619aba63c757b4",
+       sha256: "b6e66569cc3d438dd5abe514d0df50005d570bfc96c14dca8f768d020cb96171",
        target_filename: "cacert.pem"
 
 relative_path "cacerts-#{version}"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"be8981b2-77c0-44d4-934d-a93bc0b6f4be","source":"chat","resourceId":"b7cabf9e-790b-4003-a45f-70e9769a4a16","workflowId":"e91d29bb-8c33-42c4-beeb-ab07c0f913f6","codeChangeId":"e91d29bb-8c33-42c4-beeb-ab07c0f913f6","sourceType":"bits_ai_sre"} -->

Bits AI SRE Investigation • [View in Bits AI SRE Investigation](https://app.datadoghq.com/bits-ai/investigations/6250239a-444f-479d-b8c0-cc43321d620b)

Updates the cacerts bundle to version 2026-03-19 with the corresponding SHA256 hash.

This update ensures the application uses the latest CA certificates, which may include security updates, newly trusted CAs, or revoked certificates. Keeping cacerts current is essential for maintaining secure TLS connections and preventing certificate validation failures.

- Verified the new cacerts version is available at the expected URL
- Confirmed the SHA256 hash matches the downloaded certificate bundle
- Ensured the version format follows the existing naming convention (YYYY-MM-DD)

Must also sync this into the bazel PR. @aiuto will do that.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b7cabf9e-790b-4003-a45f-70e9769a4a16)

Comment @datadog to request changes

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
