### PR TITLE
Update q_branch codeowner: val06 -> lukesteensen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -894,4 +894,4 @@
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 
-/q_branch/                               @scottopell @val06
+/q_branch/                               @scottopell @lukesteensen


### PR DESCRIPTION
## Summary
- Replaces `@val06` with `@lukesteensen` as codeowner for `/q_branch/` in `.github/CODEOWNERS`

## Test plan
- [ ] Verify `@lukesteensen` is tagged on future PRs touching `/q_branch/`

> Note: team handle replacement pending org changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)