### PR TITLE
Add codeowner entry for q.py

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -842,3 +842,4 @@
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 
 /q_branch/                               @scottopell @val06
+/q.py                                    @scottopell @lukesteensen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -842,4 +842,4 @@
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 
 /q_branch/                               @scottopell @val06
-/q.py                                    @scottopell @lukesteensen
+/tasks/q.py                              @scottopell @lukesteensen


### PR DESCRIPTION
## Summary
- Adds `/q.py` codeowner entry with `@scottopell` and `@lukesteensen`, following the same pattern as the `/q_branch/` directory entry

Note: team handle replacement pending org changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)