### PR TITLE
deps: remove unused template expansion

### DIFF
--- a/deps/freetds/overlay/freetds.BUILD.bazel
+++ b/deps/freetds/overlay/freetds.BUILD.bazel
@@ -57,22 +57,6 @@ cc_library(
 )
 
 dd_agent_expand_template(
-    name = "gen_version_h",
-    out = "include/freedts/version.h",
-    substitutions = {
-        "@PACKAGE@": "freetds",
-        "@VERSION@": VERSION,
-        "@MAJOR@": VERSION.split(".")[0],
-        "@MINOR@": VERSION.split(".")[1],
-        "@SUBVERSION@": VERSION.split(".")[2],
-        # This was based on date of build. That breaks caching.
-        # Let's use date of update of this file.
-        "@BUILD_NUMBER@": "20260121",
-    },
-    template = "include/freetds/version.h.in",
-)
-
-dd_agent_expand_template(
     name = "gen_sysdep_h",
     out = "include/tds_sysdep_public.h",
     substitutions = {
@@ -96,7 +80,6 @@ cc_library(
     name = "libtdsodbc",
     srcs = [
         ":gen_sysdep_h",
-        ":gen_version_h",
         "include/freetds/alloca.h",
         "include/freetds/bool.h",
         "include/freetds/bytes.h",


### PR DESCRIPTION
### What does this PR do?

Stop generating `freetds`'s version.h ourselves

### Motivation

It turns out version.h is already present in the source archive, and the file we were generating was never used.
Notice the freedts VS freetds in the expansion output file name.

### Describe how you validated your changes

```
❯ ls -l $(bazelisk info output_base)/external/+_repo_rules+freetds/include/freetds/version.h
WARNING: Option 'remote_local_fallback_strategy' is deprecated
-rw-r--r-- 1 hugo.beauzee hugo.beauzee 1143 mai    4  2020 /home/hugo.beauzee/.cache/bazel/_bazel_hugo.beauzee/95605d1a73395e0c041bb302da387b0e/external/+_repo_rules+freetds/include/freetds/version.h
``` 

### Additional Notes
