### PR TITLE
add missing config ns for dyninst

### DIFF
--- a/cmd/system-probe/modules/dynamic_instrumentation.go
+++ b/cmd/system-probe/modules/dynamic_instrumentation.go
@@ -29,7 +29,7 @@ func init() { registerModule(DynamicInstrumentation) }
 // running Go services without restarts.
 var DynamicInstrumentation = &module.Factory{
 	Name:             config.DynamicInstrumentationModule,
-	ConfigNamespaces: []string{},
+	ConfigNamespaces: []string{"dynamic_instrumentation"},
 	Fn: func(agentConfiguration *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
 		config, err := dimod.NewConfig(agentConfiguration)
 		if err != nil {


### PR DESCRIPTION
### What does this PR do?

Fixes the config endpoint to return configuration underneath `dynamic_instrumentation` too

### Motivation

Inconsistent agent inventory results for dynamic instrumentation

### Describe how you validated your changes

### Additional Notes
