### PR TITLE
Sync q_branch codeowner update from main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -841,5 +841,5 @@
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 
-/q_branch/                               @scottopell @val06
+/q_branch/                               @scottopell @lukesteensen
 /tasks/q.py                              @scottopell @lukesteensen


### PR DESCRIPTION
## Summary
Syncs the `val06` → `lukesteensen` codeowner change for `/q_branch/` from #48067 (now merged to main) into `q-branch-observer`.

Conflict resolved: `q-branch-observer` already had the `/tasks/q.py` entry from #48068, which is preserved alongside the updated `/q_branch/` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)