### PR TITLE
Replace ad-hoc q_branch codeowners with @DataDog/q-branch team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -841,5 +841,5 @@
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 
-/q_branch/                               @scottopell @lukesteensen
-/tasks/q.py                              @scottopell @lukesteensen
+/q_branch/                               @DataDog/q-branch
+/tasks/q.py                              @DataDog/q-branch


### PR DESCRIPTION
## Summary
Replaces individual `@scottopell @lukesteensen` codeowner entries for `/q_branch/` and `/tasks/q.py` with the official `@DataDog/q-branch` team now that it has been synced through the org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)