### PR TITLE
Replace ad-hoc q_branch codeowners with @DataDog/q-branch team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -895,4 +895,4 @@
 /pkg/util/scrubber/go.mod                @DataDog/agent-runtimes
 /pkg/util/scrubber/go.sum                @DataDog/agent-runtimes
 
-/q_branch/                               @scottopell @lukesteensen
+/q_branch/                               @DataDog/q-branch

--- a/tasks/libs/pipeline/github_jira_map.yaml
+++ b/tasks/libs/pipeline/github_jira_map.yaml
@@ -53,3 +53,4 @@
 '@datadog/synthetics-executing': SYNORG
 '@datadog/agent-health': AHEALTH
 '@datadog/profiling-full-host': 'PROF'
+'@datadog/q-branch': DEFAULT_JIRA_PROJECT

--- a/tasks/libs/pipeline/github_slack_map.yaml
+++ b/tasks/libs/pipeline/github_slack_map.yaml
@@ -382,6 +382,13 @@
   review:
     name: '#universal-service-monitoring'
     id: 'C01R6Q0HQDD'
+'@datadog/q-branch':
+  notification:
+    name: '#agent-q-branch'
+    id: 'C09UDTU0H18'
+  review:
+    name: '#agent-q-branch'
+    id: 'C09UDTU0H18'
 '@datadog/windows-products':
   notification:
     name: '#windows-products-ops'


### PR DESCRIPTION
## Summary
- Replaces `@scottopell @lukesteensen` with `@DataDog/q-branch` in CODEOWNERS for `/q_branch/`
- Adds `@datadog/q-branch` to `github_slack_map.yaml` (notification + review → `#agent-q-branch` / `C09UDTU0H18`)
- Adds `@datadog/q-branch` to `github_jira_map.yaml` (using `DEFAULT_JIRA_PROJECT` / AGNTR — update to a dedicated project key when available)

Fixes the `notify.check-teams` CI check failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)