### PR TITLE
[observer] Add structured source enrichment and log pattern extractor support

### DIFF
--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -70,6 +70,8 @@ export interface SeriesInfo {
   name: string;
   tags: string[];
   pointCount: number;
+  /** True when the series is produced by a log/metric extractor (formerly _virtual.* names). */
+  virtual?: boolean;
 }
 
 export interface Point {

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -24,6 +24,12 @@ function getAggregationType(name: string): AggregationType | null {
   return match ? (match[1] as AggregationType) : null;
 }
 
+/** Log-derived (extractor) metrics; falls back to legacy `_virtual.` name prefix. */
+function seriesIsVirtual(s: SeriesInfo): boolean {
+  if (typeof s.virtual === 'boolean') return s.virtual;
+  return getBaseMetricName(s.name).startsWith('_virtual.');
+}
+
 function getDetectorComponent(anomaly: { detectorName: string; detectorComponent?: string }): string {
   return anomaly.detectorComponent ?? anomaly.detectorName;
 }
@@ -39,6 +45,7 @@ interface MetricGroup {
   namespace: string;
   baseName: string;
   members: SeriesInfo[];
+  virtual: boolean;
 }
 
 interface MetricsViewProps {
@@ -119,6 +126,7 @@ export function MetricsView({
           namespace: s.namespace,
           baseName,
           members: [],
+          virtual: seriesIsVirtual(s),
         });
       }
       groups.get(key)!.members.push(s);
@@ -163,12 +171,18 @@ export function MetricsView({
   );
 
   const virtualGroups = useMemo(
-    () => visibleGroups.filter((g) => g.baseName.startsWith('_virtual.')),
+    () => visibleGroups.filter((g) => g.virtual),
     [visibleGroups]
   );
 
   const displayGroups = useMemo(
-    () => visibleGroups.map((g) => ({ key: g.key, name: g.baseName, displayName: g.baseName })),
+    () =>
+      visibleGroups.map((g) => ({
+        key: g.key,
+        name: g.baseName,
+        displayName: g.baseName,
+        virtual: g.virtual,
+      })),
     [visibleGroups]
   );
 
@@ -190,7 +204,7 @@ export function MetricsView({
     if (scenarioHasSeries && allSeries.length === 0) return;
 
     const mainGroups = [...visibleGroups]
-      .filter((g) => g.namespace !== 'telemetry' && !g.baseName.startsWith('_virtual.'));
+      .filter((g) => g.namespace !== 'telemetry' && !g.virtual);
 
     const DEFAULT_METRIC = 'datadog.dogstatsd.client.metrics';
     const defaultGroup = mainGroups.find((g) => g.baseName === DEFAULT_METRIC);
@@ -529,7 +543,7 @@ export function MetricsView({
                   const cards = Array.from(selectedGroups)
                     .filter((key) => {
                       const g = groupByKey.get(key);
-                      return g && g.namespace !== 'telemetry' && !g.baseName.startsWith('_virtual.');
+                      return g && g.namespace !== 'telemetry' && !g.virtual;
                     })
                     .map((groupKey) => {
                       const dataList = groupSeriesData.get(groupKey) ?? [];
@@ -588,7 +602,7 @@ export function MetricsView({
                       {Array.from(selectedGroups)
                         .filter((key) => {
                           const g = groupByKey.get(key);
-                          return g && g.baseName.startsWith('_virtual.');
+                          return g && g.virtual;
                         })
                         .map((groupKey) => {
                           const dataList = groupSeriesData.get(groupKey) ?? [];

--- a/cmd/observer-testbench/ui/src/components/SeriesTree.tsx
+++ b/cmd/observer-testbench/ui/src/components/SeriesTree.tsx
@@ -1,9 +1,15 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 
+/** Native tooltip for rows where every metric under the node is extractor-backed. */
+const VIRTUAL_METRIC_GROUP_TITLE =
+  'Virtual metric — produced by log/metric extractors from log lines, not from raw DogStatsD ingestion.';
+
 interface SeriesInfo {
   key: string;
   name: string;
   displayName?: string;
+  /** True when the metric group is log-derived (extractor); used for the cyan "v" badge. */
+  virtual?: boolean;
 }
 
 interface TreeNode {
@@ -77,6 +83,7 @@ interface TreeNodeComponentProps {
   depth: number;
   selectedSeries: Set<string>;
   anomalousSources: Set<string>;
+  virtualByKey: Map<string, boolean>;
   onToggleNode: (keys: string[]) => void;
   expandedPaths: Set<string>;
   onToggleExpanded: (path: string) => void;
@@ -87,6 +94,7 @@ function TreeNodeComponent({
   depth,
   selectedSeries,
   anomalousSources,
+  virtualByKey,
   onToggleNode,
   expandedPaths,
   onToggleExpanded,
@@ -94,6 +102,9 @@ function TreeNodeComponent({
   const isExpanded = expandedPaths.has(node.fullPath);
   const hasChildren = node.children.size > 0;
   const keys = node.seriesKeys;
+  const uniqueKeys = [...new Set(keys)];
+  const onlyVirtual =
+    uniqueKeys.length > 0 && uniqueKeys.every((k) => virtualByKey.get(k) === true);
 
   const allSelected = keys.length > 0 && keys.every((k) => selectedSeries.has(k));
   const someSelected = keys.some((k) => selectedSeries.has(k));
@@ -106,8 +117,9 @@ function TreeNodeComponent({
       <div
         className={`flex items-center gap-1 py-0.5 px-1 rounded cursor-pointer ${
           hasAnomaly ? 'bg-red-900/20' : 'hover:bg-slate-700/50'
-        }`}
+        } ${onlyVirtual ? 'cursor-help' : ''}`}
         style={{ paddingLeft: `${depth * 12}px` }}
+        title={onlyVirtual ? VIRTUAL_METRIC_GROUP_TITLE : undefined}
       >
         {hasChildren && !node.isLeaf ? (
           <button
@@ -135,7 +147,7 @@ function TreeNodeComponent({
         />
 
         <span
-          className={`text-sm truncate flex-1 ${hasAnomaly ? 'text-red-400' : 'text-slate-400'}`}
+          className={`text-sm truncate flex-1 min-w-0 ${hasAnomaly ? 'text-red-400' : 'text-slate-400'}`}
           onClick={() => {
             if (hasChildren && !node.isLeaf) {
               onToggleExpanded(node.fullPath);
@@ -145,8 +157,12 @@ function TreeNodeComponent({
           {node.name}
         </span>
 
+        {onlyVirtual && (
+          <span className="text-[10px] font-semibold text-cyan-400/85 shrink-0 leading-none select-none">v</span>
+        )}
+
         {hasChildren && !node.isLeaf && (
-          <span className="text-xs text-slate-500">{keys.length}</span>
+          <span className="text-xs text-slate-500">{uniqueKeys.length}</span>
         )}
 
         {hasAnomaly && <span className="text-red-500 text-xs">!</span>}
@@ -161,6 +177,7 @@ function TreeNodeComponent({
               depth={depth + 1}
               selectedSeries={selectedSeries}
               anomalousSources={anomalousSources}
+              virtualByKey={virtualByKey}
               onToggleNode={onToggleNode}
               expandedPaths={expandedPaths}
               onToggleExpanded={onToggleExpanded}
@@ -181,6 +198,14 @@ export function SeriesTree({
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
 
   const tree = useMemo(() => buildTree(series, anomalousSources), [series, anomalousSources]);
+
+  const virtualByKey = useMemo(() => {
+    const m = new Map<string, boolean>();
+    for (const s of series) {
+      m.set(s.key, s.virtual === true);
+    }
+    return m;
+  }, [series]);
 
   const toggleExpanded = (path: string) => {
     setExpandedPaths((prev) => {
@@ -309,6 +334,7 @@ export function SeriesTree({
             depth={0}
             selectedSeries={selectedSeries}
             anomalousSources={anomalousSources}
+            virtualByKey={virtualByKey}
             onToggleNode={toggleNode}
             expandedPaths={expandedPaths}
             onToggleExpanded={toggleExpanded}

--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -58,7 +58,7 @@ Aggregation is chosen at **read time**, not write time. Storage always keeps the
 
 The observer is currently **metric-type agnostic** — it does not distinguish between Count, Gauge, Rate, etc. All metrics are treated uniformly as samples to be summarized. This is a bet on a simpler unified model; we'll see over time whether there's a good reason to introduce type-specific logic.
 
-Metrics from logs are stored with a `_virtual.` prefix (e.g. `_virtual.log.field.duration`) to distinguish them from directly observed metrics.
+Metrics from logs are stored under the extractor's component name as the namespace (e.g. `log_metrics_extractor`), distinguishing them from directly observed metrics.
 
 ### 3. Detect
 
@@ -116,7 +116,7 @@ When a log is observed, two things happen:
    ```
    ProcessLog(log LogView) → []MetricOutput
    ```
-   Each returned metric is stored as `_virtual.{name}` and flows through normal detection. Implementations should be stateless and fast.
+   Each returned metric is stored under the extractor's component name as the namespace and flows through normal detection. Implementations should be stateless and fast.
 
 2. **Detectors implementing LogObserver** receive the raw log directly, allowing log-based anomaly detection without the metrics extraction step.
 
@@ -228,7 +228,7 @@ func (m *MyExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
     content := string(log.GetContent())
     // Extract what you need synchronously — don't store the view
     return []observer.MetricOutput{{
-        Name:  "my.metric",    // stored as _virtual.my.metric
+        Name:  "my.metric",    // stored under the extractor's name as namespace
         Value: 1,
         Tags:  log.GetTags(),
     }}

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -230,8 +230,9 @@ type ProfileView interface {
 }
 
 // LogMetricsExtractor transforms observed logs into metrics.
-// Implementations should be stateless and fast since they run synchronously
-// on every observed log.
+// Implementations should be fast since they run synchronously on every observed
+// log. Extractors may keep lightweight internal state when needed for pattern
+// tracking or context enrichment.
 type LogMetricsExtractor interface {
 	// Name returns the extractor name for debugging and logging.
 	Name() string
@@ -250,14 +251,39 @@ type LogObserver interface {
 // The storage keeps full summaries (min/max/sum/count) so aggregation
 // is specified at read time, not write time.
 type MetricOutput struct {
-	Name  string
-	Value float64
-	Tags  []string
+	Name       string
+	Value      float64
+	Tags       []string
+	ContextKey string
 }
 
 // MetricName is a human-readable metric identifier (e.g., "cpu.user:avg").
 // Multiple series can share a MetricName if they differ by tags.
 type MetricName string
+
+// AnomalySource identifies the metric that an anomaly is about using
+// structured fields rather than string concatenation.
+type AnomalySource struct {
+	// Namespace identifies the component that produced this metric
+	// (e.g. an extractor name like "log_metrics_extractor", or "dogstatsd").
+	Namespace string
+	// Name is the base metric name (e.g. "log.pattern.<hash>.count", "cpu.user").
+	Name string
+	// Aggregate is the aggregation applied when reading the series.
+	Aggregate Aggregate
+}
+
+// String returns a human-readable representation (e.g. "cpu.user:avg").
+// Namespace is structural and not included in the display string.
+func (s AnomalySource) String() string {
+	if s.Name == "" {
+		return ""
+	}
+	if s.Aggregate == AggregateNone {
+		return s.Name
+	}
+	return s.Name + ":" + AggregateString(s.Aggregate)
+}
 
 // SeriesID uniquely identifies a time series (namespace + name + tags).
 type SeriesID string
@@ -279,10 +305,8 @@ type Anomaly struct {
 	// Type distinguishes log-based anomalies from metric-based ones.
 	// Defaults to AnomalyTypeMetric if not set.
 	Type AnomalyType
-	// Source identifies which metric/signal or log source the anomaly is about.
-	// For metric anomalies: the metric name (e.g., "network.retransmits:avg").
-	// For log anomalies: a descriptive source identifier (e.g., "logs").
-	Source MetricName
+	// Source identifies which metric/signal the anomaly is about.
+	Source AnomalySource
 	// SourceSeriesID uniquely identifies the source series (namespace + name + tags).
 	// Empty for log anomalies.
 	SourceSeriesID SeriesID
@@ -290,9 +314,12 @@ type Anomaly struct {
 	DetectorName string
 	Title        string
 	Description  string
-	Tags         []string
-	Timestamp    int64    // when the anomaly was detected (unix seconds)
-	Score        *float64 // confidence/severity score (nil if not available)
+	// Context carries optional enrichment about the originating signal, such as
+	// a synthesized pattern and example source data.
+	Context   *MetricContext
+	Tags      []string
+	Timestamp int64    // when the anomaly was detected (unix seconds)
+	Score     *float64 // confidence/severity score (nil if not available)
 	// DebugInfo contains detector-specific debug information explaining the detection.
 	DebugInfo *AnomalyDebugInfo
 }
@@ -438,12 +465,54 @@ type SeriesMeta struct {
 type Aggregate int
 
 const (
-	AggregateAverage Aggregate = iota
+	AggregateNone Aggregate = iota
+	AggregateAverage
 	AggregateSum
 	AggregateCount
 	AggregateMin
 	AggregateMax
 )
+
+// AggregateString returns a short string label for the aggregation type.
+func AggregateString(agg Aggregate) string {
+	switch agg {
+	case AggregateNone:
+		return "none"
+	case AggregateAverage:
+		return "avg"
+	case AggregateSum:
+		return "sum"
+	case AggregateCount:
+		return "count"
+	case AggregateMin:
+		return "min"
+	case AggregateMax:
+		return "max"
+	default:
+		return "unknown"
+	}
+}
+
+// ContextProvider resolves metric keys back to richer context about their
+// origin. Components that synthesize metrics from richer data (e.g. log
+// extractors that turn log patterns into count metrics) can implement this
+// interface so that downstream consumers (detectors, reporters) can produce
+// more descriptive anomaly reports.
+type ContextProvider interface {
+	// GetContextByKey returns contextual information for a previously emitted
+	// context key, if available.
+	GetContextByKey(key string) (MetricContext, bool)
+}
+
+// MetricContext describes the origin of a synthesized metric.
+type MetricContext struct {
+	// Pattern is the normalized pattern that generated this metric (e.g. a log signature).
+	Pattern string
+	// Example is a recent raw input that matched the pattern.
+	Example string
+	// Source identifies the originating component or data stream.
+	Source string
+}
 
 // StorageReader provides read access to time series data.
 // Detectors use this to pull whatever data they need.

--- a/comp/observer/impl/agent_internal_logs_test.go
+++ b/comp/observer/impl/agent_internal_logs_test.go
@@ -50,13 +50,14 @@ func TestAgentInternalLogsFlowIntoObserver(t *testing.T) {
 	sig := logSignature(payload, 4096)
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(sig))
-	metricName := "_virtual.log.pattern." + toHex64(h.Sum64()) + ".count"
-	tags := []string{"source:datadog-agent", "component:core", "level:info"}
+	metricName := "log.pattern." + toHex64(h.Sum64()) + ".count"
+	tags := []string{"component:core", "level:info", "observer_source:agent-internal-logs", "source:datadog-agent"}
 
 	// Poll briefly since observer processes asynchronously.
+	// Namespace is the extractor component name (log_metrics_extractor).
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if s := obs.engine.Storage().GetSeries("agent-internal-logs", metricName, tags, AggregateSum); s != nil && len(s.Points) > 0 {
+		if s := obs.engine.Storage().GetSeries("log_metrics_extractor", metricName, tags, AggregateSum); s != nil && len(s.Points) > 0 {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/comp/observer/impl/anomaly_correlator_passthrough.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough.go
@@ -86,11 +86,12 @@ func (c *DetectorPassthroughCorrelator) ActiveCorrelations() []observer.ActiveCo
 		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Timestamp < sorted[j].Timestamp })
 
 		for i, a := range sorted {
+			metricName := observer.MetricName(a.Source.String())
 			result = append(result, observer.ActiveCorrelation{
 				Pattern:         fmt.Sprintf("passthrough_%s_%d", detName, i),
 				Title:           fmt.Sprintf("Passthrough[%s]: %s", detName, a.Source),
 				MemberSeriesIDs: []observer.SeriesID{a.SourceSeriesID},
-				MetricNames:     []observer.MetricName{a.Source},
+				MetricNames:     []observer.MetricName{metricName},
 				Anomalies:       []observer.Anomaly{a},
 				FirstSeen:       a.Timestamp,
 				LastUpdated:     a.Timestamp,

--- a/comp/observer/impl/anomaly_correlator_passthrough_test.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough_test.go
@@ -13,12 +13,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func passthroughSource(name string) observer.AnomalySource {
+	return observer.AnomalySource{Name: name}
+}
+
 func TestDetectorPassthroughCorrelator_OnePerAnomaly(t *testing.T) {
 	c := NewDetectorPassthroughCorrelator()
 
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: "redis.cpu.sys", SourceSeriesID: "s1", Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "bocpd", Source: "redis.cpu.sys", SourceSeriesID: "s1", Timestamp: 105})
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: "redis.info.latency_ms", SourceSeriesID: "s2", Timestamp: 110})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), SourceSeriesID: "s1", Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "bocpd", Source: passthroughSource("redis.cpu.sys"), SourceSeriesID: "s1", Timestamp: 105})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.info.latency_ms"), SourceSeriesID: "s2", Timestamp: 110})
 
 	corrs := c.ActiveCorrelations()
 	// 3 anomalies = 3 correlations (one per anomaly)
@@ -55,7 +59,7 @@ func TestDetectorPassthroughCorrelator_TimestampOrdering(t *testing.T) {
 func TestDetectorPassthroughCorrelator_SeriesIDAndSource(t *testing.T) {
 	c := NewDetectorPassthroughCorrelator()
 
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: "redis.cpu.sys", SourceSeriesID: "s1", Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), SourceSeriesID: "s1", Timestamp: 100})
 
 	corrs := c.ActiveCorrelations()
 	require.Len(t, corrs, 1)

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -21,13 +21,13 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 
 	// Two anomalies with nearby timestamps should cluster together
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
 		Timestamp:      105, // 5 seconds later, within 10s proximity
@@ -48,13 +48,13 @@ func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 
 	// Anomalies within proximity window should cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
 		Timestamp:      108, // 8 seconds later, within 10s proximity
@@ -73,13 +73,13 @@ func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 
 	// Anomalies outside proximity window should form separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
 		Timestamp:      150, // 50 seconds later, outside 10s proximity
@@ -100,13 +100,13 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Create two separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Title:          "Anomaly B",
 		Timestamp:      120, // Far enough to be separate (20s apart)
@@ -117,7 +117,7 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Add anomaly that bridges both clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.c",
+		Source:         observer.AnomalySource{Name: "metric.c"},
 		SourceSeriesID: "ns|metric.c|",
 		Title:          "Anomaly C",
 		Timestamp:      110, // Near both clusters
@@ -138,14 +138,14 @@ func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 
 	// Multiple anomalies from the same series should all be kept
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A v1",
 		Description:    "first",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Title:          "Anomaly A v2",
 		Description:    "second",
@@ -168,13 +168,13 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 	// Same metric name, different tags = different SourceSeriesIDs
 	// Both should be separate members in the cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|host:A",
 		Title:          "Anomaly from host A",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|host:B",
 		Title:          "Anomaly from host B",
 		Timestamp:      102,
@@ -195,7 +195,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	// Add old anomaly
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.old",
+		Source:         observer.AnomalySource{Name: "metric.old"},
 		SourceSeriesID: "ns|metric.old|",
 		Title:          "Old Anomaly",
 		Timestamp:      100,
@@ -203,7 +203,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	// Add recent anomaly (advances currentDataTime)
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.new",
+		Source:         observer.AnomalySource{Name: "metric.new"},
 		SourceSeriesID: "ns|metric.new|",
 		Title:          "New Anomaly",
 		Timestamp:      200, // 100 seconds later, old one should be evicted
@@ -225,7 +225,7 @@ func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 
 	// A single anomaly should form a cluster of one
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Timestamp:      100,
 	})
@@ -244,28 +244,28 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Create a cluster of 2 and a cluster of 3
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.a",
+		Source:         observer.AnomalySource{Name: "metric.a"},
 		SourceSeriesID: "ns|metric.a|",
 		Timestamp:      100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.b",
+		Source:         observer.AnomalySource{Name: "metric.b"},
 		SourceSeriesID: "ns|metric.b|",
 		Timestamp:      105,
 	})
 
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.c",
+		Source:         observer.AnomalySource{Name: "metric.c"},
 		SourceSeriesID: "ns|metric.c|",
 		Timestamp:      200,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.d",
+		Source:         observer.AnomalySource{Name: "metric.d"},
 		SourceSeriesID: "ns|metric.d|",
 		Timestamp:      205,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.e",
+		Source:         observer.AnomalySource{Name: "metric.e"},
 		SourceSeriesID: "ns|metric.e|",
 		Timestamp:      208,
 	})
@@ -284,7 +284,7 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Once the small cluster grows to meet threshold, it should appear
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         "metric.f",
+		Source:         observer.AnomalySource{Name: "metric.f"},
 		SourceSeriesID: "ns|metric.f|",
 		Timestamp:      103,
 	})

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -139,10 +139,10 @@ func (c *CrossSignalCorrelator) Advance(dataTime int64) {
 	// Evict old entries before checking patterns
 	c.evictOldEntries()
 
-	// Extract unique signal sources from anomalies
+	// Extract unique signal sources from anomalies (display names for pattern matching)
 	sourceSet := make(map[observer.MetricName]struct{})
 	for _, entry := range c.buffer {
-		sourceSet[entry.anomaly.Source] = struct{}{}
+		sourceSet[observer.MetricName(entry.anomaly.Source.String())] = struct{}{}
 	}
 
 	// Track which patterns are currently active
@@ -209,8 +209,9 @@ func (c *CrossSignalCorrelator) collectMatchingAnomalies(pattern correlationPatt
 	bySource := make(map[observer.MetricName]observer.Anomaly)
 
 	for _, entry := range c.buffer {
+		display := observer.MetricName(entry.anomaly.Source.String())
 		for _, src := range pattern.requiredSources {
-			if entry.anomaly.Source == src {
+			if display == src {
 				existing, exists := bySource[src]
 				// Keep the one with the later timestamp (more recent)
 				if !exists || entry.anomaly.Timestamp > existing.Timestamp {

--- a/comp/observer/impl/anomaly_processor_correlator_test.go
+++ b/comp/observer/impl/anomaly_processor_correlator_test.go
@@ -13,11 +13,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func avgSource(name string) observer.AnomalySource {
+	return observer.AnomalySource{Name: name, Aggregate: observer.AggregateAverage}
+}
+
+func countSource(name string) observer.AnomalySource {
+	return observer.AnomalySource{Name: name, Aggregate: observer.AggregateCount}
+}
+
 func TestCorrelator_SingleAnomalyNoReport(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 	})
@@ -32,12 +40,12 @@ func TestCorrelator_TwoAnomaliesSameSignalNoReport(t *testing.T) {
 
 	// Add two anomalies from the same signal
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Title:       "High retransmits 1",
 		Description: "First occurrence",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Title:       "High retransmits 2",
 		Description: "Second occurrence",
 	})
@@ -53,17 +61,17 @@ func TestCorrelator_ThreeRequiredSignalsProduceReport(t *testing.T) {
 	// Add anomalies from all three required signals for kernel bottleneck pattern
 	// Note: Source names now include aggregation suffix (avg for value, count for frequency)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
+		Source:      avgSource("ebpf.lock_contention_ns"),
 		Title:       "Lock contention",
 		Description: "High lock contention detected",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
+		Source:      countSource("connection.errors"),
 		Title:       "Connection errors",
 		Description: "Connection error rate elevated",
 	})
@@ -100,7 +108,7 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 
 	// Add first anomaly at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 		Timestamp:   1000,
@@ -108,13 +116,13 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 
 	// Add remaining anomalies at data time 1031 (31 seconds later, beyond window)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
+		Source:      avgSource("ebpf.lock_contention_ns"),
 		Title:       "Lock contention",
 		Description: "High lock contention detected",
 		Timestamp:   1031,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
+		Source:      countSource("connection.errors"),
 		Title:       "Connection errors",
 		Description: "Connection error rate elevated",
 		Timestamp:   1031,
@@ -130,9 +138,9 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("network.retransmits")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("ebpf.lock_contention_ns")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: countSource("connection.errors")})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -153,9 +161,9 @@ func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("network.retransmits")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("ebpf.lock_contention_ns")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: countSource("connection.errors")})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -170,9 +178,9 @@ func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
 func TestCorrelator_BufferNotClearedAfterAdvance(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("network.retransmits")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("ebpf.lock_contention_ns")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: countSource("connection.errors")})
 
 	// First flush should create active correlations
 	correlator.Advance(0)
@@ -202,8 +210,8 @@ func TestCorrelator_PartialPatternNoActiveCorrelation(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Only two of three required signals
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("network.retransmits")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("ebpf.lock_contention_ns")})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -214,9 +222,9 @@ func TestCorrelator_ExtraSignalsStillMatch(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// All required signals plus an extra one
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("network.retransmits")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("ebpf.lock_contention_ns")})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: countSource("connection.errors")})
 	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "extra.signal"}})
 
 	correlator.Advance(0)
@@ -240,15 +248,15 @@ func TestCorrelator_ActiveCorrelationTimestamps(t *testing.T) {
 
 	// Add all required signals at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    observer.AnomalySource{Name: "network.retransmits"},
+		Source:    avgSource("network.retransmits"),
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
+		Source:    avgSource("ebpf.lock_contention_ns"),
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
+		Source:    countSource("connection.errors"),
 		Timestamp: 1000,
 	})
 
@@ -266,7 +274,7 @@ func TestCorrelator_ActiveCorrelationTimestamps(t *testing.T) {
 
 	// Add new anomalies at data time 1010
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    observer.AnomalySource{Name: "network.retransmits"},
+		Source:    avgSource("network.retransmits"),
 		Timestamp: 1010,
 	})
 
@@ -291,15 +299,15 @@ func TestCorrelator_ActiveCorrelationCleared(t *testing.T) {
 
 	// Add all required signals at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    observer.AnomalySource{Name: "network.retransmits"},
+		Source:    avgSource("network.retransmits"),
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
+		Source:    avgSource("ebpf.lock_contention_ns"),
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
+		Source:    countSource("connection.errors"),
 		Timestamp: 1000,
 	})
 
@@ -323,17 +331,17 @@ func TestCorrelator_ActiveCorrelationContainsAnomalies(t *testing.T) {
 
 	// Add anomalies with descriptions for all required signals
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Title:       "High retransmits",
 		Description: "network.retransmits:avg elevated: recent avg 100 vs baseline 10 (>3 stddev)",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
+		Source:      avgSource("ebpf.lock_contention_ns"),
 		Title:       "Lock contention",
 		Description: "ebpf.lock_contention_ns:avg elevated: recent avg 500 vs baseline 50 (>3 stddev)",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
+		Source:      countSource("connection.errors"),
 		Title:       "Connection errors",
 		Description: "connection.errors:count elevated: recent avg 25 vs baseline 2 (>3 stddev)",
 	})
@@ -365,17 +373,17 @@ func TestCorrelator_AnomaliesUpdatedOnAdvance(t *testing.T) {
 
 	// Add initial anomalies - all within 30 second window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Description: "first retransmits anomaly",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
+		Source:      avgSource("ebpf.lock_contention_ns"),
 		Description: "first lock contention anomaly",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
+		Source:      countSource("connection.errors"),
 		Description: "first connection errors anomaly",
 		Timestamp:   1010,
 	})
@@ -390,7 +398,7 @@ func TestCorrelator_AnomaliesUpdatedOnAdvance(t *testing.T) {
 
 	// Add another anomaly for one of the signals with later timestamp (still within 30s window)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Description: "second retransmits anomaly",
 		Timestamp:   1020, // later but within window
 	})
@@ -411,12 +419,12 @@ func TestCorrelator_DedupesBySourceKeepingMostRecent(t *testing.T) {
 	// Add multiple anomalies for the same source with different timestamps
 	// All timestamps within the 30-second window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Description: "oldest retransmits",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Description: "newest retransmits", // should be kept
 		Timestamp:   1025,                 // latest timestamp
 	})
@@ -428,12 +436,12 @@ func TestCorrelator_DedupesBySourceKeepingMostRecent(t *testing.T) {
 
 	// Add other required signals - all within window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
+		Source:      avgSource("ebpf.lock_contention_ns"),
 		Description: "lock contention",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
+		Source:      countSource("connection.errors"),
 		Description: "connection errors",
 		Timestamp:   1010,
 	})
@@ -463,15 +471,15 @@ func TestCorrelator_AnomaliesOnlyIncludesMatchingSignals(t *testing.T) {
 
 	// Add all required signals plus an extra one
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      avgSource("network.retransmits"),
 		Description: "retransmits anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
+		Source:      avgSource("ebpf.lock_contention_ns"),
 		Description: "lock contention anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
+		Source:      countSource("connection.errors"),
 		Description: "connection errors anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{

--- a/comp/observer/impl/anomaly_processor_correlator_test.go
+++ b/comp/observer/impl/anomaly_processor_correlator_test.go
@@ -17,7 +17,7 @@ func TestCorrelator_SingleAnomalyNoReport(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 	})
@@ -32,12 +32,12 @@ func TestCorrelator_TwoAnomaliesSameSignalNoReport(t *testing.T) {
 
 	// Add two anomalies from the same signal
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits 1",
 		Description: "First occurrence",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits 2",
 		Description: "Second occurrence",
 	})
@@ -53,17 +53,17 @@ func TestCorrelator_ThreeRequiredSignalsProduceReport(t *testing.T) {
 	// Add anomalies from all three required signals for kernel bottleneck pattern
 	// Note: Source names now include aggregation suffix (avg for value, count for frequency)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Title:       "Lock contention",
 		Description: "High lock contention detected",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Title:       "Connection errors",
 		Description: "Connection error rate elevated",
 	})
@@ -100,7 +100,7 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 
 	// Add first anomaly at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits",
 		Description: "Network retransmits exceeded threshold",
 		Timestamp:   1000,
@@ -108,13 +108,13 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 
 	// Add remaining anomalies at data time 1031 (31 seconds later, beyond window)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Title:       "Lock contention",
 		Description: "High lock contention detected",
 		Timestamp:   1031,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Title:       "Connection errors",
 		Description: "Connection error rate elevated",
 		Timestamp:   1031,
@@ -130,9 +130,9 @@ func TestCorrelator_OldAnomaliesEvicted(t *testing.T) {
 func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -153,9 +153,9 @@ func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -170,9 +170,9 @@ func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
 func TestCorrelator_BufferNotClearedAfterAdvance(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
 
 	// First flush should create active correlations
 	correlator.Advance(0)
@@ -202,8 +202,8 @@ func TestCorrelator_PartialPatternNoActiveCorrelation(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// Only two of three required signals
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -214,10 +214,10 @@ func TestCorrelator_ExtraSignalsStillMatch(t *testing.T) {
 	correlator := NewCorrelator(DefaultCorrelatorConfig())
 
 	// All required signals plus an extra one
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "network.retransmits:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "ebpf.lock_contention_ns:avg"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "connection.errors:count"})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: "extra.signal:avg"})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "network.retransmits"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "ebpf.lock_contention_ns"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "extra.signal"}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -240,15 +240,15 @@ func TestCorrelator_ActiveCorrelationTimestamps(t *testing.T) {
 
 	// Add all required signals at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "network.retransmits:avg",
+		Source:    observer.AnomalySource{Name: "network.retransmits"},
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "ebpf.lock_contention_ns:avg",
+		Source:    observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "connection.errors:count",
+		Source:    observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Timestamp: 1000,
 	})
 
@@ -266,7 +266,7 @@ func TestCorrelator_ActiveCorrelationTimestamps(t *testing.T) {
 
 	// Add new anomalies at data time 1010
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "network.retransmits:avg",
+		Source:    observer.AnomalySource{Name: "network.retransmits"},
 		Timestamp: 1010,
 	})
 
@@ -291,15 +291,15 @@ func TestCorrelator_ActiveCorrelationCleared(t *testing.T) {
 
 	// Add all required signals at data time 1000
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "network.retransmits:avg",
+		Source:    observer.AnomalySource{Name: "network.retransmits"},
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "ebpf.lock_contention_ns:avg",
+		Source:    observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Timestamp: 1000,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "connection.errors:count",
+		Source:    observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Timestamp: 1000,
 	})
 
@@ -310,7 +310,7 @@ func TestCorrelator_ActiveCorrelationCleared(t *testing.T) {
 	// Add an anomaly at data time 1035 (35 seconds later), which advances currentDataTime
 	// and causes all previous signals to expire (1000 < 1035 - 30 = 1005)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    "some.other.signal:avg",
+		Source:    observer.AnomalySource{Name: "some.other.signal"},
 		Timestamp: 1035,
 	})
 	correlator.Advance(0)
@@ -323,17 +323,17 @@ func TestCorrelator_ActiveCorrelationContainsAnomalies(t *testing.T) {
 
 	// Add anomalies with descriptions for all required signals
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Title:       "High retransmits",
 		Description: "network.retransmits:avg elevated: recent avg 100 vs baseline 10 (>3 stddev)",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Title:       "Lock contention",
 		Description: "ebpf.lock_contention_ns:avg elevated: recent avg 500 vs baseline 50 (>3 stddev)",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Title:       "Connection errors",
 		Description: "connection.errors:count elevated: recent avg 25 vs baseline 2 (>3 stddev)",
 	})
@@ -365,17 +365,17 @@ func TestCorrelator_AnomaliesUpdatedOnAdvance(t *testing.T) {
 
 	// Add initial anomalies - all within 30 second window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "first retransmits anomaly",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Description: "first lock contention anomaly",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Description: "first connection errors anomaly",
 		Timestamp:   1010,
 	})
@@ -390,7 +390,7 @@ func TestCorrelator_AnomaliesUpdatedOnAdvance(t *testing.T) {
 
 	// Add another anomaly for one of the signals with later timestamp (still within 30s window)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "second retransmits anomaly",
 		Timestamp:   1020, // later but within window
 	})
@@ -411,29 +411,29 @@ func TestCorrelator_DedupesBySourceKeepingMostRecent(t *testing.T) {
 	// Add multiple anomalies for the same source with different timestamps
 	// All timestamps within the 30-second window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "oldest retransmits",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "newest retransmits", // should be kept
 		Timestamp:   1025,                 // latest timestamp
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "middle retransmits",
 		Timestamp:   1015,
 	})
 
 	// Add other required signals - all within window
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Description: "lock contention",
 		Timestamp:   1010,
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Description: "connection errors",
 		Timestamp:   1010,
 	})
@@ -451,7 +451,7 @@ func TestCorrelator_DedupesBySourceKeepingMostRecent(t *testing.T) {
 
 	// Find the network.retransmits anomaly and verify it's the newest one
 	for _, a := range anomalies {
-		if string(a.Source) == "network.retransmits:avg" {
+		if a.Source.String() == "network.retransmits:avg" {
 			assert.Equal(t, "newest retransmits", a.Description, "should keep anomaly with latest timestamp")
 			assert.Equal(t, int64(1025), a.Timestamp, "should have latest timestamp")
 		}
@@ -463,19 +463,19 @@ func TestCorrelator_AnomaliesOnlyIncludesMatchingSignals(t *testing.T) {
 
 	// Add all required signals plus an extra one
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "network.retransmits:avg",
+		Source:      observer.AnomalySource{Name: "network.retransmits"},
 		Description: "retransmits anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "ebpf.lock_contention_ns:avg",
+		Source:      observer.AnomalySource{Name: "ebpf.lock_contention_ns"},
 		Description: "lock contention anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "connection.errors:count",
+		Source:      observer.AnomalySource{Name: "connection.errors", Aggregate: observer.AggregateCount},
 		Description: "connection errors anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      "extra.signal:avg",
+		Source:      observer.AnomalySource{Name: "extra.signal"},
 		Description: "extra signal anomaly",
 	})
 
@@ -493,6 +493,6 @@ func TestCorrelator_AnomaliesOnlyIncludesMatchingSignals(t *testing.T) {
 
 	// Verify extra signal is not included
 	for _, a := range anomalies {
-		assert.NotEqual(t, "extra.signal:avg", string(a.Source), "extra signal should not be in anomalies")
+		assert.NotEqual(t, "extra.signal:avg", a.Source.String(), "extra signal should not be in anomalies")
 	}
 }

--- a/comp/observer/impl/consumer_memory.go
+++ b/comp/observer/impl/consumer_memory.go
@@ -80,9 +80,9 @@ func (r *StdoutReporter) reportNewAnomalies(anomalies []observer.Anomaly) {
 	}
 
 	for _, anomaly := range anomalies {
-		key := string(anomaly.Source) + "|" + anomaly.DetectorName
+		key := anomaly.Source.String() + "|" + anomaly.DetectorName
 		if !r.seenRawAnomalies[key] {
-			fmt.Printf("[observer] [%s] ANOMALY: %s\n", anomaly.DetectorName, anomaly.Source)
+			fmt.Printf("[observer] [%s] ANOMALY: %s\n", anomaly.DetectorName, anomaly.Source.String())
 			fmt.Printf("           %s\n", anomaly.Description)
 			r.seenRawAnomalies[key] = true
 		}

--- a/comp/observer/impl/context_provider.go
+++ b/comp/observer/impl/context_provider.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// validateUniqueExtractorNames rejects duplicate runtime extractor names since
+// they are used as namespaces in storage and context lookup.
+func validateUniqueExtractorNames(extractors []observer.LogMetricsExtractor) {
+	seen := make(map[string]struct{}, len(extractors))
+	for _, ext := range extractors {
+		name := ext.Name()
+		if _, ok := seen[name]; ok {
+			panic(fmt.Sprintf("duplicate log extractor name: %q", name))
+		}
+		seen[name] = struct{}{}
+	}
+}
+
+// collectContextProviders discovers ContextProvider implementations among
+// instantiated extractors via type assertion. Returns a map keyed by the
+// extractor's component name (which is used as the storage namespace for
+// its metrics), enabling O(1) lookup during anomaly enrichment.
+func collectContextProviders(extractors []observer.LogMetricsExtractor) map[string]observer.ContextProvider {
+	providers := make(map[string]observer.ContextProvider)
+	for _, ext := range extractors {
+		if cp, ok := ext.(observer.ContextProvider); ok {
+			providers[ext.Name()] = cp
+		}
+	}
+	return providers
+}
+
+// truncate shortens s to maxLen, appending "..." if truncated.
+func truncate(s string, maxLen int) string {
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen]) + "..."
+}

--- a/comp/observer/impl/correlation_identity.go
+++ b/comp/observer/impl/correlation_identity.go
@@ -14,10 +14,11 @@ import (
 func sortedUniqueMetricNames(anomalies []observer.Anomaly) []observer.MetricName {
 	seen := make(map[observer.MetricName]struct{})
 	for _, a := range anomalies {
-		if a.Source == "" {
+		display := observer.MetricName(a.Source.String())
+		if display == "" {
 			continue
 		}
-		seen[a.Source] = struct{}{}
+		seen[display] = struct{}{}
 	}
 	names := make([]observer.MetricName, 0, len(seen))
 	for n := range seen {

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -24,6 +24,11 @@ type anomalyDedupKey struct {
 	title        string
 }
 
+type seriesContextRef struct {
+	namespace  string
+	contextKey string
+}
+
 // engine is the shared orchestration core for the observer pipeline.
 // It encapsulates storage, log extraction, detection, and correlation,
 // providing a single execution path used by both the live observer and testbench.
@@ -37,10 +42,12 @@ type engine struct {
 	// take a write lock; readers (stateView methods) take a read lock.
 	mu sync.RWMutex
 
-	storage     *timeSeriesStorage
-	extractors  []observerdef.LogMetricsExtractor
-	detectors   []observerdef.Detector
-	correlators []observerdef.Correlator
+	storage          *timeSeriesStorage
+	extractors       []observerdef.LogMetricsExtractor
+	detectors        []observerdef.Detector
+	correlators      []observerdef.Correlator
+	contextProviders map[string]observerdef.ContextProvider // namespace → provider
+	contextRefs      map[observerdef.SeriesID]seriesContextRef
 
 	// scheduler decides when the engine should advance analysis.
 	scheduler schedulerPolicy
@@ -59,11 +66,11 @@ type engine struct {
 	rawAnomalies         []observerdef.Anomaly
 	rawAnomalyIndex      map[anomalyDedupKey]int // O(1) dedup lookup
 	rawAnomalyMu         sync.RWMutex
-	rawAnomalyWindow     int64                           // seconds to keep (0 = unlimited)
-	maxRawAnomalies      int                             // max count to keep (0 = unlimited)
-	currentDataTime      int64                           // latest anomaly timestamp seen
-	totalAnomalyCount    int                             // total count ever (no cap)
-	uniqueAnomalySources map[observerdef.MetricName]bool // unique sources that had anomalies
+	rawAnomalyWindow     int64                              // seconds to keep (0 = unlimited)
+	maxRawAnomalies      int                                // max count to keep (0 = unlimited)
+	currentDataTime      int64                              // latest anomaly timestamp seen
+	totalAnomalyCount    int                                // total count ever (no cap)
+	uniqueAnomalySources map[observerdef.AnomalySource]bool // unique sources that had anomalies
 
 	// Accumulated correlations from all advance cycles.
 	// Correlators maintain sliding windows that evict old state, but for
@@ -91,10 +98,11 @@ type engine struct {
 
 // engineConfig holds the parameters for constructing an engine.
 type engineConfig struct {
-	storage     *timeSeriesStorage
-	extractors  []observerdef.LogMetricsExtractor
-	detectors   []observerdef.Detector
-	correlators []observerdef.Correlator
+	storage          *timeSeriesStorage
+	extractors       []observerdef.LogMetricsExtractor
+	detectors        []observerdef.Detector
+	correlators      []observerdef.Correlator
+	contextProviders map[string]observerdef.ContextProvider // namespace → provider
 
 	// scheduler is the scheduling policy. If nil, defaults to currentBehaviorPolicy.
 	scheduler schedulerPolicy
@@ -109,13 +117,16 @@ func newEngine(cfg engineConfig) *engine {
 	if sched == nil {
 		sched = &currentBehaviorPolicy{}
 	}
+	validateUniqueExtractorNames(cfg.extractors)
 
 	e := &engine{
-		storage:     cfg.storage,
-		extractors:  cfg.extractors,
-		detectors:   cfg.detectors,
-		correlators: cfg.correlators,
-		scheduler:   sched,
+		storage:          cfg.storage,
+		extractors:       cfg.extractors,
+		detectors:        cfg.detectors,
+		correlators:      cfg.correlators,
+		contextProviders: cfg.contextProviders,
+		contextRefs:      make(map[observerdef.SeriesID]seriesContextRef),
+		scheduler:        sched,
 
 		rawAnomalyWindow: cfg.rawAnomalyWindow,
 		maxRawAnomalies:  cfg.maxRawAnomalies,
@@ -177,11 +188,23 @@ func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
 // notifies log observers, and consults the scheduler policy to determine whether
 // detectors should advance. Returns advance requests that the caller should execute.
 func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
+	sourceTag := "observer_source:" + source
 	view := &logView{obs: l}
 	for _, extractor := range e.extractors {
 		metrics := extractor.ProcessLog(view)
 		for _, m := range metrics {
-			e.storage.Add(source, "_virtual."+m.Name, m.Value, l.timestampMs/1000, m.Tags)
+			tags := copyTags(m.Tags)
+			if !sliceContains(tags, sourceTag) {
+				tags = append(tags, sourceTag)
+			}
+			e.storage.Add(extractor.Name(), m.Name, m.Value, l.timestampMs/1000, tags)
+			if m.ContextKey != "" {
+				seriesID := observerdef.SeriesID(seriesKey(extractor.Name(), m.Name, tags))
+				e.contextRefs[seriesID] = seriesContextRef{
+					namespace:  extractor.Name(),
+					contextKey: m.ContextKey,
+				}
+			}
 		}
 	}
 	for _, lo := range e.logObservers {
@@ -191,6 +214,15 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 	e.storage.RecordObservationTime(dataTimeSec)
 	e.trackLatestDataTime(dataTimeSec)
 	return e.scheduler.onObservation(dataTimeSec, e.schedulerState())
+}
+
+func sliceContains(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
 }
 
 // trackLatestDataTime updates latestDataTime if the given timestamp is newer.
@@ -263,6 +295,7 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	for _, detector := range detectors {
 		result := detector.Detect(e.storage, upTo)
 		for _, anomaly := range result.Anomalies {
+			e.enrichAnomaly(&anomaly)
 			if !e.captureRawAnomaly(anomaly) {
 				continue // duplicate — skip correlators, events, and reporters
 			}
@@ -306,6 +339,34 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	}
 }
 
+// enrichAnomaly decorates an anomaly with context from the originating
+// extractor, if available. This runs automatically on every anomaly so
+// detectors don't need to be aware of context providers.
+// Lookup is keyed by the anomaly's concrete SourceSeriesID, which the engine
+// maps to a provider namespace and opaque extractor-owned context key.
+func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
+	if a.SourceSeriesID == "" {
+		return
+	}
+	ref, ok := e.contextRefs[a.SourceSeriesID]
+	if !ok {
+		return
+	}
+	provider, ok := e.contextProviders[ref.namespace]
+	if !ok {
+		return
+	}
+	ctx, ok := provider.GetContextByKey(ref.contextKey)
+	if !ok {
+		return
+	}
+	a.Context = &observerdef.MetricContext{
+		Pattern: ctx.Pattern,
+		Example: truncate(ctx.Example, 120),
+		Source:  ctx.Source,
+	}
+}
+
 // processAnomaly sends an anomaly to all registered correlators.
 func (e *engine) processAnomaly(anomaly observerdef.Anomaly) {
 	for _, correlator := range e.correlators {
@@ -323,7 +384,7 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 	e.totalAnomalyCount++
 
 	if e.uniqueAnomalySources == nil {
-		e.uniqueAnomalySources = make(map[observerdef.MetricName]bool)
+		e.uniqueAnomalySources = make(map[observerdef.AnomalySource]bool)
 	}
 	const maxUniqueSources = 500
 	if len(e.uniqueAnomalySources) < maxUniqueSources {
@@ -490,7 +551,10 @@ func (e *engine) SetExtractors(extractors []observerdef.LogMetricsExtractor) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
+	validateUniqueExtractorNames(extractors)
 	e.extractors = extractors
+	e.contextProviders = collectContextProviders(extractors)
+	e.contextRefs = make(map[observerdef.SeriesID]seriesContextRef)
 }
 
 // Reset clears analysis state so detectors will re-analyze from scratch.
@@ -511,6 +575,14 @@ func (e *engine) Reset() {
 	for _, correlator := range e.correlators {
 		correlator.Reset()
 	}
+
+	for _, extractor := range e.extractors {
+		if resetter, ok := extractor.(interface{ Reset() }); ok {
+			resetter.Reset()
+		}
+	}
+
+	e.contextRefs = make(map[observerdef.SeriesID]seriesContextRef)
 }
 
 // resetRawAnomalies clears the raw anomaly tracking state.

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"unicode/utf8"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
@@ -112,6 +113,38 @@ func (d *anomalyDetector) Detect(_ observerdef.StorageReader, _ int64) observerd
 	}
 }
 
+type stubContextProvider struct {
+	context      observerdef.MetricContext
+	ok           bool
+	requestedKey string
+}
+
+func (p *stubContextProvider) GetContextByKey(key string) (observerdef.MetricContext, bool) {
+	p.requestedKey = key
+	return p.context, p.ok
+}
+
+type stubExtractor struct {
+	name         string
+	contextByKey map[string]observerdef.MetricContext
+	resetCount   int
+}
+
+func (e *stubExtractor) Name() string { return e.name }
+
+func (e *stubExtractor) ProcessLog(_ observerdef.LogView) []observerdef.MetricOutput {
+	return nil
+}
+
+func (e *stubExtractor) GetContextByKey(key string) (observerdef.MetricContext, bool) {
+	ctx, ok := e.contextByKey[key]
+	return ctx, ok
+}
+
+func (e *stubExtractor) Reset() {
+	e.resetCount++
+}
+
 type resettableDetector struct {
 	name       string
 	resetCount int
@@ -157,8 +190,8 @@ func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
 
 func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
-		{Source: "cpu", DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|cpu|"},
-		{Source: "mem", DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|mem|"},
+		{Source: observerdef.AnomalySource{Name: "cpu"}, DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|cpu|"},
+		{Source: observerdef.AnomalySource{Name: "mem"}, DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|mem|"},
 	}
 
 	e := newEngine(engineConfig{
@@ -175,8 +208,168 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 
 	anomalyEvents := sink.eventsOfKind(eventAnomalyCreated)
 	assert.Len(t, anomalyEvents, 2)
-	assert.Equal(t, "cpu", string(anomalyEvents[0].anomalyCreated.anomaly.Source))
-	assert.Equal(t, "mem", string(anomalyEvents[1].anomalyCreated.anomaly.Source))
+	assert.Equal(t, "cpu", anomalyEvents[0].anomalyCreated.anomaly.Source.String())
+	assert.Equal(t, "mem", anomalyEvents[1].anomalyCreated.anomaly.Source.String())
+}
+
+func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T) {
+	provider := &stubContextProvider{
+		context: observerdef.MetricContext{
+			Pattern: "error <*> timeout",
+			Example: "very long example line that should still be attached as context without replacing the detector description",
+			Source:  "log_metrics_extractor",
+		},
+		ok: true,
+	}
+	anomalies := []observerdef.Anomaly{{
+		Source: observerdef.AnomalySource{
+			Namespace: "log_metrics_extractor",
+			Name:      "log.pattern.abc.count",
+			Aggregate: observerdef.AggregateCount,
+		},
+		DetectorName:   "test",
+		Description:    "detector-authored description",
+		Tags:           []string{"observer_source:source-a", "service:api"},
+		Timestamp:      99,
+		SourceSeriesID: "ns|log.pattern.abc.count|",
+	}}
+
+	e := newEngine(engineConfig{
+		storage: newTimeSeriesStorage(),
+		detectors: []observerdef.Detector{
+			&anomalyDetector{name: "test", anomalies: anomalies},
+		},
+		contextProviders: map[string]observerdef.ContextProvider{
+			"log_metrics_extractor": provider,
+		},
+	})
+	e.contextRefs[observerdef.SeriesID("ns|log.pattern.abc.count|")] = seriesContextRef{
+		namespace:  "log_metrics_extractor",
+		contextKey: "ctx-1",
+	}
+
+	sink := &collectingSink{}
+	e.Subscribe(sink)
+
+	e.Advance(100)
+
+	anomalyEvents := sink.eventsOfKind(eventAnomalyCreated)
+	require.Len(t, anomalyEvents, 1)
+	got := anomalyEvents[0].anomalyCreated.anomaly
+	assert.Equal(t, "detector-authored description", got.Description)
+	require.NotNil(t, got.Context)
+	assert.Equal(t, "error <*> timeout", got.Context.Pattern)
+	assert.Equal(t, "log_metrics_extractor", got.Context.Source)
+	assert.Contains(t, got.Context.Example, "very long example line")
+	assert.Equal(t, "ctx-1", provider.requestedKey)
+}
+
+func TestSetExtractorsRefreshesContextProviders(t *testing.T) {
+	first := &stubExtractor{name: "first", contextByKey: map[string]observerdef.MetricContext{}}
+	second := &stubExtractor{name: "second", contextByKey: map[string]observerdef.MetricContext{
+		"ctx-2": {Pattern: "p2", Example: "e2", Source: "second"},
+	}}
+	e := newEngine(engineConfig{
+		storage:          newTimeSeriesStorage(),
+		extractors:       []observerdef.LogMetricsExtractor{first},
+		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{first}),
+		detectors: []observerdef.Detector{&anomalyDetector{name: "test", anomalies: []observerdef.Anomaly{{
+			Source:         observerdef.AnomalySource{Namespace: "second", Name: "metric"},
+			Tags:           []string{"service:api"},
+			Timestamp:      1,
+			SourceSeriesID: "ns|metric|service:api",
+		}}}},
+	})
+
+	e.SetExtractors([]observerdef.LogMetricsExtractor{second})
+	e.contextRefs[observerdef.SeriesID("ns|metric|service:api")] = seriesContextRef{
+		namespace:  "second",
+		contextKey: "ctx-2",
+	}
+	result := e.Advance(2)
+	require.Len(t, result.anomalies, 1)
+	require.NotNil(t, result.anomalies[0].Context)
+	assert.Equal(t, "second", result.anomalies[0].Context.Source)
+}
+
+func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing.T) {
+	extractor := NewLogPatternExtractor()
+	e := newEngine(engineConfig{
+		storage:          newTimeSeriesStorage(),
+		extractors:       []observerdef.LogMetricsExtractor{extractor},
+		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{extractor}),
+	})
+
+	e.IngestLog("source-a", &logObs{
+		content:     []byte("GET /users/123 returned 500"),
+		tags:        []string{"service:api"},
+		timestampMs: 1_000,
+	})
+	e.IngestLog("source-b", &logObs{
+		content:     []byte("GET /users/456 returned 500"),
+		tags:        []string{"service:worker"},
+		timestampMs: 2_000,
+	})
+
+	var anomaly observerdef.Anomaly
+	for _, meta := range e.storage.ListSeries(observerdef.SeriesFilter{Namespace: extractor.Name()}) {
+		if len(meta.Tags) == 2 && containsTag(meta.Tags, "observer_source:source-a") && containsTag(meta.Tags, "service:api") {
+			anomaly = observerdef.Anomaly{
+				Source: observerdef.AnomalySource{
+					Namespace: extractor.Name(),
+					Name:      meta.Name,
+				},
+				Tags:           meta.Tags,
+				SourceSeriesID: observerdef.SeriesID(seriesKey(meta.Namespace, meta.Name, meta.Tags)),
+			}
+			break
+		}
+	}
+	require.NotEmpty(t, anomaly.Source.Name)
+
+	e.enrichAnomaly(&anomaly)
+	require.NotNil(t, anomaly.Context)
+	assert.Equal(t, "log_pattern_extractor", anomaly.Context.Source)
+	assert.Equal(t, "GET /users/123 returned 500", anomaly.Context.Example)
+	assert.Contains(t, anomaly.Context.Pattern, "*")
+	assert.NotContains(t, anomaly.Context.Example, "456")
+}
+
+func containsTag(tags []string, want string) bool {
+	for _, tag := range tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewEnginePanicsOnDuplicateExtractorNames(t *testing.T) {
+	first := &stubExtractor{name: "dup", contextByKey: map[string]observerdef.MetricContext{}}
+	second := &stubExtractor{name: "dup", contextByKey: map[string]observerdef.MetricContext{}}
+
+	assert.PanicsWithValue(t, `duplicate log extractor name: "dup"`, func() {
+		_ = newEngine(engineConfig{
+			storage:    newTimeSeriesStorage(),
+			extractors: []observerdef.LogMetricsExtractor{first, second},
+		})
+	})
+}
+
+func TestSetExtractorsPanicsOnDuplicateExtractorNames(t *testing.T) {
+	e := newEngine(engineConfig{storage: newTimeSeriesStorage()})
+	first := &stubExtractor{name: "dup", contextByKey: map[string]observerdef.MetricContext{}}
+	second := &stubExtractor{name: "dup", contextByKey: map[string]observerdef.MetricContext{}}
+
+	assert.PanicsWithValue(t, `duplicate log extractor name: "dup"`, func() {
+		e.SetExtractors([]observerdef.LogMetricsExtractor{first, second})
+	})
+}
+
+func TestTruncatePreservesUTF8RuneBoundaries(t *testing.T) {
+	got := truncate("hello世界", 6)
+	assert.Equal(t, "hello世...", got)
+	assert.True(t, utf8.ValidString(got))
 }
 
 func TestAdvanceEmitsCorrelationUpdatedEvents(t *testing.T) {
@@ -253,16 +446,19 @@ func TestReplayStoredDataEmitsEventsViaScheduler(t *testing.T) {
 func TestEngineResetResetsDetectorsAndCorrelators(t *testing.T) {
 	detector := &resettableDetector{name: "detector"}
 	correlator := &resettableCorrelator{name: "correlator"}
+	extractor := &stubExtractor{name: "extractor", contextByKey: map[string]observerdef.MetricContext{}}
 	e := newEngine(engineConfig{
 		storage:     newTimeSeriesStorage(),
 		detectors:   []observerdef.Detector{detector},
 		correlators: []observerdef.Correlator{correlator},
+		extractors:  []observerdef.LogMetricsExtractor{extractor},
 	})
 
 	e.Reset()
 
 	assert.Equal(t, 1, detector.resetCount)
 	assert.Equal(t, 1, correlator.resetCount)
+	assert.Equal(t, 1, extractor.resetCount)
 }
 
 func TestReporterEventSink(t *testing.T) {
@@ -286,7 +482,7 @@ func TestReporterEventSink(t *testing.T) {
 		kind:      eventAnomalyCreated,
 		timestamp: 100,
 		anomalyCreated: &anomalyCreatedEvent{
-			anomaly: observerdef.Anomaly{Source: "cpu"},
+			anomaly: observerdef.Anomaly{Source: observerdef.AnomalySource{Name: "cpu"}},
 		},
 	})
 	assert.Equal(t, 1, reported, "anomaly events should not trigger reporter")
@@ -303,7 +499,7 @@ func (r *countingReporter) Report(_ observerdef.ReportOutput) { *r.count++ }
 func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:         "cpu",
+			Source:         observerdef.AnomalySource{Name: "cpu"},
 			SourceSeriesID: "ns|cpu:avg|",
 			DetectorName:   "test_detector",
 			Title:          "Spike detected",
@@ -311,7 +507,7 @@ func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 			Timestamp:      100,
 		},
 		{
-			Source:         "cpu",
+			Source:         observerdef.AnomalySource{Name: "cpu"},
 			SourceSeriesID: "ns|cpu:avg|",
 			DetectorName:   "test_detector",
 			Title:          "Trend change detected",
@@ -339,7 +535,7 @@ func TestFindingM2_EmptySourceSeriesIDCollision(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
 		{
 			Type:           observerdef.AnomalyTypeLog,
-			Source:         "logs",
+			Source:         observerdef.AnomalySource{Name: "logs"},
 			SourceSeriesID: "", // empty for log anomalies
 			DetectorName:   "log_detector",
 			Title:          "Error pattern A detected",
@@ -348,7 +544,7 @@ func TestFindingM2_EmptySourceSeriesIDCollision(t *testing.T) {
 		},
 		{
 			Type:           observerdef.AnomalyTypeLog,
-			Source:         "logs",
+			Source:         observerdef.AnomalySource{Name: "logs"},
 			SourceSeriesID: "", // empty for log anomalies
 			DetectorName:   "log_detector",
 			Title:          "Error pattern B detected",
@@ -376,14 +572,14 @@ func TestFindingM3_DedupAsymmetry(t *testing.T) {
 	// Two identical anomalies (same dedup key) -- one will be deduped from rawAnomalies.
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:         "cpu",
+			Source:         observerdef.AnomalySource{Name: "cpu"},
 			SourceSeriesID: "ns|cpu:avg|",
 			DetectorName:   "test_detector",
 			Title:          "Spike",
 			Timestamp:      100,
 		},
 		{
-			Source:         "cpu",
+			Source:         observerdef.AnomalySource{Name: "cpu"},
 			SourceSeriesID: "ns|cpu:avg|",
 			DetectorName:   "test_detector",
 			Title:          "Spike",
@@ -664,4 +860,27 @@ func TestFindingM12_LogOnlyTimestampsSkippedInReplay(t *testing.T) {
 	assert.True(t, has103,
 		"DataTimestamps() should include timestamp 103 from the log observation, "+
 			"but it only returns metric timestamps: %v", dataTS)
+}
+
+func TestIngestLogCopiesMetricTagsBeforeInjectingObserverSource(t *testing.T) {
+	storage := newTimeSeriesStorage()
+	e := newEngine(engineConfig{
+		storage:    storage,
+		extractors: []observerdef.LogMetricsExtractor{&sharedTagsExtractor{}},
+	})
+
+	e.IngestLog("source-a", &logObs{
+		content:     []byte("hello"),
+		tags:        []string{"env:test"},
+		timestampMs: 1000,
+	})
+
+	seriesA := storage.GetSeries("shared_tags_extractor", "metric.a", []string{"env:test", "observer_source:source-a"}, AggregateAverage)
+	require.NotNil(t, seriesA)
+
+	seriesB := storage.GetSeries("shared_tags_extractor", "metric.b", []string{"env:test", "observer_source:source-a"}, AggregateAverage)
+	require.NotNil(t, seriesB)
+
+	assert.Nil(t, storage.GetSeries("shared_tags_extractor", "metric.a", []string{"env:test", "observer_source:source-a", "observer_source:source-a"}, AggregateAverage))
+	assert.Nil(t, storage.GetSeries("shared_tags_extractor", "metric.b", []string{"env:test", "observer_source:source-a", "observer_source:source-a"}, AggregateAverage))
 }

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -43,8 +43,17 @@ func DefaultLogMetricsExtractorConfig() LogMetricsExtractorConfig {
 // - Unstructured logs: pattern frequency -> Sum aggregation
 //
 // This is intentionally minimal; cardinality controls live in the observer storage (Step 5).
+//
+// LogMetricsExtractor also implements observer.ContextProvider, tracking the
+// pattern signature and a recent example log line for each pattern metric it
+// emits. Detectors can query this via StorageReader.GetContext to produce
+// richer anomaly descriptions.
 type LogMetricsExtractor struct {
 	config LogMetricsExtractorConfig
+
+	// patternContext tracks the signature and a recent example for each context
+	// key emitted by this extractor.
+	patternContext map[string]observer.MetricContext
 }
 
 // NewLogMetricsExtractor creates a LogMetricsExtractor with the given config.
@@ -53,6 +62,22 @@ func NewLogMetricsExtractor(config LogMetricsExtractorConfig) *LogMetricsExtract
 }
 
 func (a *LogMetricsExtractor) Name() string { return "log_metrics_extractor" }
+
+// Reset clears cached per-series context so replay/reanalysis starts from the
+// currently observed data instead of reusing stale examples.
+func (a *LogMetricsExtractor) Reset() {
+	a.patternContext = nil
+}
+
+// GetContextByKey implements observer.ContextProvider. It returns the pattern
+// signature and a recent example log line for a previously emitted context key.
+func (a *LogMetricsExtractor) GetContextByKey(key string) (observer.MetricContext, bool) {
+	if a.patternContext == nil {
+		return observer.MetricContext{}, false
+	}
+	ctx, ok := a.patternContext[key]
+	return ctx, ok
+}
 
 func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
 	content := log.GetContent()
@@ -64,10 +89,24 @@ func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.Metric
 		return nil
 	}
 
+	metricName := patternCountMetricName(patternSig)
+	contextKey := metricContextKey(metricName, tags)
+
+	// Track context for this pattern metric so detectors can enrich anomalies.
+	if a.patternContext == nil {
+		a.patternContext = make(map[string]observer.MetricContext)
+	}
+	a.patternContext[contextKey] = observer.MetricContext{
+		Pattern: patternSig,
+		Example: string(content),
+		Source:  "log_metrics_extractor",
+	}
+
 	metrics := []observer.MetricOutput{{
-		Name:  patternCountMetricName(patternSig),
-		Value: 1,
-		Tags:  tags,
+		Name:       metricName,
+		Value:      1,
+		Tags:       tags,
+		ContextKey: contextKey,
 	}}
 
 	// For JSON logs, also extract numeric field metrics
@@ -147,6 +186,10 @@ func coerceNumber(v any) (float64, bool) {
 	default:
 		return 0, false
 	}
+}
+
+func metricContextKey(metricName string, tags []string) string {
+	return seriesKey("", metricName, tags)
 }
 
 func patternCountMetricName(signature string) string {

--- a/comp/observer/impl/log_metrics_extractor_test.go
+++ b/comp/observer/impl/log_metrics_extractor_test.go
@@ -125,3 +125,48 @@ func TestLogMetricsExtractor_InvalidJSONFallsBackToUnstructured(t *testing.T) {
 	_, _ = h.Write([]byte(sig))
 	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res[0].Name)
 }
+
+func TestLogMetricsExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
+	a := &LogMetricsExtractor{}
+	log := &mockLogView{
+		content: []byte("Request completed in 45ms"),
+		tags:    []string{"service:web", "env:prod"},
+	}
+
+	res := a.ProcessLog(log)
+	require.Len(t, res, 1)
+	require.NotEmpty(t, res[0].ContextKey)
+
+	ctx, ok := a.GetContextByKey(res[0].ContextKey)
+	require.True(t, ok)
+	assert.Equal(t, "log_metrics_extractor", ctx.Source)
+	assert.Equal(t, "Request completed in 45ms", ctx.Example)
+}
+
+func TestLogMetricsExtractor_ContextKeySeparatesSameMetricByTags(t *testing.T) {
+	a := &LogMetricsExtractor{}
+	logA := &mockLogView{
+		content: []byte("Request completed in 45ms"),
+		tags:    []string{"service:api"},
+	}
+	logB := &mockLogView{
+		content: []byte("Request completed in 45ms"),
+		tags:    []string{"service:worker"},
+	}
+
+	resA := a.ProcessLog(logA)
+	resB := a.ProcessLog(logB)
+	require.Len(t, resA, 1)
+	require.Len(t, resB, 1)
+	require.Equal(t, resA[0].Name, resB[0].Name)
+	require.NotEqual(t, resA[0].ContextKey, resB[0].ContextKey)
+
+	ctxA, ok := a.GetContextByKey(resA[0].ContextKey)
+	require.True(t, ok)
+	ctxB, ok := a.GetContextByKey(resB[0].ContextKey)
+	require.True(t, ok)
+
+	assert.Equal(t, "Request completed in 45ms", ctxA.Example)
+	assert.Equal(t, "Request completed in 45ms", ctxB.Example)
+	assert.Equal(t, ctxA.Pattern, ctxB.Pattern)
+}

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -14,17 +14,12 @@ import (
 
 // PatternKeyInfo contains what can identify a pattern.
 type PatternKeyInfo struct {
-	// Hash is the ID of this object, used to find it back in the map.
-	Hash      int64
 	ClusterID int64
 }
 
 // NewPatternKeyInfo creates a PatternKeyInfo for the given cluster ID.
 func NewPatternKeyInfo(clusterID int64) PatternKeyInfo {
-	return PatternKeyInfo{
-		Hash:      clusterID + 1,
-		ClusterID: clusterID,
-	}
+	return PatternKeyInfo{ClusterID: clusterID}
 }
 
 // LogPatternExtractorConfig holds configuration for the LogPatternExtractor.
@@ -39,10 +34,16 @@ func DefaultLogPatternExtractorConfig() LogPatternExtractorConfig {
 // patterns and emits a count metric per pattern.
 type LogPatternExtractor struct {
 	PatternClusterer *patterns.PatternClusterer
-	PatternKeys      map[int64]PatternKeyInfo
+	patternContext   map[string]patternMetricContext
 }
 
 var _ observerdef.LogMetricsExtractor = (*LogPatternExtractor)(nil)
+var _ observerdef.ContextProvider = (*LogPatternExtractor)(nil)
+
+type patternMetricContext struct {
+	keyInfo PatternKeyInfo
+	example string
+}
 
 // NewLogPatternExtractor creates a new LogPatternExtractor.
 func NewLogPatternExtractor() *LogPatternExtractor {
@@ -52,13 +53,47 @@ func NewLogPatternExtractor() *LogPatternExtractor {
 			Stride: 1,
 			Index:  0,
 		}),
-		PatternKeys: make(map[int64]PatternKeyInfo),
 	}
 }
 
 // Name returns the extractor name.
 func (e *LogPatternExtractor) Name() string {
 	return "log_pattern_extractor"
+}
+
+// Reset clears clustering and cached per-series context so reanalysis starts
+// from the currently observed logs.
+func (e *LogPatternExtractor) Reset() {
+	e.PatternClusterer = patterns.NewPatternClusterer(patterns.IDComputeInfo{
+		Offset: 0,
+		Stride: 1,
+		Index:  0,
+	})
+	e.patternContext = nil
+}
+
+// GetContextByKey implements observerdef.ContextProvider for pattern metrics
+// emitted by this extractor.
+func (e *LogPatternExtractor) GetContextByKey(key string) (observerdef.MetricContext, bool) {
+	if e.patternContext == nil {
+		return observerdef.MetricContext{}, false
+	}
+	entry, ok := e.patternContext[key]
+	if !ok {
+		return observerdef.MetricContext{}, false
+	}
+
+	pattern := ""
+	cluster, err := e.PatternClusterer.GetCluster(entry.keyInfo.ClusterID)
+	if err == nil && cluster != nil {
+		pattern = cluster.PatternString()
+	}
+
+	return observerdef.MetricContext{
+		Pattern: pattern,
+		Example: entry.example,
+		Source:  e.Name(),
+	}, true
 }
 
 // ProcessLog clusters the log message and emits a count metric for its pattern.
@@ -70,11 +105,21 @@ func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) []observerdef.
 	}
 
 	patternKey := NewPatternKeyInfo(clusterResult.Cluster.ID)
-	e.PatternKeys[patternKey.Hash] = patternKey
+	metricName := fmt.Sprintf("log.%s.%x.count", e.Name(), clusterResult.Cluster.ID+1)
+	contextKey := metricContextKey(metricName, log.GetTags())
+
+	if e.patternContext == nil {
+		e.patternContext = make(map[string]patternMetricContext)
+	}
+	e.patternContext[contextKey] = patternMetricContext{
+		keyInfo: patternKey,
+		example: message,
+	}
 
 	return []observerdef.MetricOutput{{
-		Name:  fmt.Sprintf("log.%s.%x.count", e.Name(), patternKey.Hash),
-		Value: 1,
-		Tags:  log.GetTags(),
+		Name:       metricName,
+		Value:      1,
+		Tags:       log.GetTags(),
+		ContextKey: contextKey,
 	}}
 }

--- a/comp/observer/impl/log_pattern_extractor_test.go
+++ b/comp/observer/impl/log_pattern_extractor_test.go
@@ -1,0 +1,81 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogPatternExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
+	e := NewLogPatternExtractor()
+
+	log := &mockLogView{
+		content: []byte("GET /users/123 returned 500"),
+		tags:    []string{"service:web", "env:prod"},
+	}
+
+	res := e.ProcessLog(log)
+	require.Len(t, res, 1)
+	require.NotEmpty(t, res[0].ContextKey)
+
+	ctx, ok := e.GetContextByKey(res[0].ContextKey)
+	require.True(t, ok)
+	assert.Equal(t, "log_pattern_extractor", ctx.Source)
+	assert.Equal(t, "GET /users/123 returned 500", ctx.Example)
+	assert.NotEmpty(t, ctx.Pattern)
+}
+
+func TestLogPatternExtractor_ContextKeySeparatesSameMetricByTags(t *testing.T) {
+	e := NewLogPatternExtractor()
+
+	logA := &mockLogView{
+		content: []byte("GET /users/123 returned 500"),
+		tags:    []string{"service:api"},
+	}
+	logB := &mockLogView{
+		content: []byte("GET /users/456 returned 500"),
+		tags:    []string{"service:worker"},
+	}
+
+	resA := e.ProcessLog(logA)
+	resB := e.ProcessLog(logB)
+	require.Len(t, resA, 1)
+	require.Len(t, resB, 1)
+	require.Equal(t, resA[0].Name, resB[0].Name)
+	require.NotEqual(t, resA[0].ContextKey, resB[0].ContextKey)
+
+	ctxA, ok := e.GetContextByKey(resA[0].ContextKey)
+	require.True(t, ok)
+	ctxB, ok := e.GetContextByKey(resB[0].ContextKey)
+	require.True(t, ok)
+
+	assert.Equal(t, "GET /users/123 returned 500", ctxA.Example)
+	assert.Equal(t, "GET /users/456 returned 500", ctxB.Example)
+	assert.Equal(t, ctxA.Pattern, ctxB.Pattern)
+}
+
+func TestLogPatternExtractor_ResetClearsContext(t *testing.T) {
+	e := NewLogPatternExtractor()
+
+	log := &mockLogView{
+		content: []byte("GET /users/123 returned 500"),
+		tags:    []string{"service:web"},
+	}
+
+	res := e.ProcessLog(log)
+	require.Len(t, res, 1)
+
+	_, ok := e.GetContextByKey(res[0].ContextKey)
+	require.True(t, ok)
+
+	e.Reset()
+
+	_, ok = e.GetContextByKey(res[0].ContextKey)
+	assert.False(t, ok)
+}

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -394,7 +394,11 @@ func (b *BOCPDDetector) updatePosterior(state *bocpdSeriesState, x float64) (boo
 
 // makeAnomaly constructs an Anomaly for a new alert onset.
 func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, cpProb, shortRunMass float64) *observer.Anomaly {
-	seriesName := series.Name + ":" + aggSuffix(agg)
+	source := observer.AnomalySource{
+		Namespace: series.Namespace,
+		Name:      series.Name,
+		Aggregate: agg,
+	}
 	deviation := (p.Value - state.baselineMean) / state.baselineStddev
 
 	triggerType := "short-run posterior mass"
@@ -406,14 +410,15 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 		triggerThreshold = b.config.CPThreshold
 	}
 
+	displayName := source.String()
 	return &observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
-		Source:         observer.MetricName(seriesName),
-		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
+		Source:         source,
+		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, series.Name+":"+aggSuffix(agg), series.Tags)),
 		DetectorName:   b.Name(),
-		Title:          "BOCPD changepoint detected: " + seriesName,
+		Title:          "BOCPD changepoint detected: " + displayName,
 		Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",
-			seriesName, triggerType, triggerValue, triggerThreshold, cpProb, b.config.ShortRunLength, shortRunMass),
+			displayName, triggerType, triggerValue, triggerThreshold, cpProb, b.config.ShortRunLength, shortRunMass),
 		Tags:      series.Tags,
 		Timestamp: p.Timestamp,
 		DebugInfo: &observer.AnomalyDebugInfo{

--- a/comp/observer/impl/metrics_detector_bocpd_test.go
+++ b/comp/observer/impl/metrics_detector_bocpd_test.go
@@ -127,7 +127,7 @@ func TestBOCPDDetector_SustainedIncidentEmitsOnce(t *testing.T) {
 	// Should emit at most one anomaly per series/agg despite sustained shift.
 	anomalyCount := 0
 	for _, a := range result.Anomalies {
-		if a.Source == "test.metric:avg" {
+		if a.Source.String() == "test.metric:avg" {
 			anomalyCount++
 		}
 	}
@@ -193,7 +193,7 @@ func TestBOCPDDetector_RecoveryAndReAlert(t *testing.T) {
 	// Count total anomalies for m:avg across r3 and r4.
 	avgAnomalies := 0
 	for _, a := range append(r3.Anomalies, r4.Anomalies...) {
-		if a.Source == "m:avg" {
+		if a.Source.String() == "m:avg" {
 			avgAnomalies++
 		}
 	}

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"math"
+	"strings"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
@@ -147,6 +148,7 @@ func (c *CUSUMDetector) Detect(series observer.Series) observer.DetectionResult 
 func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64, debugInfo *observer.AnomalyDebugInfo) *observer.Anomaly {
 	var sHigh, sLow float64
 	cusumValues := make([]float64, 0, len(series.Points))
+	source := anomalySourceFromSeriesName(series.Name)
 
 	for i, p := range series.Points {
 		// Upper CUSUM: detect increases
@@ -173,7 +175,7 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 				debugInfo.CUSUMValues = cusumValues
 			}
 			return &observer.Anomaly{
-				Source: observer.MetricName(series.Name),
+				Source: source,
 				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ above baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
@@ -194,7 +196,7 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 				debugInfo.CUSUMValues = cusumValues
 			}
 			return &observer.Anomaly{
-				Source: observer.MetricName(series.Name),
+				Source: source,
 				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ below baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
@@ -206,6 +208,35 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 	}
 
 	return nil
+}
+
+func anomalySourceFromSeriesName(name string) observer.AnomalySource {
+	if idx := strings.LastIndex(name, ":"); idx != -1 {
+		if agg, ok := parseAggregateSuffix(name[idx+1:]); ok {
+			return observer.AnomalySource{
+				Name:      name[:idx],
+				Aggregate: agg,
+			}
+		}
+	}
+	return observer.AnomalySource{Name: name}
+}
+
+func parseAggregateSuffix(s string) (observer.Aggregate, bool) {
+	switch s {
+	case "avg":
+		return observer.AggregateAverage, true
+	case "sum":
+		return observer.AggregateSum, true
+	case "count":
+		return observer.AggregateCount, true
+	case "min":
+		return observer.AggregateMin, true
+	case "max":
+		return observer.AggregateMax, true
+	default:
+		return 0, false
+	}
 }
 
 // mean calculates the arithmetic mean of points.

--- a/comp/observer/impl/metrics_detector_cusum_test.go
+++ b/comp/observer/impl/metrics_detector_cusum_test.go
@@ -84,7 +84,7 @@ func TestCUSUMDetector_DetectsShift(t *testing.T) {
 	require.Len(t, result.Anomalies, 1, "should detect the shift")
 
 	anomaly := result.Anomalies[0]
-	assert.Equal(t, "shifted_metric", string(anomaly.Source))
+	assert.Equal(t, "shifted_metric", anomaly.Source.String())
 	assert.Contains(t, anomaly.Title, "CUSUM")
 	assert.Contains(t, anomaly.Description, "shifted")
 
@@ -209,7 +209,9 @@ func TestCUSUMDetector_SourceAndTags(t *testing.T) {
 	require.Len(t, result.Anomalies, 1)
 
 	anomaly := result.Anomalies[0]
-	assert.Equal(t, "my.metric:avg", string(anomaly.Source), "Source should match series name")
+	assert.Equal(t, "my.metric", anomaly.Source.Name, "Source name should exclude the aggregate suffix")
+	assert.Equal(t, observer.AggregateAverage, anomaly.Source.Aggregate, "Source aggregate should be parsed from the series name")
+	assert.Equal(t, "my.metric:avg", anomaly.Source.String(), "Source display should round-trip to the original series name")
 	assert.Equal(t, []string{"env:prod", "service:api"}, anomaly.Tags, "Tags should be preserved")
 }
 

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -474,7 +474,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 
 		if r.config.ThresholdSigma > 0 && threshold > 0 && score > threshold {
 			anomaly := observer.Anomaly{
-				Source:       "score",
+				Source:       observer.AnomalySource{Namespace: "rrcf", Name: "score"},
 				DetectorName: r.Name(),
 				Title:        "RRCF multivariate anomaly",
 				Description:  fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -293,7 +293,7 @@ func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
-		Source:         observer.MetricName(seriesName),
+		Source:         observer.AnomalySource{Namespace: series.Namespace, Name: series.Name, Aggregate: agg},
 		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
 		DetectorName:   d.Name(),
 		Title:          "ScanMW changepoint: " + seriesName,

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -302,7 +302,7 @@ func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
-		Source:         observer.MetricName(seriesName),
+		Source:         observer.AnomalySource{Namespace: series.Namespace, Name: series.Name, Aggregate: agg},
 		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
 		DetectorName:   d.Name(),
 		Title:          "ScanWelch changepoint: " + seriesName,

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -214,11 +214,12 @@ func NewComponent(deps Requires) Provides {
 	detectors, correlators, extractors, _ := catalog.Instantiate(settings)
 
 	eng := newEngine(engineConfig{
-		storage:     newTimeSeriesStorage(),
-		extractors:  extractors,
-		detectors:   detectors,
-		correlators: correlators,
-		scheduler:   &currentBehaviorPolicy{},
+		storage:          newTimeSeriesStorage(),
+		extractors:       extractors,
+		detectors:        detectors,
+		correlators:      correlators,
+		contextProviders: collectContextProviders(extractors),
+		scheduler:        &currentBehaviorPolicy{},
 	})
 
 	// Wire reporters via event subscription.
@@ -498,7 +499,11 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 			for j := range result.Anomalies {
 				result.Anomalies[j].Type = observerdef.AnomalyTypeMetric
 				result.Anomalies[j].DetectorName = a.detector.Name()
-				result.Anomalies[j].Source = observerdef.MetricName(seriesWithAgg.Name)
+				result.Anomalies[j].Source = observerdef.AnomalySource{
+					Namespace: series.Namespace,
+					Name:      series.Name,
+					Aggregate: agg,
+				}
 				result.Anomalies[j].SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
 			}
 			allAnomalies = append(allAnomalies, result.Anomalies...)
@@ -511,20 +516,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 
 // aggSuffix returns a short suffix for the given aggregation type.
 func aggSuffix(agg observerdef.Aggregate) string {
-	switch agg {
-	case observerdef.AggregateAverage:
-		return "avg"
-	case observerdef.AggregateSum:
-		return "sum"
-	case observerdef.AggregateCount:
-		return "count"
-	case observerdef.AggregateMin:
-		return "min"
-	case observerdef.AggregateMax:
-		return "max"
-	default:
-		return "unknown"
-	}
+	return observerdef.AggregateString(agg)
 }
 
 // RawAnomalies returns a copy of currently tracked raw anomalies.

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -105,7 +105,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			for j, a := range corr.Anomalies {
 				oc.Anomalies[j] = ObserverAnomaly{
 					Timestamp:      a.Timestamp,
-					Source:         string(a.Source),
+					Source:         a.Source.String(),
 					SourceSeriesID: string(a.SourceSeriesID),
 					Detector:       a.DetectorName,
 				}

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -51,14 +51,14 @@ func testCorrelation() observerdef.ActiveCorrelation {
 		Anomalies: []observerdef.Anomaly{
 			{
 				Timestamp:      1000,
-				Source:         "cpu.user:avg",
+				Source:         observerdef.AnomalySource{Name: "cpu.user"},
 				SourceSeriesID: "parquet|cpu.user:avg|host:a",
 				DetectorName:   "cusum",
 				Description:    "CUSUM detected shift in cpu.user:avg",
 			},
 			{
 				Timestamp:      1200,
-				Source:         "mem.used:avg",
+				Source:         observerdef.AnomalySource{Name: "mem.used"},
 				SourceSeriesID: "parquet|mem.used:avg|host:a",
 				DetectorName:   "cusum",
 				Description:    "CUSUM detected shift in mem.used:avg",
@@ -213,7 +213,7 @@ func TestWriteObserverOutput_ValidJSON(t *testing.T) {
 			Anomalies: []observerdef.Anomaly{
 				{
 					Timestamp:      100,
-					Source:         "metric:avg",
+					Source:         observerdef.AnomalySource{Name: "metric"},
 					SourceSeriesID: "s1",
 					DetectorName:   "cusum",
 				},

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -51,14 +51,14 @@ func testCorrelation() observerdef.ActiveCorrelation {
 		Anomalies: []observerdef.Anomaly{
 			{
 				Timestamp:      1000,
-				Source:         observerdef.AnomalySource{Name: "cpu.user"},
+				Source:         observerdef.AnomalySource{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
 				SourceSeriesID: "parquet|cpu.user:avg|host:a",
 				DetectorName:   "cusum",
 				Description:    "CUSUM detected shift in cpu.user:avg",
 			},
 			{
 				Timestamp:      1200,
-				Source:         observerdef.AnomalySource{Name: "mem.used"},
+				Source:         observerdef.AnomalySource{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
 				SourceSeriesID: "parquet|mem.used:avg|host:a",
 				DetectorName:   "cusum",
 				Description:    "CUSUM detected shift in mem.used:avg",

--- a/comp/observer/impl/reporter_html.go
+++ b/comp/observer/impl/reporter_html.go
@@ -1127,7 +1127,7 @@ func (r *HTMLReporter) handleAPICorrelations(w http.ResponseWriter, _ *http.Requ
 			anomalies := make([]anomalyOutput, len(ac.Anomalies))
 			for j, a := range ac.Anomalies {
 				anomalies[j] = anomalyOutput{
-					Source:      string(a.Source),
+					Source:      a.Source.String(),
 					Title:       a.Title,
 					Description: a.Description,
 					Tags:        a.Tags,
@@ -1175,7 +1175,7 @@ func (r *HTMLReporter) handleAPIRawAnomalies(w http.ResponseWriter, _ *http.Requ
 		anomalies = make([]rawAnomalyOutput, len(raw))
 		for i, a := range raw {
 			anomalies[i] = rawAnomalyOutput{
-				Source:       string(a.Source),
+				Source:       a.Source.String(),
 				DetectorName: a.DetectorName,
 				Title:        a.Title,
 				Description:  a.Description,

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -28,7 +28,7 @@ func TestHTMLReporter_Report_AddsToBuffer(t *testing.T) {
 	r.Report(observer.ReportOutput{
 		AdvancedToSec: 100,
 		NewAnomalies: []observer.Anomaly{
-			{Source: "cpu", DetectorName: "test"},
+			{Source: observer.AnomalySource{Name: "cpu"}, DetectorName: "test"},
 		},
 		ActiveCorrelations: []observer.ActiveCorrelation{
 			{Pattern: "p1", Title: "Correlation 1"},
@@ -151,7 +151,7 @@ func TestHTMLReporter_APIReports_ReturnsJSON(t *testing.T) {
 	r.Report(observer.ReportOutput{
 		AdvancedToSec: 42,
 		NewAnomalies: []observer.Anomaly{
-			{Source: "cpu"},
+			{Source: observer.AnomalySource{Name: "cpu"}},
 		},
 	})
 
@@ -413,7 +413,7 @@ func TestHTMLReporter_APICorrelations_ReturnsJSON(t *testing.T) {
 					observer.SeriesID("series|signal2|"),
 				},
 				Anomalies: []observer.Anomaly{
-					{Source: "signal1", Title: "Anomaly 1", Description: "Description 1"},
+					{Source: observer.AnomalySource{Name: "signal1"}, Title: "Anomaly 1", Description: "Description 1"},
 				},
 			},
 		},
@@ -435,7 +435,7 @@ func TestHTMLReporter_APICorrelations_ReturnsJSON(t *testing.T) {
 	assert.Equal(t, "test_pattern", correlations[0].Pattern)
 	assert.Equal(t, "Test Correlation", correlations[0].Title)
 	require.Len(t, correlations[0].Anomalies, 1)
-	assert.Equal(t, "signal1", string(correlations[0].Anomalies[0].Source))
+	assert.Equal(t, "signal1", correlations[0].Anomalies[0].Source)
 }
 
 func TestHTMLReporter_APICorrelations_NoState(t *testing.T) {

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -69,12 +69,12 @@ func TestStateView_Anomalies(t *testing.T) {
 
 	// Add some anomalies via the engine
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:       "cpu",
+		Source:       observerdef.AnomalySource{Name: "cpu"},
 		DetectorName: "cusum",
 		Timestamp:    100,
 	})
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:       "mem",
+		Source:       observerdef.AnomalySource{Name: "mem"},
 		DetectorName: "bocpd",
 		Timestamp:    101,
 	})
@@ -112,7 +112,7 @@ func TestStateView_Anomalies(t *testing.T) {
 
 	// AnomaliesForSeries filters by SourceSeriesID
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:         "disk",
+		Source:         observerdef.AnomalySource{Name: "disk"},
 		DetectorName:   "cusum",
 		Timestamp:      102,
 		SourceSeriesID: "ns|disk:avg|",
@@ -121,8 +121,8 @@ func TestStateView_Anomalies(t *testing.T) {
 	if len(diskAnomalies) != 1 {
 		t.Fatalf("expected 1 disk anomaly, got %d", len(diskAnomalies))
 	}
-	if diskAnomalies[0].Source != "disk" {
-		t.Fatalf("expected disk source, got %s", diskAnomalies[0].Source)
+	if diskAnomalies[0].Source.Name != "disk" {
+		t.Fatalf("expected disk source, got %s", diskAnomalies[0].Source.Name)
 	}
 	// Empty SourceSeriesID should not match
 	emptyAnomalies := sv.AnomaliesForSeries("")

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -212,7 +212,7 @@ func TestAggSuffix(t *testing.T) {
 	assert.Equal(t, "min", aggSuffix(AggregateMin))
 	assert.Equal(t, "max", aggSuffix(AggregateMax))
 
-	// Test unknown aggregation type
+	// Unknown aggregation type
 	assert.Equal(t, "unknown", aggSuffix(Aggregate(999)))
 }
 

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -38,7 +38,7 @@ func (d *dynamicAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime in
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{
 			{
-				Source:         observerdef.MetricName(fmt.Sprintf("%s%d", d.prefix, d.currentIndex)),
+				Source:         observerdef.AnomalySource{Name: fmt.Sprintf("%s%d", d.prefix, d.currentIndex)},
 				SourceSeriesID: observerdef.SeriesID(fmt.Sprintf("ns|%s%d|", d.prefix, d.currentIndex)),
 				DetectorName:   d.Name(),
 				Title:          fmt.Sprintf("anomaly_%d", d.currentIndex),
@@ -75,4 +75,15 @@ type noopLogExtractor struct{}
 func (e *noopLogExtractor) Name() string { return "noop_extractor" }
 func (e *noopLogExtractor) ProcessLog(_ observerdef.LogView) []observerdef.MetricOutput {
 	return nil
+}
+
+type sharedTagsExtractor struct{}
+
+func (e *sharedTagsExtractor) Name() string { return "shared_tags_extractor" }
+func (e *sharedTagsExtractor) ProcessLog(log observerdef.LogView) []observerdef.MetricOutput {
+	tags := log.GetTags()
+	return []observerdef.MetricOutput{
+		{Name: "metric.a", Value: 1, Tags: tags},
+		{Name: "metric.b", Value: 1, Tags: tags},
+	}
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -176,11 +176,12 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 	detectors, correlators, extractors, components := catalog.Instantiate(config.ComponentSettings)
 
 	eng := newEngine(engineConfig{
-		storage:     newTimeSeriesStorage(),
-		extractors:  extractors,
-		detectors:   detectors,
-		correlators: correlators,
-		scheduler:   &currentBehaviorPolicy{},
+		storage:          newTimeSeriesStorage(),
+		extractors:       extractors,
+		detectors:        detectors,
+		correlators:      correlators,
+		contextProviders: collectContextProviders(extractors),
+		scheduler:        &currentBehaviorPolicy{},
 	})
 
 	hub := newSSEHub()
@@ -823,8 +824,8 @@ func (tb *TestBench) GetMetricsAnomaliesForSeries(seriesID observerdef.SeriesID)
 func (tb *TestBench) resolveAnomalySeriesIDs(anomalies []observerdef.Anomaly) []observerdef.Anomaly {
 	for i := range anomalies {
 		a := &anomalies[i]
-		if a.SourceSeriesID == "" && a.Source != "" {
-			telemetryName := "telemetry." + a.DetectorName + "." + string(a.Source)
+		if a.SourceSeriesID == "" && a.Source.Name != "" {
+			telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
 			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
 		}
 	}
@@ -1221,7 +1222,7 @@ func (tb *TestBench) loadDemoScenario() error {
 	for _, a := range demoAnomalies {
 		anomaly := observerdef.Anomaly{
 			Type:         observerdef.AnomalyTypeLog,
-			Source:       "logs",
+			Source:       observerdef.AnomalySource{Name: "logs"},
 			DetectorName: a.detectorName,
 			Title:        a.title,
 			Description:  a.description,

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -755,6 +755,20 @@ func (tb *TestBench) GetComponents() []ComponentInfo {
 	return components
 }
 
+// extractorNamespaces returns storage namespace names used by pipeline extractors
+// (log-derived virtual metrics). Used by the testbench API to tag series.
+func (tb *TestBench) extractorNamespaces() map[string]struct{} {
+	tb.mu.RLock()
+	defer tb.mu.RUnlock()
+	out := make(map[string]struct{})
+	for _, entry := range tb.catalog.Entries() {
+		if entry.kind == componentExtractor {
+			out[entry.name] = struct{}{}
+		}
+	}
+	return out
+}
+
 // getStorage returns the storage (for API handlers).
 func (tb *TestBench) getStorage() *timeSeriesStorage {
 	tb.mu.RLock()

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -463,7 +463,7 @@ func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Req
 
 // handleNumericSeriesData resolves a compact numeric ID to series data.
 func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID observerdef.SeriesHandle, aggStr string, originalID string) {
-	var agg Aggregate
+	agg := AggregateAverage
 	switch aggStr {
 	case "avg":
 		agg = AggregateAverage
@@ -727,7 +727,7 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 			sourceSeriesID = storage.CompactSeriesID(sourceSeriesID)
 		}
 		resp := anomalyResponse{
-			Source:            string(a.Source),
+			Source:            a.Source.String(),
 			SourceSeriesID:    sourceSeriesID,
 			DetectorName:      a.DetectorName,
 			DetectorComponent: detectorComponentMap[a.DetectorName],
@@ -763,7 +763,7 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 			for _, a := range anomalies {
 				if a.DetectorName == "" || a.Timestamp == 0 {
 					log.Printf("skipping malformed anomaly response: detector=%q source=%q ts=%d",
-						a.DetectorName, a.Source, a.Timestamp)
+						a.DetectorName, a.Source.String(), a.Timestamp)
 					continue
 				}
 				response = append(response, toResponse(a))
@@ -775,7 +775,7 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 		for _, a := range anomalies {
 			if a.DetectorName == "" || a.Timestamp == 0 {
 				log.Printf("skipping malformed anomaly response: detector=%q source=%q ts=%d",
-					a.DetectorName, a.Source, a.Timestamp)
+					a.DetectorName, a.Source.String(), a.Timestamp)
 				continue
 			}
 			response = append(response, toResponse(a))
@@ -810,7 +810,7 @@ func (api *TestBenchAPI) handleLogAnomalies(w http.ResponseWriter, r *http.Reque
 	response := make([]logAnomalyResponse, 0, len(anomalies))
 	for _, a := range anomalies {
 		response = append(response, logAnomalyResponse{
-			Source:       string(a.Source),
+			Source:       a.Source.String(),
 			DetectorName: a.DetectorName,
 			Title:        a.Title,
 			Description:  a.Description,
@@ -984,7 +984,7 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 				tags = []string{}
 			}
 			anomalies[j] = anomalyOutput{
-				Source:      string(a.Source),
+				Source:      a.Source.String(),
 				Title:       a.Title,
 				Description: a.Description,
 				Timestamp:   a.Timestamp,

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -463,7 +463,7 @@ func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Req
 
 // handleNumericSeriesData resolves a compact numeric ID to series data.
 func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID observerdef.SeriesHandle, aggStr string, originalID string) {
-	agg := AggregateAverage
+	var agg Aggregate
 	switch aggStr {
 	case "avg":
 		agg = AggregateAverage

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -402,9 +402,12 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 		Name       string   `json:"name"`
 		Tags       []string `json:"tags"`
 		PointCount int      `json:"pointCount"`
+		Virtual    bool     `json:"virtual"`
 	}
 
 	var allSeries []seriesInfo
+
+	extractorNs := api.tb.extractorNamespaces()
 
 	// Get series metadata from all namespaces — no point data materialized.
 	// Use compact numeric IDs: "{numericID}:{aggSuffix}" (e.g. "42:avg").
@@ -414,12 +417,14 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 			for _, agg := range []Aggregate{AggregateAverage, AggregateCount} {
 				nameWithAgg := m.Name + ":" + aggSuffix(agg)
 				compactID := strconv.Itoa(int(m.Handle)) + ":" + aggSuffix(agg)
+				_, virtual := extractorNs[m.Namespace]
 				allSeries = append(allSeries, seriesInfo{
 					ID:         compactID,
 					Namespace:  m.Namespace,
 					Name:       nameWithAgg,
 					Tags:       m.Tags,
 					PointCount: m.PointCount,
+					Virtual:    virtual,
 				})
 			}
 		}


### PR DESCRIPTION
## Summary

This PR reshapes how observer represents and enriches synthesized metric signals.

It replaces the old stringly-typed `_virtual.` metric naming model with structured source metadata, adds engine-managed context enrichment for synthesized metrics, and brings in the log pattern extractor adapted to that model.

## What Changed

- Added structured `AnomalySource` with:
  - `Namespace`
  - `Name`
  - `Aggregate`
- Updated anomaly generation, correlation, output, and display paths to use structured sources instead of plain metric-name strings.
- Changed synthesized metric ingestion to use extractor `Name()` as the metric namespace instead of encoding origin into `_virtual.` metric names.
- Added `ContextProvider` support for synthesized metrics.
- Added `ContextKey` on `MetricOutput` so extractors can emit an opaque context reference without rebuilding full context payloads on every metric emission.
- Moved anomaly context enrichment to an engine-owned mapping from final `SourceSeriesID` to `{namespace, context key}`.
- Updated enrichment to resolve context from the final stored series identity and then call `GetContextByKey(...)` on the originating provider.
- Added duplicate extractor-name validation so namespace collisions fail fast.
- Made extractors participate in `Reset()` when they support it.
- Brought over the log pattern extractor and adapted it to the new structured source and context-provider model.
- Added focused tests for extractor context keys, enrichment, reset behavior, and extractor replacement.

## Why

Previously, synthesized metrics encoded origin and routing details into metric names, and context lookup depended on reconstructing identity from names and tags.

This PR moves those responsibilities into explicit structures:

- source identity is represented directly as namespace + metric name + aggregate
- synthesized metric namespace is the producing extractor
- context lookup is driven by final series identity in the engine
- extractors expose opaque context keys instead of depending on storage tag normalization details

That makes the model easier to reason about and gives us a cleaner path for attaching richer source context to anomalies.

## Notes For Reviewers

- Extractor names are now semantically important because they define the namespace for synthesized metrics.
- `ContextProvider` is now key-based only.
- The log pattern extractor is stateful because it tracks clustering state and context for emitted pattern metrics.
- This branch includes the new log pattern extractor work in addition to the earlier structured source/context changes.

## Validation

Targeted observer tests were run for:
- anomaly context enrichment
- extractor replacement refreshing providers
- real extractor end-to-end enrichment via stored series identity
- duplicate extractor-name rejection
- extractor reset participation
- log metrics extractor context-key behavior
- log pattern extractor context-key behavior
