### PR TITLE
franken build test 1

### DIFF
--- a/packages/agent/product/BUILD.bazel
+++ b/packages/agent/product/BUILD.bazel
@@ -33,6 +33,7 @@ pkg_filegroup(
         # we'll do that in April.
         # "//packages/agent/dependencies:all_files",
         ":dirs",
+        ":agent_binary",
         ":example_config",
 
         # TODO: rtloader
@@ -94,4 +95,13 @@ pkg_files(
     renames = {
         "//pkg/config:agent_config": "datadog.yaml.example",
     },
+)
+
+pkg_files(
+    name = "agent_binary",
+    srcs = [
+        "//bin/agent",
+    ],
+    attributes = pkg_attributes(mode = "755"),
+    prefix = "bin/agent_dup",
 )

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -234,6 +234,10 @@ def build(
             check_deadcode=os.getenv("DEPLOY_AGENT") == "true",
             coverage=os.getenv("E2E_COVERAGE_PIPELINE") == "true",
         )
+        build_path = os.path.join(BIN_PATH, "BUILD.bazel")
+        if not os.path.exists(build_path):
+            with open(build_path, "w") as build_file:
+                build_file.write("""exports_files(glob(["**"]))\n""")
 
     if embedded_path is None:
         embedded_path = get_embedded_path(ctx)
@@ -247,8 +251,13 @@ def build(
         bundled_agent_bin = os.path.join(bundled_agent_dir, bin_name(build))
         agent_fullpath = os.path.normpath(os.path.join(embedded_path, "..", "bin", "agent", bin_name("agent")))
 
-        if not os.path.exists(os.path.dirname(bundled_agent_bin)):
-            os.mkdir(os.path.dirname(bundled_agent_bin))
+        bin_dir = os.path.dirname(bundled_agent_bin)
+        if not os.path.exists(bin_dir):
+            os.mkdir(bin_dir)
+        build_path = os.path.join(bin_dir, "BUILD.bazel")
+        if not os.path.exists(build_path):
+            with open(build_path, "w") as build_file:
+                build_file.write("""exports_files(glob(["**"]))\n""")
 
         create_launcher(ctx, build, agent_fullpath, bundled_agent_bin)
 


### PR DESCRIPTION
Create BUILD files from dda agent.build to see that we can pick up the binary from a bazel command.

## why this works
- We only make the BUILD files in places we have put output.

## why it doesn't
bazel test //... builds more than it should. We can't build the package standalone.


