### PR TITLE
Also trigger Windows CI on `MODULE.bazel*` changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@
   - pkg/logs/util/windowsevent/**/*
   - pkg/network/driver/**/*
 
-  # cmd/ 
+  # cmd/
   - cmd/agent/**/*
   - cmd/process-agent/**/*
   - cmd/security-agent/**/*
@@ -70,6 +70,7 @@
   - tools/windows/**/*
 
   # Build/packaging
+  - MODULE.bazel*
   - omnibus/**/*
   - packages/**/*
   - deps/**/*


### PR DESCRIPTION
### What does this PR do?
Add `MODULE.bazel*` to the `windows_path_2` change filter in `.gitlab-ci.yml`.

### Motivation
`MODULE.bazel` and `MODULE.bazel.lock` live at the repo root, not under `bazel/**/*`.
Bumping Bazel module deps (e.g. `rules_python` on a dev branch silently skips all Windows jobs because none of the three Windows path anchors cover those files, so Windows build and test regressions go undetected until the change lands on `main`.

### Describe how you validated your changes
Observed missing Windows jobs on the `bump-rules-python` branch...

### Additional Notes
Otherwise we would have faced an incident...