### PR TITLE
[context-provider-poc-reviewable] Add UI changes for virtual metrics

### DIFF
--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -70,6 +70,8 @@ export interface SeriesInfo {
   name: string;
   tags: string[];
   pointCount: number;
+  /** True when the series is produced by a log/metric extractor (formerly _virtual.* names). */
+  virtual?: boolean;
 }
 
 export interface Point {

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -176,7 +176,13 @@ export function MetricsView({
   );
 
   const displayGroups = useMemo(
-    () => visibleGroups.map((g) => ({ key: g.key, name: g.baseName, displayName: g.baseName })),
+    () =>
+      visibleGroups.map((g) => ({
+        key: g.key,
+        name: g.baseName,
+        displayName: g.baseName,
+        virtual: g.virtual,
+      })),
     [visibleGroups]
   );
 

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -24,6 +24,12 @@ function getAggregationType(name: string): AggregationType | null {
   return match ? (match[1] as AggregationType) : null;
 }
 
+/** Log-derived (extractor) metrics; falls back to legacy `_virtual.` name prefix. */
+function seriesIsVirtual(s: SeriesInfo): boolean {
+  if (typeof s.virtual === 'boolean') return s.virtual;
+  return getBaseMetricName(s.name).startsWith('_virtual.');
+}
+
 function getDetectorComponent(anomaly: { detectorName: string; detectorComponent?: string }): string {
   return anomaly.detectorComponent ?? anomaly.detectorName;
 }
@@ -39,6 +45,7 @@ interface MetricGroup {
   namespace: string;
   baseName: string;
   members: SeriesInfo[];
+  virtual: boolean;
 }
 
 interface MetricsViewProps {
@@ -119,6 +126,7 @@ export function MetricsView({
           namespace: s.namespace,
           baseName,
           members: [],
+          virtual: seriesIsVirtual(s),
         });
       }
       groups.get(key)!.members.push(s);
@@ -163,7 +171,7 @@ export function MetricsView({
   );
 
   const virtualGroups = useMemo(
-    () => visibleGroups.filter((g) => g.baseName.startsWith('_virtual.')),
+    () => visibleGroups.filter((g) => g.virtual),
     [visibleGroups]
   );
 
@@ -190,7 +198,7 @@ export function MetricsView({
     if (scenarioHasSeries && allSeries.length === 0) return;
 
     const mainGroups = [...visibleGroups]
-      .filter((g) => g.namespace !== 'telemetry' && !g.baseName.startsWith('_virtual.'));
+      .filter((g) => g.namespace !== 'telemetry' && !g.virtual);
 
     const DEFAULT_METRIC = 'datadog.dogstatsd.client.metrics';
     const defaultGroup = mainGroups.find((g) => g.baseName === DEFAULT_METRIC);
@@ -529,7 +537,7 @@ export function MetricsView({
                   const cards = Array.from(selectedGroups)
                     .filter((key) => {
                       const g = groupByKey.get(key);
-                      return g && g.namespace !== 'telemetry' && !g.baseName.startsWith('_virtual.');
+                      return g && g.namespace !== 'telemetry' && !g.virtual;
                     })
                     .map((groupKey) => {
                       const dataList = groupSeriesData.get(groupKey) ?? [];
@@ -588,7 +596,7 @@ export function MetricsView({
                       {Array.from(selectedGroups)
                         .filter((key) => {
                           const g = groupByKey.get(key);
-                          return g && g.baseName.startsWith('_virtual.');
+                          return g && g.virtual;
                         })
                         .map((groupKey) => {
                           const dataList = groupSeriesData.get(groupKey) ?? [];

--- a/cmd/observer-testbench/ui/src/components/SeriesTree.tsx
+++ b/cmd/observer-testbench/ui/src/components/SeriesTree.tsx
@@ -1,9 +1,15 @@
 import { useState, useMemo, useRef, useEffect } from 'react';
 
+/** Native tooltip for rows where every metric under the node is extractor-backed. */
+const VIRTUAL_METRIC_GROUP_TITLE =
+  'Virtual metric — produced by log/metric extractors from log lines, not from raw DogStatsD ingestion.';
+
 interface SeriesInfo {
   key: string;
   name: string;
   displayName?: string;
+  /** True when the metric group is log-derived (extractor); used for the cyan "v" badge. */
+  virtual?: boolean;
 }
 
 interface TreeNode {
@@ -77,6 +83,7 @@ interface TreeNodeComponentProps {
   depth: number;
   selectedSeries: Set<string>;
   anomalousSources: Set<string>;
+  virtualByKey: Map<string, boolean>;
   onToggleNode: (keys: string[]) => void;
   expandedPaths: Set<string>;
   onToggleExpanded: (path: string) => void;
@@ -87,6 +94,7 @@ function TreeNodeComponent({
   depth,
   selectedSeries,
   anomalousSources,
+  virtualByKey,
   onToggleNode,
   expandedPaths,
   onToggleExpanded,
@@ -94,6 +102,9 @@ function TreeNodeComponent({
   const isExpanded = expandedPaths.has(node.fullPath);
   const hasChildren = node.children.size > 0;
   const keys = node.seriesKeys;
+  const uniqueKeys = [...new Set(keys)];
+  const onlyVirtual =
+    uniqueKeys.length > 0 && uniqueKeys.every((k) => virtualByKey.get(k) === true);
 
   const allSelected = keys.length > 0 && keys.every((k) => selectedSeries.has(k));
   const someSelected = keys.some((k) => selectedSeries.has(k));
@@ -106,8 +117,9 @@ function TreeNodeComponent({
       <div
         className={`flex items-center gap-1 py-0.5 px-1 rounded cursor-pointer ${
           hasAnomaly ? 'bg-red-900/20' : 'hover:bg-slate-700/50'
-        }`}
+        } ${onlyVirtual ? 'cursor-help' : ''}`}
         style={{ paddingLeft: `${depth * 12}px` }}
+        title={onlyVirtual ? VIRTUAL_METRIC_GROUP_TITLE : undefined}
       >
         {hasChildren && !node.isLeaf ? (
           <button
@@ -135,7 +147,7 @@ function TreeNodeComponent({
         />
 
         <span
-          className={`text-sm truncate flex-1 ${hasAnomaly ? 'text-red-400' : 'text-slate-400'}`}
+          className={`text-sm truncate flex-1 min-w-0 ${hasAnomaly ? 'text-red-400' : 'text-slate-400'}`}
           onClick={() => {
             if (hasChildren && !node.isLeaf) {
               onToggleExpanded(node.fullPath);
@@ -145,8 +157,12 @@ function TreeNodeComponent({
           {node.name}
         </span>
 
+        {onlyVirtual && (
+          <span className="text-[10px] font-semibold text-cyan-400/85 shrink-0 leading-none select-none">v</span>
+        )}
+
         {hasChildren && !node.isLeaf && (
-          <span className="text-xs text-slate-500">{keys.length}</span>
+          <span className="text-xs text-slate-500">{uniqueKeys.length}</span>
         )}
 
         {hasAnomaly && <span className="text-red-500 text-xs">!</span>}
@@ -161,6 +177,7 @@ function TreeNodeComponent({
               depth={depth + 1}
               selectedSeries={selectedSeries}
               anomalousSources={anomalousSources}
+              virtualByKey={virtualByKey}
               onToggleNode={onToggleNode}
               expandedPaths={expandedPaths}
               onToggleExpanded={onToggleExpanded}
@@ -181,6 +198,14 @@ export function SeriesTree({
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
 
   const tree = useMemo(() => buildTree(series, anomalousSources), [series, anomalousSources]);
+
+  const virtualByKey = useMemo(() => {
+    const m = new Map<string, boolean>();
+    for (const s of series) {
+      m.set(s.key, s.virtual === true);
+    }
+    return m;
+  }, [series]);
 
   const toggleExpanded = (path: string) => {
     setExpandedPaths((prev) => {
@@ -309,6 +334,7 @@ export function SeriesTree({
             depth={0}
             selectedSeries={selectedSeries}
             anomalousSources={anomalousSources}
+            virtualByKey={virtualByKey}
             onToggleNode={toggleNode}
             expandedPaths={expandedPaths}
             onToggleExpanded={toggleExpanded}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -755,6 +755,20 @@ func (tb *TestBench) GetComponents() []ComponentInfo {
 	return components
 }
 
+// extractorNamespaces returns storage namespace names used by pipeline extractors
+// (log-derived virtual metrics). Used by the testbench API to tag series.
+func (tb *TestBench) extractorNamespaces() map[string]struct{} {
+	tb.mu.RLock()
+	defer tb.mu.RUnlock()
+	out := make(map[string]struct{})
+	for _, entry := range tb.catalog.Entries() {
+		if entry.kind == componentExtractor {
+			out[entry.name] = struct{}{}
+		}
+	}
+	return out
+}
+
 // getStorage returns the storage (for API handlers).
 func (tb *TestBench) getStorage() *timeSeriesStorage {
 	tb.mu.RLock()

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -402,9 +402,12 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 		Name       string   `json:"name"`
 		Tags       []string `json:"tags"`
 		PointCount int      `json:"pointCount"`
+		Virtual    bool     `json:"virtual"`
 	}
 
 	var allSeries []seriesInfo
+
+	extractorNs := api.tb.extractorNamespaces()
 
 	// Get series metadata from all namespaces — no point data materialized.
 	// Use compact numeric IDs: "{numericID}:{aggSuffix}" (e.g. "42:avg").
@@ -414,12 +417,14 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 			for _, agg := range []Aggregate{AggregateAverage, AggregateCount} {
 				nameWithAgg := m.Name + ":" + aggSuffix(agg)
 				compactID := strconv.Itoa(int(m.Handle)) + ":" + aggSuffix(agg)
+				_, virtual := extractorNs[m.Namespace]
 				allSeries = append(allSeries, seriesInfo{
 					ID:         compactID,
 					Namespace:  m.Namespace,
 					Name:       nameWithAgg,
 					Tags:       m.Tags,
 					PointCount: m.PointCount,
+					Virtual:    virtual,
 				})
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

This updates the UI to not rely on `_virtual` prefix anymore. It also adds a `v` label to see which metric is virtual since they are not grouped anymore.

<img width="433" height="90" alt="Screenshot 2026-03-20 at 08 54 39" src="https://github.com/user-attachments/assets/98fe0a73-08ac-4dc8-97bd-9f4e72c1c6ac" />

### Motivation

### Describe how you validated your changes

### Additional Notes
