### PR TITLE
fix(workloadmeta): fix data race and duplicate registration in process collector telemetry

### DIFF
--- a/comp/core/telemetry/telemetryimpl/telemetry.go
+++ b/comp/core/telemetry/telemetryimpl/telemetry.go
@@ -73,8 +73,6 @@ func newTelemetryComponent(deps dependencies) telemetry.Component {
 }
 
 func newTelemetry() telemetry.Component {
-	mutex.Lock()
-	defer mutex.Unlock()
 	return &telemetryImpl{
 		mutex:    &mutex,
 		registry: registry,

--- a/comp/core/telemetry/telemetryimpl/telemetry.go
+++ b/comp/core/telemetry/telemetryimpl/telemetry.go
@@ -73,6 +73,8 @@ func newTelemetryComponent(deps dependencies) telemetry.Component {
 }
 
 func newTelemetry() telemetry.Component {
+	mutex.Lock()
+	defer mutex.Unlock()
 	return &telemetryImpl{
 		mutex:    &mutex,
 		registry: registry,

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -93,7 +93,7 @@ type Event struct {
 
 func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.Clock, processProbe procutil.Probe, config pkgconfigmodel.Reader, systemProbeConfig pkgconfigmodel.Reader) collector {
 	var discoveredServicesGauge telemetry.Gauge
-	if systemProbeConfig.GetBool("discovery.enabled") {
+	if serviceDiscoveryEnabled(systemProbeConfig) {
 		discoveredServicesGauge = telemetry.NewGaugeWithOpts(
 			collectorID,
 			"discovered_services",
@@ -170,7 +170,11 @@ func (c *collector) isProcessCollectionEnabled() bool {
 
 // isServiceDiscoveryEnabled returns a boolean indicating if service discovery is enabled
 func (c *collector) isServiceDiscoveryEnabled() bool {
-	return c.systemProbeConfig.GetBool("discovery.enabled")
+	return serviceDiscoveryEnabled(c.systemProbeConfig)
+}
+
+func serviceDiscoveryEnabled(systemProbeConfig pkgconfigmodel.Reader) bool {
+	return systemProbeConfig.GetBool("discovery.enabled")
 }
 
 // isGPUMonitoringEnabled returns a boolean indicating if GPU monitoring is enabled

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -92,7 +92,17 @@ type Event struct {
 }
 
 func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.Clock, processProbe procutil.Probe, config pkgconfigmodel.Reader, systemProbeConfig pkgconfigmodel.Reader) collector {
-	c := collector{
+	var discoveredServicesGauge telemetry.Gauge
+	if systemProbeConfig.GetBool("discovery.enabled") {
+		discoveredServicesGauge = telemetry.NewGaugeWithOpts(
+			collectorID,
+			"discovered_services",
+			[]string{},
+			"Number of discovered alive services.",
+			telemetry.DefaultOptions,
+		)
+	}
+	return collector{
 		id:                     id,
 		catalog:                catalog,
 		clock:                  clock,
@@ -108,17 +118,8 @@ func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.
 		ignoredPids:              make(core.PidSet),
 		pidHeartbeats:            make(map[int32]time.Time),
 		knownInjectionStatusPids: make(core.PidSet),
+		metricDiscoveredServices: discoveredServicesGauge,
 	}
-	if c.isServiceDiscoveryEnabled() {
-		c.metricDiscoveredServices = telemetry.NewGaugeWithOpts(
-			collectorID,
-			"discovered_services",
-			[]string{},
-			"Number of discovered alive services.",
-			telemetry.DefaultOptions,
-		)
-	}
-	return c
 }
 
 type dependencies struct {

--- a/comp/core/workloadmeta/collectors/internal/process/process_collector.go
+++ b/comp/core/workloadmeta/collectors/internal/process/process_collector.go
@@ -92,7 +92,7 @@ type Event struct {
 }
 
 func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.Clock, processProbe procutil.Probe, config pkgconfigmodel.Reader, systemProbeConfig pkgconfigmodel.Reader) collector {
-	return collector{
+	c := collector{
 		id:                     id,
 		catalog:                catalog,
 		clock:                  clock,
@@ -109,6 +109,16 @@ func newProcessCollector(id string, catalog workloadmeta.AgentType, clock clock.
 		pidHeartbeats:            make(map[int32]time.Time),
 		knownInjectionStatusPids: make(core.PidSet),
 	}
+	if c.isServiceDiscoveryEnabled() {
+		c.metricDiscoveredServices = telemetry.NewGaugeWithOpts(
+			collectorID,
+			"discovered_services",
+			[]string{},
+			"Number of discovered alive services.",
+			telemetry.DefaultOptions,
+		)
+	}
+	return c
 }
 
 type dependencies struct {
@@ -213,14 +223,6 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Component) err
 
 	if c.isServiceDiscoveryEnabled() {
 		serviceCollectionInterval := c.getServiceCollectionInterval()
-		// Initialize service discovery metric
-		c.metricDiscoveredServices = telemetry.NewGaugeWithOpts(
-			collectorID,
-			"discovered_services",
-			[]string{},
-			"Number of discovered alive services.",
-			telemetry.DefaultOptions,
-		)
 
 		if c.isProcessCollectionEnabled() || c.isLanguageCollectionEnabled() {
 			log.Debug("Starting cached service collection (process collection enabled)")


### PR DESCRIPTION
### What does this PR do?

Moves the `discovered_services` telemetry gauge initialization from the process collector's `Start()` method to the `newProcessCollector()` constructor. This fixes both a data race and a duplicate metrics registration panic.

### Motivation

Enabling `discovery.enabled` by default on Linux caused the process workloadmeta collector to start in tests where it previously didn't. This exposed two latent bugs:

1. **Data race**: `Start()` is called from `startCandidatesWithRetry` in a background goroutine (`store.go:74`). It calls `telemetry.NewGaugeWithOpts()` → `GetCompatComponent()` → `newTelemetry()`, which reads the global `registry` variable without holding the mutex. Meanwhile, the fx Stop hook calls `Reset()`, which writes to `registry` under the mutex. Since the background goroutine is fire-and-forget (the fx Start hook returns immediately), fx Stop can begin while the goroutine is still running.

2. **Duplicate registration panic** (with `-count=N`): Leaked background goroutines from test run N survive into test run N+1. After `Reset()` creates a new registry between runs, both the leaked goroutine and the new test's collector try to register the same gauge on the same new registry.

Both issues are fixed by moving the gauge initialization to the constructor, which runs synchronously during fx construction — before Start and well before Stop.

### Describe how you validated your changes

Reproduced the data race by running:
```
dda inv test --targets=./cmd/agent/subcommands/processchecks/ --race --extra-args="-count=20"
```

After the fix, confirmed 80/80 passes across multiple batches with the race detector enabled.