### PR TITLE
[PROF-14075][full-host][standalone] inject required k8sattribute and healthcheck extension

### DIFF
--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -248,6 +248,31 @@ func TestConverterWithoutAgent(t *testing.T) {
 			provided: "no_agent/preserve-res-attrs-no-system/in.yaml",
 			expected: "no_agent/preserve-res-attrs-no-system/out.yaml",
 		},
+		{
+			name:     "preserves-user-health-check",
+			provided: "no_agent/preserve-healthcheck/in.yaml",
+			expected: "no_agent/preserve-healthcheck/out.yaml",
+		},
+		{
+			name:     "health-check-global-not-in-service",
+			provided: "no_agent/healthcheck-global-not-service/in.yaml",
+			expected: "no_agent/healthcheck-global-not-service/out.yaml",
+		},
+		{
+			name:     "preserves-user-k8sattributes",
+			provided: "no_agent/preserve-k8sattr/in.yaml",
+			expected: "no_agent/preserve-k8sattr/out.yaml",
+		},
+		{
+			name:     "preserves-user-k8sattributes-custom-name",
+			provided: "no_agent/preserve-k8sattr-custom/in.yaml",
+			expected: "no_agent/preserve-k8sattr-custom/out.yaml",
+		},
+		{
+			name:     "k8sattr-already-has-container-id",
+			provided: "no_agent/k8sattr-has-containerid/in.yaml",
+			expected: "no_agent/k8sattr-has-containerid/out.yaml",
+		},
 	}
 
 	runSuccessTests(t, newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}), tests)

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -47,6 +47,9 @@ var resourceDetectionDefaultConfig = confMap{
 //   - If hostprofiler::symbol_uploader::enabled == true, convert api_key/app_key to strings in each endpoint
 //   - If no hostprofiler is used & configured, add minimal one with symbol_uploader: false
 //   - remove ddprofiling & hpflare extensions
+//   - At least one health_check extension declared and activated
+//   - At least one k8sattributes processor declared and used in the profiles pipeline, with pod_association configured
+//     with at least one source configured to use resource_attribute from container.id
 type converterWithoutAgent struct{}
 
 func newConverterWithoutAgent(convSettings confmap.ConverterSettings) confmap.Converter {
@@ -92,6 +95,13 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 	if err != nil {
 		return err
 	}
+
+	// TODO: remove forceK8sAttributesInProfilesPipeline once profile SIG is supported in upstream helm chart.
+	newProcessorNames, err = forceK8sAttributesInProfilesPipeline(confStringMap, newProcessorNames)
+	if err != nil {
+		return err
+	}
+
 	newProcessorNames, err = addProfilerMetadataTags(confStringMap, newProcessorNames)
 	if err != nil {
 		return err
@@ -112,8 +122,17 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 		return err
 	}
 
+	// Ensures k8sattributes processor has a pod_association source configured to use resource_attribute from container.id
+	if err := ensureK8sAttributesPodAssociation(confStringMap); err != nil {
+		return err
+	}
+
 	// Remove agent-only extensions
 	if err := c.removeAgentOnlyExtensions(confStringMap); err != nil {
+		return err
+	}
+
+	if err := c.ensureHealthCheckExtension(confStringMap); err != nil {
 		return err
 	}
 
@@ -389,4 +408,145 @@ func (c *converterWithoutAgent) removeAgentOnlyExtensions(conf confMap) error {
 	}
 
 	return nil
+}
+
+// ensureHealthCheckExtension adds a default health_check extension if none is
+// already configured. It touches both the global extensions section and the
+// service.extensions list so the extension is actually activated.
+func (c *converterWithoutAgent) ensureHealthCheckExtension(conf confMap) error {
+	service, err := Ensure[confMap](conf, "service")
+	if err != nil {
+		return err
+	}
+
+	serviceExtensions, err := Ensure[[]any](service, "extensions")
+	if err != nil {
+		return err
+	}
+
+	for _, extAny := range serviceExtensions {
+		ext, ok := extAny.(string)
+		if !ok {
+			return errors.New("extension names in service should be strings")
+		}
+		if isComponentType(ext, componentTypeHealthCheck) {
+			return nil
+		}
+	}
+
+	extensions, err := Ensure[confMap](conf, "extensions")
+	if err != nil {
+		return err
+	}
+
+	if _, exists := extensions[defaultHealthCheckName]; !exists {
+		extensions[defaultHealthCheckName] = confMap{
+			"endpoint": defaultHealthCheckEndpoint,
+		}
+	}
+
+	service["extensions"] = append(serviceExtensions, defaultHealthCheckName)
+	slog.Warn("Added default health_check extension to user configuration")
+	return nil
+}
+
+// forceK8sAttributesInProfilesPipeline adds a default k8sattributes processor
+// to the profiles pipeline if none is already present there.
+// TODO: remove forceK8sAttributesInProfilesPipeline once profile SIG is supported in upstream helm chart.
+func forceK8sAttributesInProfilesPipeline(conf confMap, processorNames []any) ([]any, error) {
+	for _, nameAny := range processorNames {
+		name, ok := nameAny.(string)
+		if !ok {
+			return nil, fmt.Errorf("processor name must be a string, got %T", nameAny)
+		}
+		if isComponentType(name, componentTypeK8sAttributes) {
+			return processorNames, nil
+		}
+	}
+
+	processors, err := Ensure[confMap](conf, "processors")
+	if err != nil {
+		return nil, err
+	}
+	if _, exists := processors[defaultK8sAttributesName]; !exists {
+		if err := Set(processors, defaultK8sAttributesName, confMap{}); err != nil {
+			return nil, err
+		}
+	}
+
+	slog.Warn("Added default k8sattributes processor to profiles pipeline")
+	return append(processorNames, defaultK8sAttributesName), nil
+}
+
+// ensureK8sAttributesPodAssociation walks every k8sattributes processor in the
+// global processors section and ensures each one has a container.id
+// pod_association source.
+func ensureK8sAttributesPodAssociation(conf confMap) error {
+	processors, ok := Get[confMap](conf, "processors")
+	if !ok {
+		return nil
+	}
+
+	for name := range processors {
+		if !isComponentType(name, componentTypeK8sAttributes) {
+			continue
+		}
+		k8sConfig, err := Ensure[confMap](conf, pathPrefixProcessors+name)
+		if err != nil {
+			return err
+		}
+		if err := ensureContainerIDPodAssociation(k8sConfig); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureContainerIDPodAssociation ensures pod_association contains a source
+// with {from: resource_attribute, name: container.id}. Appends it if missing,
+// leaves the existing list untouched otherwise.
+func ensureContainerIDPodAssociation(k8sConfig confMap) error {
+	podAssoc, err := Ensure[[]any](k8sConfig, "pod_association")
+	if err != nil {
+		return err
+	}
+
+	if hasContainerIDSource(podAssoc) {
+		return nil
+	}
+
+	k8sConfig["pod_association"] = append(podAssoc, confMap{
+		"sources": []any{
+			confMap{
+				"from": "resource_attribute",
+				"name": "container.id",
+			},
+		},
+	})
+	return nil
+}
+
+func hasContainerIDSource(podAssoc []any) bool {
+	for _, assocAny := range podAssoc {
+		assoc, ok := assocAny.(confMap)
+		if !ok {
+			continue
+		}
+		sources, ok := Get[[]any](assoc, "sources")
+		if !ok {
+			continue
+		}
+		for _, srcAny := range sources {
+			src, ok := srcAny.(confMap)
+			if !ok {
+				continue
+			}
+			from, hasFrom := src["from"]
+			name, hasName := src["name"]
+			if hasFrom && hasName && from == "resource_attribute" && name == "container.id" {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -450,6 +450,9 @@ func (c *converterWithoutAgent) ensureHealthCheckExtension(conf confMap) error {
 //  2. wires it into the profiles pipeline if not already there
 //
 // If no k8sattributes processor exists in the user config, nothing happens.
+
+// TODO: At the moment k8s preset doesn't add k8sattributes to profiles processor pipeline, once it does, we can remove:
+//  2. wires it into the profiles pipeline if not already there
 func ensureK8sAttributesProcessor(conf confMap, processorNames []any) ([]any, error) {
 	processors, ok := Get[confMap](conf, "processors")
 	if !ok {

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -126,9 +126,9 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 		return err
 	}
 
-	if err := c.ensureHealthCheckExtension(confStringMap); err != nil {
-		return err
-	}
+	//if err := c.ensureHealthCheckExtension(confStringMap); err != nil {
+	//	return err
+	//}
 
 	// infraattributes processor can also be used in metrics pipeline
 	if err := c.ensureMetricsPipeline(confStringMap); err != nil {

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -126,9 +126,9 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 		return err
 	}
 
-	//if err := c.ensureHealthCheckExtension(confStringMap); err != nil {
-	//	return err
-	//}
+	if err := c.ensureHealthCheckExtension(confStringMap); err != nil {
+		return err
+	}
 
 	// infraattributes processor can also be used in metrics pipeline
 	if err := c.ensureMetricsPipeline(confStringMap); err != nil {
@@ -509,6 +509,7 @@ func ensureContainerIDPodAssociation(k8sConfig confMap) error {
 			},
 		},
 	})
+	slog.Warn("Added container.id pod_association source to k8sattributes processor")
 	return nil
 }
 

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -96,8 +96,7 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 		return err
 	}
 
-	// TODO: remove forceK8sAttributesInProfilesPipeline once profile SIG is supported in upstream helm chart.
-	newProcessorNames, err = forceK8sAttributesInProfilesPipeline(confStringMap, newProcessorNames)
+	newProcessorNames, err = ensureK8sAttributesProcessor(confStringMap, newProcessorNames)
 	if err != nil {
 		return err
 	}
@@ -119,11 +118,6 @@ func (c *converterWithoutAgent) Convert(_ context.Context, conf *confmap.Conf) e
 	// Go through every configured processor to make sure there are no infraattributes declared that were not in the
 	// pipeline
 	if err := c.ensureGlobalProcessors(confStringMap); err != nil {
-		return err
-	}
-
-	// Ensures k8sattributes processor has a pod_association source configured to use resource_attribute from container.id
-	if err := ensureK8sAttributesPodAssociation(confStringMap); err != nil {
 		return err
 	}
 
@@ -450,56 +444,48 @@ func (c *converterWithoutAgent) ensureHealthCheckExtension(conf confMap) error {
 	return nil
 }
 
-// forceK8sAttributesInProfilesPipeline adds a default k8sattributes processor
-// to the profiles pipeline if none is already present there.
-// TODO: remove forceK8sAttributesInProfilesPipeline once profile SIG is supported in upstream helm chart.
-func forceK8sAttributesInProfilesPipeline(conf confMap, processorNames []any) ([]any, error) {
+// ensureK8sAttributesProcessor handles k8sattributes processors that the user
+// already defined in the global processors section. For each one it:
+//  1. ensures the container.id pod_association source is present
+//  2. wires it into the profiles pipeline if not already there
+//
+// If no k8sattributes processor exists in the user config, nothing happens.
+func ensureK8sAttributesProcessor(conf confMap, processorNames []any) ([]any, error) {
+	processors, ok := Get[confMap](conf, "processors")
+	if !ok {
+		return processorNames, nil
+	}
+
+	alreadyInPipeline := make(map[string]bool)
 	for _, nameAny := range processorNames {
 		name, ok := nameAny.(string)
 		if !ok {
 			return nil, fmt.Errorf("processor name must be a string, got %T", nameAny)
 		}
 		if isComponentType(name, componentTypeK8sAttributes) {
-			return processorNames, nil
+			alreadyInPipeline[name] = true
 		}
-	}
-
-	processors, err := Ensure[confMap](conf, "processors")
-	if err != nil {
-		return nil, err
-	}
-	if _, exists := processors[defaultK8sAttributesName]; !exists {
-		if err := Set(processors, defaultK8sAttributesName, confMap{}); err != nil {
-			return nil, err
-		}
-	}
-
-	slog.Warn("Added default k8sattributes processor to profiles pipeline")
-	return append(processorNames, defaultK8sAttributesName), nil
-}
-
-// ensureK8sAttributesPodAssociation walks every k8sattributes processor in the
-// global processors section and ensures each one has a container.id
-// pod_association source.
-func ensureK8sAttributesPodAssociation(conf confMap) error {
-	processors, ok := Get[confMap](conf, "processors")
-	if !ok {
-		return nil
 	}
 
 	for name := range processors {
 		if !isComponentType(name, componentTypeK8sAttributes) {
 			continue
 		}
+
 		k8sConfig, err := Ensure[confMap](conf, pathPrefixProcessors+name)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if err := ensureContainerIDPodAssociation(k8sConfig); err != nil {
-			return err
+			return nil, err
+		}
+
+		if !alreadyInPipeline[name] {
+			processorNames = append(processorNames, name)
 		}
 	}
-	return nil
+
+	return processorNames, nil
 }
 
 // ensureContainerIDPodAssociation ensures pod_association contains a source

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -37,6 +37,8 @@ const (
 	componentTypeOtlpHTTP          = "otlphttp"
 	componentTypeDDProfiling       = "ddprofiling"
 	componentTypeHPFlare           = "hpflare"
+	componentTypeHealthCheck       = "health_check"
+	componentTypeK8sAttributes     = "k8sattributes"
 )
 
 // Default component names
@@ -44,6 +46,9 @@ const (
 	defaultInfraAttributesName   = "infraattributes/default"
 	defaultResourceDetectionName = "resourcedetection/default"
 	defaultHostProfilerName      = "hostprofiler"
+	defaultHealthCheckName       = "health_check"
+	defaultHealthCheckEndpoint   = "${env:MY_POD_IP:-localhost}:13133"
+	defaultK8sAttributesName     = "k8sattributes"
 )
 
 // Configuration paths used multiple times across converters

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -47,7 +47,7 @@ const (
 	defaultResourceDetectionName = "resourcedetection/default"
 	defaultHostProfilerName      = "hostprofiler"
 	defaultHealthCheckName       = "health_check"
-	defaultHealthCheckEndpoint   = "${env:MY_POD_IP:-localhost}:13133"
+	defaultHealthCheckEndpoint   = "0.0.0.0:13133"
 	defaultK8sAttributesName     = "k8sattributes"
 )
 

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -28,6 +36,8 @@ receivers:
             enabled: false
     otlp: {}
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -36,6 +46,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -46,7 +41,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -28,6 +36,8 @@ receivers:
             enabled: false
     otlp: {}
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -36,6 +46,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -46,7 +41,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - otlp

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -48,7 +43,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -30,6 +38,8 @@ receivers:
                 - api_key: "12345"
                   app_key: test-app-key
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -38,6 +48,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -48,7 +43,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -30,6 +38,8 @@ receivers:
                 - api_key: test-key
                   app_key: "67890"
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -38,6 +48,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: "12345"
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -27,6 +35,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -35,6 +45,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: "12345"
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -27,6 +35,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -35,6 +45,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -27,6 +35,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -35,6 +45,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -27,6 +35,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -36,6 +46,7 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -46,7 +41,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -27,6 +35,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -35,6 +45,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/healthcheck-global-not-service/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/healthcheck-global-not-service/in.yaml
@@ -1,0 +1,18 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors: {}
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:9090"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: []
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/healthcheck-global-not-service/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/healthcheck-global-not-service/out.yaml
@@ -6,11 +6,6 @@ extensions:
     health_check:
         endpoint: 0.0.0.0:9090
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/healthcheck-global-not-service/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/healthcheck-global-not-service/out.yaml
@@ -1,18 +1,11 @@
 exporters:
     otlphttp:
-        endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key
 extensions:
-    custom:
-        config: value
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
-    other:
-        config: value
+        endpoint: 0.0.0.0:9090
 processors:
-    batch:
-        timeout: 10s
     k8sattributes:
         pod_association:
             - sources:
@@ -43,8 +36,6 @@ receivers:
             enabled: false
 service:
     extensions:
-        - custom
-        - other
         - health_check
     pipelines:
         metrics:
@@ -53,7 +44,6 @@ service:
             exporters:
                 - otlphttp
             processors:
-                - batch
                 - resourcedetection/default
                 - k8sattributes
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -6,13 +6,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -49,7 +44,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -4,7 +4,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -29,6 +37,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -39,6 +49,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/k8sattr-has-containerid/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/k8sattr-has-containerid/in.yaml
@@ -1,0 +1,22 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  k8sattributes:
+    pod_association:
+      - sources:
+          - from: resource_attribute
+            name: container.id
+      - sources:
+          - from: connection
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [k8sattributes]
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/k8sattr-has-containerid/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/k8sattr-has-containerid/out.yaml
@@ -4,7 +4,7 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
     k8sattributes:
         pod_association:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/k8sattr-has-containerid/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/k8sattr-has-containerid/out.yaml
@@ -1,23 +1,18 @@
 exporters:
     otlphttp:
-        endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key
 extensions:
-    custom:
-        config: value
     health_check:
         endpoint: ${env:MY_POD_IP:-localhost}:13133
-    other:
-        config: value
 processors:
-    batch:
-        timeout: 10s
     k8sattributes:
         pod_association:
             - sources:
                 - from: resource_attribute
                   name: container.id
+            - sources:
+                - from: connection
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -43,8 +38,6 @@ receivers:
             enabled: false
 service:
     extensions:
-        - custom
-        - other
         - health_check
     pipelines:
         metrics:
@@ -53,9 +46,8 @@ service:
             exporters:
                 - otlphttp
             processors:
-                - batch
-                - resourcedetection/default
                 - k8sattributes
+                - resourcedetection/default
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -36,6 +44,8 @@ receivers:
                 - api_key: "33333"
                   app_key: string-app
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -44,6 +54,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -54,7 +49,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -8,13 +8,8 @@ exporters:
             dd-api-key: staging-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -51,7 +46,6 @@ service:
                 - logging
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -6,7 +6,15 @@ exporters:
     otlphttp/staging:
         headers:
             dd-api-key: staging-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -31,6 +39,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -41,6 +51,7 @@ service:
                 - logging
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -50,7 +45,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -32,6 +40,8 @@ receivers:
                 - api_key: "123"
                   app_key: "456"
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -40,6 +50,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -27,6 +35,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -35,6 +45,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-healthcheck/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-healthcheck/in.yaml
@@ -1,0 +1,20 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors: {}
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+extensions:
+  health_check/custom:
+    endpoint: "0.0.0.0:8080"
+service:
+  extensions:
+    - health_check/custom
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: []
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-healthcheck/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-healthcheck/out.yaml
@@ -1,18 +1,11 @@
 exporters:
     otlphttp:
-        endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key
 extensions:
-    custom:
-        config: value
-    health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
-    other:
-        config: value
+    health_check/custom:
+        endpoint: 0.0.0.0:8080
 processors:
-    batch:
-        timeout: 10s
     k8sattributes:
         pod_association:
             - sources:
@@ -43,9 +36,7 @@ receivers:
             enabled: false
 service:
     extensions:
-        - custom
-        - other
-        - health_check
+        - health_check/custom
     pipelines:
         metrics:
             processors: []
@@ -53,7 +44,6 @@ service:
             exporters:
                 - otlphttp
             processors:
-                - batch
                 - resourcedetection/default
                 - k8sattributes
                 - resource/dd-profiler-internal-metadata

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-healthcheck/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-healthcheck/out.yaml
@@ -6,11 +6,6 @@ extensions:
     health_check/custom:
         endpoint: 0.0.0.0:8080
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -23,6 +31,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -31,6 +41,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -41,7 +36,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -25,6 +33,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -33,6 +43,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -43,7 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr-custom/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr-custom/in.yaml
@@ -1,0 +1,19 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  k8sattributes/enrichment:
+    pod_association:
+      - sources:
+          - from: connection
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [k8sattributes/enrichment]
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr-custom/out.yaml
@@ -4,7 +4,7 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
     k8sattributes/enrichment:
         pod_association:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr-custom/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr-custom/out.yaml
@@ -1,20 +1,15 @@
 exporters:
     otlphttp:
-        endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key
 extensions:
-    custom:
-        config: value
     health_check:
         endpoint: ${env:MY_POD_IP:-localhost}:13133
-    other:
-        config: value
 processors:
-    batch:
-        timeout: 10s
-    k8sattributes:
+    k8sattributes/enrichment:
         pod_association:
+            - sources:
+                - from: connection
             - sources:
                 - from: resource_attribute
                   name: container.id
@@ -43,8 +38,6 @@ receivers:
             enabled: false
 service:
     extensions:
-        - custom
-        - other
         - health_check
     pipelines:
         metrics:
@@ -53,9 +46,8 @@ service:
             exporters:
                 - otlphttp
             processors:
-                - batch
+                - k8sattributes/enrichment
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr/in.yaml
@@ -1,0 +1,19 @@
+receivers:
+  hostprofiler:
+    symbol_uploader:
+      enabled: false
+processors:
+  k8sattributes:
+    pod_association:
+      - sources:
+          - from: connection
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: "test-key"
+service:
+  pipelines:
+    profiles:
+      receivers: [hostprofiler]
+      processors: [k8sattributes]
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr/out.yaml
@@ -4,7 +4,7 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
     k8sattributes:
         pod_association:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-k8sattr/out.yaml
@@ -1,20 +1,15 @@
 exporters:
     otlphttp:
-        endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key
 extensions:
-    custom:
-        config: value
     health_check:
         endpoint: ${env:MY_POD_IP:-localhost}:13133
-    other:
-        config: value
 processors:
-    batch:
-        timeout: 10s
     k8sattributes:
         pod_association:
+            - sources:
+                - from: connection
             - sources:
                 - from: resource_attribute
                   name: container.id
@@ -43,8 +38,6 @@ receivers:
             enabled: false
 service:
     extensions:
-        - custom
-        - other
         - health_check
     pipelines:
         metrics:
@@ -53,9 +46,8 @@ service:
             exporters:
                 - otlphttp
             processors:
-                - batch
-                - resourcedetection/default
                 - k8sattributes
+                - resourcedetection/default
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -25,6 +33,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -33,6 +43,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -43,7 +38,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -49,7 +44,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -31,6 +39,8 @@ receivers:
             grpc:
                 endpoint: 0.0.0.0:4317
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -39,6 +49,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -28,6 +36,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -36,6 +46,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -46,7 +41,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -2,11 +2,19 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
     batch:
         timeout: 10s
     infraattributes_custom:
         other_config: value
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     myinfraat tributes:
         some_config: value
     resource/dd-profiler-internal-metadata:
@@ -33,6 +41,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -44,6 +54,7 @@ service:
                 - infraattributes_custom
                 - batch
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -4,17 +4,12 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
     batch:
         timeout: 10s
     infraattributes_custom:
         other_config: value
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     myinfraat tributes:
         some_config: value
     resource/dd-profiler-internal-metadata:
@@ -54,7 +49,6 @@ service:
                 - infraattributes_custom
                 - batch
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -7,17 +7,12 @@ extensions:
     custom:
         config: value
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
     other:
         config: value
 processors:
     batch:
         timeout: 10s
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -55,7 +50,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -4,15 +4,10 @@ exporters:
             dd-api-key: test-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
     batch:
         timeout: 10s
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -51,7 +46,6 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -2,9 +2,17 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
     batch:
         timeout: 10s
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -29,6 +37,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             exporters:
@@ -41,6 +51,7 @@ service:
             processors:
                 - batch
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -27,6 +35,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -35,6 +45,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -45,7 +40,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -27,6 +35,8 @@ receivers:
         symbol_uploader:
             enabled: false
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -35,6 +45,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -4,13 +4,8 @@ exporters:
             dd-api-key: test-api-key
 extensions:
     health_check:
-        endpoint: ${env:MY_POD_IP:-localhost}:13133
+        endpoint: 0.0.0.0:13133
 processors:
-    k8sattributes:
-        pod_association:
-            - sources:
-                - from: resource_attribute
-                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -48,7 +43,6 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
-                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -2,7 +2,15 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+extensions:
+    health_check:
+        endpoint: ${env:MY_POD_IP:-localhost}:13133
 processors:
+    k8sattributes:
+        pod_association:
+            - sources:
+                - from: resource_attribute
+                  name: container.id
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
@@ -30,6 +38,8 @@ receivers:
                 - api_key: test-key
                   app_key: test-app-key
 service:
+    extensions:
+        - health_check
     pipelines:
         metrics:
             processors: []
@@ -38,6 +48,7 @@ service:
                 - otlphttp
             processors:
                 - resourcedetection/default
+                - k8sattributes
                 - resource/dd-profiler-internal-metadata
             receivers:
                 - hostprofiler


### PR DESCRIPTION
### What does this PR do?

In standalone mode, the converter injects new component to make sure it works with `k8s` helm preset:
- health_check extension: added to `service.extensions` and `extension`. User-defined configs are preserved.
- k8sattributes processor: when the user defines a k8sattributes processor in their config, the converter ensures `container.id` is present in `pod_association` sources (appended, never overriding) and wires the processor into the profiles pipeline if missing.

### Motivation

When deploying the standalone profiler on EKS using the OTel Helm chart's kubernetesAttributes preset, the injected k8sattributes configuration uses k8s.pod.ip, k8s.pod.uid, and the connection for pod association. However, the eBPF profiler only emits container.id on profiles. Because none of the preset's association sources match, pod correlation silently fails.

Rather than requiring users to manually override the preset configuration, the converter needs to append container.id to pod_association alongside any existing sources. Currently, the k8sattributes processor is added to all processor pipelines except the profiles pipeline; therefore, we must inject it manually until this is addressed upstream.

Additionally, the health_check extension is required for Kubernetes liveness and readiness probes, but it is not injected by the preset unless explicitly configured. Since the profiler cannot run properly in Kubernetes without it, the converter adds it by default.

### Describe how you validated your changes

### Additional Notes
