### PR TITLE
[SQG] Bump the gates using exceptions

### DIFF
--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -1,9 +1,9 @@
 static_quality_gate_agent_deb_amd64:
-  max_on_disk_size: 750.72 MiB
-  max_on_wire_size: 177.7 MiB
+  max_on_disk_size: 753.38 MiB
+  max_on_wire_size: 178.36 MiB
 static_quality_gate_agent_deb_amd64_fips:
-  max_on_disk_size: 711.23 MiB
-  max_on_wire_size: 172.23 MiB
+  max_on_disk_size: 713.9 MiB
+  max_on_wire_size: 172.79 MiB
 static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 320.58 MiB
   max_on_wire_size: 79.97 MiB
@@ -11,41 +11,41 @@ static_quality_gate_agent_msi:
   max_on_disk_size: 1062.52 MiB
   max_on_wire_size: 146.22 MiB
 static_quality_gate_agent_rpm_amd64:
-  max_on_disk_size: 750.69 MiB
-  max_on_wire_size: 180.78 MiB
+  max_on_disk_size: 753.35 MiB
+  max_on_wire_size: 181.83 MiB
 static_quality_gate_agent_rpm_amd64_fips:
-  max_on_disk_size: 711.21 MiB
+  max_on_disk_size: 713.88 MiB
   max_on_wire_size: 173.37 MiB
 static_quality_gate_agent_rpm_arm64:
-  max_on_disk_size: 732.89 MiB
-  max_on_wire_size: 161.61 MiB
+  max_on_disk_size: 735.29 MiB
+  max_on_wire_size: 163.06 MiB
 static_quality_gate_agent_rpm_arm64_fips:
-  max_on_disk_size: 694.44 MiB
-  max_on_wire_size: 155.91 MiB
+  max_on_disk_size: 696.84 MiB
+  max_on_wire_size: 156.17 MiB
 static_quality_gate_agent_suse_amd64:
-  max_on_disk_size: 750.69 MiB
-  max_on_wire_size: 180.78 MiB
+  max_on_disk_size: 753.35 MiB
+  max_on_wire_size: 181.83 MiB
 static_quality_gate_agent_suse_amd64_fips:
-  max_on_disk_size: 711.21 MiB
+  max_on_disk_size: 713.88 MiB
   max_on_wire_size: 173.37 MiB
 static_quality_gate_agent_suse_arm64:
-  max_on_disk_size: 732.89 MiB
-  max_on_wire_size: 161.61 MiB
+  max_on_disk_size: 735.29 MiB
+  max_on_wire_size: 163.06 MiB
 static_quality_gate_agent_suse_arm64_fips:
-  max_on_disk_size: 694.44 MiB
-  max_on_wire_size: 155.91 MiB
+  max_on_disk_size: 696.84 MiB
+  max_on_wire_size: 156.17 MiB
 static_quality_gate_docker_agent_amd64:
-  max_on_disk_size: 813.04 MiB
-  max_on_wire_size: 271.24 MiB
+  max_on_disk_size: 815.7 MiB
+  max_on_wire_size: 272.48 MiB
 static_quality_gate_docker_agent_arm64:
-  max_on_disk_size: 819.57 MiB
-  max_on_wire_size: 259.8 MiB
+  max_on_disk_size: 821.97 MiB
+  max_on_wire_size: 261.06 MiB
 static_quality_gate_docker_agent_jmx_amd64:
-  max_on_disk_size: 1003.92 MiB
-  max_on_wire_size: 339.87 MiB
+  max_on_disk_size: 1006.58 MiB
+  max_on_wire_size: 341.1 MiB
 static_quality_gate_docker_agent_jmx_arm64:
-  max_on_disk_size: 999.17 MiB
-  max_on_wire_size: 324.39 MiB
+  max_on_disk_size: 1001.57 MiB
+  max_on_wire_size: 325.62 MiB
 static_quality_gate_docker_cluster_agent_amd64:
   max_on_disk_size: 206.27 MiB
   max_on_wire_size: 72.92 MiB


### PR DESCRIPTION
### What does this PR do?
We had 3 PRs (#47737, #47388, #47527) merged in the past couple of weeks related to **procmgr**. According to this [exception record](https://datadoghq.atlassian.net/wiki/spaces/ABLD/pages/6266291223/Agent+Process+Manager+-+Quality+Gates+Decision+Records) we should bump the gates to keep the headroom for other work.
