### PR TITLE
[WINA-2483] Update config template to show OS-appropriate allowlist

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4953,9 +4953,6 @@ api_key:
 #   # for the list of available actions.
 #
 #   actions_allowlist:
-{{ if eq .OS "windows" -}}
-#     - com.datadoghq.script.runPredefinedPowershellScript
-{{ else -}}
-#     - com.datadoghq.script.runPredefinedScript
-{{ end -}}
+#     - com.datadoghq.script.runPredefinedPowershellScript   # on Windows
+#     - com.datadoghq.script.runPredefinedScript                       # on Linux and Darwin
 {{ end -}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4946,13 +4946,16 @@ api_key:
 #
 #   self_enroll: true
 
-#   # @param actions_allowlist - list of strings - optional
-#   # @env DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST - comma separated list of strings - optional
+#   # @param actions_allowlist - list of strings - optional - default: {{ if eq .OS "windows" }}["com.datadoghq.script.runPredefinedPowershellScript"]{{ else }}["com.datadoghq.script.runPredefinedScript"]{{ end }}
+#   # @env DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST - comma separated list of strings - optional - default: {{ if eq .OS "windows" }}"com.datadoghq.script.runPredefinedPowershellScript"{{ else }}"com.datadoghq.script.runPredefinedScript"{{ end }}
 #   # List of actions that the Private Action Runner is allowed to execute.
 #   # See http://docs.datadoghq.com/actions/private_actions/use_private_actions#change-the-allowlist-of-a-runner
 #   # for the list of available actions.
 #
 #   actions_allowlist:
-#     - com.datadoghq.script.runPredefinedPowershellScript   # on Windows
-#     - com.datadoghq.script.runPredefinedScript                       # on Linux and Darwin
+{{ if (eq .OS "windows") -}}
+#     - com.datadoghq.script.runPredefinedPowershellScript
+{{ else -}}
+#     - com.datadoghq.script.runPredefinedScript
+{{ end -}}
 {{ end -}}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4953,5 +4953,9 @@ api_key:
 #   # for the list of available actions.
 #
 #   actions_allowlist:
+{{ if eq .OS "windows" -}}
+#     - com.datadoghq.script.runPredefinedPowershellScript
+{{ else -}}
 #     - com.datadoghq.script.runPredefinedScript
+{{ end -}}
 {{ end -}}

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -6,7 +6,9 @@
 package setup
 
 import (
+
 	"path"
+	"runtime"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
@@ -69,7 +71,11 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 	// General config
 	config.BindEnvAndSetDefault(PARTaskConcurrency, 5)
 	config.BindEnvAndSetDefault(PARTaskTimeoutSeconds, 60)
-	config.BindEnvAndSetDefault(PARActionsAllowlist, []string{})
+	if runtime.GOOS == "windows" {
+		config.BindEnvAndSetDefault(PARActionsAllowlist, []string{"com.datadoghq.script.runPredefinedPowershellScript"})
+	} else {
+		config.BindEnvAndSetDefault(PARActionsAllowlist, []string{"com.datadoghq.script.runPredefinedScript"})
+	}
 	config.ParseEnvAsStringSlice(PARActionsAllowlist, func(s string) []string {
 		return strings.Split(s, ",")
 	})

--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -6,7 +6,6 @@
 package setup
 
 import (
-
 	"path"
 	"runtime"
 	"strings"

--- a/pkg/config/setup/privateactionrunner_test.go
+++ b/pkg/config/setup/privateactionrunner_test.go
@@ -60,7 +60,13 @@ func TestPrivateActionRunnerRestrictedShellAllowedPathsEmptyEnv(t *testing.T) {
 func TestPrivateActionRunnerAllowlistDefaultsEmpty(t *testing.T) {
 	cfg := newTestConf(t)
 
-	assert.Empty(t, cfg.GetStringSlice(PARActionsAllowlist))
+	// actions_allowlist defaults to an OS-appropriate script action, not empty.
+	allowlist := cfg.GetStringSlice(PARActionsAllowlist)
+	assert.Len(t, allowlist, 1)
+	assert.Contains(t, []string{
+		"com.datadoghq.script.runPredefinedScript",
+		"com.datadoghq.script.runPredefinedPowershellScript",
+	}, allowlist[0])
 	assert.Empty(t, cfg.GetStringSlice(PARHttpAllowlist))
 	assert.Equal(t, []string{defaultLogPath}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
 }

--- a/releasenotes/notes/par-os-aware-default-allowlist-3b9e21fa74dc8a05.yaml
+++ b/releasenotes/notes/par-os-aware-default-allowlist-3b9e21fa74dc8a05.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Private Action Runner ``actions_allowlist`` now defaults to an OS-appropriate
+    script action when not explicitly configured:
+    ``com.datadoghq.script.runPredefinedPowershellScript`` on Windows and
+    ``com.datadoghq.script.runPredefinedScript`` on Linux/macOS.
+    Previously the default was an empty list, leaving the runner unable to execute
+    any actions without manual configuration.


### PR DESCRIPTION
### What does this PR do?
Updates the `config_template.yaml` example for `private_action_runner.actions_allowlist` to show the OS-appropriate default action:
  - Windows: com.datadoghq.script.runPredefinedPowershellScript
  - Linux / macOS: com.datadoghq.script.runPredefinedScript
This affects the commented-out reference section in datadog.yaml.example that is installed alongside the Agent.

### Motivation
The previous example unconditionally showed `runPredefinedScript,` which is a bash/shell action unavailable on Windows. Users consulting `datadog.yaml.example` on a Windows host would copy the wrong action name into their config.

### Describe how you validated your changes
Verified by rendering the template for Windows, and Linux is implicitly verified as `else` case:
```
# Render the template for all platforms
mkdir C:\tmp\rendered
go run .\pkg\config\render_config\render_config.go agent-py3 .\pkg\config\config_template.yaml C:\tmp\datadog_windows.yaml

# Check the output
Select-String -Path "C:\tmp\datadog_windows.yaml" -Pattern "actions_allowlist" -Context 0,2
# Expected: com.datadoghq.script.runPredefinedPowershellScript
```

### Additional Notes
This is a follow-up on https://github.com/DataDog/datadog-agent/pull/48064. The runtime behavior is handled separately in pkg/fleet/installer/setup/common/setup.go and was fixed in the previous PR. This Here we only improve the reference documentation file that ships with the MSI.