### PR TITLE
[bazel] fetch snmp-traps db from GitHub instead of S3

### DIFF
--- a/.adms/bazel/adms.mirror.cfg
+++ b/.adms/bazel/adms.mirror.cfg
@@ -107,6 +107,7 @@ rewrite (pyyaml.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (python.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (mirrors.kernel.org)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
 rewrite (curl.haxx.se)/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/$2
+rewrite (github.com)/DataDog/ndm-traps-db/releases/download/(.*) depot-read-api-bzl.us1.ddbuild.io/$1/releases/download/$2
 
 # Rewrite Rules for External Hosts - Specific Language Ecosystems
 #######################################################################

--- a/deps/snmp_traps/BUILD.bazel
+++ b/deps/snmp_traps/BUILD.bazel
@@ -1,13 +1,18 @@
-# dd-compile-policy - make the prebuilt compiler part of the distribution.
-
 load("@rules_pkg//pkg:install.bzl", "pkg_install")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
+genrule(
+    name = "snmp_traps_gz",
+    srcs = ["@snmp_traps//:generated/dd_traps_db.json"],
+    outs = ["dd_traps_db.json.gz"],
+    cmd = "gzip -9 -c $< > $@",
+)
+
 pkg_files(
     name = "all_files",
-    srcs = ["@snmp_traps//file"],
+    srcs = [":snmp_traps_gz"],
     attributes = pkg_attributes(
         group = "root",
         mode = "0644",
@@ -18,12 +23,6 @@ pkg_files(
         "//:macos_x86_64": "etc/conf.d/snmp.d/traps_db",
         "//conditions:default": "etc/datadog-agent/conf.d/snmp.d/traps_db",
     }),
-    # This is subtle.  http_file does not preserve the original name.
-    # It always uses the target `@repo//file`, and the name of the file
-    # you get is "downloaded".
-    renames = {
-        "@snmp_traps//file": "dd_traps_db.json.gz",
-    },
 )
 
 pkg_install(

--- a/deps/snmp_traps/BUILD.bazel
+++ b/deps/snmp_traps/BUILD.bazel
@@ -3,16 +3,9 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 
 package(default_visibility = ["//packages:__subpackages__"])
 
-genrule(
-    name = "snmp_traps_gz",
-    srcs = ["@snmp_traps//:generated/dd_traps_db.json"],
-    outs = ["dd_traps_db.json.gz"],
-    cmd = "gzip -9 -c $< > $@",
-)
-
 pkg_files(
     name = "all_files",
-    srcs = [":snmp_traps_gz"],
+    srcs = ["@snmp_traps//file"],
     attributes = pkg_attributes(
         group = "root",
         mode = "0644",
@@ -23,6 +16,11 @@ pkg_files(
         "//:macos_x86_64": "etc/conf.d/snmp.d/traps_db",
         "//conditions:default": "etc/datadog-agent/conf.d/snmp.d/traps_db",
     }),
+    # http_file does not preserve the original name — it always exposes `@repo//file`
+    # with the content saved as "downloaded".
+    renames = {
+        "@snmp_traps//file": "dd_traps_db.json.gz",
+    },
 )
 
 pkg_install(

--- a/deps/snmp_traps/snmp_traps.MODULE.bazel
+++ b/deps/snmp_traps/snmp_traps.MODULE.bazel
@@ -1,18 +1,15 @@
 # snmp-traps
 
-http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 VERSION = "0.5.0"
 
-http_archive(
+http_file(
     name = "snmp_traps",
-    sha256 = "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5",
+    sha256 = "3ec097d9fd30183b462d647162cce4c389e243620d06ed3e0a9fa8c8d3149fe5",
     urls = [
-        "https://github.com/DataDog/snmp-traps/archive/refs/tags/v{version}.tar.gz".format(
+        "https://github.com/DataDog/ndm-traps-db/releases/download/v{version}/dd_traps_db-{version}.json.gz".format(
             version = VERSION,
         ),
     ],
-    strip_prefix = "snmp-traps-{version}".format(version = VERSION),
-    build_file_content = """exports_files(["generated/dd_traps_db.json"])
-""",
 )

--- a/deps/snmp_traps/snmp_traps.MODULE.bazel
+++ b/deps/snmp_traps/snmp_traps.MODULE.bazel
@@ -6,7 +6,7 @@ VERSION = "0.5.0"
 
 http_archive(
     name = "snmp_traps",
-    sha256 = "",  # TODO: fill in sha256 of the v0.5.0 archive
+    sha256 = "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5",
     urls = [
         "https://github.com/DataDog/snmp-traps/archive/refs/tags/v{version}.tar.gz".format(
             version = VERSION,

--- a/deps/snmp_traps/snmp_traps.MODULE.bazel
+++ b/deps/snmp_traps/snmp_traps.MODULE.bazel
@@ -1,16 +1,18 @@
 # snmp-traps
 
-http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-VERSION = "0.4.0"
+VERSION = "0.5.0"
 
-# TODO: Where does this come from? If we pull it in, we should know the license.
-http_file(
+http_archive(
     name = "snmp_traps",
-    sha256 = "04fb9d43754c2656edf35f08fbad11ba8dc20d52654962933f3dd8f4d463b42c",
+    sha256 = "",  # TODO: fill in sha256 of the v0.5.0 archive
     urls = [
-        "https://s3.amazonaws.com/dd-agent-omnibus/snmp_traps_db/dd_traps_db-{version}.json.gz".format(
+        "https://github.com/DataDog/snmp-traps/archive/refs/tags/v{version}.tar.gz".format(
             version = VERSION,
         ),
     ],
+    strip_prefix = "snmp-traps-{version}".format(version = VERSION),
+    build_file_content = """exports_files(["generated/dd_traps_db.json"])
+""",
 )


### PR DESCRIPTION
## Summary

- Replace `http_file` downloading a pre-compressed file from S3 with `http_archive` fetching the `DataDog/snmp-traps` GitHub repo at tag `v0.5.0`
- Add a `genrule` to gzip-compress `generated/dd_traps_db.json` at level 9, producing `dd_traps_db.json.gz`
- Update `pkg_files` to use the compressed genrule output; drop the old `renames` workaround that was needed for `http_file`'s unnamed `downloaded` target

## Notes

- Uses `archive/refs/tags/` URL format (consistent with how `security-agent-policies` is fetched), which ADMS can proxy for private repos
- The `sha256` in `snmp_traps.MODULE.bazel` is left empty and needs to be filled in before this can be merged: `curl -sL https://github.com/DataDog/snmp-traps/archive/refs/tags/v0.5.0.tar.gz | sha256sum`

## Test plan

- [ ] Fill in the `sha256` for the v0.5.0 archive
- [ ] `bazel build //deps/snmp_traps:all_files` succeeds
- [ ] Verify `dd_traps_db.json.gz` is produced and valid: `gunzip -t bazel-bin/deps/snmp_traps/dd_traps_db.json.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)