### PR TITLE
[autoscaling] Default to rollout; rollout if patch is forbidden

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-agent/pkg/version v0.77.0-devel.0.20260213154712-e02b9359151a
 	github.com/DataDog/datadog-go/v5 v5.8.3
-	github.com/DataDog/datadog-operator/api v0.0.0-20260319233601-89009e69cbf6
+	github.com/DataDog/datadog-operator/api v0.0.0-20260323152500-0887e50ccf73
 	github.com/DataDog/datadog-traceroute v1.0.13
 	github.com/DataDog/ebpf-manager v0.7.16
 	github.com/DataDog/go-sqllexer v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dX
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go/v5 v5.8.3 h1:s58CUJ9s8lezjhTNJO/SxkPBv2qZjS3ktpRSqGF5n0s=
 github.com/DataDog/datadog-go/v5 v5.8.3/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
-github.com/DataDog/datadog-operator/api v0.0.0-20260319233601-89009e69cbf6 h1:TUJ672ide6L+7aNllO/tCThxJG0VPVnIyuWxve4gxio=
-github.com/DataDog/datadog-operator/api v0.0.0-20260319233601-89009e69cbf6/go.mod h1:dMnKkWiv5j5UuRfaRUPXVDHG/79JG4S3llffsX4J+ko=
+github.com/DataDog/datadog-operator/api v0.0.0-20260323152500-0887e50ccf73 h1:c9uNLuEey0R0xP1ETZ620UhE67zp+WsGoSYJmhC5A8Y=
+github.com/DataDog/datadog-operator/api v0.0.0-20260323152500-0887e50ccf73/go.mod h1:dMnKkWiv5j5UuRfaRUPXVDHG/79JG4S3llffsX4J+ko=
 github.com/DataDog/datadog-traceroute v1.0.13 h1:PBkmwNCRqDrjFMXi/W9yTydFOKuxr8fcP08NVKXri1U=
 github.com/DataDog/datadog-traceroute v1.0.13/go.mod h1:ywOVt342keSUAzy1Aa47td4+2yl8WJsYQ+m7PlEDy8o=
 github.com/DataDog/ddtrivy v0.0.0-20260115083325-07614fb0b8d5 h1:R6uhWnfvq23xRAoV3vK9sc6D5pDHxEEDYBgs2YbcX8s=

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical.go
@@ -161,8 +161,9 @@ func (u *verticalController) syncInternal(
 	podsByResizeStatus map[PodResizeStatus][]classifiedPod,
 ) (autoscaling.ProcessResult, error) {
 
-	// Fall back to rollout if TriggerRollout mode is set or if the API server
-	// does not support in-place resize (pods/resize subresource unavailable).
+	// Fall back to rollout if in-place scaling is not enabled via config, if
+	// TriggerRollout mode is explicitly set, or if the API server does not
+	// support in-place resize (pods/resize subresource unavailable).
 	if isRolloutRequired(autoscalerInternal) || !u.isInPlaceResizeSupported() {
 		switch targetGVK.Kind {
 		case k8sutil.DeploymentKind:

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical.go
@@ -332,22 +332,6 @@ func (u *verticalController) patchInPlace(ctx context.Context, autoscalerInterna
 	return nil
 }
 
-// shouldEvictDeferred reports whether a pod in PodResizePending/Deferred state should be
-// evicted because it has waited longer than ResizePendingPeriod.
-func shouldEvictDeferred(podAutoscaler *datadoghq.DatadogPodAutoscaler, now time.Time) bool {
-	if podAutoscaler.Spec.ApplyPolicy == nil || podAutoscaler.Spec.ApplyPolicy.Update == nil {
-		return false
-	}
-	period := podAutoscaler.Spec.ApplyPolicy.Update.ResizePendingPeriod
-	if period <= 0 {
-		return false
-	}
-	if podAutoscaler.Status.Vertical == nil || podAutoscaler.Status.Vertical.LastAction == nil {
-		return false
-	}
-	return now.Sub(podAutoscaler.Status.Vertical.LastAction.Time.Time) > time.Duration(period)*time.Second
-}
-
 // triggerRollout patches the target workload's pod template to trigger a rollout.
 // This is shared logic used by all workload types that support vertical scaling.
 func (u *verticalController) triggerRollout(

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical.go
@@ -182,6 +182,7 @@ func (u *verticalController) syncInternal(
 	// If this is a new recommendation, record the action (regardless of whether the patches
 	// below succeed) and reset the eviction counter for this cycle.
 	var toEvictOnPatchFailure []classifiedPod
+	var patchForbidden bool
 	if needsPatch := podsByResizeStatus[PodResizeStatusNeedsPatch]; len(needsPatch) > 0 {
 		lastAction := autoscalerInternal.VerticalLastAction()
 		if lastAction == nil || lastAction.Version != recommendationID {
@@ -199,6 +200,9 @@ func (u *verticalController) syncInternal(
 					// Pod is already gone; the pod watcher hasn't caught up yet. Skip eviction.
 					log.Debugf("pod %s/%s not found during resize patch, likely already evicted: %v", cp.pod.Namespace, cp.pod.Name, err)
 					continue
+				}
+				if k8serrors.IsForbidden(err) {
+					patchForbidden = true
 				}
 				log.Warnf("failed to patch pod %s/%s in place: %v", cp.pod.Namespace, cp.pod.Name, err)
 				toEvictOnPatchFailure = append(toEvictOnPatchFailure, cp)
@@ -219,10 +223,15 @@ func (u *verticalController) syncInternal(
 		}
 	}
 
-	// If any pod has been stuck in an unresolvable state for longer than RolloutFallbackDelay,
-	// escalate to a full rollout rather than continuing to attempt evictions.
-	if shouldFallbackToRollout(toEvict, podAutoscaler, now) {
-		log.Infof("In-place resize fallback: pods stuck too long, triggering rollout for autoscaler %s", autoscalerInternal.ID())
+	// If the resize patch was rejected as forbidden (e.g. RBAC missing for
+	// pods/resize), or any pod has been stuck in an unresolvable state for longer
+	// than RolloutFallbackDelay, escalate to a full rollout.
+	if shouldFallbackToRollout(toEvict, podAutoscaler, now, patchForbidden) {
+		if patchForbidden {
+			log.Infof("In-place resize fallback: pods/resize patch forbidden, triggering rollout for autoscaler %s", autoscalerInternal.ID())
+		} else {
+			log.Infof("In-place resize fallback: pods stuck too long, triggering rollout for autoscaler %s", autoscalerInternal.ID())
+		}
 		return u.triggerRollout(ctx, podAutoscaler, autoscalerInternal, target, targetGVK, recommendationID)
 	}
 

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	workloadpatcher "github.com/DataDog/datadog-agent/pkg/clusteragent/patcher"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -503,14 +504,20 @@ func shouldFallbackToRollout(toEvict []classifiedPod, podAutoscaler *datadoghq.D
 }
 
 // isRolloutRequired checks if a rollout is required for the podAutoscaler.
-// The default mode is in-place (Auto); only an explicit TriggerRollout mode forces a rollout.
+// In-place scaling requires both the global config flag
+// (autoscaling.workload.in_place_vertical_scaling.enabled) AND an explicit
+// ApplyPolicy.Update.Mode of "Auto" on the DPA. All other cases use rollout.
 func isRolloutRequired(autoscalerInternal *model.PodAutoscalerInternal) bool {
-	spec := autoscalerInternal.Spec()
-	if spec == nil || spec.ApplyPolicy == nil || spec.ApplyPolicy.Update == nil {
-		return false
+	if !pkgconfigsetup.Datadog().GetBool("autoscaling.workload.in_place_vertical_scaling.enabled") {
+		return true
 	}
 
-	return spec.ApplyPolicy.Update.Mode == datadoghqcommon.DatadogPodAutoscalerTriggerRolloutMode
+	spec := autoscalerInternal.Spec()
+	if spec == nil || spec.ApplyPolicy == nil || spec.ApplyPolicy.Update == nil {
+		return true
+	}
+
+	return spec.ApplyPolicy.Update.Mode != datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode
 }
 
 // getPodResizeStatus returns the resize status of pod and the LastTransitionTime

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -31,6 +31,12 @@ const (
 	// for StatefulSets and DaemonSets. This is managed by Kubernetes itself and changes whenever
 	// any part of the pod template changes.
 	controllerRevisionHashLabel = "controller-revision-hash"
+
+	// defaultResizePendingPeriod is the default delay for the resize pending period in seconds
+	defaultResizePendingPeriod int32 = 600
+
+	// defaultRolloutFallbackDelay is the default delay for the rollout fallback in seconds
+	defaultRolloutFallbackDelay int32 = 1200
 )
 
 const inPlaceResizeSupportedCacheTTL = 15 * time.Minute
@@ -483,6 +489,21 @@ func clampResourceList(rl corev1.ResourceList, minAllowed, maxAllowed corev1.Res
 	return modified
 }
 
+// shouldEvictDeferred returns true if the time since the last action is greater than the resize pending period, false otherwise
+func shouldEvictDeferred(podAutoscaler *datadoghq.DatadogPodAutoscaler, now time.Time) bool {
+	var period = defaultResizePendingPeriod
+	// If the DPA has a configured resize pending period, use that instead of the default
+	if podAutoscaler.Spec.ApplyPolicy != nil && podAutoscaler.Spec.ApplyPolicy.Update != nil && podAutoscaler.Spec.ApplyPolicy.Update.ResizePendingPeriod > 0 {
+		period = podAutoscaler.Spec.ApplyPolicy.Update.ResizePendingPeriod
+	}
+
+	if podAutoscaler.Status.Vertical == nil || podAutoscaler.Status.Vertical.LastAction == nil {
+		return false
+	}
+
+	return now.Sub(podAutoscaler.Status.Vertical.LastAction.Time.Time) > time.Duration(period)*time.Second
+}
+
 // shouldFallbackToRollout returns true if a rollout should be triggered instead
 // of continuing to attempt in-place resizing
 func shouldFallbackToRollout(toEvict []classifiedPod, podAutoscaler *datadoghq.DatadogPodAutoscaler, now time.Time, patchForbidden bool) bool {
@@ -490,13 +511,12 @@ func shouldFallbackToRollout(toEvict []classifiedPod, podAutoscaler *datadoghq.D
 		return true
 	}
 
-	if podAutoscaler.Spec.ApplyPolicy == nil || podAutoscaler.Spec.ApplyPolicy.Update == nil {
-		return false
+	var delay = defaultRolloutFallbackDelay
+	// If the DPA has a configured rollout fallback delay, use that instead of the default
+	if podAutoscaler.Spec.ApplyPolicy != nil && podAutoscaler.Spec.ApplyPolicy.Update != nil && podAutoscaler.Spec.ApplyPolicy.Update.RolloutFallbackDelay > 0 {
+		delay = podAutoscaler.Spec.ApplyPolicy.Update.RolloutFallbackDelay
 	}
-	delay := podAutoscaler.Spec.ApplyPolicy.Update.RolloutFallbackDelay
-	if delay <= 0 {
-		return false
-	}
+
 	threshold := time.Duration(delay) * time.Second
 	for _, cp := range toEvict {
 		if !cp.lastTransitionTime.IsZero() && now.Sub(cp.lastTransitionTime) > threshold {
@@ -507,20 +527,19 @@ func shouldFallbackToRollout(toEvict []classifiedPod, podAutoscaler *datadoghq.D
 }
 
 // isRolloutRequired checks if a rollout is required for the podAutoscaler.
-// In-place scaling requires both the global config flag
-// (autoscaling.workload.in_place_vertical_scaling.enabled) AND an explicit
-// ApplyPolicy.Update.Strategy of "Auto" on the DPA. All other cases use rollout.
+// A rollout is required when:
+//
+//	a) The global config flag (autoscaling.workload.in_place_vertical_scaling.enabled) is disabled, or
+//	b) The DPA explicitly sets Strategy: TriggerRollout
 func isRolloutRequired(autoscalerInternal *model.PodAutoscalerInternal) bool {
 	if !pkgconfigsetup.Datadog().GetBool("autoscaling.workload.in_place_vertical_scaling.enabled") {
 		return true
 	}
-
 	spec := autoscalerInternal.Spec()
 	if spec == nil || spec.ApplyPolicy == nil || spec.ApplyPolicy.Update == nil {
-		return true
+		return false
 	}
-
-	return spec.ApplyPolicy.Update.Strategy != datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy
+	return spec.ApplyPolicy.Update.Strategy == datadoghqcommon.DatadogPodAutoscalerTriggerRolloutUpdateStrategy
 }
 
 // getPodResizeStatus returns the resize status of pod and the LastTransitionTime

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -196,7 +196,7 @@ func shouldTriggerRollout(
 	}
 
 	// Step 2: Check if we already triggered a rollout for THIS recommendation
-	if lastAction != nil && lastAction.Version == recommendationID {
+	if lastAction != nil && lastAction.Type == datadoghqcommon.DatadogPodAutoscalerRolloutTriggeredVerticalActionType && lastAction.Version == recommendationID {
 		log.Debugf("Rollout already triggered for recommendation %s on autoscaler %s, waiting for completion",
 			recommendationID, autoscalerID)
 		return rolloutDecisionWait
@@ -483,10 +483,13 @@ func clampResourceList(rl corev1.ResourceList, minAllowed, maxAllowed corev1.Res
 	return modified
 }
 
-// shouldFallbackToRollout returns true if any pod in toEvict has been stuck in its
-// unresolvable state longer than RolloutFallbackDelay seconds, indicating that
-// eviction is not making progress and a full rollout should be triggered instead.
-func shouldFallbackToRollout(toEvict []classifiedPod, podAutoscaler *datadoghq.DatadogPodAutoscaler, now time.Time) bool {
+// shouldFallbackToRollout returns true if a rollout should be triggered instead
+// of continuing to attempt in-place resizing
+func shouldFallbackToRollout(toEvict []classifiedPod, podAutoscaler *datadoghq.DatadogPodAutoscaler, now time.Time, patchForbidden bool) bool {
+	if patchForbidden {
+		return true
+	}
+
 	if podAutoscaler.Spec.ApplyPolicy == nil || podAutoscaler.Spec.ApplyPolicy.Update == nil {
 		return false
 	}

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -509,7 +509,7 @@ func shouldFallbackToRollout(toEvict []classifiedPod, podAutoscaler *datadoghq.D
 // isRolloutRequired checks if a rollout is required for the podAutoscaler.
 // In-place scaling requires both the global config flag
 // (autoscaling.workload.in_place_vertical_scaling.enabled) AND an explicit
-// ApplyPolicy.Update.Mode of "Auto" on the DPA. All other cases use rollout.
+// ApplyPolicy.Update.Strategy of "Auto" on the DPA. All other cases use rollout.
 func isRolloutRequired(autoscalerInternal *model.PodAutoscalerInternal) bool {
 	if !pkgconfigsetup.Datadog().GetBool("autoscaling.workload.in_place_vertical_scaling.enabled") {
 		return true
@@ -520,7 +520,7 @@ func isRolloutRequired(autoscalerInternal *model.PodAutoscalerInternal) bool {
 		return true
 	}
 
-	return spec.ApplyPolicy.Update.Mode != datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode
+	return spec.ApplyPolicy.Update.Strategy != datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy
 }
 
 // getPodResizeStatus returns the resize status of pod and the LastTransitionTime

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
@@ -161,10 +161,11 @@ func TestShouldTriggerRollout_AlreadyTriggered(t *testing.T) {
 	}
 	podsPerRecommendationID := map[string]int32{"old-rec": 1, recommendationID: 0}
 
-	// Last action was for THIS recommendation
+	// Last action was a rollout for THIS recommendation
 	lastAction := &datadoghqcommon.DatadogPodAutoscalerVerticalAction{
 		Time:    metav1.NewTime(time.Now().Add(-1 * time.Minute)),
 		Version: recommendationID,
+		Type:    datadoghqcommon.DatadogPodAutoscalerRolloutTriggeredVerticalActionType,
 	}
 
 	decision := shouldTriggerRollout(

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
@@ -650,8 +650,8 @@ func interceptEvictions(k8sClient *k8sfake.Clientset) {
 }
 
 // buildInPlacePAI builds a PodAutoscalerInternal for in-place mode tests.
-// mode controls ApplyPolicy.Update.Mode; use "" (empty) for in-place (non-TriggerRollout).
-func buildInPlacePAI(ns, name string, sv *model.VerticalScalingValues, mode datadoghqcommon.DatadogPodAutoscalerUpdateMode) model.PodAutoscalerInternal {
+// strategy controls ApplyPolicy.Update.Strategy; use "" (empty) for in-place (non-TriggerRollout).
+func buildInPlacePAI(ns, name string, sv *model.VerticalScalingValues, strategy datadoghqcommon.DatadogPodAutoscalerUpdateStrategy) model.PodAutoscalerInternal {
 	return (&model.FakePodAutoscalerInternal{
 		Namespace: ns,
 		Name:      name,
@@ -659,7 +659,7 @@ func buildInPlacePAI(ns, name string, sv *model.VerticalScalingValues, mode data
 			TargetRef: v2.CrossVersionObjectReference{Name: "target", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
 			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
-					Mode: mode,
+					Strategy: strategy,
 				},
 			},
 		},
@@ -707,7 +707,7 @@ func (f *verticalControllerFixture) runSyncInPlaceMode(t *testing.T, dpa *datado
 	if sv == nil {
 		sv = scalingValWithRequests(recommendationID, "500m")
 	}
-	// Config enabled + Mode: Auto -> in-place path.
+	// Config enabled + Strategy: Auto -> in-place path.
 	ai := (&model.FakePodAutoscalerInternal{
 		Namespace:     "default",
 		Name:          "ai",
@@ -715,7 +715,7 @@ func (f *verticalControllerFixture) runSyncInPlaceMode(t *testing.T, dpa *datado
 		Spec: &datadoghq.DatadogPodAutoscalerSpec{
 			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
-					Mode: datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode,
+					Strategy: datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
 				},
 			},
 		},
@@ -988,10 +988,10 @@ func TestSyncInternal_InPlace_NoFallback_WhenDelayZero(t *testing.T) {
 	assert.Equal(t, 1, countEvictions(t, k8sClient.Actions()))
 }
 
-// TestSyncInternal_TriggerRolloutMode_UsesRolloutPath verifies that when
-// ApplyPolicy.Update.Mode is TriggerRollout, syncInternal patches the workload
+// TestSyncInternal_TriggerRolloutStrategy_UsesRolloutPath verifies that when
+// ApplyPolicy.Update.Strategy is TriggerRollout, syncInternal patches the workload
 // (rollout path) rather than individual pods.
-func TestSyncInternal_TriggerRolloutMode_UsesRolloutPath(t *testing.T) {
+func TestSyncInternal_TriggerRolloutStrategy_UsesRolloutPath(t *testing.T) {
 	f := newVerticalControllerFixture(t, time.Now())
 	f.createTarget("default", "d1", kubernetes.DeploymentKind)
 
@@ -1014,7 +1014,7 @@ func TestSyncInternal_TriggerRolloutMode_UsesRolloutPath(t *testing.T) {
 			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
 			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
-					Mode: datadoghqcommon.DatadogPodAutoscalerTriggerRolloutMode,
+					Strategy: datadoghqcommon.DatadogPodAutoscalerTriggerRolloutUpdateStrategy,
 				},
 			},
 		},
@@ -1074,9 +1074,9 @@ func TestSyncInternal_ConfigDisabled_NoApplyPolicy_UsesRolloutPath(t *testing.T)
 	assert.True(t, workloadPatched, "Config disabled + no ApplyPolicy must use rollout path")
 }
 
-// TestSyncInternal_ConfigDisabled_AutoMode_UsesRolloutPath verifies that with the
-// config flag disabled, even a DPA with Mode: Auto still uses the rollout path.
-func TestSyncInternal_ConfigDisabled_AutoMode_UsesRolloutPath(t *testing.T) {
+// TestSyncInternal_ConfigDisabled_AutoStrategy_UsesRolloutPath verifies that with the
+// config flag disabled, even a DPA with Strategy: Auto still uses the rollout path.
+func TestSyncInternal_ConfigDisabled_AutoStrategy_UsesRolloutPath(t *testing.T) {
 	// Config flag defaults to false — do not set it.
 	f := newVerticalControllerFixture(t, time.Now())
 	f.createTarget("default", "d1", kubernetes.DeploymentKind)
@@ -1092,7 +1092,7 @@ func TestSyncInternal_ConfigDisabled_AutoMode_UsesRolloutPath(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
 	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
 
-	// Mode: Auto but config disabled -> rollout.
+	// Strategy: Auto but config disabled -> rollout.
 	ai := (&model.FakePodAutoscalerInternal{
 		Namespace: "default",
 		Name:      "ai",
@@ -1101,7 +1101,7 @@ func TestSyncInternal_ConfigDisabled_AutoMode_UsesRolloutPath(t *testing.T) {
 			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
 			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
-					Mode: datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode,
+					Strategy: datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
 				},
 			},
 		},
@@ -1117,7 +1117,7 @@ func TestSyncInternal_ConfigDisabled_AutoMode_UsesRolloutPath(t *testing.T) {
 		buildPodsByResizeStatus(pods, "r1"),
 	)
 	assert.NoError(t, err)
-	assert.True(t, workloadPatched, "Config disabled + Mode: Auto must still use rollout path")
+	assert.True(t, workloadPatched, "Config disabled + Strategy: Auto must still use rollout path")
 }
 
 // TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath verifies that with the
@@ -1163,9 +1163,9 @@ func TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath(t *testing.T)
 	assert.True(t, workloadPatched, "Config enabled but no ApplyPolicy must use rollout path")
 }
 
-// TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath verifies that in-place scaling
-// is used only when the config flag is enabled AND the DPA explicitly sets Mode: Auto.
-func TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath(t *testing.T) {
+// TestSyncInternal_InPlaceEnabled_AutoStrategy_UsesInPlacePath verifies that in-place scaling
+// is used only when the config flag is enabled AND the DPA explicitly sets Strategy: Auto.
+func TestSyncInternal_InPlaceEnabled_AutoStrategy_UsesInPlacePath(t *testing.T) {
 	pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", true)
 	defer pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", false)
 
@@ -1180,7 +1180,7 @@ func TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
 	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
 
-	// Config enabled + Mode: Auto -> in-place path.
+	// Config enabled + Strategy: Auto -> in-place path.
 	ai := (&model.FakePodAutoscalerInternal{
 		Namespace: "default",
 		Name:      "ai",
@@ -1189,7 +1189,7 @@ func TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath(t *testing.T) {
 			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
 			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
 				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
-					Mode: datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode,
+					Strategy: datadoghqcommon.DatadogPodAutoscalerAutoUpdateStrategy,
 				},
 			},
 		},
@@ -1206,5 +1206,5 @@ func TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath(t *testing.T) {
 		buildPodsByResizeStatus(pods, "r1"),
 	)
 	assert.NoError(t, err)
-	assert.False(t, workloadPatched, "Config enabled + Mode: Auto must use in-place path, not rollout")
+	assert.False(t, workloadPatched, "Config enabled + Strategy: Auto must use in-place path, not rollout")
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
@@ -1033,51 +1033,6 @@ func TestSyncInternal_TriggerRolloutMode_UsesRolloutPath(t *testing.T) {
 	assert.True(t, workloadPatched, "TriggerRollout mode must patch the workload, not pods")
 }
 
-// TestSyncInternal_DefaultConfig_UsesRolloutPath verifies that a DPA with no ApplyPolicy
-// uses the rollout path when in_place_vertical_scaling is disabled (default).
-func TestSyncInternal_DefaultConfig_UsesRolloutPath(t *testing.T) {
-	f := newVerticalControllerFixture(t, time.Now())
-	f.createTarget("default", "d1", kubernetes.DeploymentKind)
-
-	workloadPatched := false
-	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		workloadPatched = true
-		return true, &unstructured.Unstructured{Object: map[string]any{
-			"metadata": map[string]any{"name": "d1", "namespace": "default"},
-		}}, nil
-	})
-
-	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
-	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
-
-	// DPA sets Mode: Auto, but the config flag is off -> rollout path.
-	ai := (&model.FakePodAutoscalerInternal{
-		Namespace: "default",
-		Name:      "ai",
-		TargetGVK: gvk,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
-			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
-				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
-					Mode: datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode,
-				},
-			},
-		},
-		ScalingValues: model.ScalingValues{Vertical: scalingValWithRequests("r1", "500m")},
-	}).Build()
-
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"}}
-	pods := []*workloadmeta.KubernetesPod{pod("p1", "old", kubernetes.ReplicaSetKind, "rs1")}
-
-	_, err := f.controller.syncInternal(
-		context.Background(), fakeAutoscaler, &ai, target, gvk, "r1",
-		pods, map[string]int32{"old": 1}, map[string]int32{"rs1": 1},
-		buildPodsByResizeStatus(pods, "r1"),
-	)
-	assert.NoError(t, err)
-	assert.True(t, workloadPatched, "Mode: Auto with config disabled must still use rollout path")
-}
-
 // TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath verifies that in-place scaling
 // is used only when the config flag is enabled AND the DPA explicitly sets Mode: Auto.
 func TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath(t *testing.T) {
@@ -1122,47 +1077,4 @@ func TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.False(t, workloadPatched, "Config enabled + Mode: Auto must use in-place path, not rollout")
-}
-
-// TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath verifies that even with
-// the config flag enabled, a DPA without an explicit Mode: Auto still uses rollout.
-func TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath(t *testing.T) {
-	pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", true)
-	defer pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", false)
-
-	f := newVerticalControllerFixture(t, time.Now())
-	f.createTarget("default", "d1", kubernetes.DeploymentKind)
-
-	workloadPatched := false
-	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		workloadPatched = true
-		return true, &unstructured.Unstructured{Object: map[string]any{
-			"metadata": map[string]any{"name": "d1", "namespace": "default"},
-		}}, nil
-	})
-
-	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
-	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
-
-	// Config enabled but no ApplyPolicy -> rollout path.
-	ai := (&model.FakePodAutoscalerInternal{
-		Namespace: "default",
-		Name:      "ai",
-		TargetGVK: gvk,
-		Spec: &datadoghq.DatadogPodAutoscalerSpec{
-			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
-		},
-		ScalingValues: model.ScalingValues{Vertical: scalingValWithRequests("r1", "500m")},
-	}).Build()
-
-	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"}}
-	pods := []*workloadmeta.KubernetesPod{pod("p1", "old", kubernetes.ReplicaSetKind, "rs1")}
-
-	_, err := f.controller.syncInternal(
-		context.Background(), fakeAutoscaler, &ai, target, gvk, "r1",
-		pods, map[string]int32{"old": 1}, map[string]int32{"rs1": 1},
-		buildPodsByResizeStatus(pods, "r1"),
-	)
-	assert.NoError(t, err)
-	assert.True(t, workloadPatched, "Config enabled but no ApplyPolicy must use rollout path")
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
@@ -1033,6 +1033,136 @@ func TestSyncInternal_TriggerRolloutMode_UsesRolloutPath(t *testing.T) {
 	assert.True(t, workloadPatched, "TriggerRollout mode must patch the workload, not pods")
 }
 
+// TestSyncInternal_ConfigDisabled_NoApplyPolicy_UsesRolloutPath verifies that with the
+// config flag disabled (default) and no ApplyPolicy on the DPA, the rollout path is used.
+func TestSyncInternal_ConfigDisabled_NoApplyPolicy_UsesRolloutPath(t *testing.T) {
+	// Config flag defaults to false — do not set it.
+	f := newVerticalControllerFixture(t, time.Now())
+	f.createTarget("default", "d1", kubernetes.DeploymentKind)
+
+	workloadPatched := false
+	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		workloadPatched = true
+		return true, &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "d1", "namespace": "default"},
+		}}, nil
+	})
+
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
+	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
+
+	// No ApplyPolicy, config disabled -> rollout.
+	ai := (&model.FakePodAutoscalerInternal{
+		Namespace: "default",
+		Name:      "ai",
+		TargetGVK: gvk,
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
+		},
+		ScalingValues: model.ScalingValues{Vertical: scalingValWithRequests("r1", "500m")},
+	}).Build()
+
+	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"}}
+	pods := []*workloadmeta.KubernetesPod{pod("p1", "old", kubernetes.ReplicaSetKind, "rs1")}
+
+	_, err := f.controller.syncInternal(
+		context.Background(), fakeAutoscaler, &ai, target, gvk, "r1",
+		pods, map[string]int32{"old": 1}, map[string]int32{"rs1": 1},
+		buildPodsByResizeStatus(pods, "r1"),
+	)
+	assert.NoError(t, err)
+	assert.True(t, workloadPatched, "Config disabled + no ApplyPolicy must use rollout path")
+}
+
+// TestSyncInternal_ConfigDisabled_AutoMode_UsesRolloutPath verifies that with the
+// config flag disabled, even a DPA with Mode: Auto still uses the rollout path.
+func TestSyncInternal_ConfigDisabled_AutoMode_UsesRolloutPath(t *testing.T) {
+	// Config flag defaults to false — do not set it.
+	f := newVerticalControllerFixture(t, time.Now())
+	f.createTarget("default", "d1", kubernetes.DeploymentKind)
+
+	workloadPatched := false
+	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		workloadPatched = true
+		return true, &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "d1", "namespace": "default"},
+		}}, nil
+	})
+
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
+	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
+
+	// Mode: Auto but config disabled -> rollout.
+	ai := (&model.FakePodAutoscalerInternal{
+		Namespace: "default",
+		Name:      "ai",
+		TargetGVK: gvk,
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
+					Mode: datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode,
+				},
+			},
+		},
+		ScalingValues: model.ScalingValues{Vertical: scalingValWithRequests("r1", "500m")},
+	}).Build()
+
+	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"}}
+	pods := []*workloadmeta.KubernetesPod{pod("p1", "old", kubernetes.ReplicaSetKind, "rs1")}
+
+	_, err := f.controller.syncInternal(
+		context.Background(), fakeAutoscaler, &ai, target, gvk, "r1",
+		pods, map[string]int32{"old": 1}, map[string]int32{"rs1": 1},
+		buildPodsByResizeStatus(pods, "r1"),
+	)
+	assert.NoError(t, err)
+	assert.True(t, workloadPatched, "Config disabled + Mode: Auto must still use rollout path")
+}
+
+// TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath verifies that with the
+// config flag enabled but no ApplyPolicy on the DPA, the rollout path is still used.
+func TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath(t *testing.T) {
+	pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", true)
+	defer pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", false)
+
+	f := newVerticalControllerFixture(t, time.Now())
+	f.createTarget("default", "d1", kubernetes.DeploymentKind)
+
+	workloadPatched := false
+	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		workloadPatched = true
+		return true, &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "d1", "namespace": "default"},
+		}}, nil
+	})
+
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
+	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
+
+	// Config enabled but no ApplyPolicy -> rollout.
+	ai := (&model.FakePodAutoscalerInternal{
+		Namespace: "default",
+		Name:      "ai",
+		TargetGVK: gvk,
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
+		},
+		ScalingValues: model.ScalingValues{Vertical: scalingValWithRequests("r1", "500m")},
+	}).Build()
+
+	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"}}
+	pods := []*workloadmeta.KubernetesPod{pod("p1", "old", kubernetes.ReplicaSetKind, "rs1")}
+
+	_, err := f.controller.syncInternal(
+		context.Background(), fakeAutoscaler, &ai, target, gvk, "r1",
+		pods, map[string]int32{"old": 1}, map[string]int32{"rs1": 1},
+		buildPodsByResizeStatus(pods, "r1"),
+	)
+	assert.NoError(t, err)
+	assert.True(t, workloadPatched, "Config enabled but no ApplyPolicy must use rollout path")
+}
+
 // TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath verifies that in-place scaling
 // is used only when the config flag is enabled AND the DPA explicitly sets Mode: Auto.
 func TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath(t *testing.T) {

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling/workload/model"
 	workloadpatcher "github.com/DataDog/datadog-agent/pkg/clusteragent/patcher"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 
@@ -691,20 +692,33 @@ func TestPatchInPlace_NeedsPatch_PatchesResources(t *testing.T) {
 	assert.Equal(t, 2, patchCallCount, "expected resize patch + annotation patch for pod needing update")
 }
 
-// runSyncInPlaceMode runs syncInternal against a deployment target using the in-place path
+// runSyncInPlaceMode runs syncInternal against a deployment target using the in-place path.
+// It enables the in_place_vertical_scaling config and sets Mode: Auto on the DPA.
 func (f *verticalControllerFixture) runSyncInPlaceMode(t *testing.T, dpa *datadoghq.DatadogPodAutoscaler, sv *model.VerticalScalingValues, recommendationID string, pods []*workloadmeta.KubernetesPod) (autoscaling.ProcessResult, error) {
 	t.Helper()
+	pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", true)
+	t.Cleanup(func() {
+		pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", false)
+	})
+
 	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
 	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "target"}
 
 	if sv == nil {
 		sv = scalingValWithRequests(recommendationID, "500m")
 	}
-	// No ApplyPolicy -> isRolloutRequired returns false -> in-place path.
+	// Config enabled + Mode: Auto -> in-place path.
 	ai := (&model.FakePodAutoscalerInternal{
 		Namespace:     "default",
 		Name:          "ai",
 		ScalingValues: model.ScalingValues{Vertical: sv},
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
+					Mode: datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode,
+				},
+			},
+		},
 	}).Build()
 
 	if dpa == nil {
@@ -1019,9 +1033,57 @@ func TestSyncInternal_TriggerRolloutMode_UsesRolloutPath(t *testing.T) {
 	assert.True(t, workloadPatched, "TriggerRollout mode must patch the workload, not pods")
 }
 
-// TestSyncInternal_DefaultMode_UsesInPlacePath verifies that a DPA with no ApplyPolicy
-// (the default) uses the in-place path and does NOT trigger a workload rollout.
-func TestSyncInternal_DefaultMode_UsesInPlacePath(t *testing.T) {
+// TestSyncInternal_DefaultConfig_UsesRolloutPath verifies that a DPA with no ApplyPolicy
+// uses the rollout path when in_place_vertical_scaling is disabled (default).
+func TestSyncInternal_DefaultConfig_UsesRolloutPath(t *testing.T) {
+	f := newVerticalControllerFixture(t, time.Now())
+	f.createTarget("default", "d1", kubernetes.DeploymentKind)
+
+	workloadPatched := false
+	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		workloadPatched = true
+		return true, &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "d1", "namespace": "default"},
+		}}, nil
+	})
+
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
+	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
+
+	// DPA sets Mode: Auto, but the config flag is off -> rollout path.
+	ai := (&model.FakePodAutoscalerInternal{
+		Namespace: "default",
+		Name:      "ai",
+		TargetGVK: gvk,
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
+					Mode: datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode,
+				},
+			},
+		},
+		ScalingValues: model.ScalingValues{Vertical: scalingValWithRequests("r1", "500m")},
+	}).Build()
+
+	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"}}
+	pods := []*workloadmeta.KubernetesPod{pod("p1", "old", kubernetes.ReplicaSetKind, "rs1")}
+
+	_, err := f.controller.syncInternal(
+		context.Background(), fakeAutoscaler, &ai, target, gvk, "r1",
+		pods, map[string]int32{"old": 1}, map[string]int32{"rs1": 1},
+		buildPodsByResizeStatus(pods, "r1"),
+	)
+	assert.NoError(t, err)
+	assert.True(t, workloadPatched, "Mode: Auto with config disabled must still use rollout path")
+}
+
+// TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath verifies that in-place scaling
+// is used only when the config flag is enabled AND the DPA explicitly sets Mode: Auto.
+func TestSyncInternal_InPlaceEnabled_AutoMode_UsesInPlacePath(t *testing.T) {
+	pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", true)
+	defer pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", false)
+
 	f := newVerticalControllerFixture(t, time.Now())
 
 	workloadPatched := false
@@ -1033,13 +1095,18 @@ func TestSyncInternal_DefaultMode_UsesInPlacePath(t *testing.T) {
 	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
 	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
 
-	// No ApplyPolicy at all -> isRolloutRequired returns false -> in-place path.
+	// Config enabled + Mode: Auto -> in-place path.
 	ai := (&model.FakePodAutoscalerInternal{
 		Namespace: "default",
 		Name:      "ai",
 		TargetGVK: gvk,
 		Spec: &datadoghq.DatadogPodAutoscalerSpec{
 			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
+			ApplyPolicy: &datadoghq.DatadogPodAutoscalerApplyPolicy{
+				Update: &datadoghqcommon.DatadogPodAutoscalerUpdatePolicy{
+					Mode: datadoghqcommon.DatadogPodAutoscalerAutoUpdateMode,
+				},
+			},
 		},
 		ScalingValues: model.ScalingValues{Vertical: scalingValWithRequests("r1", "500m")},
 	}).Build()
@@ -1054,5 +1121,48 @@ func TestSyncInternal_DefaultMode_UsesInPlacePath(t *testing.T) {
 		buildPodsByResizeStatus(pods, "r1"),
 	)
 	assert.NoError(t, err)
-	assert.False(t, workloadPatched, "nil ApplyPolicy (default) must use in-place path, not rollout")
+	assert.False(t, workloadPatched, "Config enabled + Mode: Auto must use in-place path, not rollout")
+}
+
+// TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath verifies that even with
+// the config flag enabled, a DPA without an explicit Mode: Auto still uses rollout.
+func TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath(t *testing.T) {
+	pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", true)
+	defer pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", false)
+
+	f := newVerticalControllerFixture(t, time.Now())
+	f.createTarget("default", "d1", kubernetes.DeploymentKind)
+
+	workloadPatched := false
+	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
+		workloadPatched = true
+		return true, &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"name": "d1", "namespace": "default"},
+		}}, nil
+	})
+
+	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
+	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
+
+	// Config enabled but no ApplyPolicy -> rollout path.
+	ai := (&model.FakePodAutoscalerInternal{
+		Namespace: "default",
+		Name:      "ai",
+		TargetGVK: gvk,
+		Spec: &datadoghq.DatadogPodAutoscalerSpec{
+			TargetRef: v2.CrossVersionObjectReference{Name: "d1", Kind: kubernetes.DeploymentKind, APIVersion: "apps/v1"},
+		},
+		ScalingValues: model.ScalingValues{Vertical: scalingValWithRequests("r1", "500m")},
+	}).Build()
+
+	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"}}
+	pods := []*workloadmeta.KubernetesPod{pod("p1", "old", kubernetes.ReplicaSetKind, "rs1")}
+
+	_, err := f.controller.syncInternal(
+		context.Background(), fakeAutoscaler, &ai, target, gvk, "r1",
+		pods, map[string]int32{"old": 1}, map[string]int32{"rs1": 1},
+		buildPodsByResizeStatus(pods, "r1"),
+	)
+	assert.NoError(t, err)
+	assert.True(t, workloadPatched, "Config enabled but no ApplyPolicy must use rollout path")
 }

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_test.go
@@ -961,33 +961,6 @@ func TestSyncInternal_InPlace_NoFallback_WhenNotStuckLongEnough(t *testing.T) {
 	assert.Equal(t, 1, countEvictions(t, k8sClient.Actions()), "eviction must proceed when under the fallback threshold")
 }
 
-// TestSyncInternal_InPlace_NoFallback_WhenDelayZero verifies that RolloutFallbackDelay=0
-// (disabled) never triggers the rollout fallback, even for a long-stuck pod.
-func TestSyncInternal_InPlace_NoFallback_WhenDelayZero(t *testing.T) {
-	now := time.Now()
-	f := newVerticalControllerFixture(t, now)
-	k8sClient := f.attachK8sClient()
-	interceptEvictions(k8sClient)
-
-	workloadPatched := false
-	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
-		workloadPatched = true
-		return true, &unstructured.Unstructured{}, nil
-	})
-
-	stuckSince := now.Add(-24 * time.Hour)
-	pods := []*workloadmeta.KubernetesPod{
-		podWithResizeConditionAt("p1", "r1", kubernetes.ReplicaSetKind, "rs1",
-			kubePodConditionResizePending, kubePodConditionResizePendingReasonInfeasible, stuckSince),
-	}
-	dpa := makeDPAWithFallbackDelay("default", "ai", 0) // disabled
-
-	_, err := f.runSyncInPlaceMode(t, dpa, nil, "r1", pods)
-	assert.NoError(t, err)
-	assert.False(t, workloadPatched, "rollout fallback must not trigger when RolloutFallbackDelay is 0")
-	assert.Equal(t, 1, countEvictions(t, k8sClient.Actions()))
-}
-
 // TestSyncInternal_TriggerRolloutStrategy_UsesRolloutPath verifies that when
 // ApplyPolicy.Update.Strategy is TriggerRollout, syncInternal patches the workload
 // (rollout path) rather than individual pods.
@@ -1120,27 +1093,23 @@ func TestSyncInternal_ConfigDisabled_AutoStrategy_UsesRolloutPath(t *testing.T) 
 	assert.True(t, workloadPatched, "Config disabled + Strategy: Auto must still use rollout path")
 }
 
-// TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath verifies that with the
-// config flag enabled but no ApplyPolicy on the DPA, the rollout path is still used.
-func TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath(t *testing.T) {
+// TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesInPlacePath verifies that with the
+// config flag enabled and no ApplyPolicy on the DPA, in-place is used (Auto strategy is assumed).
+func TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesInPlacePath(t *testing.T) {
 	pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", true)
 	defer pkgconfigsetup.Datadog().SetWithoutSource("autoscaling.workload.in_place_vertical_scaling.enabled", false)
 
 	f := newVerticalControllerFixture(t, time.Now())
-	f.createTarget("default", "d1", kubernetes.DeploymentKind)
 
 	workloadPatched := false
 	f.dynamicClient.PrependReactor("patch", "deployments", func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		workloadPatched = true
-		return true, &unstructured.Unstructured{Object: map[string]any{
-			"metadata": map[string]any{"name": "d1", "namespace": "default"},
-		}}, nil
+		return true, &unstructured.Unstructured{}, nil
 	})
 
 	gvk := schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: kubernetes.DeploymentKind}
 	target := NamespacedPodOwner{Namespace: "default", Kind: kubernetes.DeploymentKind, Name: "d1"}
 
-	// Config enabled but no ApplyPolicy -> rollout.
 	ai := (&model.FakePodAutoscalerInternal{
 		Namespace: "default",
 		Name:      "ai",
@@ -1152,15 +1121,15 @@ func TestSyncInternal_InPlaceEnabled_NoApplyPolicy_UsesRolloutPath(t *testing.T)
 	}).Build()
 
 	fakeAutoscaler := &datadoghq.DatadogPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "ai", Namespace: "default"}}
-	pods := []*workloadmeta.KubernetesPod{pod("p1", "old", kubernetes.ReplicaSetKind, "rs1")}
+	pods := []*workloadmeta.KubernetesPod{pod("p1", "r1", kubernetes.ReplicaSetKind, "rs1")}
 
 	_, err := f.controller.syncInternal(
 		context.Background(), fakeAutoscaler, &ai, target, gvk, "r1",
-		pods, map[string]int32{"old": 1}, map[string]int32{"rs1": 1},
+		pods, map[string]int32{"r1": 1}, map[string]int32{"rs1": 1},
 		buildPodsByResizeStatus(pods, "r1"),
 	)
 	assert.NoError(t, err)
-	assert.True(t, workloadPatched, "Config enabled but no ApplyPolicy must use rollout path")
+	assert.False(t, workloadPatched, "Config enabled + nil ApplyPolicy must use in-place path")
 }
 
 // TestSyncInternal_InPlaceEnabled_AutoStrategy_UsesInPlacePath verifies that in-place scaling

--- a/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_profile.go
+++ b/pkg/clusteragent/autoscaling/workload/model/pod_autoscaler_profile.go
@@ -16,8 +16,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 	datadoghq "github.com/DataDog/datadog-operator/api/datadoghq/v1alpha2"
+
+	"github.com/DataDog/datadog-agent/pkg/clusteragent/autoscaling"
 )
 
 const (
@@ -185,7 +186,6 @@ func (p *PodAutoscalerProfileInternal) UpdateWorkloads(workloads []NamespacedObj
 // BuildStatus constructs a DatadogPodAutoscalerClusterProfileStatus from the internal state.
 func (p *PodAutoscalerProfileInternal) BuildStatus(currentTime metav1.Time, currentStatus *datadoghq.DatadogPodAutoscalerProfileStatus) datadoghq.DatadogPodAutoscalerProfileStatus {
 	status := datadoghq.DatadogPodAutoscalerProfileStatus{
-		ObservedGeneration:    p.generation,
 		TemplateHash:          p.templateHash,
 		ControlledAutoscalers: int32(len(p.workloads)),
 	}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1250,9 +1250,6 @@ func autoscaling(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.ca_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.cert_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.key_file", "")
-	// When enabled, allows in-place vertical pod autoscaling for DatadogPodAutoscalers
-	// that explicitly set ApplyPolicy.Update.Mode to "Auto". When disabled (default),
-	// all vertical scaling uses rolling restarts regardless of the DPA's update mode.
 	config.BindEnvAndSetDefault("autoscaling.workload.in_place_vertical_scaling.enabled", false)
 	config.BindEnvAndSetDefault("autoscaling.failover.metrics", []string{"container.memory.usage", "container.cpu.usage"})
 

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1250,6 +1250,10 @@ func autoscaling(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.ca_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.cert_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.key_file", "")
+	// When enabled, allows in-place vertical pod autoscaling for DatadogPodAutoscalers
+	// that explicitly set ApplyPolicy.Update.Mode to "Auto". When disabled (default),
+	// all vertical scaling uses rolling restarts regardless of the DPA's update mode.
+	config.BindEnvAndSetDefault("autoscaling.workload.in_place_vertical_scaling.enabled", false)
 	config.BindEnvAndSetDefault("autoscaling.failover.metrics", []string{"container.memory.usage", "container.cpu.usage"})
 
 	// Cluster autoscaling product


### PR DESCRIPTION
### What does this PR do?
- Add `autoscaling.workload.in_place_vertical_scaling.enabled` config option 
  + For now, disable in-place VPA by default
- Trigger rollouts if patches are forbidden by the API server
- Fixes logic detecting when rollouts should happen

### Motivation
Solve issues that occur from having outdated RBACs or outdated CRDs installed on the cluster

### Describe how you validated your changes
First change is tested via unit tests for the four scenarios (config option x DPA option)

Second change is tested by deploying to a local cluster with a cluster agent does not have `CREATE pods/resize` permission, and it falls back to roll out. 
<img width="1393" height="644" alt="image" src="https://github.com/user-attachments/assets/d47fe574-50fe-4c55-8aea-a08f88e578a0" />

### Additional Notes
