### PR TITLE
feat(fleet): Remove FIPS guard from installer daemon

### DIFF
--- a/pkg/fleet/daemon/daemon.go
+++ b/pkg/fleet/daemon/daemon.go
@@ -27,7 +27,6 @@ import (
 	agentconfig "github.com/DataDog/datadog-agent/comp/core/config"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/client"
 	"github.com/DataDog/datadog-agent/pkg/config/utils"
-	"github.com/DataDog/datadog-agent/pkg/fips"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/bootstrap"
 	"github.com/DataDog/datadog-agent/pkg/fleet/installer/config"
@@ -355,17 +354,6 @@ func (d *daemonImpl) Start(_ context.Context) error {
 		return nil
 	}
 
-	// If FIPS is enabled, don't start the daemon
-	fipsEnabled, err := fips.Enabled()
-	if err != nil {
-		log.Warnf("Could not determine FIPS status, exiting: %v", err)
-		return nil
-	}
-	if fipsEnabled {
-		log.Info("FIPS mode is enabled, fleet daemon will not start")
-		return nil
-	}
-
 	go func() {
 		gcTicker := time.NewTicker(d.gcInterval)
 		defer gcTicker.Stop()
@@ -409,15 +397,6 @@ func (d *daemonImpl) Stop(_ context.Context) error {
 
 	// If remote updates are disabled, we don't need to stop the updater daemon background goroutine as it was never started, we return early
 	if !d.env.RemoteUpdates {
-		return d.taskDB.Close()
-	}
-
-	// Same, if FIPS is enabled, the updater daemon background goroutine was never started, we return early
-	fipsEnabled, err := fips.Enabled()
-	if err != nil {
-		log.Warnf("Could not determine FIPS status: %v", err)
-	}
-	if fipsEnabled {
 		return d.taskDB.Close()
 	}
 

--- a/releasenotes/notes/remove-fips-guard-installer-daemon-bf363f0e1a784539.yaml
+++ b/releasenotes/notes/remove-fips-guard-installer-daemon-bf363f0e1a784539.yaml
@@ -1,6 +1,5 @@
 ---
 enhancements:
   - |
-    The installer daemon no longer refuses to start in FIPS environments.
-    When Remote Configuration is explicitly enabled, the daemon now operates
-    normally regardless of FIPS mode.
+    Remote Agent Management is now enabled by default on FIPS environments
+    when Remote Configuration is explicitly enabled.

--- a/releasenotes/notes/remove-fips-guard-installer-daemon-bf363f0e1a784539.yaml
+++ b/releasenotes/notes/remove-fips-guard-installer-daemon-bf363f0e1a784539.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The installer daemon no longer refuses to start in FIPS environments.
+    When Remote Configuration is explicitly enabled, the daemon now operates
+    normally regardless of FIPS mode.

--- a/test/new-e2e/tests/installer/unix/package_agent_test.go
+++ b/test/new-e2e/tests/installer/unix/package_agent_test.go
@@ -503,7 +503,8 @@ func (s *packageAgentSuite) TestInstallFips() {
 	s.host.WaitForUnitActive(s.T(), agentUnit, traceUnit)
 	s.host.WaitForUnitExited(s.T(), 0, processUnit, dataPlaneUnit, probeUnit)
 
-	// Important: the installer daemon shouldn't start if FIPS is enabled. Remote Config will be disabled and the unit will exit with code 255.
+	// Remote Config is disabled by default for FIPS/FED agents, so the RC client fails to init and the unit exits with code 255.
+	// If remote_configuration.enabled is explicitly set to true, the daemon would start normally.
 	s.host.WaitForUnitExited(s.T(), 255, installerUnit)
 
 	state := s.host.State()


### PR DESCRIPTION
### What does this PR do?

Removes the explicit FIPS guard in the installer daemon's `Start()` and `Stop()` methods. Previously, the daemon checked `fips.Enabled()` and refused to start in FIPS environments, even when Remote Configuration was explicitly enabled. Now, the daemon lets RC availability determine whether it operates.

### Motivation

In FIPS environments where a user has explicitly set `remote_configuration.enabled: true`, the daemon should be allowed to start and operate with RC polling. The hardcoded FIPS guard was blocking this use case unnecessarily.

The existing safety net remains: without explicit RC enablement, FIPS/FED agents still have RC disabled by default (`IsRemoteConfigEnabled()` returns false), so the RC client fails to init and the daemon exits — same end result as before, just without the redundant FIPS check.

### Describe how you validated your changes

- `dda inv test --targets=./pkg/fleet/daemon/...` — all tests pass
- Reviewed the e2e test `TestInstallFips` — the assertion (exit code 255) remains correct since RC is still disabled by default for FED agents; updated the comment to reflect the new reason

### Additional Notes

- **FIPS + RC not explicitly enabled** (default): No behavioral change. RC service returns None, updater component fails to init, daemon exits with code 255.
- **FIPS + `remote_configuration.enabled: true`**: Daemon now starts and operates fully with RC polling. Previously blocked by the FIPS guard.