### PR TITLE
omnibus: provide missing --install_dir when installing dependencies

### DIFF
--- a/omnibus/config/software/datadog-agent-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-dependencies.rb
@@ -33,7 +33,7 @@ dependency 'pympler'
 dependency 'datadog-agent-integrations-py3'
 
 build do
-    command_on_repo_root "bazelisk run #{flavor_flag} -- //packages/agent/dependencies:install --destdir=#{install_dir}"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} #{flavor_flag} -- //packages/agent/dependencies:install --destdir=#{install_dir}"
 end
 
 build do

--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -31,9 +31,9 @@ build do
 
 	if linux_target?
 	    if heroku_target?
-               command_on_repo_root "bazelisk run -- //packages/agent/heroku:license_files_install --destdir=#{install_dir}"
+               command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //packages/agent/heroku:license_files_install --destdir=#{install_dir}"
             else
-               command_on_repo_root "bazelisk run -- //packages/agent/linux:license_files_install --destdir=#{install_dir}"
+               command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //packages/agent/linux:license_files_install --destdir=#{install_dir}"
             end
         end
 

--- a/omnibus/config/software/datadog-agent-installer-symlinks.rb
+++ b/omnibus/config/software/datadog-agent-installer-symlinks.rb
@@ -10,7 +10,7 @@ build do
 
   block do
     if linux_target? and install_dir == '/opt/datadog-agent'
-      command_on_repo_root "bazelisk run -- //packages/agent/linux:install --destdir='/'"
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //packages/agent/linux:install --destdir='/'"
       project.extra_package_file "/opt/datadog-packages/datadog-agent"
       project.extra_package_file "/opt/datadog-packages/run"
       # private action runner: pkg/privateactionrunner/autoconnections/conf

--- a/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3-dependencies.rb
@@ -7,14 +7,14 @@ dependency 'openssl3'
 if linux_target?
 
   build do
-    command_on_repo_root "bazelisk run -- @unixodbc//:install --destdir='#{install_dir}'"
-    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @unixodbc//:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libodbc.so" \
     " #{install_dir}/embedded/lib/libodbccr.so" \
     " #{install_dir}/embedded/lib/libodbcinst.so"
 
-    command_on_repo_root "bazelisk run -- @freetds//:install --destdir='#{install_dir}'"
-    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @freetds//:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libtdsodbc.so"
 
     unless heroku_target?
@@ -43,9 +43,9 @@ if linux_target?
           'kinit',
         ]
 
-      command_on_repo_root "bazelisk run -- //deps/msodbcsql18:install --destdir='#{install_dir}'"
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //deps/msodbcsql18:install --destdir='#{install_dir}'"
       # (TODO(agent-build): Check if we still need pc files)
-      command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
         + lib_files.map{ |l| "#{install_dir}/embedded/lib/#{l}" }.join(' ') \
         + " " \
         + bin_files.map{ |bin| "#{install_dir}/embedded/bin/#{bin}" }.join(' ') \
@@ -53,7 +53,7 @@ if linux_target?
     end
 
     # gstatus binary used by the glusterfs integration
-    command_on_repo_root "bazelisk run -- //deps/gstatus:install --destdir='#{install_dir}'"
-    command_on_repo_root "bazelisk run -- //deps/nfsiostat:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //deps/gstatus:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //deps/nfsiostat:install --destdir='#{install_dir}'"
   end
 end

--- a/omnibus/config/software/openscap.rb
+++ b/omnibus/config/software/openscap.rb
@@ -7,68 +7,68 @@ name 'openscap'
 default_version '1.4.3'
 
 build do
-  command_on_repo_root "bazelisk run -- @acl//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @acl//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libacl.so"
 
-  command_on_repo_root "bazelisk run -- @attr//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @attr//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libattr.so"
 
-  command_on_repo_root "bazelisk run -- @dbus//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @dbus//:install --destdir='#{install_dir}'"
 
-  command_on_repo_root "bazelisk run -- @libselinux//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @libselinux//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libselinux.so"
 
-  command_on_repo_root "bazelisk run -- @libsepol//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @libsepol//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libsepol.so"
 
-  command_on_repo_root "bazelisk run -- @libyaml//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @libyaml//:install --destdir='#{install_dir}'"
   sh_lib = if linux_target? then "libyaml.so" else "libyaml.dylib" end
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
     "#{install_dir}/embedded/lib/#{sh_lib}"
 
-  command_on_repo_root "bazelisk run -- @pcre2//:install --destdir=#{install_dir}"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix " \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @pcre2//:install --destdir=#{install_dir}"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix " \
     "--prefix #{install_dir}/embedded " \
     "#{install_dir}/embedded/lib/libpcre2*.so"
 
-  command_on_repo_root "bazelisk run -- @popt//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @popt//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libpopt.so"
 
-  command_on_repo_root "bazelisk run -- @rpm//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @rpm//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/librpm.so" \
     " #{install_dir}/embedded/lib/librpmio.so"
 
-  command_on_repo_root "bazelisk run -- @util-linux//:blkid_install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @util-linux//:blkid_install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libblkid.so"
 
-  command_on_repo_root "bazelisk run -- @gpg-error//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- @gcrypt//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @gpg-error//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @gcrypt//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libgcrypt.so" \
     " #{install_dir}/embedded/lib/libgpg-error.so" \
 
-  command_on_repo_root "bazelisk run -- @libxml2//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @libxml2//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libxml2.so"
 
-  command_on_repo_root "bazelisk run -- @libxslt//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @libxslt//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libxslt.so" \
     " #{install_dir}/embedded/lib/libexslt.so"
 
-  command_on_repo_root "bazelisk run -- @xmlsec//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @xmlsec//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libxmlsec1*.so" \
 
-  command_on_repo_root "bazelisk run -- @openscap//:install --destdir='#{install_dir}'"
-  command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @openscap//:install --destdir='#{install_dir}'"
+  command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
     " #{install_dir}/embedded/lib/libopenscap.so" \
     " #{install_dir}/embedded/lib/libopenscap_sce.so" \
     " #{install_dir}/embedded/bin/oscap" \

--- a/omnibus/config/software/openssl3.rb
+++ b/omnibus/config/software/openssl3.rb
@@ -27,10 +27,10 @@ relative_path "openssl-#{version}"
 build do
   flavor_flag = fips_mode? ? "--//packages/agent:flavor=fips" : ""
 
-  command_on_repo_root "bazelisk run #{flavor_flag} -- @openssl//:install --destdir=#{install_dir}"
+  command_on_repo_root "bazelisk run #{flavor_flag} --//:install_dir=#{install_dir} -- @openssl//:install --destdir=#{install_dir}"
 
   unless windows?
-    command_on_repo_root "bazelisk run -- @zlib//:install --destdir=#{install_dir}"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @zlib//:install --destdir=#{install_dir}"
     # build_agent_dmg.sh sets INSTALL_DIR to some temporary folder.
     # This messes up openssl's internal paths. So we have to use another variable
     # so that replace_prefix and fix_openssl_paths set path correctly inside of the
@@ -49,19 +49,19 @@ build do
 
     files_to_patch = files_to_patch.map { |path| "#{install_dir}/embedded/#{path}" }
 
-    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix #{install_dir}/embedded #{files_to_patch.join(' ')}"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix #{install_dir}/embedded #{files_to_patch.join(' ')}"
 
-    command_on_repo_root "bazelisk run -- //deps/openssl:fix_openssl_paths --destdir #{real_install_dir}/embedded" \
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //deps/openssl:fix_openssl_paths --destdir #{real_install_dir}/embedded" \
       " #{install_dir}/embedded/lib/libssl#{lib_extension}" \
       " #{install_dir}/embedded/lib/libcrypto#{lib_extension}" \
   end
   if fips_mode?
-    command_on_repo_root "bazelisk run -- @openssl_fips//:install --destdir=#{install_dir}"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @openssl_fips//:install --destdir=#{install_dir}"
     if windows?
-      command_on_repo_root "bazelisk run -- @openssl_fips//:configure_fips --destdir=\"#{install_dir}/embedded3\" --embedded_ssl_dir=\"C:/Program Files/Datadog/Datadog Agent/embedded3/ssl\""
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @openssl_fips//:configure_fips --destdir=\"#{install_dir}/embedded3\" --embedded_ssl_dir=\"C:/Program Files/Datadog/Datadog Agent/embedded3/ssl\""
     else
-      command_on_repo_root "bazelisk run -- @openssl_fips//:configure_fips --destdir=#{install_dir}/embedded"
-      command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix #{install_dir}/embedded" \
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @openssl_fips//:configure_fips --destdir=#{install_dir}/embedded"
+      command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix #{install_dir}/embedded" \
         " #{install_dir}/embedded/lib/ossl-modules/fips.so"
     end
   end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -5,16 +5,16 @@ default_version "3.13.12"
 unless windows?
   build do
     # Temporary deps. When we fix auto-rpath fixing these will disappear.
-    command_on_repo_root "bazelisk run -- @bzip2//:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @bzip2//:install --destdir='#{install_dir}'"
 
-    command_on_repo_root "bazelisk run -- @xz//:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @xz//:install --destdir='#{install_dir}'"
     sh_lib = if linux_target? then "liblzma.so" else "liblzma.dylib" end
-    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
       "#{install_dir}/embedded/lib/#{sh_lib}"
 
-    command_on_repo_root "bazelisk run -- @sqlite3//:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @sqlite3//:install --destdir='#{install_dir}'"
     sh_lib = if linux_target? then "libsqlite3.so" else "libsqlite3.dylib" end
-    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded' " \
        "#{install_dir}/embedded/lib/#{sh_lib}"
   end
 end
@@ -30,13 +30,13 @@ build do
 
   if !windows_target?
     env = with_standard_compiler_flags(with_embedded_path)
-    command_on_repo_root "bazelisk run -- @cpython//:install --destdir='#{install_dir}'"
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- @cpython//:install --destdir='#{install_dir}'"
     sh_ext = if linux_target? then "so" else "dylib" end
-    command_on_repo_root "bazelisk run -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
+    command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
       " #{install_dir}/embedded/lib/libpython3.*#{sh_ext}" \
       " #{install_dir}/embedded/lib/python3.13/lib-dynload/*.so" \
       " #{install_dir}/embedded/bin/python3*"
   else
-    command_on_repo_root "bazelisk run #{flavor_flag} -- @cpython//:install --destdir=#{install_dir}"
+    command_on_repo_root "bazelisk run #{flavor_flag} --//:install_dir=#{install_dir} -- @cpython//:install --destdir=#{install_dir}"
   end
 end


### PR DESCRIPTION
### What does this PR do?

Add a missing install_dir flag value when installing some of our dependencies

### Motivation

Ensuring our build recipes have the correct information at their disposal.
Currently, this doesn't change anything, but when we start to patch rpath at packaging time, we'll need the correct install dir to be provided.

### Describe how you validated your changes

CI & local build

### Additional Notes
