### PR TITLE
fix(renovate): Prevent warnings in configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,13 @@
     "minimumReleaseAge": "7 days",
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
-    "prPriority": -1,
     "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com", "200755185+dd-octo-sts[bot]@users.noreply.github.com"],
     "platformCommit": "enabled",
     "packageRules": [
+      {
+        "matchDepNames": ["*"],
+        "prPriority": -1
+      },
       {
         "matchDepNames": ["integrations-core"],
         "changelogUrl": "https://github.com/DataDog/integrations-core/compare/{{currentDigest}}..{{newDigest}}",
@@ -127,6 +130,11 @@
       {
         "matchManagers": ["bazel-module"],
         "matchDepTypes": ["git_override"],
+        "enabled": false
+      },
+      {
+        "matchManagers": ["bundler"],
+        "matchDepNames": ["omnibus"],
         "enabled": false
       }
     ],


### PR DESCRIPTION
### What does this PR do?
Prevent warnings in the renovate configuration
- deactivate omnibus updates in bundler, it's covered by the regex package manager
- do not use priority as top level argument

### Motivation
Tech debt

### Describe how you validated your changes

### Additional Notes


