### PR TITLE
fix(renovate): silence bundler git-refs registry warning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -145,6 +145,11 @@
         "matchManagers": ["bundler"],
         "matchDepNames": ["omnibus"],
         "enabled": false
+      },
+      {
+        "matchManagers": ["bundler"],
+        "matchDatasources": ["git-refs"],
+        "registryUrls": []
       }
     ],
     "customManagers" : [


### PR DESCRIPTION
### What does this PR do?
Silences the recurring Renovate dashboard warning:

> ⚠️ WARN: Custom registries are not allowed for this datasource and will be ignored

### Motivation
The bundler manager extracts the Gemfile's top-level `source 'https://rubygems.org'` line and attaches it as `registryUrls` to **every** gem in the file — including gems pulled via `git:` sources (`chef-sugar`, `omnibus`) which resolve through the `git-refs` datasource. `git-refs` has `customRegistrySupport: false`, so Renovate logs the warning on every run and surfaces it under "repoProblems" on the dashboard.

The warning is cosmetic — Renovate was ignoring the URL anyway and `git-refs` lookups still succeeded — but it was polluting the dashboard.

### Describe how you validated your changes
Inspected the Renovate job log (`2026-04-24T09:06Z` run): only one WARN at level 40 with `datasource: git-refs, registryUrls: ["https://rubygems.org"]`, originating from the bundler extraction of `omnibus/Gemfile`. Extraction-level warnings fire before `packageRules` disable filters, which is why the existing `omnibus` disable rule didn't silence it.

Added a `packageRules` entry that clears `registryUrls` for bundler deps routed through `git-refs`:

```json
{
  "matchManagers": ["bundler"],
  "matchDatasources": ["git-refs"],
  "registryUrls": []
}
```

Waiting for the next Renovate run to confirm the repoProblems entry disappears from the dashboard.

### Additional Notes
- **PR was originally titled "Enable bazelisk manager"** — the original work has since been superseded on `main` (the bazelisk `packageRule` is already there, and `main` dropped the `enabledManagers` allowlist in favour of `config:recommended`, which enables bazelisk by default). The branch was reused rather than opening a new PR.
- No impact on dependency updates, including the pending `chef-sugar v5.1.12` update PR — `registryUrls: []` only silences the warning.