### PR TITLE
Bake run into host profiler entrypoint

### DIFF
--- a/Dockerfiles/ddot-ebpf/Dockerfile
+++ b/Dockerfiles/ddot-ebpf/Dockerfile
@@ -47,5 +47,5 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends binutils && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-ENTRYPOINT ["/opt/datadog-agent/embedded/bin/full-host-profiler"]
-CMD ["run", "--config", "/etc/datadog-agent/host-profiler-config.yaml"]
+ENTRYPOINT ["/opt/datadog-agent/embedded/bin/full-host-profiler", "run"]
+CMD ["--config", "/etc/datadog-agent/host-profiler-config.yaml"]


### PR DESCRIPTION
### What does this PR do?
Upstream operator relies on entrypoint baked in image, and there is no CRD-level option to inject run as a positional argument (spec.args only supports --key=value pairs). Overriding entrypoint not supported yet (https://github.com/open-telemetry/opentelemetry-operator/issues/3188).

Downside is as run is a subcommand it belongs in CMD more than ENTRYPOINT. In our case, binary expects a run argument, so we need this hack.

No impact on DD helm/operator as CMD is overridden.



### Motivation

### Describe how you validated your changes

### Additional Notes
