### PR TITLE
[EBPF-1067] gpu: avoid aliasing when building metric tags

### DIFF
--- a/pkg/collector/corechecks/gpu/gpu.go
+++ b/pkg/collector/corechecks/gpu/gpu.go
@@ -412,7 +412,12 @@ func (c *Check) emitSingleMetric(metric *nvidia.Metric, snd sender.Sender, curre
 	}
 
 	metricName := gpuMetricsNs + metric.Name
-	allTags := append(append(deviceTags, metricTags...), metric.Tags...)
+	// Build into a fresh slice so we do not append into deviceTags' backing
+	// array and leak tags across metrics for the same device.
+	allTags := make([]string, 0, len(deviceTags)+len(metricTags)+len(metric.Tags))
+	allTags = append(allTags, deviceTags...)
+	allTags = append(allTags, metricTags...)
+	allTags = append(allTags, metric.Tags...)
 
 	// Use the current execution time as the timestamp for the metrics, that way we can ensure that the metrics are aligned with the check interval.
 	// We need this to ensure weighted metrics are calibrated correctly.

--- a/pkg/collector/corechecks/gpu/gpu_test.go
+++ b/pkg/collector/corechecks/gpu/gpu_test.go
@@ -453,6 +453,43 @@ func mockMatchesTags(expectedTags []string) interface{} {
 	})
 }
 
+func TestEmitSingleMetricDoesNotAliasDeviceTags(t *testing.T) {
+	mockSender := mocksender.NewMockSender("gpu")
+	mockSender.SetupAcceptAll()
+
+	check := &Check{}
+	deviceTags := make([]string, 1, 4)
+	deviceTags[0] = "gpu_uuid:gpu-1"
+
+	firstMetric := &nvidia.Metric{
+		Name:  "utilization",
+		Value: 1,
+		Type:  ddmetrics.GaugeType,
+		Tags:  []string{"source:first"},
+	}
+	secondMetric := &nvidia.Metric{
+		Name:  "utilization",
+		Value: 2,
+		Type:  ddmetrics.GaugeType,
+		Tags:  []string{"source:second"},
+	}
+
+	now := time.Now()
+	require.NoError(t, check.emitSingleMetric(firstMetric, mockSender, now, nil, deviceTags))
+	require.NoError(t, check.emitSingleMetric(secondMetric, mockSender, now, nil, deviceTags))
+
+	require.Len(t, mockSender.Mock.Calls, 2)
+
+	firstTags, ok := mockSender.Mock.Calls[0].Arguments.Get(3).([]string)
+	require.True(t, ok)
+	secondTags, ok := mockSender.Mock.Calls[1].Arguments.Get(3).([]string)
+	require.True(t, ok)
+
+	require.Equal(t, []string{"gpu_uuid:gpu-1", "source:first"}, firstTags)
+	require.Equal(t, []string{"gpu_uuid:gpu-1", "source:second"}, secondTags)
+	require.Equal(t, []string{"gpu_uuid:gpu-1"}, deviceTags)
+}
+
 func TestTagsChangeBetweenRuns(t *testing.T) {
 	// Create a mock sender
 	mockSender := mocksender.NewMockSender("gpu")


### PR DESCRIPTION
### What does this PR do?
Build GPU metric tags into a fresh buffer before appending workload and custom tags. This avoids mutating device tag backing storage across metric emissions and adds a regression test covering the aliasing case.

### Motivation
GPU metrics with additional tags could reuse shared slice backing storage and leak tags between emissions for the same device. Building the final tag slice independently keeps each emission isolated.

### Describe how you validated your changes
Ran `go test ./pkg/collector/corechecks/gpu -tags 'test nvml'`.
Added a regression test covering repeated `emitSingleMetric` calls with spare capacity in `deviceTags`.

### Additional Notes