### PR TITLE
[ACTP] [PAR] Allow task inputs to override execution timeout

### DIFF
--- a/pkg/privateactionrunner/runners/workflow_executor.go
+++ b/pkg/privateactionrunner/runners/workflow_executor.go
@@ -123,12 +123,16 @@ func (l *Loop) handleTask(
 	taskCtx, taskCtxCancel := context.WithCancel(ctx)
 	defer taskCtxCancel()
 
-	timeoutCtx, timeoutCancel := util.CreateTimeoutContext(taskCtx, l.runner.config.TaskTimeoutSeconds)
+	timeoutSeconds := task.TimeoutSeconds()
+	if timeoutSeconds == nil {
+		timeoutSeconds = l.runner.config.TaskTimeoutSeconds
+	}
+	timeoutCtx, timeoutCancel := util.CreateTimeoutContext(taskCtx, timeoutSeconds)
 	defer timeoutCancel()
 
 	output, err := l.runner.RunTask(timeoutCtx, task, credential)
 
-	if isTimeout, timeoutErr := util.HandleTimeoutError(timeoutCtx, err, l.runner.config.TaskTimeoutSeconds, logger); isTimeout {
+	if isTimeout, timeoutErr := util.HandleTimeoutError(timeoutCtx, err, timeoutSeconds, logger); isTimeout {
 		l.publishFailure(ctx, task, timeoutErr)
 		return
 	}

--- a/pkg/privateactionrunner/types/task.go
+++ b/pkg/privateactionrunner/types/task.go
@@ -35,6 +35,31 @@ type Attributes struct {
 	ConnectionInfo        *privateactionspb.ConnectionInfo                `json:"connection_info"`
 }
 
+// TimeoutSeconds returns the timeout from the task inputs if present and a valid number, otherwise nil.
+func (task *Task) TimeoutSeconds() *int32 {
+	if task.Data.Attributes == nil {
+		return nil
+	}
+	v, ok := task.Data.Attributes.Inputs["timeout"]
+	if !ok {
+		return nil
+	}
+	switch t := v.(type) {
+	case float64:
+		val := int32(t)
+		return &val
+	case int32:
+		return &t
+	case int64:
+		val := int32(t)
+		return &val
+	case int:
+		val := int32(t)
+		return &val
+	}
+	return nil
+}
+
 func (task *Task) GetFQN() string {
 	return fmt.Sprintf("%s.%s", task.Data.Attributes.BundleID, task.Data.Attributes.Name)
 }

--- a/pkg/privateactionrunner/types/task.go
+++ b/pkg/privateactionrunner/types/task.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 
 	actionsclientpb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/actionsclient"
 	privateactionspb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/privateactionrunner/privateactions"
@@ -35,7 +36,8 @@ type Attributes struct {
 	ConnectionInfo        *privateactionspb.ConnectionInfo                `json:"connection_info"`
 }
 
-// TimeoutSeconds returns the timeout from the task inputs if present and a valid number, otherwise nil.
+// TimeoutSeconds returns the timeout from the task inputs if present, positive, and within int32
+// range. Returns nil (fall back to config) for missing, non-integer, non-positive, or out-of-range values.
 func (task *Task) TimeoutSeconds() *int32 {
 	if task.Data.Attributes == nil {
 		return nil
@@ -44,20 +46,30 @@ func (task *Task) TimeoutSeconds() *int32 {
 	if !ok {
 		return nil
 	}
+
+	var n int64
 	switch t := v.(type) {
 	case float64:
-		val := int32(t)
-		return &val
+		if t != math.Trunc(t) {
+			// Non-integer float (e.g. 1.5) — reject.
+			return nil
+		}
+		n = int64(t)
 	case int32:
-		return &t
+		n = int64(t)
 	case int64:
-		val := int32(t)
-		return &val
+		n = t
 	case int:
-		val := int32(t)
-		return &val
+		n = int64(t)
+	default:
+		return nil
 	}
-	return nil
+
+	if n <= 0 || n > math.MaxInt32 {
+		return nil
+	}
+	val := int32(n)
+	return &val
 }
 
 func (task *Task) GetFQN() string {

--- a/pkg/privateactionrunner/types/task_test.go
+++ b/pkg/privateactionrunner/types/task_test.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package types
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeTaskWithTimeout(v interface{}) *Task {
+	t := &Task{}
+	t.Data.Attributes = &Attributes{
+		Inputs: map[string]interface{}{"timeout": v},
+	}
+	return t
+}
+
+func int32ptr(v int32) *int32 { return &v }
+
+func TestTimeoutSeconds(t *testing.T) {
+	tests := []struct {
+		name string
+		task *Task
+		want *int32
+	}{
+		{
+			name: "nil attributes",
+			task: &Task{},
+			want: nil,
+		},
+		{
+			name: "missing key",
+			task: func() *Task {
+				task := &Task{}
+				task.Data.Attributes = &Attributes{Inputs: map[string]interface{}{}}
+				return task
+			}(),
+			want: nil,
+		},
+		// Valid float64 (normal JSON numbers)
+		{
+			name: "float64 valid",
+			task: makeTaskWithTimeout(float64(30)),
+			want: int32ptr(30),
+		},
+		// float64 overflow (> MaxInt32) — must fall back to nil
+		{
+			name: "float64 overflow",
+			task: makeTaskWithTimeout(float64(math.MaxInt32) + 1),
+			want: nil,
+		},
+		// float64 negative — must fall back to nil
+		{
+			name: "float64 negative",
+			task: makeTaskWithTimeout(float64(-1)),
+			want: nil,
+		},
+		// float64 zero — must fall back to nil
+		{
+			name: "float64 zero",
+			task: makeTaskWithTimeout(float64(0)),
+			want: nil,
+		},
+		// Non-integer float — must fall back to nil
+		{
+			name: "float64 non-integer",
+			task: makeTaskWithTimeout(float64(1.5)),
+			want: nil,
+		},
+		// int32 valid
+		{
+			name: "int32 valid",
+			task: makeTaskWithTimeout(int32(60)),
+			want: int32ptr(60),
+		},
+		// int32 negative
+		{
+			name: "int32 negative",
+			task: makeTaskWithTimeout(int32(-5)),
+			want: nil,
+		},
+		// int64 within range
+		{
+			name: "int64 valid",
+			task: makeTaskWithTimeout(int64(120)),
+			want: int32ptr(120),
+		},
+		// int64 overflow
+		{
+			name: "int64 overflow",
+			task: makeTaskWithTimeout(int64(math.MaxInt32) + 1),
+			want: nil,
+		},
+		// int within range
+		{
+			name: "int valid",
+			task: makeTaskWithTimeout(int(90)),
+			want: int32ptr(90),
+		},
+		// string value — must fall back to nil
+		{
+			name: "string value",
+			task: makeTaskWithTimeout("30"),
+			want: nil,
+		},
+		// bool value — must fall back to nil
+		{
+			name: "bool value",
+			task: makeTaskWithTimeout(true),
+			want: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.task.TimeoutSeconds()
+			if tc.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+				assert.Equal(t, *tc.want, *got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a `TimeoutSeconds()` method on `Task` that reads a numeric `timeout` field from task inputs. The workflow executor now uses this per-task timeout when present, falling back to the config-level `TaskTimeoutSeconds` otherwise.

### Motivation

Some workflows may need a different execution timeout than the global runner configuration. This allows the caller to specify a per-task timeout via the task inputs without requiring a config change.

### Describe how you validated your changes

- Builds cleanly (`go build ./pkg/privateactionrunner/...`)
- Existing unit tests pass (pre-push hook)
- `TimeoutSeconds()` handles all numeric types that JSON unmarshaling can produce (`float64`, `int`, `int32`, `int64`), returning `nil` for absent or non-numeric values

### Additional Notes

`inputs["timeout"]` is JSON-decoded as `float64` by default when unmarshaled into `map[string]interface{}`, so the `float64` case is the primary code path in practice.