### PR TITLE
fix(fleet): Restore installer layer in Windows agent OCI package

### DIFF
--- a/.gitlab/windows/build/packaging/oci.yml
+++ b/.gitlab/windows/build/packaging/oci.yml
@@ -95,6 +95,14 @@ agent_win_oci:
 
         EXTRA_FLAGS="${EXTRA_FLAGS} --extension ddot=${DDOT_EXTENSION_DIR}"
       fi
+    - |
+      INSTALLER_BIN=$(ls -1 "${PIPE_DIR}"/datadog-installer-*-x86_64.exe 2>/dev/null | head -1)
+      if [ -n "$INSTALLER_BIN" ]; then
+        EXTRA_FLAGS="${EXTRA_FLAGS} --installer ${INSTALLER_BIN}"
+      else
+        echo "ERROR: No installer binary found for datadog-agent OCI package"
+        exit 1
+      fi
     - export PATH="$PATH:$(go env GOPATH)/bin"
     - datadog-package create --version "${PACKAGE_VERSION}" --package "${OCI_PRODUCT}" --os windows --arch amd64 --archive --archive-path "${PIPE_DIR}/${OCI_PRODUCT}-${PACKAGE_VERSION}-windows-amd64.oci.tar" ${EXTRA_FLAGS} "${SRC_DIR}/"
     - ls -l "${PIPE_DIR}"

--- a/test/new-e2e/tests/installer/windows/base_suite.go
+++ b/test/new-e2e/tests/installer/windows/base_suite.go
@@ -198,10 +198,10 @@ func (s *BaseSuite) createStableAgent() {
 	}
 	// else, use the defaults (last stable release)
 
-	agentVersion := "7.75.0"
-	agentVersionPackage := "7.75.0-1"
+	agentVersion := "7.77.0"
+	agentVersionPackage := "7.77.0-1"
 	agentRegistry := consts.StableS3OCIRegistry
-	agentMSIURL := "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-7.75.0.msi"
+	agentMSIURL := "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-7.77.0.msi"
 	// Allow override of version and version package via environment variables
 	if val := os.Getenv("STABLE_AGENT_VERSION"); val != "" {
 		agentVersion = val


### PR DESCRIPTION
### What does this PR do?

Restores the `--installer` flag when creating the Windows Agent OCI package in `agent_win_oci`, and bumps the E2E test stable agent version from 7.75.0 to 7.77.0.

**CI fix** (`.gitlab/windows/build/packaging/oci.yml`): The `agent_win_oci` job overrides the parent `.package_oci_win` template's `script:` block (added by #45789 for DDOT extension handling), which means the `--installer` logic from the parent template is never executed. This adds the installer binary lookup directly into the job's script.

**Test fix** (`base_suite.go`): Bumps the default stable agent version from 7.75.0 to 7.77.0. The `InstallerBootstrapMode` registry key support was added in #46024 (Feb 2026), after 7.75.0 was released. With 7.75.0, `TestUpgradeAgentPackageOCIBootstrap` silently falls back to MSI extraction when the OCI layer is missing, masking the regression. 7.77.0 supports `InstallerBootstrapMode`, so the bootstrap tests now actually enforce OCI-only and MSI-only paths.

### Motivation

This is the same regression pattern as #46024: the `--installer` flag was accidentally dropped from the Windows OCI build when #45789 overrode the parent template's script to add DDOT extension support. Without the flag, the OCI package has no installer layer and all upgrades silently use the slower MSI admin install fallback.

### Describe how you validated your changes

Existing E2E tests: `TestUpgradeAgentPackageOCIBootstrap` and `TestUpgradeAgentPackageMSIBootstrap` will now properly validate the OCI and MSI bootstrap paths with the 7.77.0 stable version.

### Additional Notes

Predecessor: #46024 (original restore of the installer layer on Linux).
Related: #45789 (DDOT extension PR that introduced the override).