### PR TITLE
Use bpf_core_field_exists for TCP congestion stats instead of LOAD_CONSTANT offsets

### DIFF
--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -314,9 +314,8 @@ static __always_inline void handle_congestion_stats(conn_tuple_t *t, struct sock
     if (val == NULL) {
         return;
     }
-    __u8 ecn = 0;
-
 #if defined(COMPILE_CORE)
+    __u8 ecn = 0;
     if (bpf_core_field_exists(struct tcp_sock, reord_seen)) {
         BPF_CORE_READ_INTO(&val->reord_seen, tcp_sk(sk), reord_seen);
     }
@@ -331,6 +330,7 @@ static __always_inline void handle_congestion_stats(conn_tuple_t *t, struct sock
         val->ecn_negotiated = ecn & 1; // ecn_flags bit 0 (TCP_ECN_OK) indicates whether ECN was negotiated for this connection
     }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+    __u8 ecn = 0;
     BPF_CORE_READ_INTO(&val->reord_seen,   tcp_sk(sk), reord_seen);
     BPF_CORE_READ_INTO(&val->delivered_ce, tcp_sk(sk), delivered_ce);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
@@ -346,9 +346,9 @@ static __always_inline void handle_congestion_stats(conn_tuple_t *t, struct sock
 // connection close time and takes the max of the tcp_stats value vs the sock value.
 static __always_inline void finalize_congestion_stats(struct sock *sk, tcp_stats_t *ts) {
 #if !defined(COMPILE_PREBUILT)
+#if defined(COMPILE_CORE)
     __u32 val = 0;
     __u8 ecn = 0;
-#if defined(COMPILE_CORE)
     if (bpf_core_field_exists(struct tcp_sock, reord_seen)) {
         BPF_CORE_READ_INTO(&val, tcp_sk(sk), reord_seen);
         if (val > ts->reord_seen)
@@ -371,6 +371,8 @@ static __always_inline void finalize_congestion_stats(struct sock *sk, tcp_stats
         ts->ecn_negotiated = ecn & 1; // ecn_flags bit 0 (TCP_ECN_OK) indicates whether ECN was negotiated for this connection
     }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+    __u32 val = 0;
+    __u8 ecn = 0;
     BPF_CORE_READ_INTO(&val, tcp_sk(sk), reord_seen);
     if (val > ts->reord_seen)
         ts->reord_seen = val;

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -326,15 +326,19 @@ static __always_inline void handle_congestion_stats(conn_tuple_t *t, struct sock
     if (bpf_core_field_exists(struct tcp_sock, delivered_ce)) {
         BPF_CORE_READ_INTO(&val->delivered_ce, tcp_sk(sk), delivered_ce);
     }
+    if (bpf_core_field_exists(struct tcp_sock, ecn_flags)) {
+        BPF_CORE_READ_INTO(&ecn, tcp_sk(sk), ecn_flags);
+        val->ecn_negotiated = ecn & 1; // ecn_flags bit 0 (TCP_ECN_OK) indicates whether ECN was negotiated for this connection
+    }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
     BPF_CORE_READ_INTO(&val->reord_seen,   tcp_sk(sk), reord_seen);
     BPF_CORE_READ_INTO(&val->delivered_ce, tcp_sk(sk), delivered_ce);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
     BPF_CORE_READ_INTO(&val->rcv_ooopack,  tcp_sk(sk), rcv_ooopack);
 #endif
-#endif
     BPF_CORE_READ_INTO(&ecn, tcp_sk(sk), ecn_flags);
-    val->ecn_negotiated = ecn & 1; // ecn_flags bit 0 (TCP_ECN_OK) indicates whether ECN was negotiated for this connection
+    val->ecn_negotiated = ecn & 1;
+#endif
 #endif
 }
 
@@ -342,8 +346,9 @@ static __always_inline void handle_congestion_stats(conn_tuple_t *t, struct sock
 // connection close time and takes the max of the tcp_stats value vs the sock value.
 static __always_inline void finalize_congestion_stats(struct sock *sk, tcp_stats_t *ts) {
 #if !defined(COMPILE_PREBUILT)
-#if defined(COMPILE_CORE)
     __u32 val = 0;
+    __u8 ecn = 0;
+#if defined(COMPILE_CORE)
     if (bpf_core_field_exists(struct tcp_sock, reord_seen)) {
         BPF_CORE_READ_INTO(&val, tcp_sk(sk), reord_seen);
         if (val > ts->reord_seen)
@@ -361,8 +366,11 @@ static __always_inline void finalize_congestion_stats(struct sock *sk, tcp_stats
         if (val > ts->delivered_ce)
             ts->delivered_ce = val;
     }
+    if (bpf_core_field_exists(struct tcp_sock, ecn_flags)) {
+        BPF_CORE_READ_INTO(&ecn, tcp_sk(sk), ecn_flags);
+        ts->ecn_negotiated = ecn & 1; // ecn_flags bit 0 (TCP_ECN_OK) indicates whether ECN was negotiated for this connection
+    }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
-    __u32 val = 0;
     BPF_CORE_READ_INTO(&val, tcp_sk(sk), reord_seen);
     if (val > ts->reord_seen)
         ts->reord_seen = val;
@@ -376,10 +384,9 @@ static __always_inline void finalize_congestion_stats(struct sock *sk, tcp_stats
     if (val > ts->rcv_ooopack)
         ts->rcv_ooopack = val;
 #endif
-#endif
-    __u8 ecn = 0;
     BPF_CORE_READ_INTO(&ecn, tcp_sk(sk), ecn_flags);
-    ts->ecn_negotiated = ecn & 1; // ecn_flags bit 0 (TCP_ECN_OK) indicates whether ECN was negotiated for this connection
+    ts->ecn_negotiated = ecn & 1;
+#endif
 #endif
 }
 

--- a/pkg/network/ebpf/c/tracer/stats.h
+++ b/pkg/network/ebpf/c/tracer/stats.h
@@ -314,43 +314,17 @@ static __always_inline void handle_congestion_stats(conn_tuple_t *t, struct sock
     if (val == NULL) {
         return;
     }
+    __u8 ecn = 0;
 
-    // On CO-RE, we cannot use BPF_CORE_READ_INTO because poisoned CO-RE
-    // relocations for missing fields are not pruned by the BPF verifier on
-    // older kernels (e.g. 4.15), even when guarded by bpf_core_field_exists().
-    // Instead, Go looks up the field offsets via BTF at startup and passes them
-    // as constants. A zero offset means the field doesn't exist on this kernel.
 #if defined(COMPILE_CORE)
-    __u64 reord_seen_offset = 0;
-    LOAD_CONSTANT("reord_seen_offset", reord_seen_offset);
-    if (reord_seen_offset > 0) {
-        __u32 tmp = 0;
-        bpf_probe_read_kernel(&tmp, sizeof(tmp), (char *)sk + reord_seen_offset);
-        val->reord_seen = tmp;
+    if (bpf_core_field_exists(struct tcp_sock, reord_seen)) {
+        BPF_CORE_READ_INTO(&val->reord_seen, tcp_sk(sk), reord_seen);
     }
-    __u64 rcv_ooopack_offset = 0;
-    LOAD_CONSTANT("rcv_ooopack_offset", rcv_ooopack_offset);
-    if (rcv_ooopack_offset > 0) {
-        __u32 tmp = 0;
-        bpf_probe_read_kernel(&tmp, sizeof(tmp), (char *)sk + rcv_ooopack_offset);
-        val->rcv_ooopack = tmp;
+    if (bpf_core_field_exists(struct tcp_sock, rcv_ooopack)) {
+        BPF_CORE_READ_INTO(&val->rcv_ooopack, tcp_sk(sk), rcv_ooopack);
     }
-    __u64 delivered_ce_offset = 0;
-    LOAD_CONSTANT("delivered_ce_offset", delivered_ce_offset);
-    if (delivered_ce_offset > 0) {
-        __u32 tmp = 0;
-        bpf_probe_read_kernel(&tmp, sizeof(tmp), (char *)sk + delivered_ce_offset);
-        val->delivered_ce = tmp;
-    }
-    // ECN negotiation: ecn_flags is a u8 in vmlinux headers (was a bitfield
-    // in kernel source on older versions, but BTF exposes it as a full byte).
-    // Read via offset to avoid poisoned CO-RE relocations on older kernels.
-    __u64 ecn_flags_offset = 0;
-    LOAD_CONSTANT("ecn_flags_offset", ecn_flags_offset);
-    if (ecn_flags_offset > 0) {
-        __u8 ecn = 0;
-        bpf_probe_read_kernel(&ecn, sizeof(ecn), (char *)sk + ecn_flags_offset);
-        val->ecn_negotiated = (ecn & 1) ? 1 : 0;
+    if (bpf_core_field_exists(struct tcp_sock, delivered_ce)) {
+        BPF_CORE_READ_INTO(&val->delivered_ce, tcp_sk(sk), delivered_ce);
     }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
     BPF_CORE_READ_INTO(&val->reord_seen,   tcp_sk(sk), reord_seen);
@@ -358,14 +332,9 @@ static __always_inline void handle_congestion_stats(conn_tuple_t *t, struct sock
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
     BPF_CORE_READ_INTO(&val->rcv_ooopack,  tcp_sk(sk), rcv_ooopack);
 #endif
-    // ECN negotiation: ecn_flags is u8 in vmlinux headers. Bit 0 (TCP_ECN_OK)
-    // indicates ECN was successfully negotiated for this connection.
-    {
-        u8 ecn = 0;
-        BPF_CORE_READ_INTO(&ecn, tcp_sk(sk), ecn_flags);
-        val->ecn_negotiated = (ecn & 1) ? 1 : 0;
-    }
 #endif
+    BPF_CORE_READ_INTO(&ecn, tcp_sk(sk), ecn_flags);
+    val->ecn_negotiated = ecn & 1; // ecn_flags bit 0 (TCP_ECN_OK) indicates whether ECN was negotiated for this connection
 #endif
 }
 
@@ -375,37 +344,22 @@ static __always_inline void finalize_congestion_stats(struct sock *sk, tcp_stats
 #if !defined(COMPILE_PREBUILT)
 #if defined(COMPILE_CORE)
     __u32 val = 0;
-    __u64 reord_seen_offset = 0;
-    LOAD_CONSTANT("reord_seen_offset", reord_seen_offset);
-    if (reord_seen_offset > 0) {
-        val = 0;
-        bpf_probe_read_kernel(&val, sizeof(val), (char *)sk + reord_seen_offset);
+    if (bpf_core_field_exists(struct tcp_sock, reord_seen)) {
+        BPF_CORE_READ_INTO(&val, tcp_sk(sk), reord_seen);
         if (val > ts->reord_seen)
             ts->reord_seen = val;
     }
-    __u64 rcv_ooopack_offset = 0;
-    LOAD_CONSTANT("rcv_ooopack_offset", rcv_ooopack_offset);
-    if (rcv_ooopack_offset > 0) {
+    if (bpf_core_field_exists(struct tcp_sock, rcv_ooopack)) {
         val = 0;
-        bpf_probe_read_kernel(&val, sizeof(val), (char *)sk + rcv_ooopack_offset);
+        BPF_CORE_READ_INTO(&val, tcp_sk(sk), rcv_ooopack);
         if (val > ts->rcv_ooopack)
             ts->rcv_ooopack = val;
     }
-    __u64 delivered_ce_offset = 0;
-    LOAD_CONSTANT("delivered_ce_offset", delivered_ce_offset);
-    if (delivered_ce_offset > 0) {
+    if (bpf_core_field_exists(struct tcp_sock, delivered_ce)) {
         val = 0;
-        bpf_probe_read_kernel(&val, sizeof(val), (char *)sk + delivered_ce_offset);
+        BPF_CORE_READ_INTO(&val, tcp_sk(sk), delivered_ce);
         if (val > ts->delivered_ce)
             ts->delivered_ce = val;
-    }
-    // ECN negotiation: read via offset (same approach as handle_congestion_stats).
-    __u64 ecn_flags_offset = 0;
-    LOAD_CONSTANT("ecn_flags_offset", ecn_flags_offset);
-    if (ecn_flags_offset > 0) {
-        __u8 ecn = 0;
-        bpf_probe_read_kernel(&ecn, sizeof(ecn), (char *)sk + ecn_flags_offset);
-        ts->ecn_negotiated = (ecn & 1) ? 1 : 0;
     }
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
     __u32 val = 0;
@@ -422,13 +376,10 @@ static __always_inline void finalize_congestion_stats(struct sock *sk, tcp_stats
     if (val > ts->rcv_ooopack)
         ts->rcv_ooopack = val;
 #endif
-    // ECN negotiation: not a counter, just a flag — always overwrite.
-    {
-        u8 ecn = 0;
-        BPF_CORE_READ_INTO(&ecn, tcp_sk(sk), ecn_flags);
-        ts->ecn_negotiated = (ecn & 1) ? 1 : 0;
-    }
 #endif
+    __u8 ecn = 0;
+    BPF_CORE_READ_INTO(&ecn, tcp_sk(sk), ecn_flags);
+    ts->ecn_negotiated = ecn & 1; // ecn_flags bit 0 (TCP_ECN_OK) indicates whether ECN was negotiated for this connection
 #endif
 }
 

--- a/pkg/network/tracer/connection/ebpf_tracer.go
+++ b/pkg/network/tracer/connection/ebpf_tracer.go
@@ -21,7 +21,7 @@ import (
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/ebpf-manager/tracefs"
 	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/btf"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/sys/unix"
 
@@ -221,16 +221,6 @@ func newEbpfTracer(config *config.Config, _ telemetryComponent.Component) (Trace
 	mgrOptions.ConstantEditors = append(mgrOptions.ConstantEditors,
 		manager.ConstantEditor{Name: "ephemeral_range_begin", Value: uint64(begin)},
 		manager.ConstantEditor{Name: "ephemeral_range_end", Value: uint64(end)})
-
-	// Pass tcp_sock field offsets for fields that can't use BPF_CORE_READ_INTO
-	// on older kernels (see comment in handle_congestion_stats()).
-	if spec, err := ddebpf.GetKernelSpec(); err == nil {
-		mgrOptions.ConstantEditors = append(mgrOptions.ConstantEditors,
-			manager.ConstantEditor{Name: "reord_seen_offset", Value: tcpSockFieldOffset(spec, "reord_seen")},
-			manager.ConstantEditor{Name: "rcv_ooopack_offset", Value: tcpSockFieldOffset(spec, "rcv_ooopack")},
-			manager.ConstantEditor{Name: "delivered_ce_offset", Value: tcpSockFieldOffset(spec, "delivered_ce")},
-			manager.ConstantEditor{Name: "ecn_flags_offset", Value: tcpSockFieldOffset(spec, "ecn_flags")})
-	}
 
 	connPool := ddsync.NewDefaultTypedPool[network.ConnectionStats]()
 	var extractor *batchExtractor
@@ -447,49 +437,6 @@ func boolConst(name string, value bool) manager.ConstantEditor {
 	}
 
 	return c
-}
-
-// tcpSockFieldOffset returns the byte offset of a field within the kernel's
-// tcp_sock struct by looking it up in BTF. Returns 0 if BTF is unavailable or
-// the field doesn't exist (e.g. on kernels older than when the field was added).
-// This is used to pass offsets as LOAD_CONSTANT values to CO-RE BPF programs
-// for fields that cannot use BPF_CORE_READ_INTO because poisoned CO-RE
-// relocations are not pruned by the BPF verifier on older kernels (e.g. 4.15).
-func tcpSockFieldOffset(spec *btf.Spec, fieldName string) uint64 {
-	var tcpSock *btf.Struct
-	if err := spec.TypeByName("tcp_sock", &tcpSock); err != nil {
-		return 0
-	}
-	return findFieldOffset(tcpSock, fieldName)
-}
-
-// findFieldOffset searches for a field by name in a BTF struct, recursing into
-// anonymous struct/union members. This handles kernels (6.8+) where tcp_sock
-// fields may be reorganized into __cacheline_group anonymous structs.
-func findFieldOffset(s *btf.Struct, fieldName string) uint64 {
-	return findFieldOffsetInMembers(s.Members, fieldName)
-}
-
-func findFieldOffsetInMembers(members []btf.Member, fieldName string) uint64 {
-	for _, m := range members {
-		if m.Name == fieldName {
-			return uint64(m.Offset.Bytes())
-		}
-		// Recurse into anonymous structs/unions (Name == "")
-		if m.Name == "" {
-			var innerMembers []btf.Member
-			switch inner := m.Type.(type) {
-			case *btf.Struct:
-				innerMembers = inner.Members
-			case *btf.Union:
-				innerMembers = inner.Members
-			}
-			if off := findFieldOffsetInMembers(innerMembers, fieldName); off > 0 {
-				return uint64(m.Offset.Bytes()) + off
-			}
-		}
-	}
-	return 0
 }
 
 func (t *ebpfTracer) closedPerfCallback(c *network.ConnectionStats) {


### PR DESCRIPTION
### What does this PR do?
Replace manual `LOAD_CONSTANT` + `bpf_probe_read_kernel` with `bpf_core_field_exists` + `BPF_CORE_READ_INTO` for TCP congestion stats fields (`reord_seen`, `rcv_ooopack`, `delivered_ce`, `ecn_flags`) in both `handle_congestion_stats` and `finalize_congestion_stats`.

Remove the Go-side BTF offset lookup (`tcpSockFieldOffset`, `findFieldOffset`) and the constant editors that passed offsets to BPF programs.

### Motivation
The previous approach was unnecessarily complicated, using `bpf_core_field_exists` is the idiomatic approach.

### Describe how you validated your changes
Ran unit tests.

### Additional Notes