### PR TITLE
docs(windows-e2e): add AGENTS.md, running_tests.md, and run-windows-e2e skill

### DIFF
--- a/.claude/skills/run-windows-e2e/SKILL.md
+++ b/.claude/skills/run-windows-e2e/SKILL.md
@@ -22,15 +22,15 @@ Map suite names to Go package paths:
 
 | Suite | Package path |
 |-------|-------------|
-| `install-test` | `./test/new-e2e/tests/windows/install-test/...` |
-| `service-test` | `./test/new-e2e/tests/windows/service-test/...` |
-| `fips-test` | `./test/new-e2e/tests/windows/fips-test/...` |
-| `domain-test` | `./test/new-e2e/tests/windows/domain-test/...` |
-| `agent-package` | `./test/new-e2e/tests/installer/windows/suites/agent-package/...` |
-| `install-script` | `./test/new-e2e/tests/installer/windows/suites/install-script/...` |
-| `install-exe` | `./test/new-e2e/tests/installer/windows/suites/install-exe/...` |
-| `ddot-package` | `./test/new-e2e/tests/installer/windows/suites/ddot-package/...` |
-| `apm-inject-package` | `./test/new-e2e/tests/installer/windows/suites/apm-inject-package/...` |
+| `install-test` | `./test/new-e2e/tests/windows/install-test` |
+| `service-test` | `./test/new-e2e/tests/windows/service-test` |
+| `fips-test` | `./test/new-e2e/tests/windows/fips-test` |
+| `domain-test` | `./test/new-e2e/tests/windows/domain-test` |
+| `agent-package` | `./test/new-e2e/tests/installer/windows/suites/agent-package` |
+| `install-script` | `./test/new-e2e/tests/installer/windows/suites/install-script` |
+| `install-exe` | `./test/new-e2e/tests/installer/windows/suites/install-exe` |
+| `ddot-package` | `./test/new-e2e/tests/installer/windows/suites/ddot-package` |
+| `apm-inject-package` | `./test/new-e2e/tests/installer/windows/suites/apm-inject-package` |
 
 If the user gives a partial name or test function, search with Glob/Grep under `test/new-e2e/tests/windows/` and `test/new-e2e/tests/installer/windows/` to resolve it.
 
@@ -90,6 +90,8 @@ level and at the subtest level — to avoid accidentally running multiple tests
 that share a name prefix (e.g. `TestUpgradeAgentPackage$` won't match
 `TestUpgradeAgentPackageOCIBootstrap`).
 
+**Important:** Use the exact package path (no trailing `/...`). Using `/...` causes Go to buffer all output per-package and only print it when the package finishes, making the test appear silent. Without `/...`, output streams live as the test runs.
+
 ```bash
 go test -v -timeout 30m -tags test <package-path> -run <TestFunction>$
 ```
@@ -97,13 +99,13 @@ go test -v -timeout 30m -tags test <package-path> -run <TestFunction>$
 For example:
 ```bash
 # MSI install test
-go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/install-test/... -run TestInstall$
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/install-test -run TestInstall$
 
 # Service lifecycle test
-go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/service-test/... -run TestServiceBehaviorPowerShell$
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/service-test -run TestServiceBehaviorPowerShell$
 
 # Fleet Automation — agent package
-go test -v -timeout 30m -tags test ./test/new-e2e/tests/installer/windows/suites/agent-package/... -run "TestAgentUpgrades$/TestUpgradeAgentPackage$"
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/installer/windows/suites/agent-package -run "TestAgentUpgrades$/TestUpgradeAgentPackage$"
 ```
 
 Show the full command to the user and confirm before running.

--- a/.claude/skills/run-windows-e2e/SKILL.md
+++ b/.claude/skills/run-windows-e2e/SKILL.md
@@ -125,7 +125,7 @@ go test -v -timeout 30m -tags test <package-path> -run <TestFunction>$
 
 When the test completes:
 - Report pass/fail.
-- On failure, point the user to test outputs at `~/e2e-output/latest/` (locally) — this directory contains WER crash dumps, agent logs, installer logs, and Windows event logs collected by the suite's `AfterTest` hook.
+- On failure, point the user to test outputs at `~/e2e-output/latest/` (locally) — this directory contains WER crash dumps, agent logs, installer logs, and Windows event logs collected by the suite's `AfterTest` hook. If `devMode` is enabled the VM is still running — offer to help the user RDP or SSH into it to troubleshoot (see "Accessing the test VM" below).
 - If the stack is locked (`error: the stack is currently locked`), suggest:
   - `dda inv new-e2e-tests.clean` — remove Pulumi locks
   - `dda inv new-e2e-tests.clean -s` — also wipe local stack state

--- a/.claude/skills/run-windows-e2e/SKILL.md
+++ b/.claude/skills/run-windows-e2e/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: run-windows-e2e
+description: Run Windows E2E tests (MSI install tests or Fleet Automation/installer tests) locally against AWS-provisioned VMs
+allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
+argument-hint: "[suite] [TestFunctionName] [--build release|pipeline|local] [--pipeline-id <id>] [--version <version>]"
+---
+
+Run Windows E2E tests from `test/new-e2e/tests/windows/` or `test/new-e2e/tests/installer/windows/`.
+
+## Instructions
+
+### Step 1 — Parse `$ARGUMENTS`
+
+Determine:
+- **Suite**: which test suite to run (e.g. `install-test`, `service-test`, `agent-package`, `install-script`). If not provided, ask the user.
+- **Test function**: specific `TestXxx` function to run. Most suites expect exactly one test per run — ask the user which one if not specified.
+- **Artifact source**: `--build pipeline` (default), `--build local`, or `--build release`. If `--pipeline-id <id>` is given, pass it through.
+- **Branch**: if the user mentions a specific branch (e.g. "from main", "latest main build"), note it — pass `--branch <name>` to `setup-env` in Step 3. The default is the current git branch, which may have no pipelines if it's a local feature branch.
+
+Map suite names to Go package paths:
+
+| Suite | Package path |
+|-------|-------------|
+| `install-test` | `./test/new-e2e/tests/windows/install-test/...` |
+| `service-test` | `./test/new-e2e/tests/windows/service-test/...` |
+| `fips-test` | `./test/new-e2e/tests/windows/fips-test/...` |
+| `domain-test` | `./test/new-e2e/tests/windows/domain-test/...` |
+| `agent-package` | `./test/new-e2e/tests/installer/windows/suites/agent-package/...` |
+| `install-script` | `./test/new-e2e/tests/installer/windows/suites/install-script/...` |
+| `install-exe` | `./test/new-e2e/tests/installer/windows/suites/install-exe/...` |
+| `ddot-package` | `./test/new-e2e/tests/installer/windows/suites/ddot-package/...` |
+| `apm-inject-package` | `./test/new-e2e/tests/installer/windows/suites/apm-inject-package/...` |
+
+If the user gives a partial name or test function, search with Glob/Grep under `test/new-e2e/tests/windows/` and `test/new-e2e/tests/installer/windows/` to resolve it.
+
+### Step 2 — Check prerequisites
+
+**a) Check `~/.test_infra_config.yaml`:**
+```bash
+test -f ~/.test_infra_config.yaml && echo "EXISTS" || echo "MISSING"
+```
+
+**b) Check `pulumi`:**
+```bash
+pulumi version 2>/dev/null || echo "MISSING"
+```
+
+If either is missing, offer to walk the user through setup via:
+```bash
+dda inv e2e.setup
+```
+This task (defined in `tasks/e2e_framework/setup/`) validates CLI tools, installs Pulumi if missing, prompts for AWS keypair paths, Datadog API key, and Pulumi passphrase, then writes `~/.test_infra_config.yaml`. Run it and wait for the user to complete the interactive prompts before continuing.
+
+If prerequisites exist but `devMode` is not set in `~/.test_infra_config.yaml`, mention that setting `devMode: true` in that file will reuse VMs across runs (much faster for iterative development).
+
+### Step 3 — Resolve artifact environment variables
+
+Run `setup-env` with `--fmt json` to capture the required env vars as JSON — no manual `eval` step needed.
+
+**From a pipeline (most common):**
+
+```bash
+dda inv new-e2e-tests.setup-env --build pipeline --fmt json [--branch <branch>] [--pipeline-id <id>]
+```
+
+The task auto-resolves a GitLab token via `ddtool` if configured. If that fails it will print an error asking for `GITLAB_TOKEN` to be set — in that case ask the user to provide it and retry with `GITLAB_TOKEN=<token> dda inv new-e2e-tests.setup-env ...`.
+
+**From a local build:**
+```bash
+dda inv new-e2e-tests.setup-env --build local --fmt json
+```
+If `--build local` and the user hasn't built yet, remind them to run `dda inv msi.build` first (plus `dda inv msi.package-oci` for installer/OCI tests).
+
+**Parse the JSON output** — it will be a map of `"VAR_NAME": "value"` pairs. Collect all key=value pairs; you will prepend them inline to the `go test` command in Step 5 so no shell `eval` is required.
+
+### Step 4 — Check for stale state (dev mode only)
+
+If `devMode: true` is configured and the user is rerunning a test, the previous VM may still have the agent installed from the prior run. Ask whether they've cleaned up:
+
+- **MSI install tests** (`install-test/`, `domain-test/`, `fips-test/`): uninstall the agent via Add/Remove Programs or `MsiExec.exe /x {product-code}` on the remote VM.
+- **Installer/Fleet Automation tests** (`installer/windows/`): run `datadog-installer.exe purge` on the remote VM.
+
+If unsure, advise them to clean up to avoid state leaking between test runs.
+
+### Step 5 — Build and confirm the `go test` command
+
+The `-run` flag takes a Go regex. Always anchor with `$` — both at the suite
+level and at the subtest level — to avoid accidentally running multiple tests
+that share a name prefix (e.g. `TestUpgradeAgentPackage$` won't match
+`TestUpgradeAgentPackageOCIBootstrap`).
+
+```bash
+go test -v -timeout 30m -tags test <package-path> -run <TestFunction>$
+```
+
+For example:
+```bash
+# MSI install test
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/install-test/... -run TestInstall$
+
+# Service lifecycle test
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/service-test/... -run TestServiceBehaviorPowerShell$
+
+# Fleet Automation — agent package
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/installer/windows/suites/agent-package/... -run "TestAgentUpgrades$/TestUpgradeAgentPackage$"
+```
+
+Show the full command to the user and confirm before running.
+
+### Step 6 — Run the test
+
+Warn the user that AWS SSO authentication may open a browser window automatically
+when the test starts. The test will pause until the login is completed — this is
+expected. If `AWS_PROFILE` is set to a non-sandbox profile it will cause auth
+errors; advise them to `unset AWS_PROFILE` before running.
+
+Run with `run_in_background: true` since tests provision real AWS VMs and can take 20–60 minutes.
+
+```bash
+go test -v -timeout 30m -tags test <package-path> -run <TestFunction>$
+```
+
+### Step 7 — Report results
+
+When the test completes:
+- Report pass/fail.
+- On failure, point the user to test outputs at `~/e2e-output/latest/` (locally) — this directory contains WER crash dumps, agent logs, installer logs, and Windows event logs collected by the suite's `AfterTest` hook.
+- If the stack is locked (`error: the stack is currently locked`), suggest:
+  - `dda inv new-e2e-tests.clean` — remove Pulumi locks
+  - `dda inv new-e2e-tests.clean -s` — also wipe local stack state
+  - `dda inv new-e2e-tests.clean --output` — clear local test output
+  - If cleanup says "Cleanup supported for local state only": run `pulumi login --local` first
+- If there are AWS auth errors (`not authorized to perform: ecr:BatchGetImage`), check whether `AWS_PROFILE` is set to a non-sandbox profile — unset it and retry. The framework automatically uses `sso-agent-sandbox-account-admin`.
+
+## Accessing the test VM (dev mode)
+
+When `devMode` is enabled the VM persists after the test. To connect:
+
+**Find the stack name** — either from test output (`Creating workspace for stack: user-e2e-<suitename>-<hash>`) or:
+```bash
+pulumi stack ls --all
+```
+
+**Get connection details (IP, username, password):**
+```bash
+pulumi stack --stack organization/e2elocal/<stack-name> output --json --show-secrets
+```
+
+**RDP** (opens RDP, prints credentials, copies password to clipboard):
+```bash
+dda inv aws.rdp-vm --stack-name <stack-name>
+```
+Note: `dda inv aws.show-vm` does NOT work for e2e test stacks — it prepends
+the username twice and looks for the wrong output key (`"aws-vm"` instead of
+`"dd-Host-aws-vm"`).
+
+**SSH** — use the `privateKeyPath` from `~/.test_infra_config.yaml`:
+```bash
+ssh -i <privateKeyPath> -o StrictHostKeyChecking=no <username>@<ip> "<command>"
+```
+
+Check `osFamily` in the JSON output to determine the remote shell:
+- `osFamily: 1` = Linux → use `&&` or `;` (bash)
+- `osFamily: 2` = Windows → use `;` as separator (PowerShell, `&&` is invalid)
+
+## Notes
+
+- These tests provision real AWS EC2 Windows VMs — valid AWS credentials (`agent-sandbox` account) and `PULUMI_CONFIG_PASSPHRASE` (or equivalent in config) are required. These VMs can be accessed with SSH, the key is configued in `~/.test_infra_config.yaml`. The test's pulumi state contains the IP address, username, and password.
+- Most tests install the agent as part of the test and expect a clean starting state. Run them one at a time.
+- Use `E2E_DEV_MODE=true` (or `devMode: true` in `~/.test_infra_config.yaml`) to reuse the VM across runs during development.
+- See `test/new-e2e/tests/windows/running_tests.md` for a full reference.

--- a/.claude/skills/run-windows-e2e/SKILL.md
+++ b/.claude/skills/run-windows-e2e/SKILL.md
@@ -115,7 +115,7 @@ when the test starts. The test will pause until the login is completed — this 
 expected. If `AWS_PROFILE` is set to a non-sandbox profile it will cause auth
 errors; advise them to `unset AWS_PROFILE` before running.
 
-Run with `run_in_background: true` since tests provision real AWS VMs and can take 20–60 minutes.
+Run with `run_in_background: true` since tests provision real AWS VMs. VM provisioning takes a few minutes; once the VM is up, SSH becomes available in under 60s for Linux VMs and under 180s for Windows VMs. If SSH is not available within those windows, troubleshoot before assuming the test is still running normally (see SSH availability note below).
 
 ```bash
 go test -v -timeout 30m -tags test <package-path> -run <TestFunction>$
@@ -163,6 +163,10 @@ ssh -i <privateKeyPath> -o StrictHostKeyChecking=no <username>@<ip> "<command>"
 Check `osFamily` in the JSON output to determine the remote shell:
 - `osFamily: 1` = Linux → use `&&` or `;` (bash)
 - `osFamily: 2` = Windows → use `;` as separator (PowerShell, `&&` is invalid)
+
+**SSH availability:** SSH should be reachable in under 60s for Linux VMs and under 180s for Windows VMs after the VM is provisioned. If it takes longer:
+- Verify the SSH key is loaded in your SSH agent (`ssh-add -l`) or pass `-i` explicitly
+- Check that the keypair name in `~/.test_infra_config.yaml` matches the AWS key pair used to provision the VM — a mismatch means the wrong public key was injected and authentication will always fail
 
 ## Notes
 

--- a/.claude/skills/run-windows-e2e/SKILL.md
+++ b/.claude/skills/run-windows-e2e/SKILL.md
@@ -15,6 +15,7 @@ Determine:
 - **Suite**: which test suite to run (e.g. `install-test`, `service-test`, `agent-package`, `install-script`). If not provided, ask the user.
 - **Test function**: specific `TestXxx` function to run. Most suites expect exactly one test per run — ask the user which one if not specified.
 - **Artifact source**: `--build pipeline` (default), `--build local`, or `--build release`. If `--pipeline-id <id>` is given, pass it through.
+- **Stable/previous version** (upgrade tests only): if the user specifies a version to upgrade *from*, run `setup-env` a second time with `--prefix STABLE_AGENT --build <mode>` (same modes as current: `pipeline`, `local`, or `release`) plus any relevant flags (`--version`, `--pipeline-id`, etc.) and merge those vars into the inline env block, overriding the defaults from the first run.
 - **Branch**: if the user mentions a specific branch (e.g. "from main", "latest main build"), note it — pass `--branch <name>` to `setup-env` in Step 3. The default is the current git branch, which may have no pipelines if it's a local feature branch.
 
 Map suite names to Go package paths:

--- a/test/new-e2e/tests/installer/windows/AGENTS.md
+++ b/test/new-e2e/tests/installer/windows/AGENTS.md
@@ -1,0 +1,171 @@
+# Windows Fleet Automation / Installer E2E Tests
+
+Tests for the Datadog Fleet Automation stack on Windows: installation and
+upgrade of the Agent and its OCI packages via `datadog-installer.exe` and the
+`Install-Datadog.ps1` setup script. Tests cover the happy path (install,
+upgrade, uninstall) and edge cases (rollback, stopping experiments, custom
+agent user/path, config experiments, persisting extensions). DDOT is
+currently the only Agent extension and has its own suite.
+
+Tests run on AWS-provisioned Windows VMs with no pre-installed agent or
+fakeintake. After every test, WER crash dumps are collected; on failure,
+agent logs, installer logs, and Windows event logs are downloaded.
+
+## Directory structure
+
+```
+installer/windows/
+├── base_suite.go          # BaseSuite: artifact resolution, WER dumps, per-test setup
+├── installer.go           # DatadogInstallerRunner interface + DatadogInstaller impl
+├── install_script.go      # DatadogInstallScript / DatadogInstallExe: runs setup scripts
+├── agent_package.go       # AgentVersionManager: holds MSI + OCI package pair for a version
+├── consts/                # Package names, binary paths, service name, registry keys, OCI registries
+├── remote-host-assertions/ # Chainable assertions targeting a remote Windows host
+├── suite-assertions/      # Suite-level Require() wrapper (returns *SuiteAssertions)
+└── suites/
+    ├── agent-package/     # Agent install, upgrade, rollback, config experiments, domain/GMSA, persisting extensions
+    ├── apm-inject-package/ # APM auto-injection (IIS + Java)
+    ├── apm-library-dotnet-package/ # .NET APM library package
+    ├── ddot-package/      # DDOT Agent extension package
+    ├── install-exe/       # datadog-installer.exe bootstrap
+    ├── install-script/    # Install-Datadog.ps1 setup script and custom agent user
+    └── installer-package/ # (deprecated) Legacy installer MSI tests
+```
+
+## Base suite
+
+`BaseSuite` (in `base_suite.go`) extends `e2e.BaseSuite[environments.WindowsHost]`.
+The three key things it sets up:
+
+**Current and stable agent versions** — resolved from environment variables
+into `*AgentVersionManager` values, accessible via `s.CurrentAgentVersion()`
+and `s.StableAgentVersion()`. Suites that need non-default artifacts can
+override resolution by setting `s.CreateCurrentAgent` or `s.CreateStableAgent`
+before `SetupSuite` runs.
+
+**Install script** — a `DatadogInstallScript` / `DatadogInstallExe` is
+created per test and accessible via `s.InstallScript()`. Suites can replace
+the implementation with `s.SetInstallScriptImpl()`.
+
+**Assertions** — `s.Require()` returns `*SuiteAssertions` (from
+`suite-assertions/`), which wraps testify's `Require` with fluent host
+assertions:
+
+```go
+s.Require().Host(s.Env().RemoteHost).HasARunningDatadogAgentService()
+s.Require().Host(s.Env().RemoteHost).
+    HasDatadogInstaller().Status().
+    HasPackage("datadog-agent").
+    WithStableVersionMatchPredicate(func(v string) {
+        s.Require().Contains(v, s.CurrentAgentVersion().Version())
+    })
+```
+
+## Experiment model
+
+Fleet Automation upgrades OCI packages through an *experiment* slot alongside
+the *stable* slot. The full lifecycle and hook sequence is documented in
+`pkg/fleet/installer/packages/README.md`. The short version:
+
+- **`StartExperiment`** — installs the new version into the experiment slot.
+- **`PromoteExperiment`** — makes the experiment the new stable; the old
+  version is removed.
+- **`StopExperiment`** — discards the experiment; the original stable is
+  restored.
+
+**Windows difference:** both the stable and experiment package directories
+exist on disk simultaneously (as on other platforms), but the Windows Agent
+package is an MSI rather than a set of loose files. `StartExperiment` and
+`StopExperiment` therefore perform a full MSI uninstall of the current version
+followed by a full MSI install of the target version, rather than an in-place
+file swap.
+
+Tests in `suites/agent-package/` exercise all three paths, including rollback
+scenarios where an experiment is stopped after a failed upgrade.
+
+## Key types
+
+**`DatadogInstallerRunner`** (interface in `installer.go`) — wraps
+`datadog-installer.exe` subcommands executed on the remote host:
+`InstallPackage`, `StartExperiment`, `Status`, etc. plus `Install`/`Uninstall` for the MSI itself.
+Access via `s.Installer()`.
+
+**`DatadogInstallScript`** / **`DatadogInstallExe`** (in `install_script.go`)
+— runs `Install-Datadog.ps1` or `datadog-installer.exe setup` on the remote
+host. Access via `s.InstallScript()`.
+
+**`AgentVersionManager`** (in `agent_package.go`) — holds the version string,
+OCI package config, and MSI package for a given agent version. Used by suites
+that need to install the stable version first and then upgrade to the current.
+
+## Package resolution
+
+Two agent versions are resolved at suite startup from environment variables:
+
+| Prefix | Role | Key env vars |
+|---|---|---|
+| `CURRENT_AGENT` | Agent built by the current pipeline | `CURRENT_AGENT_VERSION`, `CURRENT_AGENT_VERSION_PACKAGE` |
+| `STABLE_AGENT` | Baseline for upgrade tests (default: 7.75.0) | `STABLE_AGENT_VERSION`, `STABLE_AGENT_VERSION_PACKAGE` |
+
+Both MSI and OCI artifacts are resolved per version. `WithDevEnvOverrides(prefix)`
+applies env var overrides locally but is a no-op in CI (when `CI` is set).
+
+## Running tests
+
+See `tests/windows/running_tests.md` for environment setup and `go test`
+invocations. Also see `doc.go` in this package for installer-specific
+quick-start instructions.
+
+## CI
+
+Jobs are in `.gitlab/windows/test/e2e_install_packages/windows.yml`.
+The `new-e2e-installer-windows` job runs the full `./tests/installer/windows`
+target. Individual package suites (e.g. `new-e2e-windows-ddot-package-a7-x86_64`)
+have their own jobs with specific `needs` for the OCI artifacts they require.
+
+## Adding a new test
+
+1. **Decide where the test belongs.** See `tests/windows/AGENTS.md` "Where to
+   add a new test" section. Fleet Automation / OCI package tests belong here.
+
+2. **Add to an existing suite or create a new one.**
+   - If the test fits an existing suite (e.g. agent upgrades go in
+     `suites/agent-package/`, install script scenarios in `suites/install-script/`),
+     add a new method to the existing suite struct.
+   - If it covers a new OCI package or a distinct feature area, create a new
+     suite under `suites/<package-name>/`. The suite struct should embed
+     `BaseSuite` and define a `TestXxx` entry point:
+
+   ```go
+   func TestMyPackage(t *testing.T) {
+       e2e.Run(t, &testMyPackageSuite{},
+           e2e.WithProvisioner(awsHostWindows.ProvisionerNoAgentNoFakeIntake()))
+   }
+
+   type testMyPackageSuite struct {
+       windows.BaseSuite
+   }
+
+   func (s *testMyPackageSuite) TestInstallMyPackage() {
+       s.InstallScript().Run(s.Env().RemoteHost)
+       s.Require().Host(s.Env().RemoteHost).HasARunningDatadogAgentService()
+       // ... package-specific assertions ...
+   }
+   ```
+
+3. **Add the test to the CI matrix.** In
+   `.gitlab/windows/test/e2e_install_packages/windows.yml`, add a new entry to
+   the `parallel: matrix` for the `new-e2e-installer-windows` job:
+
+   ```yaml
+   - EXTRA_PARAMS: --run "TestMyPackage$/TestInstallMyPackage$"
+   ```
+
+   If the test requires new OCI artifacts, also add the corresponding
+   `deploy_*_oci` job to the `needs` list.
+
+4. **Use existing helpers.** Use `s.Installer()` for `datadog-installer.exe`
+   commands, `s.InstallScript()` for setup scripts, and the fluent assertions
+   from `remote-host-assertions/` and `suite-assertions/`. Check
+   `tests/windows/common/` for Go wrappers before writing one-off
+   PowerShell commands.

--- a/test/new-e2e/tests/windows/AGENTS.md
+++ b/test/new-e2e/tests/windows/AGENTS.md
@@ -1,0 +1,154 @@
+# Windows Agent E2E Tests
+
+Tests for the Windows Agent. Scenarios include MSI installation,
+uninstallation, upgrades, service lifecycle, file/registry/permission
+correctness, FIPS mode, domain/AD-joined hosts, and Windows-specific
+components (NPM, APM, certificates). Shared Windows utilities (services,
+registry, ACL, event logs, crash dumps, etc.) live in `common/`.
+
+Tests run on AWS-provisioned Windows VMs (no pre-installed agent, no
+fakeintake). The VM is created fresh per test run unless DevMode is active.
+
+## Subdirectories
+
+Each test area has its own `AGENTS.md`. Non-obvious ones:
+
+**`domain-test/`** tests MSI install and upgrade on a domain controller, using
+the e2e-framework's `activedirectory` Pulumi component to stand up Active
+Directory before the agent is installed. The tests follow the same patterns as
+`install-test/` and reuse its `Tester` helper. Domain *client* tests (joining
+a non-DC host to the domain) are not yet implemented.
+
+**`components/`** contains Pulumi components that configure small aspects of
+the host environment (Windows Defender exclusions, FIPS mode, test-signing,
+certificate host). They have no tests of their own. Prefer `common/` utilities
+for anything that can be done after provisioning; these components are only
+necessary when the host must be configured before Pulumi installs the agent.
+
+## Base suite
+
+`BaseAgentInstallerSuite` (`base_agent_installer_suite.go`) is the base for
+all MSI installer tests. It resolves the MSI package from environment
+variables at suite startup (stored in `s.AgentPackage`) and provides
+`s.InstallAgent(host, opts...)` and `s.NewTestClientForHost(host)`.
+Individual test packages embed this (directly or through a further local base)
+and add their own `BeforeTest`/`AfterTest` hooks for snapshots, event log
+capture, crash dumps, and diagnostics.
+
+## Package resolution
+
+The MSI under test is resolved from environment variables at suite startup.
+
+| Env var | Effect |
+|---|---|
+| `CURRENT_AGENT_MSI_URL` | Direct URL (local `file://` or HTTPS); skips all other resolution |
+| `CURRENT_AGENT_PIPELINE` | Fetches MSI from S3 pipeline artifacts |
+| `CURRENT_AGENT_SOURCE_VERSION` | Looks up MSI in `installers_v2.json` |
+| `CURRENT_AGENT_ASSERT_VERSION` | Version string for assertions (e.g. `7.66.0-devel`) |
+| `CURRENT_AGENT_ASSERT_PACKAGE_VERSION` | URL-safe package version for assertions |
+
+For upgrade tests, the same pattern applies with the `STABLE_AGENT_` prefix.
+`GetLastStablePackageFromEnv()` reads `STABLE_AGENT_*` variables.
+
+Resolution priority: direct URL > pipeline ID > version lookup. If none are
+set, `GetPackageFromEnv()` falls back to the latest stable MSI.
+
+## Test entry point pattern
+
+Tests use [testify suites](https://pkg.go.dev/github.com/stretchr/testify/suite).
+Each test file defines a suite struct that embeds the appropriate base suite,
+and a top-level `TestXxx(t *testing.T)` function as the Go test entry point.
+
+Tests in `install-test/` use the package-level `Run` helper (defined in
+`install-test/base.go`) which sets the provisioner, stack naming, and
+parallelism:
+
+```go
+func TestInstall(t *testing.T) {
+    installtest.Run(t, &testInstallSuite{})
+}
+
+type testInstallSuite struct {
+    baseAgentMSISuite
+}
+
+func (s *testInstallSuite) TestInstall() {
+    vm := s.Env().RemoteHost
+    remoteMSIPath := s.installAgentPackage(vm, s.AgentPackage)
+    s.Require().NoError(...)
+    s.Run("subtest name", func() { ... })
+}
+```
+
+Suites outside `install-test/` that extend `BaseAgentInstallerSuite` directly
+call `e2e.Run` with an explicit provisioner:
+
+```go
+func TestFoo(t *testing.T) {
+    e2e.Run(t, &testFooSuite{},
+        e2e.WithProvisioner(awsHostWindows.ProvisionerNoAgentNoFakeIntake()))
+}
+```
+
+## Where to add a new test
+
+- **MSI install/uninstall/upgrade/repair** — `tests/windows/install-test/`.
+  Uses the MSI installer helpers (`baseAgentMSISuite`, `Tester`).
+- **Fleet Automation / OCI packages** (`datadog-installer.exe`,
+  `Install-Datadog.ps1`, experiment lifecycle) —
+  `tests/installer/windows/`. Uses the installer helpers (`BaseSuite`,
+  `DatadogInstallerRunner`).
+- **Agent functional or integration tests** that need a pre-installed running
+  agent and fakeintake — prefer the Pulumi provisioner to install and
+  configure the agent, then use fakeintake for assertions (see
+  `tests/windows/service-test/` for an example, or the parent
+  `test/new-e2e/` framework docs).
+- **Domain controller / AD-joined host** — `tests/windows/domain-test/`.
+- **FIPS mode** — `tests/windows/fips-test/`.
+
+Each subdirectory's `AGENTS.md` has a step-by-step "Adding a new test"
+recipe with code templates and CI matrix instructions.
+
+## Running tests
+
+See `running_tests.md` in this directory for setup-env, local builds,
+and `go test` invocations.
+
+## CI configuration
+
+CI jobs for these tests live in two files under `.gitlab/windows/test/`:
+
+**`e2e/windows.yml`** — general Windows e2e jobs (service tests, certificate,
+FIPS compliance, system probe, etc.). Jobs use `EXTRA_PARAMS: --run TestFoo`
+to select a specific test function or suite.
+
+**`e2e_install_packages/windows.yml`** — MSI install/upgrade/domain jobs.
+Because each test function provisions its own VM, these jobs use a
+`parallel: matrix` with one entry per test function so they run concurrently:
+
+```yaml
+parallel:
+  matrix:
+    - E2E_MSI_TEST: TestInstall
+    - E2E_MSI_TEST: TestUpgrade
+    - E2E_MSI_TEST: TestRepair
+```
+
+The matrix value is passed through as `EXTRA_PARAMS: --run "$E2E_MSI_TEST$"`.
+
+## Common utilities
+
+Shared Windows helpers live in `common/`. **Before writing one-off
+PowerShell commands in a test, check `common/` and `common/agent/` for
+an existing helper** — many operations already have Go wrappers.
+
+Key areas: Windows services, registry, ACL/permissions, local users, event
+logs, WER crash dumps, procdump, filesystem snapshots, process management,
+network diagnostics, and PowerShell command builder.
+
+Agent-specific helpers (package resolution, MSI install/uninstall, config
+root, product codes) live in `common/agent/`.
+
+API reference (for humans):
+- [common](https://pkg.go.dev/github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common)
+- [common/agent](https://pkg.go.dev/github.com/DataDog/datadog-agent/test/new-e2e/tests/windows/common/agent)

--- a/test/new-e2e/tests/windows/fips-test/AGENTS.md
+++ b/test/new-e2e/tests/windows/fips-test/AGENTS.md
@@ -1,0 +1,43 @@
+# Windows FIPS Agent MSI Tests
+
+Tests for the Windows FIPS Agent MSI installer. Covers installation of the
+FIPS Agent in standard and alternate directories, and mutual exclusivity
+between the standard Agent and the FIPS Agent (each should refuse to install
+over the other).
+
+These tests use the FIPS-flavor MSI (`WINDOWS_AGENT_FLAVOR=fips`) alongside
+the standard MSI. Both are resolved from environment variables using the same
+`CURRENT_AGENT_*` / `STABLE_AGENT_*` pattern as the other MSI tests (see
+parent `AGENTS.md`).
+
+## What is tested
+
+Beyond install/uninstall correctness, the FIPS tests validate the OpenSSL
+setup that the MSI is responsible for:
+
+- `fips.dll` (the OpenSSL FIPS provider) is present under `embedded3/lib/ossl-modules/`
+- `fipsmodule.cnf` is present and valid — verified by running
+  `openssl.exe fipsinstall -verify` against it
+- The MSI writes the correct OpenSSL directory paths (`OPENSSLDIR`, `ENGINESDIR`,
+  `MODULESDIR`) into the registry under
+  `HKLM:\SOFTWARE\Wow6432Node\OpenSSL-<version>-datadog-fips-agent`, and
+  those paths exist on disk
+- `openssl.exe version -a` reports paths that match the registry values and
+  is compiled with `-DOSSL_WINCTX=datadog-fips-agent`
+
+## Related tests
+
+FIPS cipher and compliance tests for Windows live in a separate package:
+`test/new-e2e/tests/fips-compliance/`. That package contains:
+
+- **`TestWindowsVM`** (`fips_win_test.go`) — validates the FIPS Agent runs
+  correctly on a Windows VM
+- **`TestFIPSCiphersWindowsSuite`** (`fips_ciphers_win_test.go`) — validates
+  that the agent only negotiates FIPS-approved cipher suites
+
+## CI
+
+Jobs are in `.gitlab/windows/test/e2e_install_packages/windows.yml` under
+`new-e2e-windows-agent-a7-x86_64-fips`. The compliance tests are in
+`.gitlab/windows/test/e2e/windows.yml` under
+`new-e2e-windows-fips-compliance-test`.

--- a/test/new-e2e/tests/windows/install-test/AGENTS.md
+++ b/test/new-e2e/tests/windows/install-test/AGENTS.md
@@ -1,0 +1,111 @@
+# Windows Agent MSI Install Tests
+
+Tests for the Windows Agent MSI installer. Covers install, uninstall,
+repair, upgrade (including from v5/v6), custom install paths, agent user
+configuration, sub-service options, NPM, autologger, and persisting
+integrations. After every test, WER crash dumps are collected; if a test
+fails, agent logs and Windows event logs are also downloaded.
+
+## What is tested
+
+The `Tester` helper (`installtester.go`) validates the expected post-install
+and post-uninstall state. Checks include:
+
+- File and directory layout (install path, config root)
+- ACLs and permissions on installed files and directories
+- System paths are not modified by install or uninstall
+- Windows service configuration (names, start type, account)
+- Agent user creation, SID, and group membership
+- Registry keys written by the installer
+- Python version and that Python check commands work
+- Code signing on agent binaries
+
+## Files
+
+```
+install-test/
+├── base.go                        # baseAgentMSISuite: BeforeTest/AfterTest hooks, install helpers
+├── installtester.go               # Tester: post-install expectation helpers
+├── assert.go                      # Standalone assertion functions (user, version, permissions)
+├── system_file_tester.go          # Validates system files are not modified by install/uninstall
+├── install_test.go                # TestInstall, TestRepair, TestInstallOpts, TestInstallFail, ...
+├── upgrade_test.go                # TestUpgrade, TestUpgradeRollback, TestUpgradeChangeUser, ...
+├── agent_user_test.go             # TestAgentUser (user-only, dotslash, hostname, LocalSystem, SYSTEM)
+├── npm_test.go                    # TestNPM* (install with NPM, upgrades)
+├── install_subservices_test.go    # TestSubServicesOpts (all/no subservices)
+├── persisting_integrations_test.go # TestPersistingIntegrations*
+├── autologger_test.go             # TestInstallWithAutologger*
+└── service-test/                  # Sub-package: expected service state definitions used by Tester
+                                   #   (not a runnable test package — only provides data for assertions)
+```
+
+## Base suite
+
+`baseAgentMSISuite` (defined in `base.go`) embeds
+`windows.BaseAgentInstallerSuite[environments.WindowsHost]` and adds
+`BeforeTest`/`AfterTest` hooks, the `installAgentPackage()` helper (which
+wraps MSI install with xperf tracing and procdump), and cleanup utilities.
+
+## Test entry point
+
+All tests use `installtest.Run` (defined in `base.go`) rather than calling
+`e2e.Run` directly. It sets the provisioner, stack naming, and parallelism.
+Suite structs embed `baseAgentMSISuite`; use `s.newTester(vm)` to get a
+`Tester` and call `t.TestInstallExpectations` / `t.TestUninstallExpectations`
+to validate the full post-install/post-uninstall state.
+
+## Running tests
+
+See `../running_tests.md` for environment setup and `go test` invocations.
+
+## CI
+
+Jobs for this package are in
+`.gitlab/windows/test/e2e_install_packages/windows.yml`. Each test function
+runs as its own parallel job via the `E2E_MSI_TEST` matrix (see parent
+`AGENTS.md` for details).
+
+## Adding a new test
+
+1. **Decide where the test belongs.** See the parent `AGENTS.md` "Where to
+   add a new test" section. MSI install/uninstall/upgrade tests belong here.
+
+2. **Add to an existing suite or create a new one.**
+   - If the test fits an existing test area (e.g. upgrades go in
+     `upgrade_test.go`, agent user scenarios in `agent_user_test.go`), add a
+     new method to the existing suite struct.
+   - If it covers a new area, create a new `*_test.go` file with a new suite
+     struct that embeds `baseAgentMSISuite` and a top-level `TestXxx` entry
+     point using `installtest.Run`:
+
+   ```go
+   func TestMyFeature(t *testing.T) {
+       installtest.Run(t, &testMyFeatureSuite{})
+   }
+
+   type testMyFeatureSuite struct {
+       baseAgentMSISuite
+   }
+
+   func (s *testMyFeatureSuite) TestMyFeature() {
+       vm := s.Env().RemoteHost
+       s.installAgentPackage(vm, s.AgentPackage)
+       t := s.newTester(vm)
+       t.TestInstallExpectations(s.T())
+       // ... additional assertions ...
+   }
+   ```
+
+3. **Add the test to the CI matrix.** In
+   `.gitlab/windows/test/e2e_install_packages/windows.yml`, add a new entry to
+   the `parallel: matrix` for the appropriate job
+   (`new-e2e-windows-agent-msi-windows-server-a7-x86_64`):
+
+   ```yaml
+   - E2E_MSI_TEST: TestMyFeature
+   ```
+
+4. **Use existing helpers.** Check `common/` and `common/agent/` for existing
+   Go wrappers (services, registry, ACL, event logs) before writing one-off
+   PowerShell commands. Use `s.newTester(vm)` for post-install/uninstall
+   validation.

--- a/test/new-e2e/tests/windows/running_tests.md
+++ b/test/new-e2e/tests/windows/running_tests.md
@@ -192,6 +192,15 @@ Windows VMs run PowerShell over SSH, so use `;` as the command separator
 ssh -i <privateKeyPath> -o StrictHostKeyChecking=no <username>@<ip> "<commands>"
 ```
 
+SSH becomes available in under 60s for Linux VMs and under 180s for Windows
+VMs after provisioning. If it takes longer than that:
+
+- Make sure the key is loaded in your SSH agent (`ssh-add -l`) or pass `-i`
+  explicitly to the `ssh` command.
+- Verify that the keypair name in `~/.test_infra_config.yaml` matches the AWS
+  key pair used to provision the VM — a name mismatch means the wrong public
+  key was injected and authentication will always fail.
+
 ## Troubleshooting
 
 ### Pulumi lock errors

--- a/test/new-e2e/tests/windows/running_tests.md
+++ b/test/new-e2e/tests/windows/running_tests.md
@@ -1,0 +1,228 @@
+# Running Windows E2E Tests
+
+Instructions for running Windows E2E tests locally. Applies to both
+MSI install tests (`tests/windows/`) and Fleet Automation / installer
+tests (`tests/installer/windows/`).
+
+If you are using Claude Code, the `/run-windows-e2e` skill can handle
+the setup-env, environment variable wiring, and `go test` invocation
+for you interactively.
+
+## Prerequisites
+
+Follow the general E2E setup guide first:
+[docs/public/how-to/test/e2e.md](../../../../docs/public/how-to/test/e2e.md)
+
+This covers:
+- AWS `agent-sandbox` account access and `aws-vault` setup
+- `PULUMI_CONFIG_PASSPHRASE` requirement
+- Required tooling (Go, Python, `dda`)
+
+The Windows tests provision real AWS EC2 Windows instances and require the
+same AWS access as all other E2E tests. Without valid AWS credentials and
+`PULUMI_CONFIG_PASSPHRASE` set, the test run will fail before any test code
+executes.
+
+## Persistent configuration
+
+Most run parameters are easier to set once in `~/.test_infra_config.yaml`
+rather than as environment variables each session. The relevant fields are
+your AWS keypair paths, Datadog API key (required — the agent MSI install
+needs a valid key), Pulumi passphrase (alternative to the
+`PULUMI_CONFIG_PASSPHRASE` env var), and `devMode` (see below).
+
+## Dev mode
+
+By default each test run provisions a fresh VM and destroys it afterwards.
+During local development this makes test-fix-rerun loops very slow. Set
+`devMode: true` in `~/.test_infra_config.yaml` (shown above) to reuse the
+same VM across runs. The VM is identified by the Pulumi stack name, which
+is derived from the test package and suite name.
+
+Alternatively set it per-run:
+
+```bash
+E2E_DEV_MODE=true go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/install-test/...
+```
+
+Or in VSCode:
+```json
+"go.testEnvVars": {
+  "E2E_DEV_MODE": "true"
+}
+```
+
+## Setting up artifact environment variables
+
+Windows tests need to know which MSI and/or OCI package to use. The
+`setup-env` helper configures the required environment variables.
+
+### Using pipeline artifacts
+
+Auto-detect the most recent successful pipeline on your current branch
+(use `--branch main` to target `main` instead):
+
+```powershell
+# PowerShell
+dda inv new-e2e-tests.setup-env --build pipeline --fmt powershell | Invoke-Expression
+```
+
+```bash
+# Bash/WSL
+eval "$(dda inv new-e2e-tests.setup-env --build pipeline)"
+```
+
+The task auto-resolves a GitLab token via `ddtool` if configured. If
+that fails it will ask you to set `GITLAB_TOKEN` manually.
+
+To target a specific pipeline:
+
+```powershell
+dda inv new-e2e-tests.setup-env --build pipeline --pipeline-id <id> --fmt powershell | Invoke-Expression
+```
+
+### Using local artifacts
+
+Build the MSI first (add `msi.package-oci` if running installer tests):
+
+```bash
+dda inv msi.build
+# produces omnibus/pkg/datadog-agent-<version>-x86_64.msi
+
+dda inv msi.package-oci   # only needed for installer/windows tests
+# produces omnibus/pkg/datadog-agent-<version>-windows-amd64.oci.tar
+```
+
+Then point the tests at the local build:
+
+```powershell
+dda inv new-e2e-tests.setup-env --build local --fmt powershell | Invoke-Expression
+```
+
+## Running a specific suite
+
+The `-run` flag takes a Go regex. The trailing `$` anchors to an exact match —
+important both at the suite level (preventing `TestInstall` from also matching
+`TestInstallOpts`, `TestInstallFail`, etc.) and at the subtest level when
+targeting a specific subtest (preventing `TestUpgradeAgentPackage` from also
+matching `TestUpgradeAgentPackageOCIBootstrap` and other variants).
+
+```bash
+# MSI install tests — run one test function
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/install-test/... -run TestInstall$
+
+# Service lifecycle tests
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/windows/service-test/... -run TestServiceBehaviorPowerShell$
+
+# Installer / Fleet Automation — agent package (install, upgrade, rollback, experiments)
+go test -v -timeout 30m -tags test ./test/new-e2e/tests/installer/windows/suites/agent-package/... -run TestAgentInstalls$
+```
+
+AWS SSO authentication may open a browser window automatically when the test
+starts — the test will pause until login completes. This is expected.
+
+Most tests are designed to run one at a time — they install the agent as part
+of the test and expect a clean starting state. When using dev mode and reusing
+a VM, uninstall the agent (MSI tests) or run `datadog-installer.exe purge`
+(installer tests) between runs to avoid state leaking between tests.
+
+See each suite's AGENTS.md for the full list of test functions and the CI job
+names that map to them.
+
+## Test outputs
+
+Test output files (logs, crash dumps, event logs, agent logs) are written via
+`runner.GetProfile().CreateOutputSubDir()` to:
+
+```
+~/e2e-output/<suite-name>/<timestamp>/
+~/e2e-output/latest/                    ← symlink to the most recent run
+```
+
+When a test fails, the suite's `AfterTest` hook automatically collects
+diagnostics into the output directory — WER crash dumps, Windows event logs
+(`.evtx`), agent logs, and installer logs depending on the suite. Check
+`~/e2e-output/latest/` first when investigating a failure.
+
+In CI, outputs are stored as GitLab job artifacts and accessible from the
+job's artifact browser in the pipeline UI.
+
+## Accessing the test VM
+
+When `devMode` is enabled the VM stays alive after the test. You can find
+connection details via the Pulumi stack.
+
+### Finding the stack name
+
+Two ways:
+- From test output: look for `Creating workspace for stack: user-e2e-<suitename>-<hash>`
+- From the CLI: `pulumi stack ls --all` — find the entry matching the suite name
+
+The stack name format is `user-e2e-<suitename-lowercase>-<hash>`.
+
+### Getting connection details
+
+```bash
+# Full JSON: IP address, username, password
+pulumi stack --stack organization/e2elocal/<stack-name> output --json --show-secrets
+```
+
+The output includes `address` (private IP), `username` (`Administrator`), and
+`password`. The OS family and flavor are also present as integers — see
+`test/e2e-framework/components/os/const.go` for the enum values
+(`WindowsFamily = 2`, `WindowsServer = 509`, `WindowsClient = 510`).
+
+### RDP
+
+```bash
+# Opens RDP and prints IP + password (copies password to clipboard)
+dda inv aws.rdp-vm --stack-name <stack-name>
+```
+
+Note: `dda inv aws.show-vm` does **not** work for e2e test stacks — it is only
+for VMs created with `dda inv aws.create-vm`.
+
+### SSH
+
+The SSH key is the `privateKeyPath` from `~/.test_infra_config.yaml`.
+Windows VMs run PowerShell over SSH, so use `;` as the command separator
+(`&&` is not valid in PowerShell):
+
+```bash
+ssh -i <privateKeyPath> -o StrictHostKeyChecking=no <username>@<ip> "<commands>"
+```
+
+## Troubleshooting
+
+### Pulumi lock errors
+
+If you see `error: the stack is currently locked by 1 lock(s)`:
+
+```bash
+dda inv new-e2e-tests.clean        # remove local Pulumi locks
+dda inv new-e2e-tests.clean -s     # also clean local stack state
+dda inv new-e2e-tests.clean --output  # clear local test output
+```
+
+If cleanup reports "Cleanup supported for local state only":
+
+```bash
+pulumi login --local
+```
+
+### AWS account
+
+Local runs must use the `agent-sandbox` AWS account (CI uses `agent-qa`).
+The e2e framework automatically uses the `sso-agent-sandbox-account-admin`
+profile, so no explicit `aws-vault` invocation is needed.
+
+However, if `AWS_PROFILE` is already set in your environment to a different
+profile, it will override the automatic selection and cause auth errors. Unset
+it before running:
+
+```bash
+unset AWS_PROFILE
+```
+
+A common symptom of the wrong account:
+`User: arn:aws:sts::... is not authorized to perform: ecr:BatchGetImage`

--- a/test/new-e2e/tests/windows/service-test/AGENTS.md
+++ b/test/new-e2e/tests/windows/service-test/AGENTS.md
@@ -1,0 +1,42 @@
+# Windows Agent Service Tests
+
+Tests for Windows Agent service lifecycle behavior. Unlike `install-test/`,
+the agent here is installed by the Pulumi provisioner (not by the test itself),
+so the suite starts with a running agent already present. Each test then
+repeatedly starts and stops it, measuring and validating the behavior of each
+cycle.
+
+## What is tested
+
+- All agent services start when the agent is started, and stop when it is stopped
+- Service stop time (no service hits its hard stop timeout, which would produce an event log warning)
+- Event log errors and warnings during start/stop cycles
+- Hard-exit event log entries (service crashed rather than stopped cleanly)
+- Correct behavior when individual sub-services (System Probe, Process Agent, Trace Agent, Installer) are disabled in config
+- Starting a disabled service is handled gracefully
+
+Each test suite is run twice: once normally, and once with **Driver Verifier**
+enabled on the agent's kernel drivers. Driver Verifier applies additional
+runtime checks that can surface memory and synchronization bugs; timeouts are
+scaled up significantly for those runs.
+
+## Diagnostics collected
+
+After each test: WER crash dumps and the system crash dump (`MEMORY.DMP`) are
+checked and downloaded. On failure: agent logs, event log errors/warnings, and
+host diagnostics (I/O counters, disk queue length, process handle counts) are
+collected.
+
+## Test variants
+
+Both variants are defined in `startstop_test.go`. The same suite runs
+under two start/stop mechanisms to verify both work correctly:
+
+- **`TestServiceBehaviorAgentCommand`** — uses `agent.exe start-service` / `stop-service`
+- **`TestServiceBehaviorPowerShell`** — uses PowerShell `Start-Service` / `Stop-Service`
+
+## CI
+
+Jobs are in `.gitlab/windows/test/e2e/windows.yml` under
+`new-e2e-windows-service-test`. Each test function runs as its own parallel
+job via a `parallel: matrix`.


### PR DESCRIPTION
### What does this PR do?

Adds `AGENTS.md` files, a `running_tests.md`, and a Claude Code `/run-windows-e2e` skill for the Windows E2E test suites.

**AGENTS.md files** added to:
- `test/new-e2e/tests/windows/` — top-level index: MSI and Fleet Automation hierarchies, base suite, package resolution, CI config, common utilities
- `test/new-e2e/tests/windows/install-test/` — what `Tester` validates, file layout, suite pattern, CI matrix
- `test/new-e2e/tests/windows/service-test/` — start/stop lifecycle testing, Driver Verifier, diagnostics
- `test/new-e2e/tests/windows/fips-test/` — FIPS MSI validation, `fipsmodule.cnf`, OpenSSL registry paths
- `test/new-e2e/tests/installer/windows/` — Fleet Automation / OCI package tests, experiment model (including Windows-specific full MSI uninstall+reinstall), key types, package resolution

**`running_tests.md`** — end-to-end guide: prerequisites, dev mode, artifact setup via `setup-env`, running suites with correct `-run` anchoring, accessing test VMs (Pulumi stack outputs, RDP, SSH), and troubleshooting (Pulumi locks, AWS account/profile issues).

**`.claude/skills/run-windows-e2e/SKILL.md`** — Claude Code skill that checks prerequisites, resolves artifacts via `setup-env --fmt json`, inlines env vars into the `go test` command, and reports results with pointers to `~/e2e-output/latest/` on failure.

### Motivation

https://datadoghq.atlassian.net/browse/WINA-2516

No single reference existed for how Windows E2E tests are structured, how to run them locally, or how to access provisioned VMs during development. This adds that context in a format useful to both human developers and AI coding assistants.

### Describe how you validated your changes

checkout the branch and ask claude
```
run TestUpgradeAgentPackageOCIBootstrap to test upgrading from release version 7.77.0 to a recent main pipeline build /run-windows-e2e
```

after the test provisions the VM, ask claude to RDP or SSH into the test VM

NOTE: some workflows may be partially dependent on https://github.com/DataDog/datadog-agent/pull/47181, you can just ask claude to merge it in locally.