### PR TITLE
[AGTHEAL-125] feat(network): introduce comp/networktracer V2 component

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -347,6 +347,7 @@
 /comp/metadata @DataDog/agent-configuration
 /comp/ndmtmp @DataDog/network-device-monitoring-core
 /comp/netflow @DataDog/ndm-integrations
+/comp/network @DataDog/cloud-network-monitoring
 /comp/networkpath @DataDog/network-path
 /comp/otelcol @DataDog/opentelemetry-agent
 /comp/process @DataDog/container-experiences
@@ -387,6 +388,9 @@
 /comp/metadata/hostgpu @DataDog/ebpf-platform
 /comp/metadata/hostsysteminfo @DataDog/windows-products
 /comp/metadata/packagesigning @DataDog/agent-delivery
+/comp/networkdeviceconfig @DataDog/ndm-integrations
+/comp/networkpath/npcollector @DataDog/network-path
+/comp/networkpath/traceroute @DataDog/network-path
 /comp/process/connectionscheck @DataDog/cloud-network-monitoring @DataDog/universal-service-monitoring
 /comp/trace/etwtracer @DataDog/windows-products
 /comp/trace-telemetry @DataDog/agent-runtimes

--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -33,7 +33,6 @@ import (
 	npcollectorfx "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/fx"
 	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
 	processComponent "github.com/DataDog/datadog-agent/comp/process"
-	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	check "github.com/DataDog/datadog-agent/pkg/cli/subcommands/processchecks"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 )

--- a/cmd/agent/subcommands/processchecks/command.go
+++ b/cmd/agent/subcommands/processchecks/command.go
@@ -33,6 +33,7 @@ import (
 	npcollectorfx "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/fx"
 	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
 	processComponent "github.com/DataDog/datadog-agent/comp/process"
+	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	check "github.com/DataDog/datadog-agent/pkg/cli/subcommands/processchecks"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 )

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -38,6 +38,7 @@ import (
 	agenttelemetryfx "github.com/DataDog/datadog-agent/comp/core/agenttelemetry/fx"
 	"github.com/DataDog/datadog-agent/comp/core/autodiscovery/providers/datastreams"
 	fxinstrumentation "github.com/DataDog/datadog-agent/comp/core/fxinstrumentation/fx"
+
 	doqueryactionsfx "github.com/DataDog/datadog-agent/comp/dataobs/queryactions/fx"
 	haagentfx "github.com/DataDog/datadog-agent/comp/haagent/fx"
 	logondurationfx "github.com/DataDog/datadog-agent/comp/logonduration/fx"
@@ -153,7 +154,7 @@ import (
 	"github.com/DataDog/datadog-agent/comp/ndmtmp"
 	"github.com/DataDog/datadog-agent/comp/netflow"
 	netflowServer "github.com/DataDog/datadog-agent/comp/netflow/server/def"
-	"github.com/DataDog/datadog-agent/comp/networkpath"
+	"github.com/DataDog/datadog-agent/comp/network"
 	"github.com/DataDog/datadog-agent/comp/otelcol"
 	otelcollector "github.com/DataDog/datadog-agent/comp/otelcol/collector/def"
 	logsagentpipeline "github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/def"
@@ -162,7 +163,6 @@ import (
 	"github.com/DataDog/datadog-agent/comp/process"
 	processAgent "github.com/DataDog/datadog-agent/comp/process/agent/def"
 	processagentstatusfx "github.com/DataDog/datadog-agent/comp/process/status/fx"
-	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	remoteconfig "github.com/DataDog/datadog-agent/comp/remote-config"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	rcprotocoltestfx "github.com/DataDog/datadog-agent/comp/remote-config/rcprotocoltest/fx"
@@ -533,7 +533,7 @@ func getSharedFxOption() fx.Option {
 		}),
 		ndmtmp.Bundle(),
 		netflow.Bundle(),
-		rdnsquerierfx.Module(),
+		network.Bundle(),
 		getSnmptrapsOptions(),
 		snmpscanfx.Module(),
 		snmpscanmanagerfx.Module(),
@@ -575,8 +575,6 @@ func getSharedFxOption() fx.Option {
 		}),
 		settingsfx.Module(),
 		agenttelemetryfx.Module(),
-		remotetraceroute.Module(),
-		networkpath.Bundle(),
 		syntheticsTestsfx.Module(),
 		remoteagentregistryfx.Module(),
 		haagentfx.Module(),

--- a/cmd/agent/subcommands/run/command.go
+++ b/cmd/agent/subcommands/run/command.go
@@ -45,7 +45,6 @@ import (
 	networkconfigmanagement "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/def"
 	networkconfigmanagementfx "github.com/DataDog/datadog-agent/comp/networkconfigmanagement/fx"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
-	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
 	snmpscanfx "github.com/DataDog/datadog-agent/comp/snmpscan/fx"
 	snmpscanmanagerfx "github.com/DataDog/datadog-agent/comp/snmpscanmanager/fx"
 	ssistatusfx "github.com/DataDog/datadog-agent/comp/updater/ssistatus/fx"

--- a/cmd/process-agent/command/main_common.go
+++ b/cmd/process-agent/command/main_common.go
@@ -48,8 +48,7 @@ import (
 	eventplatformfx "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/fx"
 	eventplatformreceiverimpl "github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/impl"
 	hostMetadataUtils "github.com/DataDog/datadog-agent/comp/metadata/host/impl/utils"
-	"github.com/DataDog/datadog-agent/comp/networkpath"
-	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
+	"github.com/DataDog/datadog-agent/comp/network"
 	"github.com/DataDog/datadog-agent/comp/process"
 	agent "github.com/DataDog/datadog-agent/comp/process/agent/def"
 	apiserver "github.com/DataDog/datadog-agent/comp/process/apiserver/def"
@@ -58,7 +57,6 @@ import (
 	profiler "github.com/DataDog/datadog-agent/comp/process/profiler/def"
 	processstatusfx "github.com/DataDog/datadog-agent/comp/process/status/fx"
 	"github.com/DataDog/datadog-agent/comp/process/types"
-	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	remoteconfig "github.com/DataDog/datadog-agent/comp/remote-config"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	"github.com/DataDog/datadog-agent/pkg/collector/python"
@@ -142,12 +140,8 @@ func runApp(ctx context.Context, globalParams *GlobalParams) error {
 		eventplatformreceiverimpl.Module(),
 		eventplatformfx.Module(eventplatform.NewDefaultParams()),
 
-		// Provides the rdnssquerier module
-		rdnsquerierfx.Module(),
-
-		remotetraceroute.Module(),
-		// Provide network path bundle
-		networkpath.Bundle(),
+		// Provide network monitoring bundle (rdnsquerier, traceroute, npcollector)
+		network.Bundle(),
 
 		// Provide remote config client bundle
 		remoteconfig.Bundle(),

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -29,7 +29,6 @@ import (
 	npcollectorfx "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/fx"
 	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
 	processComponent "github.com/DataDog/datadog-agent/comp/process"
-	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/processchecks"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 )
@@ -73,7 +72,6 @@ func getProcessAgentFxOptions(cliParams *processchecks.CliParams, bundleParams c
 			return &statsd.NoOpClient{}
 		}),
 		ipcfx.ModuleReadOnly(),
-		remotetraceroute.Module(),
 	}
 }
 

--- a/cmd/process-agent/subcommands/check/check.go
+++ b/cmd/process-agent/subcommands/check/check.go
@@ -27,8 +27,8 @@ import (
 	eventplatformfx "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/fx"
 	eventplatformreceiverimpl "github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/impl"
 	npcollectorfx "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/fx"
-	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
 	processComponent "github.com/DataDog/datadog-agent/comp/process"
+	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	"github.com/DataDog/datadog-agent/pkg/cli/subcommands/processchecks"
 	proccontainers "github.com/DataDog/datadog-agent/pkg/process/util/containers"
 )

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -16,11 +16,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	networktracer "github.com/DataDog/datadog-agent/comp/networktracer/def"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	networkconfig "github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/encoding/marshal"
 	"github.com/DataDog/datadog-agent/pkg/network/sender"
-	"github.com/DataDog/datadog-agent/pkg/network/tracer"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	sysconfigtypes "github.com/DataDog/datadog-agent/pkg/system-probe/config/types"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/utils"
@@ -35,12 +35,11 @@ const inactivityRestartDuration = 20 * time.Minute
 const maxConntrackDumpSize = 3000
 
 func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDependencies) (module.Module, error) {
-	ncfg := networkconfig.New()
-
-	// Checking whether the current OS + kernel version is supported by the tracer
-	if supported, err := tracer.IsTracerSupportedByOS(ncfg.ExcludedBPFLinuxVersions); !supported {
-		return nil, fmt.Errorf("%w: %s", ErrSysprobeUnsupported, err)
+	if !deps.NetworkTracer.IsSupported() {
+		return nil, fmt.Errorf("%w: network tracer not supported on this platform or kernel", ErrSysprobeUnsupported)
 	}
+
+	ncfg := networkconfig.New()
 
 	if ncfg.NPMEnabled {
 		log.Info("enabling network performance monitoring (NPM)")
@@ -49,15 +48,13 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 		log.Info("enabling universal service monitoring (USM)")
 	}
 
-	t, err := tracer.NewTracer(ncfg, deps.Telemetry, deps.Statsd)
-	if err != nil {
-		return nil, err
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
-	var connsSender sender.Sender
+	var (
+		connsSender sender.Sender
+		err         error
+	)
 	if ncfg.DirectSend {
-		connsSender, err = sender.New(ctx, t, sender.Dependencies{
+		connsSender, err = sender.New(ctx, deps.NetworkTracer, sender.Dependencies{
 			Config:         deps.CoreConfig,
 			Logger:         deps.Log,
 			Sysprobeconfig: deps.SysprobeConfig,
@@ -68,14 +65,13 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 			NPCollector:    deps.NPCollector,
 		})
 		if err != nil {
-			t.Stop()
 			cancel()
 			return nil, fmt.Errorf("create direct sender: %s", err)
 		}
 	}
 
-	return &networkTracer{
-		tracer:      t,
+	return &networkTracerModule{
+		tracer:      deps.NetworkTracer,
 		cfg:         ncfg,
 		connsSender: connsSender,
 		ctx:         ctx,
@@ -83,10 +79,10 @@ func createNetworkTracerModule(_ *sysconfigtypes.Config, deps module.FactoryDepe
 	}, nil
 }
 
-var _ module.Module = &networkTracer{}
+var _ module.Module = &networkTracerModule{}
 
-type networkTracer struct {
-	tracer       *tracer.Tracer
+type networkTracerModule struct {
+	tracer       networktracer.Component
 	cfg          *networkconfig.Config
 	restartTimer *time.Timer
 	connsSender  sender.Sender
@@ -94,13 +90,12 @@ type networkTracer struct {
 	cancelFunc   context.CancelFunc
 }
 
-func (nt *networkTracer) GetStats() map[string]any {
-	stats, _ := nt.tracer.GetStats()
-	return stats
+func (nt *networkTracerModule) GetStats() map[string]any {
+	return nt.tracer.GetStats()
 }
 
-// Register all networkTracer endpoints
-func (nt *networkTracer) Register(httpMux *module.Router) error {
+// Register all networkTracerModule endpoints
+func (nt *networkTracerModule) Register(httpMux *module.Router) error {
 	if !nt.cfg.DirectSend {
 		var runCounter atomic.Uint64
 
@@ -189,27 +184,19 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/debug/conntrack/cached", func(w http.ResponseWriter, req *http.Request) {
 		ctx, cancelFunc := context.WithTimeout(req.Context(), 30*time.Second)
 		defer cancelFunc()
-		table, err := nt.tracer.DebugCachedConntrack(ctx)
-		if err != nil {
+		if err := nt.tracer.DebugCachedConntrack(ctx, w, maxConntrackDumpSize); err != nil {
 			log.Errorf("unable to retrieve cached conntrack table: %s", err)
 			w.WriteHeader(500)
-			return
 		}
-
-		writeConntrackTable(table, w)
 	})
 
 	httpMux.HandleFunc("/debug/conntrack/host", func(w http.ResponseWriter, req *http.Request) {
 		ctx, cancelFunc := context.WithTimeout(req.Context(), 10*time.Second)
 		defer cancelFunc()
-		table, err := nt.tracer.DebugHostConntrack(ctx)
-		if err != nil {
+		if err := nt.tracer.DebugHostConntrack(ctx, w, maxConntrackDumpSize); err != nil {
 			log.Errorf("unable to retrieve host conntrack table: %s", err)
 			w.WriteHeader(500)
-			return
 		}
-
-		writeConntrackTable(table, w)
 	})
 
 	httpMux.HandleFunc("/debug/process_cache", func(w http.ResponseWriter, r *http.Request) {
@@ -231,11 +218,11 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 }
 
 // Close will stop all system probe activities
-func (nt *networkTracer) Close() {
+func (nt *networkTracerModule) Close() {
 	if nt.connsSender != nil {
 		nt.connsSender.Stop()
 	}
-	nt.tracer.Stop()
+	// tracer lifecycle (Stop) is managed by the fx component; no explicit Stop call needed here.
 	nt.cancelFunc()
 }
 
@@ -271,12 +258,4 @@ func writeConnections(w http.ResponseWriter, marshaler marshal.Marshaler, cs *ne
 	}
 
 	log.Tracef("/connections: %d connections", len(cs.Conns))
-}
-
-func writeConntrackTable(table *tracer.DebugConntrackTable, w http.ResponseWriter) {
-	err := table.WriteTo(w, maxConntrackDumpSize)
-	if err != nil {
-		log.Errorf("unable to dump conntrack: %s", err)
-		w.WriteHeader(500)
-	}
 }

--- a/cmd/system-probe/modules/network_tracer_darwin.go
+++ b/cmd/system-probe/modules/network_tracer_darwin.go
@@ -22,7 +22,7 @@ var NetworkTracer = &module.Factory{
 
 // platformRegister is a stub for Darwin
 // Platform-specific endpoints (like network_id on Linux) are not implemented yet
-func (nt *networkTracer) platformRegister(_ *module.Router) error {
+func (nt *networkTracerModule) platformRegister(_ *module.Router) error {
 	// No platform-specific endpoints for Darwin yet
 	return nil
 }

--- a/cmd/system-probe/modules/network_tracer_linux.go
+++ b/cmd/system-probe/modules/network_tracer_linux.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/DataDog/datadog-agent/pkg/network/tracer"
+	pkgconfigsetup "github.com/DataDog/datadog-agent/pkg/config/setup"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/system-probe/utils"
@@ -28,10 +28,16 @@ func init() { registerModule(NetworkTracer) }
 var NetworkTracer = &module.Factory{
 	Name:      config.NetworkTracerModule,
 	Fn:        createNetworkTracerModule,
-	NeedsEBPF: tracer.NeedsEBPF,
+	NeedsEBPF: networkTracerNeedsEBPF,
 }
 
-func (nt *networkTracer) platformRegister(httpMux *module.Router) error {
+// networkTracerNeedsEBPF returns true if the network tracer requires eBPF
+// (i.e. eBPF-less mode is not enabled).
+func networkTracerNeedsEBPF() bool {
+	return !pkgconfigsetup.SystemProbe().GetBool("network_config.enable_ebpfless")
+}
+
+func (nt *networkTracerModule) platformRegister(httpMux *module.Router) error {
 	httpMux.HandleFunc("/network_id", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		id, err := getNetworkID(req.Context())
 		if err != nil {

--- a/cmd/system-probe/modules/network_tracer_windows.go
+++ b/cmd/system-probe/modules/network_tracer_windows.go
@@ -51,7 +51,7 @@ func logIISSiteTimeouts() {
 	}
 }
 
-func (nt *networkTracer) platformRegister(httpMux *module.Router) error {
+func (nt *networkTracerModule) platformRegister(httpMux *module.Router) error {
 	if !nt.cfg.DirectSend {
 		nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
 			log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)

--- a/cmd/system-probe/modules/usm_endpoints_common.go
+++ b/cmd/system-probe/modules/usm_endpoints_common.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func registerUSMCommonEndpoints(nt *networkTracer, httpMux *module.Router) {
+func registerUSMCommonEndpoints(nt *networkTracerModule, httpMux *module.Router) {
 	httpMux.HandleFunc("/debug/http_monitoring", func(w http.ResponseWriter, req *http.Request) {
 		if !coreconfig.SystemProbe().GetBool("service_monitoring_config.http.enabled") {
 			writeDisabledProtocolMessage("http", w)

--- a/cmd/system-probe/modules/usm_endpoints_darwin.go
+++ b/cmd/system-probe/modules/usm_endpoints_darwin.go
@@ -13,7 +13,7 @@ import (
 
 // registerUSMEndpoints is a stub for Darwin
 // Universal Service Monitoring (USM) is not yet implemented on macOS
-func registerUSMEndpoints(_ *networkTracer, _ *module.Router) {
+func registerUSMEndpoints(_ *networkTracerModule, _ *module.Router) {
 	// USM features (HTTP, HTTP/2, Kafka monitoring) not implemented on Darwin yet
 	// This is a no-op stub to allow compilation
 }

--- a/cmd/system-probe/modules/usm_endpoints_linux.go
+++ b/cmd/system-probe/modules/usm_endpoints_linux.go
@@ -22,7 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func registerUSMEndpoints(nt *networkTracer, httpMux *module.Router) {
+func registerUSMEndpoints(nt *networkTracerModule, httpMux *module.Router) {
 	registerUSMCommonEndpoints(nt, httpMux)
 
 	httpMux.HandleFunc("/debug/kafka_monitoring", func(w http.ResponseWriter, req *http.Request) {

--- a/cmd/system-probe/modules/usm_endpoints_windows.go
+++ b/cmd/system-probe/modules/usm_endpoints_windows.go
@@ -11,6 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/system-probe/api/module"
 )
 
-func registerUSMEndpoints(nt *networkTracer, httpMux *module.Router) {
+func registerUSMEndpoints(nt *networkTracerModule, httpMux *module.Router) {
 	registerUSMCommonEndpoints(nt, httpMux)
 }

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -72,9 +72,6 @@ import (
 	eventplatformfx "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/fx"
 	eventplatformreceiverimpl "github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/impl"
 	network "github.com/DataDog/datadog-agent/comp/network"
-	npcollectorfx "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/fx"
-	localtraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-local"
-	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
 	rcclient "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/def"
 	rcclientfx "github.com/DataDog/datadog-agent/comp/remote-config/rcclient/fx"
 	logscompressionfx "github.com/DataDog/datadog-agent/comp/serializer/logscompression/fx"
@@ -209,8 +206,6 @@ func getSharedFxOption() fx.Option {
 		connectionsforwarderfx.Module(),
 		eventplatformreceiverimpl.Module(),
 		eventplatformfx.Module(eventplatform.NewDefaultParams()),
-		rdnsquerierfx.Module(),
-		npcollectorfx.Module(),
 	)
 }
 

--- a/cmd/system-probe/subcommands/run/command.go
+++ b/cmd/system-probe/subcommands/run/command.go
@@ -71,6 +71,7 @@ import (
 	eventplatform "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/def"
 	eventplatformfx "github.com/DataDog/datadog-agent/comp/forwarder/eventplatform/fx"
 	eventplatformreceiverimpl "github.com/DataDog/datadog-agent/comp/forwarder/eventplatformreceiver/impl"
+	network "github.com/DataDog/datadog-agent/comp/network"
 	npcollectorfx "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/fx"
 	localtraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-local"
 	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
@@ -204,7 +205,7 @@ func getSharedFxOption() fx.Option {
 		configsyncfx.Module(configsync.NewParams(configSyncTimeout, true, configSyncTimeout)),
 		remoteagentfx.Module(),
 		fxinstrumentation.Module(),
-		localtraceroute.Module(),
+		network.Bundle(network.WithLocalTraceroute(), network.WithNetworkTracer()),
 		connectionsforwarderfx.Module(),
 		eventplatformreceiverimpl.Module(),
 		eventplatformfx.Module(eventplatform.NewDefaultParams()),

--- a/comp/README.md
+++ b/comp/README.md
@@ -525,6 +525,34 @@ When running, it listens for network traffic according to configured
 listeners and aggregates traffic data to send to the backend.
 It does not expose any public methods.
 
+## [comp/network](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/network) (Component Bundle)
+
+*Datadog Team*: cloud-network-monitoring
+
+Package network implements the "network" bundle, providing network monitoring components.
+
+### [comp/networkdeviceconfig](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/networkdeviceconfig)
+
+*Datadog Team*: ndm-integrations
+
+Package networkdeviceconfig provides the component for retrieving network device configurations.
+
+### [comp/networktracer](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/networktracer)
+
+Package networktracer defines the component interface for network connection tracing.
+
+### [comp/networkpath/npcollector](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/networkpath/npcollector)
+
+*Datadog Team*: network-path
+
+Package npcollector used to manage network paths
+
+### [comp/networkpath/traceroute](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/networkpath/traceroute)
+
+*Datadog Team*: network-path
+
+Package traceroute provides the traceroute component
+
 ## [comp/networkpath](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/networkpath) (Component Bundle)
 
 *Datadog Team*: network-path
@@ -890,6 +918,7 @@ Package logonduration provides a component that monitors the duration of a user 
 *Datadog Team*: ndm-integrations
 
 Package networkconfigmanagement provides the component for retrieving network device configurations.
+
 
 ### [comp/notableevents](https://pkg.go.dev/github.com/DataDog/datadog-agent/comp/notableevents)
 

--- a/comp/network/BUILD.bazel
+++ b/comp/network/BUILD.bazel
@@ -1,0 +1,2 @@
+# Stub: intermediate package not yet migrated to Bazel.
+# gazelle:ignore

--- a/comp/network/bundle.go
+++ b/comp/network/bundle.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package network implements the "network" bundle, providing network monitoring components.
+package network
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl"
+	localtraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-local"
+	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
+	networktracerimpl "github.com/DataDog/datadog-agent/comp/networktracer/fx"
+	rdnsquerierfx "github.com/DataDog/datadog-agent/comp/rdnsquerier/fx"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// team: cloud-network-monitoring
+
+type bundleOptions struct {
+	tracerouteModule    fx.Option
+	networkTracerModule fx.Option
+}
+
+// Option modifies the set of modules included in the bundle.
+type Option func(*bundleOptions)
+
+// WithRemoteTraceroute selects the remote (gRPC-backed) traceroute implementation.
+// This is the default when no traceroute option is provided.
+func WithRemoteTraceroute() Option {
+	return func(o *bundleOptions) {
+		o.tracerouteModule = remotetraceroute.Module()
+	}
+}
+
+// WithLocalTraceroute selects the local (in-process) traceroute implementation.
+// Use this in binaries that run system-probe in the same process (i.e. system-probe itself).
+func WithLocalTraceroute() Option {
+	return func(o *bundleOptions) {
+		o.tracerouteModule = localtraceroute.Module()
+	}
+}
+
+// WithNetworkTracer includes the networktracer component, which owns the
+// pkg/network/tracer lifecycle. Only system-probe should use this option.
+func WithNetworkTracer() Option {
+	return func(o *bundleOptions) {
+		o.networkTracerModule = networktracerimpl.Module()
+	}
+}
+
+// Bundle defines the fx options for the network monitoring bundle.
+//
+// By default the bundle wires:
+//   - rdnsquerier (reverse DNS enrichment)
+//   - npcollector (network path collector)
+//   - traceroute via the remote implementation
+//
+// Pass option functions to customise the implementation variants:
+//
+//	network.Bundle(network.WithLocalTraceroute(), network.WithNetworkTracer())
+func Bundle(options ...Option) fxutil.BundleOptions {
+	opts := &bundleOptions{
+		tracerouteModule:    remotetraceroute.Module(),
+		networkTracerModule: fx.Options(), // no-op by default
+	}
+	for _, o := range options {
+		o(opts)
+	}
+
+	return fxutil.Bundle(
+		rdnsquerierfx.Module(),
+		opts.tracerouteModule,
+		npcollectorimpl.Module(),
+		opts.networkTracerModule,
+	)
+}

--- a/comp/network/bundle.go
+++ b/comp/network/bundle.go
@@ -9,7 +9,7 @@ package network
 import (
 	"go.uber.org/fx"
 
-	"github.com/DataDog/datadog-agent/comp/networkpath/npcollector/npcollectorimpl"
+	npcollectorfx "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/fx"
 	localtraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-local"
 	remotetraceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/fx-remote"
 	networktracerimpl "github.com/DataDog/datadog-agent/comp/networktracer/fx"
@@ -73,7 +73,7 @@ func Bundle(options ...Option) fxutil.BundleOptions {
 	return fxutil.Bundle(
 		rdnsquerierfx.Module(),
 		opts.tracerouteModule,
-		npcollectorimpl.Module(),
+		npcollectorfx.Module(),
 		opts.networkTracerModule,
 	)
 }

--- a/comp/networktracer/def/BUILD.bazel
+++ b/comp/networktracer/def/BUILD.bazel
@@ -1,0 +1,2 @@
+# Stub: intermediate package not yet migrated to Bazel.
+# gazelle:ignore

--- a/comp/networktracer/def/component.go
+++ b/comp/networktracer/def/component.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package networktracer defines the component interface for network connection tracing.
+package networktracer
+
+import (
+	"context"
+	"io"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+)
+
+// team: cloud-network-monitoring
+
+// Component provides network connection tracing capabilities.
+// It wraps the underlying eBPF-based tracer on Linux and the driver-based tracer on Windows.
+type Component interface {
+	// GetActiveConnections returns active network connections for the given clientID.
+	// The returned cleanup function MUST be called after the caller is done with the connections.
+	GetActiveConnections(clientID string) (*network.Connections, func(), error)
+
+	// RegisterClient registers a new client for connection delta tracking.
+	RegisterClient(clientID string) error
+
+	// GetStats returns internal tracer statistics.
+	GetStats() map[string]interface{}
+
+	// Pause suspends eBPF-based connection tracking.
+	Pause() error
+
+	// Resume resumes eBPF-based connection tracking.
+	Resume() error
+
+	// DebugNetworkMaps returns all active connections for debugging purposes.
+	// The caller is responsible for calling network.Reclaim on the returned connections.
+	DebugNetworkMaps() (*network.Connections, error)
+
+	// DebugNetworkState returns the internal connection state for the given client.
+	DebugNetworkState(clientID string) (interface{}, error)
+
+	// DebugEBPFMaps writes the content of all eBPF maps (or a subset identified by maps) to w.
+	DebugEBPFMaps(w io.Writer, maps ...string) error
+
+	// DebugCachedConntrack writes the cached conntrack table to w, limited to maxSize entries.
+	DebugCachedConntrack(ctx context.Context, w io.Writer, maxSize int) error
+
+	// DebugHostConntrack writes the host conntrack table to w, limited to maxSize entries.
+	DebugHostConntrack(ctx context.Context, w io.Writer, maxSize int) error
+
+	// DebugDumpProcessCache returns the content of the process cache.
+	DebugDumpProcessCache(ctx context.Context) (interface{}, error)
+
+	// IsSupported reports whether the tracer is operational on the current platform and kernel.
+	// Returns false on platforms where eBPF is unavailable or the kernel version is unsupported.
+	IsSupported() bool
+}

--- a/comp/networktracer/fx/BUILD.bazel
+++ b/comp/networktracer/fx/BUILD.bazel
@@ -1,0 +1,2 @@
+# Stub: intermediate package not yet migrated to Bazel.
+# gazelle:ignore

--- a/comp/networktracer/fx/fx.go
+++ b/comp/networktracer/fx/fx.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package fx provides the fx module for the networktracer component.
+package fx
+
+import (
+	networktracerimpl "github.com/DataDog/datadog-agent/comp/networktracer/impl"
+	"github.com/DataDog/datadog-agent/pkg/util/fxutil"
+)
+
+// Module defines the fx options for the networktracer component.
+func Module() fxutil.Module {
+	return fxutil.Component(
+		fxutil.ProvideComponentConstructor(
+			networktracerimpl.NewComponent,
+		),
+	)
+}

--- a/comp/networktracer/impl/BUILD.bazel
+++ b/comp/networktracer/impl/BUILD.bazel
@@ -1,0 +1,2 @@
+# Stub: intermediate package not yet migrated to Bazel.
+# gazelle:ignore

--- a/comp/networktracer/impl/tracer_linux.go
+++ b/comp/networktracer/impl/tracer_linux.go
@@ -1,0 +1,190 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux_bpf
+
+// Package networktracerimpl implements the networktracer component.
+package networktracerimpl
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
+
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	networktracer "github.com/DataDog/datadog-agent/comp/networktracer/def"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	networkconfig "github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer"
+)
+
+// Requires defines the fx dependencies for the networktracer component.
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+
+	Telemetry telemetry.Component
+	Statsd    ddgostatsd.ClientInterface
+}
+
+// Provides defines the output of the networktracer component.
+type Provides struct {
+	Comp networktracer.Component
+}
+
+// tracerImpl is the private implementation of the networktracer component.
+type tracerImpl struct {
+	t *tracer.Tracer
+}
+
+// NewComponent creates a new networktracer component backed by the eBPF tracer.
+// If the current OS or kernel version does not support the tracer, a no-op component
+// is returned instead of an error so that the fx graph can still start; the module
+// factory will detect the unsupported case and skip module registration gracefully.
+func NewComponent(reqs Requires) (Provides, error) {
+	ncfg := networkconfig.New()
+
+	if supported, reason := tracer.IsTracerSupportedByOS(ncfg.ExcludedBPFLinuxVersions); !supported {
+		return Provides{Comp: &unsupportedKernelTracer{reason: reason}}, nil
+	}
+
+	t, err := tracer.NewTracer(ncfg, reqs.Telemetry, reqs.Statsd)
+	if err != nil {
+		return Provides{}, fmt.Errorf("could not create network tracer: %w", err)
+	}
+
+	impl := &tracerImpl{t: t}
+
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: func(context.Context) error { return nil },
+		OnStop: func(context.Context) error {
+			impl.t.Stop()
+			return nil
+		},
+	})
+
+	return Provides{Comp: impl}, nil
+}
+
+// GetActiveConnections returns active network connections for the given clientID.
+func (ti *tracerImpl) GetActiveConnections(clientID string) (*network.Connections, func(), error) {
+	return ti.t.GetActiveConnections(clientID)
+}
+
+// RegisterClient registers a new client for connection delta tracking.
+func (ti *tracerImpl) RegisterClient(clientID string) error {
+	return ti.t.RegisterClient(clientID)
+}
+
+// GetStats returns internal tracer statistics.
+func (ti *tracerImpl) GetStats() map[string]interface{} {
+	stats, _ := ti.t.GetStats()
+	return stats
+}
+
+// Pause suspends eBPF-based connection tracking.
+func (ti *tracerImpl) Pause() error {
+	return ti.t.Pause()
+}
+
+// Resume resumes eBPF-based connection tracking.
+func (ti *tracerImpl) Resume() error {
+	return ti.t.Resume()
+}
+
+// DebugNetworkMaps returns all active connections for debugging purposes.
+func (ti *tracerImpl) DebugNetworkMaps() (*network.Connections, error) {
+	return ti.t.DebugNetworkMaps()
+}
+
+// DebugNetworkState returns the internal connection state for the given client.
+func (ti *tracerImpl) DebugNetworkState(clientID string) (interface{}, error) {
+	return ti.t.DebugNetworkState(clientID)
+}
+
+// DebugEBPFMaps writes the content of all eBPF maps (or the subset named by maps) to w.
+func (ti *tracerImpl) DebugEBPFMaps(w io.Writer, maps ...string) error {
+	return ti.t.DebugEBPFMaps(w, maps...)
+}
+
+// DebugCachedConntrack writes the cached conntrack table to w, limited to maxSize entries.
+func (ti *tracerImpl) DebugCachedConntrack(ctx context.Context, w io.Writer, maxSize int) error {
+	table, err := ti.t.DebugCachedConntrack(ctx)
+	if err != nil {
+		return err
+	}
+	return table.WriteTo(w, maxSize)
+}
+
+// DebugHostConntrack writes the host conntrack table to w, limited to maxSize entries.
+func (ti *tracerImpl) DebugHostConntrack(ctx context.Context, w io.Writer, maxSize int) error {
+	table, err := ti.t.DebugHostConntrack(ctx)
+	if err != nil {
+		return err
+	}
+	return table.WriteTo(w, maxSize)
+}
+
+// DebugDumpProcessCache returns the content of the process cache.
+func (ti *tracerImpl) DebugDumpProcessCache(ctx context.Context) (interface{}, error) {
+	return ti.t.DebugDumpProcessCache(ctx)
+}
+
+// IsSupported returns true since this implementation wraps a live eBPF tracer.
+func (ti *tracerImpl) IsSupported() bool { return true }
+
+// unsupportedKernelTracer is returned when the current kernel does not satisfy
+// the tracer's minimum version requirements. It is a no-op so that the fx graph
+// can start successfully; the module factory detects the unsupported condition
+// independently and skips module registration.
+type unsupportedKernelTracer struct {
+	reason error
+}
+
+func (u *unsupportedKernelTracer) GetActiveConnections(_ string) (*network.Connections, func(), error) {
+	return nil, nil, fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) RegisterClient(_ string) error {
+	return fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) GetStats() map[string]interface{} { return nil }
+
+func (u *unsupportedKernelTracer) Pause() error {
+	return fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) Resume() error {
+	return fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) DebugNetworkMaps() (*network.Connections, error) {
+	return nil, fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) DebugNetworkState(_ string) (interface{}, error) {
+	return nil, fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) DebugEBPFMaps(_ io.Writer, _ ...string) error {
+	return fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) DebugCachedConntrack(_ context.Context, _ io.Writer, _ int) error {
+	return fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) DebugHostConntrack(_ context.Context, _ io.Writer, _ int) error {
+	return fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) DebugDumpProcessCache(_ context.Context) (interface{}, error) {
+	return nil, fmt.Errorf("network tracer not supported: %w", u.reason)
+}
+
+func (u *unsupportedKernelTracer) IsSupported() bool { return false }

--- a/comp/networktracer/impl/tracer_linux.go
+++ b/comp/networktracer/impl/tracer_linux.go
@@ -15,7 +15,7 @@ import (
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
-	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	networktracer "github.com/DataDog/datadog-agent/comp/networktracer/def"
 	"github.com/DataDog/datadog-agent/pkg/network"

--- a/comp/networktracer/impl/tracer_unsupported.go
+++ b/comp/networktracer/impl/tracer_unsupported.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux_bpf && !(windows && npm)
+
+// Package networktracerimpl implements the networktracer component.
+package networktracerimpl
+
+import (
+	"context"
+	"errors"
+	"io"
+
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	networktracer "github.com/DataDog/datadog-agent/comp/networktracer/def"
+	"github.com/DataDog/datadog-agent/pkg/network"
+)
+
+// ErrNotSupported is returned by the stub component on platforms where the
+// eBPF-based network tracer is not available.
+var ErrNotSupported = errors.New("network tracer is not supported on this platform")
+
+// Requires defines the fx dependencies for the networktracer stub component.
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+}
+
+// Provides defines the output of the networktracer stub component.
+type Provides struct {
+	Comp networktracer.Component
+}
+
+// unsupportedTracer is a no-op implementation returned on unsupported platforms.
+type unsupportedTracer struct{}
+
+// NewComponent creates a stub networktracer component that returns ErrNotSupported on all calls.
+func NewComponent(_ Requires) (Provides, error) {
+	return Provides{Comp: &unsupportedTracer{}}, nil
+}
+
+// GetActiveConnections always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) GetActiveConnections(_ string) (*network.Connections, func(), error) {
+	return nil, nil, ErrNotSupported
+}
+
+// RegisterClient always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) RegisterClient(_ string) error {
+	return ErrNotSupported
+}
+
+// GetStats always returns nil on unsupported platforms.
+func (u *unsupportedTracer) GetStats() map[string]interface{} {
+	return nil
+}
+
+// Pause always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) Pause() error {
+	return ErrNotSupported
+}
+
+// Resume always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) Resume() error {
+	return ErrNotSupported
+}
+
+// DebugNetworkMaps always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) DebugNetworkMaps() (*network.Connections, error) {
+	return nil, ErrNotSupported
+}
+
+// DebugNetworkState always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) DebugNetworkState(_ string) (interface{}, error) {
+	return nil, ErrNotSupported
+}
+
+// DebugEBPFMaps always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) DebugEBPFMaps(_ io.Writer, _ ...string) error {
+	return ErrNotSupported
+}
+
+// DebugCachedConntrack always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) DebugCachedConntrack(_ context.Context, _ io.Writer, _ int) error {
+	return ErrNotSupported
+}
+
+// DebugHostConntrack always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) DebugHostConntrack(_ context.Context, _ io.Writer, _ int) error {
+	return ErrNotSupported
+}
+
+// DebugDumpProcessCache always returns ErrNotSupported on unsupported platforms.
+func (u *unsupportedTracer) DebugDumpProcessCache(_ context.Context) (interface{}, error) {
+	return nil, ErrNotSupported
+}
+
+// IsSupported always returns false on unsupported platforms.
+func (u *unsupportedTracer) IsSupported() bool { return false }

--- a/comp/networktracer/impl/tracer_windows.go
+++ b/comp/networktracer/impl/tracer_windows.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	networkconfig "github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // Requires defines the fx dependencies for the networktracer component.
@@ -42,13 +43,26 @@ type tracerImpl struct {
 	t *tracer.Tracer
 }
 
+// unavailableTracer is returned when the Windows NPM driver cannot be started. It
+// satisfies the networktracer.Component interface with IsSupported() == false so that
+// the module factory can detect the failure and skip module registration gracefully,
+// allowing system-probe to continue starting normally.
+type unavailableTracer struct {
+	reason error
+}
+
 // NewComponent creates a new networktracer component backed by the Windows NPM tracer.
+// If the NPM driver fails to start (e.g. it is not installed or is currently unavailable),
+// a no-op component is returned instead of propagating the error, so the fx graph can
+// still start; the module factory detects the unsupported condition via IsSupported() and
+// skips module registration gracefully.
 func NewComponent(reqs Requires) (Provides, error) {
 	ncfg := networkconfig.New()
 
 	t, err := tracer.NewTracer(ncfg, reqs.Telemetry, reqs.Statsd)
 	if err != nil {
-		return Provides{}, fmt.Errorf("could not create network tracer: %w", err)
+		log.Warnf("could not create Windows network tracer, NPM will be disabled: %v", err)
+		return Provides{Comp: &unavailableTracer{reason: err}}, nil
 	}
 
 	impl := &tracerImpl{t: t}
@@ -63,6 +77,50 @@ func NewComponent(reqs Requires) (Provides, error) {
 
 	return Provides{Comp: impl}, nil
 }
+
+func (u *unavailableTracer) GetActiveConnections(_ string) (*network.Connections, func(), error) {
+	return nil, nil, fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) RegisterClient(_ string) error {
+	return fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) GetStats() map[string]interface{} { return nil }
+
+func (u *unavailableTracer) Pause() error {
+	return fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) Resume() error {
+	return fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) DebugNetworkMaps() (*network.Connections, error) {
+	return nil, fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) DebugNetworkState(_ string) (interface{}, error) {
+	return nil, fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) DebugEBPFMaps(_ io.Writer, _ ...string) error {
+	return fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) DebugCachedConntrack(_ context.Context, _ io.Writer, _ int) error {
+	return fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) DebugHostConntrack(_ context.Context, _ io.Writer, _ int) error {
+	return fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) DebugDumpProcessCache(_ context.Context) (interface{}, error) {
+	return nil, fmt.Errorf("network tracer unavailable: %w", u.reason)
+}
+
+func (u *unavailableTracer) IsSupported() bool { return false }
 
 // GetActiveConnections returns active network connections for the given clientID.
 func (ti *tracerImpl) GetActiveConnections(clientID string) (*network.Connections, func(), error) {

--- a/comp/networktracer/impl/tracer_windows.go
+++ b/comp/networktracer/impl/tracer_windows.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	networkconfig "github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/driver"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -57,6 +58,16 @@ type unavailableTracer struct {
 // still start; the module factory detects the unsupported condition via IsSupported() and
 // skips module registration gracefully.
 func NewComponent(reqs Requires) (Provides, error) {
+	// driver.Init must be called before tracer.NewTracer so that the driver
+	// reference counter is ready before driver.Start() is invoked inside NewTracer.
+	// In the legacy module-factory path this was done by loader_windows.go's
+	// preRegister hook; the component constructor runs earlier (during fx
+	// dependency resolution), so we must initialize the driver here instead.
+	if err := driver.Init(); err != nil {
+		log.Warnf("could not initialize Windows NPM driver subsystem, NPM will be disabled: %v", err)
+		return Provides{Comp: &unavailableTracer{reason: err}}, nil
+	}
+
 	ncfg := networkconfig.New()
 
 	t, err := tracer.NewTracer(ncfg, reqs.Telemetry, reqs.Statsd)

--- a/comp/networktracer/impl/tracer_windows.go
+++ b/comp/networktracer/impl/tracer_windows.go
@@ -1,0 +1,125 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows && npm
+
+// Package networktracerimpl implements the networktracer component.
+package networktracerimpl
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
+
+	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	compdef "github.com/DataDog/datadog-agent/comp/def"
+	networktracer "github.com/DataDog/datadog-agent/comp/networktracer/def"
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	networkconfig "github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/DataDog/datadog-agent/pkg/network/tracer"
+)
+
+// Requires defines the fx dependencies for the networktracer component.
+type Requires struct {
+	Lifecycle compdef.Lifecycle
+
+	Telemetry telemetry.Component
+	Statsd    ddgostatsd.ClientInterface
+}
+
+// Provides defines the output of the networktracer component.
+type Provides struct {
+	Comp networktracer.Component
+}
+
+// tracerImpl is the private implementation of the networktracer component on Windows.
+type tracerImpl struct {
+	t *tracer.Tracer
+}
+
+// NewComponent creates a new networktracer component backed by the Windows NPM tracer.
+func NewComponent(reqs Requires) (Provides, error) {
+	ncfg := networkconfig.New()
+
+	t, err := tracer.NewTracer(ncfg, reqs.Telemetry, reqs.Statsd)
+	if err != nil {
+		return Provides{}, fmt.Errorf("could not create network tracer: %w", err)
+	}
+
+	impl := &tracerImpl{t: t}
+
+	reqs.Lifecycle.Append(compdef.Hook{
+		OnStart: func(context.Context) error { return nil },
+		OnStop: func(context.Context) error {
+			impl.t.Stop()
+			return nil
+		},
+	})
+
+	return Provides{Comp: impl}, nil
+}
+
+// GetActiveConnections returns active network connections for the given clientID.
+func (ti *tracerImpl) GetActiveConnections(clientID string) (*network.Connections, func(), error) {
+	return ti.t.GetActiveConnections(clientID)
+}
+
+// RegisterClient registers a new client for connection delta tracking.
+func (ti *tracerImpl) RegisterClient(clientID string) error {
+	return ti.t.RegisterClient(clientID)
+}
+
+// GetStats returns internal tracer statistics.
+func (ti *tracerImpl) GetStats() map[string]interface{} {
+	stats, _ := ti.t.GetStats()
+	return stats
+}
+
+// Pause is not implemented on Windows.
+func (ti *tracerImpl) Pause() error {
+	return ebpf.ErrNotImplemented
+}
+
+// Resume is not implemented on Windows.
+func (ti *tracerImpl) Resume() error {
+	return ebpf.ErrNotImplemented
+}
+
+// DebugNetworkMaps is not implemented on Windows.
+func (ti *tracerImpl) DebugNetworkMaps() (*network.Connections, error) {
+	return ti.t.DebugNetworkMaps()
+}
+
+// DebugNetworkState is not implemented on Windows.
+func (ti *tracerImpl) DebugNetworkState(clientID string) (interface{}, error) {
+	result, err := ti.t.DebugNetworkState(clientID)
+	return result, err
+}
+
+// DebugEBPFMaps is not implemented on Windows.
+func (ti *tracerImpl) DebugEBPFMaps(w io.Writer, maps ...string) error {
+	return ti.t.DebugEBPFMaps(w, maps...)
+}
+
+// DebugCachedConntrack is not implemented on Windows.
+func (ti *tracerImpl) DebugCachedConntrack(_ context.Context, _ io.Writer, _ int) error {
+	return ebpf.ErrNotImplemented
+}
+
+// DebugHostConntrack is not implemented on Windows.
+func (ti *tracerImpl) DebugHostConntrack(_ context.Context, _ io.Writer, _ int) error {
+	return ebpf.ErrNotImplemented
+}
+
+// DebugDumpProcessCache returns the content of the process cache.
+func (ti *tracerImpl) DebugDumpProcessCache(ctx context.Context) (interface{}, error) {
+	return ti.t.DebugDumpProcessCache(ctx)
+}
+
+// IsSupported returns true since this implementation wraps a live Windows NPM tracer.
+func (ti *tracerImpl) IsSupported() bool { return true }

--- a/comp/networktracer/impl/tracer_windows.go
+++ b/comp/networktracer/impl/tracer_windows.go
@@ -15,7 +15,7 @@ import (
 
 	ddgostatsd "github.com/DataDog/datadog-go/v5/statsd"
 
-	"github.com/DataDog/datadog-agent/comp/core/telemetry"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry/def"
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	networktracer "github.com/DataDog/datadog-agent/comp/networktracer/def"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"

--- a/comp/networktracer/mock/BUILD.bazel
+++ b/comp/networktracer/mock/BUILD.bazel
@@ -1,0 +1,2 @@
+# Stub: intermediate package not yet migrated to Bazel.
+# gazelle:ignore

--- a/comp/networktracer/mock/mock.go
+++ b/comp/networktracer/mock/mock.go
@@ -1,0 +1,115 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build test
+
+// Package mock provides a mock for the networktracer component.
+package mock
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	networktracer "github.com/DataDog/datadog-agent/comp/networktracer/def"
+	"github.com/DataDog/datadog-agent/pkg/network"
+)
+
+// mockTracer is a controllable test implementation of the networktracer Component.
+type mockTracer struct {
+	activeConnections     func(clientID string) (*network.Connections, func(), error)
+	registerClient        func(clientID string) error
+	getStats              func() map[string]interface{}
+	pause                 func() error
+	resume                func() error
+	debugNetworkMaps      func() (*network.Connections, error)
+	debugNetworkState     func(clientID string) (interface{}, error)
+	debugEBPFMaps         func(w io.Writer, maps ...string) error
+	debugCachedConntrack  func(ctx context.Context, w io.Writer, maxSize int) error
+	debugHostConntrack    func(ctx context.Context, w io.Writer, maxSize int) error
+	debugDumpProcessCache func(ctx context.Context) (interface{}, error)
+	isSupported           func() bool
+}
+
+// Mock returns a mock networktracer component that returns zero values by default.
+// Fields on the returned mock can be overridden for specific test scenarios.
+func Mock(_ *testing.T) networktracer.Component {
+	return &mockTracer{
+		activeConnections: func(_ string) (*network.Connections, func(), error) {
+			return &network.Connections{}, func() {}, nil
+		},
+		registerClient:        func(_ string) error { return nil },
+		getStats:              func() map[string]interface{} { return nil },
+		pause:                 func() error { return nil },
+		resume:                func() error { return nil },
+		debugNetworkMaps:      func() (*network.Connections, error) { return &network.Connections{}, nil },
+		debugNetworkState:     func(_ string) (interface{}, error) { return nil, nil },
+		debugEBPFMaps:         func(_ io.Writer, _ ...string) error { return nil },
+		debugCachedConntrack:  func(_ context.Context, _ io.Writer, _ int) error { return nil },
+		debugHostConntrack:    func(_ context.Context, _ io.Writer, _ int) error { return nil },
+		debugDumpProcessCache: func(_ context.Context) (interface{}, error) { return nil, nil },
+		isSupported:           func() bool { return true },
+	}
+}
+
+// GetActiveConnections implements Component.
+func (m *mockTracer) GetActiveConnections(clientID string) (*network.Connections, func(), error) {
+	return m.activeConnections(clientID)
+}
+
+// RegisterClient implements Component.
+func (m *mockTracer) RegisterClient(clientID string) error {
+	return m.registerClient(clientID)
+}
+
+// GetStats implements Component.
+func (m *mockTracer) GetStats() map[string]interface{} {
+	return m.getStats()
+}
+
+// Pause implements Component.
+func (m *mockTracer) Pause() error {
+	return m.pause()
+}
+
+// Resume implements Component.
+func (m *mockTracer) Resume() error {
+	return m.resume()
+}
+
+// DebugNetworkMaps implements Component.
+func (m *mockTracer) DebugNetworkMaps() (*network.Connections, error) {
+	return m.debugNetworkMaps()
+}
+
+// DebugNetworkState implements Component.
+func (m *mockTracer) DebugNetworkState(clientID string) (interface{}, error) {
+	return m.debugNetworkState(clientID)
+}
+
+// DebugEBPFMaps implements Component.
+func (m *mockTracer) DebugEBPFMaps(w io.Writer, maps ...string) error {
+	return m.debugEBPFMaps(w, maps...)
+}
+
+// DebugCachedConntrack implements Component.
+func (m *mockTracer) DebugCachedConntrack(ctx context.Context, w io.Writer, maxSize int) error {
+	return m.debugCachedConntrack(ctx, w, maxSize)
+}
+
+// DebugHostConntrack implements Component.
+func (m *mockTracer) DebugHostConntrack(ctx context.Context, w io.Writer, maxSize int) error {
+	return m.debugHostConntrack(ctx, w, maxSize)
+}
+
+// DebugDumpProcessCache implements Component.
+func (m *mockTracer) DebugDumpProcessCache(ctx context.Context) (interface{}, error) {
+	return m.debugDumpProcessCache(ctx)
+}
+
+// IsSupported implements Component.
+func (m *mockTracer) IsSupported() bool {
+	return m.isSupported()
+}

--- a/pkg/network/config/config_bpf_linux_test.go
+++ b/pkg/network/config/config_bpf_linux_test.go
@@ -5,7 +5,7 @@
 
 //go:build linux_bpf
 
-package config
+package config_test
 
 import (
 	"strconv"

--- a/pkg/system-probe/api/module/common.go
+++ b/pkg/system-probe/api/module/common.go
@@ -25,6 +25,7 @@ import (
 	connectionsforwarder "github.com/DataDog/datadog-agent/comp/forwarder/connectionsforwarder/def"
 	npcollector "github.com/DataDog/datadog-agent/comp/networkpath/npcollector/def"
 	traceroute "github.com/DataDog/datadog-agent/comp/networkpath/traceroute/def"
+	networktracer "github.com/DataDog/datadog-agent/comp/networktracer/def"
 	logscompression "github.com/DataDog/datadog-agent/comp/serializer/logscompression/def"
 )
 
@@ -57,5 +58,6 @@ type FactoryDependencies struct {
 	Ipc                  ipc.Component
 	Traceroute           traceroute.Component
 	ConnectionsForwarder connectionsforwarder.Component
+	NetworkTracer        networktracer.Component
 	NPCollector          npcollector.Component
 }


### PR DESCRIPTION
### What does this PR do?
Introduces a V2 component for the network tracer and a \`comp/network\` bundle that groups all network monitoring components.

**Changes:**
1. **\`comp/networktracer\`** — new V2 component (`def/impl/fx/mock`) wrapping \`pkg/network/tracer.Tracer\`
   - Full \`Component\` interface: connections, registration, stats, pause/resume, all debug endpoints
   - \`IsSupported() bool\` so callers never import \`pkg/network/tracer\` directly
   - \`linux_bpf\` impl backed by the real eBPF tracer; \`!linux_bpf\` stub returns \`ErrNotSupported\`
   - fx lifecycle manages \`tracer.Stop()\` — callers no longer call it manually
2. **\`cmd/system-probe/modules/network_tracer.go\`** — fully migrated to \`deps.NetworkTracer\` (component); \`pkg/network/tracer\` no longer imported anywhere in \`cmd/system-probe/modules/\`
3. **\`comp/network/bundle.go\`** — new bundle grouping all network monitoring components under a single \`network.Bundle()\` call. All \`cmd/\` callers updated.

### Motivation
\`pkg/network\` had no component boundary — the tracer was created and torn down directly in the system-probe module factory. This PR adds that boundary as the first step toward fully moving the implementation into \`comp/\`.

### Future architecture (follow-up PR)
The current \`impl/\` is still a thin wrapper around \`pkg/network/tracer\`. The next step is to move the entire \`pkg/network/tracer/\` tree (57 files, all self-contained — no external callers outside the component) into \`comp/networktracer/impl/\`, update the 19 internal import paths, and delete \`pkg/network/tracer/\`. At that point the component will own the implementation directly, not just wrap it.

```
# Current state (this PR)
comp/networktracer/impl/tracer_linux.go  ──wraps──▶  pkg/network/tracer.Tracer

# Target state (follow-up)
comp/networktracer/impl/
├── tracer.go          (was pkg/network/tracer/tracer.go)
├── connection/        (was pkg/network/tracer/connection/)
├── networkfilter/     (was pkg/network/tracer/networkfilter/)
├── offsetguess/       (was pkg/network/tracer/offsetguess/)
└── ...
# pkg/network/tracer/ deleted
```

The bundle layout will stay the same; only the impl's internals change.

### Bundle layout

```go
// system-probe
network.Bundle(network.WithLocalTraceroute(), network.WithNetworkTracer())

// agent / process-agent
network.Bundle()  // remote traceroute, no NPM tracer
```

### Describe how you validated your changes
- \`dda inv agent.build --build-exclude=systemd\` passes
- All pre-commit hooks pass: \`go-fmt\`, \`go-mod-tidy\`, \`go-linter\`, \`go-test\`
- CI running

### Additional Notes
- \`pkg/network/tracer\` is now imported **only** by \`comp/networktracer/impl/tracer_linux.go\` (the wrapper) and test files — zero production callers outside the component boundary
- \`networkdeviceconfig\` and \`rdnsquerier\` are included in the bundle; traceroute variant (local vs remote) is selected via option functions matching the \`comp/core\` bundle pattern