### PR TITLE
[ACTP] [PAR] Surface self-enrollment errors to log before process exit

### DIFF
--- a/comp/privateactionrunner/impl/privateactionrunner.go
+++ b/comp/privateactionrunner/impl/privateactionrunner.go
@@ -151,6 +151,7 @@ func (p *PrivateActionRunner) getRunnerConfig(ctx context.Context) (*parconfig.C
 		p.logger.Info("Identity not found and self-enrollment enabled. Self-enrolling private action runner")
 		updatedCfg, err := p.performSelfEnrollment(ctx, cfg)
 		if err != nil {
+			p.logger.Errorf("Self-enrollment failed: %v", err)
 			return nil, fmt.Errorf("self-enrollment failed: %w", err)
 		}
 		p.coreConfig.Set(parPrivateKey, updatedCfg.PrivateKey, model.SourceAgentRuntime)
@@ -185,8 +186,10 @@ func (p *PrivateActionRunner) start(ctx context.Context) error {
 	// Keep the parent context's deadline for the startup phase (config, enrollment, etc.)
 	// but allow Stop() to cancel as well.
 	ctx, p.cancelStart = context.WithCancel(ctx)
+	defer p.logger.Flush()
 	cfg, err := p.getRunnerConfig(ctx)
 	if err != nil {
+		p.logger.Errorf("Private action runner failed to start: %v", err)
 		return err
 	}
 	p.logger.Info("Private action runner starting")


### PR DESCRIPTION
### What does this PR do?

Logs self-enrollment errors and flushes the logger before the private action runner exits, so failures are visible in the log file instead of being silently dropped.

### Motivation

When self-enrollment fails (e.g. due to a missing app key permission), the process crashes before the error is flushed to the log sink. This makes debugging very difficult — the log only shows "Self-enrolling private action runner" with no indication of what went wrong.

Two changes:
- Log the enrollment error at `ERROR` level in `getRunnerConfig` immediately when it occurs
- Add `defer p.logger.Flush()` in `start()` to guarantee the log is written regardless of how the function exits

### Describe how you validated your changes

Reproduced locally by configuring an app key without the required workflow automation scope, confirmed the error message now appears in the log.

### Additional Notes

The `defer p.logger.Flush()` also covers any future error paths added to `start()`.