### PR TITLE
Fix Python hermetic toolchain check for Bazel 9

### DIFF
--- a/bazel/tests/does_python_work.py
+++ b/bazel/tests/does_python_work.py
@@ -1,6 +1,5 @@
 """Smoke test to make sure python works."""
 
-import os.path
 import platform
 import sys
 import unittest
@@ -11,7 +10,7 @@ class TestCase(unittest.TestCase):
     def test_python_comes_from_hermetic_toolchain(self):
         normalized_arch = {"AMD64": "x86_64", "arm64": "aarch64"}.get(platform.machine(), platform.machine())
         self.assertRegex(
-            os.path.realpath(sys.executable),
+            platform.__file__,  # sys.executable may be a venv wrapper or a CAS path
             f"rules_python.+{normalized_arch}.+{platform.system().lower()}",
             "python must come from hermetic toolchain instead of host!",
         )


### PR DESCRIPTION
### What does this PR do?
Fix `//bazel/tests:does_python_work` for Bazel 9 compatibility.

### Motivation
Since Bazel 9, external repository contents are stored in a Content-Addressable Store (CAS) under `cache/repos/v1/contents/<hash>/...` instead of the human-readable named path under `external/`.

`os.path.realpath(sys.executable)` now resolves to the CAS path, which no longer contains `rules_python`, so the assertion fails:
```
  AssertionError: Regex didn't match: 'rules_python.+x86_64.+linux'
  not found in
  '.../cache/repos/v1/contents/e0e23621.../bin/python3.12' :
  python must come from hermetic toolchain instead of host!
```
Actual stdlib install paths are unaffected.

### Describe how you validated your changes
`bazel test //bazel/tests:does_python_work` passes.