### PR TITLE
Disable `repo_contents_cache` when in-workspace for Bazel 9

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -32,14 +32,16 @@ if [ -n "${XDG_CACHE_HOME:-}" ]; then
 fi
 
 # "--startup cmd ..." -> "--startup cmd --config=ci ..."
-if [[ $# -gt 0 && -n "${CI:-}" && -z "${GITHUB_ACTIONS:-}" ]]; then
+if [[ $# -gt 0 && -n "${CI:-}" ]]; then
   args=()
   cmd=
   for arg in "$@"; do
     args+=("$arg")
     if [[ -z "$cmd" && "$arg" != -* ]]; then
       cmd=$arg
-      args+=(--config=ci)
+      [ -z "${GITHUB_ACTIONS:-}" ] && args+=(--config=ci)
+      # https://github.com/bazelbuild/bazel/issues/26384
+      [ "${XDG_CACHE_HOME:-}" = "$(dirname "$(dirname "$0")")/.cache" ] && args+=(--repo_contents_cache=)
     fi
   done
   set -- "${args[@]}"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -38,7 +38,7 @@ if defined XDG_CACHE_HOME (
   set "bazel_home=%XDG_CACHE_HOME%\bazel"
   set bazel_home_startup_option="--output_user_root=!bazel_home!"
 ) else (
-  set "XDG_CACHE_HOME=%~dp0..\.cache"
+  for %%i in ("%~dp0..\.cache") do set "XDG_CACHE_HOME=%%~fi"
 )
 
 :: Check legacy max path length of 260 characters got lifted, or fail with instructions
@@ -55,7 +55,15 @@ if not exist "!more_than_260_chars!" (
 )
 
 set "args=%*"
-if defined args if defined CI if not defined GITHUB_ACTIONS call :inject_ci_args
+if defined args if defined CI (
+  set "ci_args="
+  if not defined GITHUB_ACTIONS set "ci_args=--config=ci"
+  :: https://github.com/bazelbuild/bazel/issues/26384
+  for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" (
+    if defined ci_args (set "ci_args=!ci_args! --repo_contents_cache=") else set "ci_args=--repo_contents_cache="
+  )
+  if defined ci_args call :inject_ci_args
+)
 "%BAZEL_REAL%" !bazel_home_startup_option! !args!
 exit /b !errorlevel!
 
@@ -73,7 +81,7 @@ for /f "tokens=1* delims= " %%i in ("!next_args!") do (
   ) else (
     if defined startup_args set "startup_args=!startup_args:~1! "
     set "cmd=%%i"
-    set "args=!startup_args!!cmd! --config=ci %%j"
+    set "args=!startup_args!!cmd! !ci_args! %%j"
   )
 )
 if not defined cmd if defined next_args goto :parse_next_arg


### PR DESCRIPTION
### What does this PR do?
Extends the CI argument injection in `tools/bazel*` beyond just `--config=ci` to `--repo_contents_cache=` (disabled, matching Bazel 8.4+ default) when using an in-workspace cache path (i.e. on Linux ephemeral runners).

### Motivation
When `XDG_CACHE_HOME` is not explicitly set to a persistent directory (i.e. on Linux ephemeral CI runners), the cache lands under the repo-scoped `.cache` directory (both GitLab and GitHub Actions want in-workspace cache paths), leading to:
```
ERROR: The repo contents cache [/path/to/repos/v1/contents] is inside the main repo [/path/to/datadog-agent]. This can cause spurious failures. Disable the repo contents cache with `--repo_contents_cache=`, or specify `--repo_contents_cache=<path outside the main repo>`.
```

`--repo_contents_cache` stores a workspace-independent copy of fetched external repository trees under `{--repository_cache}/contents` and defaults to `"null"` (enabled) as of Bazel 9.0.

It had been disabled by default (bazelbuild/bazel#26802) in Bazel 8.4+ precisely because of the issues described in bazelbuild/bazel#26384.

The present change therefore keeps it disabled in this very case **until Bazel figures out a way to honor the `.cache` exclusion in `.bazelignore`**.