### PR TITLE
ci(renovate): add workflow to repin Bazel lockfile on Cargo updates

### DIFF
--- a/.github/workflows/cargo-bazel-repin.yml
+++ b/.github/workflows/cargo-bazel-repin.yml
@@ -1,0 +1,53 @@
+---
+name: "Repin Bazel Lockfile And Generate Rust Licenses"
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+
+permissions: {}
+jobs:
+  repin_and_generate_licenses:
+    if: ${{ github.repository == 'DataDog/datadog-agent' && github.event.pull_request.user.login == 'renovate[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies-cargo') }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: ./.github/actions/bazel-cache
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+      - name: Repin Bazel Rust lockfile
+        run: bazel mod deps --lockfile_mode=refresh --repo_env=REPIN=1
+      - name: Generate Rust licenses
+        run: |
+          cargo install --git https://github.com/DataDog/rust-license-tool dd-rust-license-tool
+          cd pkg/discovery/module/rust && dd-rust-license-tool write
+      - name: Create commit
+        id: commit
+        run: |
+          if git diff --quiet; then
+            echo "No changes to commit"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git config --global user.name "Login will be determined by the Github API based on the creator of the token"
+            git config --global user.email ""
+            git commit -am "[renovate skip] Auto-repin Bazel lockfile and regenerate Rust licenses"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+      - name: "Push signed commits"
+        if: steps.commit.outputs.has_changes == 'true'
+        uses: chouetz/push-signed-commits@9b123e8898e6176af65b9427b434e07aebe7f72f
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          local_branch_name: ${{ github.head_ref }}
+          remote_name: "origin"
+          remote_branch_name: ${{ github.head_ref }}

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
     "enabledManagers": ["custom.regex", "pre-commit", "github-actions", "dockerfile", "docker-compose", "cargo", "bazel-module"],
     "labels": ["dependencies", "changelog/no-changelog", "qa/no-code-change"],
     "stopUpdatingLabel": "stop-updating",
+    "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
     "platformCommit": "enabled",
     "packageRules": [
       {
@@ -52,6 +53,11 @@
         "matchManagers": ["docker-compose"],
         "matchFileNames": ["**/testdata/**", "**/fixtures/**", "**/testfixtures/**", "pkg/collector/corechecks/oracle/compose/**"],
         "enabled": false
+      },
+      {
+        "matchManagers": ["cargo"],
+        "labels": ["dependencies", "dependencies-cargo", "changelog/no-changelog", "qa/no-code-change"],
+        "schedule": ["on saturday"]
       }
     ],
     "pre-commit": {


### PR DESCRIPTION
### What does this PR do?

Adds a GitHub Actions workflow and Renovate config changes to automatically fix CI failures on Renovate Cargo (Rust) PRs:

1. **New workflow** (`.github/workflows/cargo-bazel-repin.yml`): Triggered on Renovate Cargo PRs, it repins the Bazel Rust lockfile (`MODULE.bazel.lock`) and regenerates `LICENSE-3rdparty.csv`, then pushes the changes back to the PR branch.

2. **Renovate config** (`renovate.json`):
   - Added `gitIgnoredAuthors` so Renovate ignores commits from `github-actions[bot]` and keeps updating the branch after the workflow pushes
   - Added a `cargo` package rule with `dependencies-cargo` label (used to gate the workflow) and a Saturday schedule

### Motivation

Currently, all Renovate Cargo PRs fail CI because:
- `bazel:mod-deps` fails — `MODULE.bazel.lock` is stale after `Cargo.lock` changes
- `lint_rust_licenses` fails — `LICENSE-3rdparty.csv` doesn't reflect new transitive deps

This mirrors the existing `go-mod-tidy.yml` pattern used for Dependabot Go PRs.

See failing PRs: #48109 (clap), #48110 (nix), #48112 (phf), #48113 (prost)

### Describe how you validated your changes

Workflow structure validated against the existing `go-mod-tidy.yml` workflow. The Bazel repin command matches what the `bazel:mod-deps` CI job runs (`.gitlab/build/bazel/lint.yml`). License generation matches `tasks/licenses.py:generate_rust_licenses`.

### Additional Notes

- The `dtolnay/rust-toolchain` action is pinned by SHA (v1)
- The `push-signed-commits` action reuses the same version as `go-mod-tidy.yml`