### PR TITLE
Make run subcommand optional for host profiler

### DIFF
--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -48,11 +48,8 @@ func MakeRootCommand() *cobra.Command {
 	// Add --agent-config as an alias for --core-config
 	hostProfiler.PersistentFlags().StringVar(&globalParams.CoreConfPath, "agent-config", "", "alias for --core-config")
 
-	for _, cmd := range runCmds {
-		cmd.Flags().SetNormalizeFunc(normalizeCoreConfig)
-		hostProfiler.AddCommand(cmd)
-	}
-
+	runCmds[0].Flags().SetNormalizeFunc(normalizeCoreConfig)
+	hostProfiler.AddCommand(runCmds[0])
 	hostProfiler.AddCommand(version.MakeCommand("Host profiler"))
 
 	return &hostProfiler

--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -28,17 +28,18 @@ func normalizeCoreConfig(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 }
 
 // MakeRootCommand makes the top-level Cobra command for this app.
+// The root command is the `run` command, so `host-profiler` and `host-profiler run` are equivalent.
 func MakeRootCommand() *cobra.Command {
-	hostProfiler := &cobra.Command{
-		Use:   "host-profiler [command]",
-		Short: "Collects host profiling data and sends it to Datadog.",
-		Long:  `The Datadog Host Profiler leverages eBPF-based profiling to collect low-overhead, system-wide performance data from Linux hosts. Built on the OpenTelemetry eBPF Profiler, it captures CPU, memory, and other resource usage across all processes, enabling deep visibility into application and system behavior. Collected profiles are sent to Datadog.`,
-	}
-
 	globalParams := globalparams.GlobalParams{}
 	globalParamsGetter := func() *globalparams.GlobalParams {
 		return &globalParams
 	}
+
+	runCmds := run.MakeCommand(globalParamsGetter)
+	hostProfiler := *runCmds[0]
+	hostProfiler.Use = "host-profiler [command]"
+	hostProfiler.Short = "Collects host profiling data and sends it to Datadog."
+	hostProfiler.Long = `The Datadog Host Profiler leverages eBPF-based profiling to collect low-overhead, system-wide performance data from Linux hosts. Built on the OpenTelemetry eBPF Profiler, it captures CPU, memory, and other resource usage across all processes, enabling deep visibility into application and system behavior. Collected profiles are sent to Datadog.`
 
 	hostProfiler.PersistentFlags().StringVarP(&globalParams.ConfFilePath, "config", "c", "", "path to host-profiler configuration file")
 	hostProfiler.PersistentFlags().StringVarP(&globalParams.CoreConfPath, "core-config", "", "", "Location to the Datadog Agent config file. If this value is not set, infra attribute processor and all features related to the Agent will not be enabled.")
@@ -47,25 +48,13 @@ func MakeRootCommand() *cobra.Command {
 	// Add --agent-config as an alias for --core-config
 	hostProfiler.PersistentFlags().StringVar(&globalParams.CoreConfPath, "agent-config", "", "alias for --core-config")
 
-	for _, subCommandFactory := range hostProfilerSubcommands() {
-		subcommands := subCommandFactory(globalParamsGetter)
-		for _, cmd := range subcommands {
-			cmd.Flags().SetNormalizeFunc(normalizeCoreConfig)
-			hostProfiler.AddCommand(cmd)
-		}
+	for _, cmd := range runCmds {
+		cmd.Flags().SetNormalizeFunc(normalizeCoreConfig)
+		hostProfiler.AddCommand(cmd)
 	}
 
-	return hostProfiler
+	hostProfiler.AddCommand(version.MakeCommand("Host profiler"))
+
+	return &hostProfiler
 }
 
-type subcommandFactory func(func() *globalparams.GlobalParams) []*cobra.Command
-
-// hostProfilerSubcommands returns SubcommandFactories for the subcommands supported.
-func hostProfilerSubcommands() []subcommandFactory {
-	return []subcommandFactory{
-		run.MakeCommand,
-		func(_ func() *globalparams.GlobalParams) []*cobra.Command {
-			return []*cobra.Command{version.MakeCommand("Host profiler")}
-		},
-	}
-}

--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -48,6 +48,7 @@ func MakeRootCommand() *cobra.Command {
 	// Add --agent-config as an alias for --core-config
 	hostProfiler.PersistentFlags().StringVar(&globalParams.CoreConfPath, "agent-config", "", "alias for --core-config")
 
+	// hostProfiler is a shallow copy of runCmds[0] so normalizeCoreConfig also applies to runCmds[0] subcommand below.
 	hostProfiler.Flags().SetNormalizeFunc(normalizeCoreConfig)
 	hostProfiler.AddCommand(runCmds[0])
 	hostProfiler.AddCommand(version.MakeCommand("Host profiler"))

--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -48,7 +48,7 @@ func MakeRootCommand() *cobra.Command {
 	// Add --agent-config as an alias for --core-config
 	hostProfiler.PersistentFlags().StringVar(&globalParams.CoreConfPath, "agent-config", "", "alias for --core-config")
 
-	runCmds[0].Flags().SetNormalizeFunc(normalizeCoreConfig)
+	hostProfiler.Flags().SetNormalizeFunc(normalizeCoreConfig)
 	hostProfiler.AddCommand(runCmds[0])
 	hostProfiler.AddCommand(version.MakeCommand("Host profiler"))
 

--- a/cmd/host-profiler/command/command.go
+++ b/cmd/host-profiler/command/command.go
@@ -57,4 +57,3 @@ func MakeRootCommand() *cobra.Command {
 
 	return &hostProfiler
 }
-


### PR DESCRIPTION
### What does this PR do?

This PR makes the `run` subcommand optional for host profiler. Upstream operator relies on entrypoint baked in image, and there is no CRD-level option to inject run as a positional argument (spec.args only supports --key=value pairs). 

No impact on DD helm/operator.

Follow up to #48125

### Motivation

### Describe how you validated your changes

### Additional Notes
