### PR TITLE
[CWS] Fix race

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -119,14 +119,15 @@ type EBPFProbe struct {
 	kernelVersion  *kernel.Version
 
 	// internals
-	event          *model.Event
-	dnsLayer       *layers.DNS
-	monitors       *EBPFMonitors
-	profileManager securityprofile.ProfileManager
-	fieldHandlers  *EBPFFieldHandlers
-	eventPool      *ddsync.TypedPool[model.Event]
-	variableStore  *eval.VariableStore
-	numCPU         int
+	event           *model.Event
+	dnsLayer        *layers.DNS
+	monitors        *EBPFMonitors
+	profileManager  securityprofile.ProfileManager
+	fieldHandlers   *EBPFFieldHandlers
+	eventPool       *ddsync.TypedPool[model.Event]
+	variableStore   *eval.VariableStore
+	variableStoreMu sync.RWMutex
+	numCPU          int
 
 	ctx       context.Context
 	cancelFnc context.CancelFunc
@@ -993,6 +994,8 @@ func (p *EBPFProbe) EventMarshallerCtor(event *model.Event) func() events.EventM
 
 // evalOpts returns the eval options containing the current variable store
 func (p *EBPFProbe) evalOpts() *eval.Opts {
+	p.variableStoreMu.RLock()
+	defer p.variableStoreMu.RUnlock()
 	return &eval.Opts{VariableStore: p.variableStore}
 }
 
@@ -2503,7 +2506,9 @@ func (p *EBPFProbe) ApplyRuleSet(rs *rules.RuleSet) (*kfilters.FilterReport, boo
 // OnNewRuleSetLoaded resets statistics and states once a new rule set is loaded
 func (p *EBPFProbe) OnNewRuleSetLoaded(rs *rules.RuleSet) {
 	p.processKiller.Reset(rs)
+	p.variableStoreMu.Lock()
 	p.variableStore = rs.GetVariableStore()
+	p.variableStoreMu.Unlock()
 
 	p.HandleRemediationStatus(rs)
 }


### PR DESCRIPTION
### What does this PR do?

Protected p.variableStore against a data race between OnNewRuleSetLoaded (policy reload goroutine) and evalOpts (API server goroutine) using a sync.RWMutex: write-locked on assignment, read-locked on access.

Race seen in this [job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1525861970): 

````
WARNING: DATA RACE
Read at 0x00c000004638 by goroutine 2897:
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).evalOpts()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:992 +0x9b
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).SendRemediationEvent()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/remediations_linux.go:365 +0x34
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).SendCustomEventKillAction()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/remediations_linux.go:303 +0x284
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).SendCustomEventKillAction()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:368 +0xf5
  github.com/DataDog/datadog-agent/pkg/security/module.SendCustomEventKillAction()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:335 +0x102
  github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).start.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:373 +0x335
  github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).dequeue.func1()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:257 +0x339
  github.com/DataDog/datadog-agent/pkg/security/module.slicesDeleteUntilFalse()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:281 +0x2e0
  github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).dequeue()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:249 +0xfe
  github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:347 +0x153
  github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).Start.func2()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:428 +0x9d
Previous write at 0x00c000004638 by goroutine 5534:
  github.com/DataDog/datadog-agent/pkg/security/probe.(*EBPFProbe).OnNewRuleSetLoaded()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe_ebpf.go:2518 +0xb8
  github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).OnNewRuleSetLoaded()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:235 +0x92
  github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleEngine).LoadPolicies()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/rules/engine.go:422 +0xd04
  github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).reloadPolicies()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:134 +0x2e4
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:729 +0x19a4
  github.com/DataDog/datadog-agent/pkg/security/tests.TestRemediationCustomEventNotTriggered()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/action_test.go:1755 +0xc4a
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x44
Goroutine 2897 (running) created at:
  github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:426 +0x452
  github.com/DataDog/datadog-agent/pkg/security/module.(*CWSConsumer).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/module/cws.go:219 +0x164
  github.com/DataDog/datadog-agent/pkg/eventmonitor.(*EventMonitor).Start()
      /go/src/github.com/DataDog/datadog-agent/pkg/eventmonitor/eventmonitor.go:117 +0x141
  github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester_linux.go:855 +0x369e
  github.com/DataDog/datadog-agent/pkg/security/tests.TestActionHash()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/action_test.go:626 +0x7fc
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x44
Goroutine 5534 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1997 +0x9d2
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2477 +0x85
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x21c
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2475 +0x96c
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2337 +0xed4
  github.com/DataDog/datadog-agent/pkg/security/tests.TestMain()
      /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/main_test.go:29 +0x139
  main.main()
      _testmain.go:523 +0x171
==================
    testing.go:1617: race detected during execution of test
=== FAIL: pkg/security TestRemediationCustomEventNotTriggered (15.37s)
````

### Motivation

### Describe how you validated your changes

### Additional Notes
