### PR TITLE
Also set `GIT_DEPTH: 0` for `files_inventory_check` job

### DIFF
--- a/.gitlab/test/functional_test/files_inventory_check.yml
+++ b/.gitlab/test/functional_test/files_inventory_check.yml
@@ -7,6 +7,9 @@ files_inventory_check:
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
+  variables:
+    GIT_DEPTH: 0
+    OVERRIDE_GIT_STRATEGY: clone
   needs:
     - agent_deb-x64-a7
   script:


### PR DESCRIPTION
### What does this PR do?
Set `GIT_DEPTH: 0` and `OVERRIDE_GIT_STRATEGY: clone` so the job fetches the full commit history before determining the ancestor for package size comparison.

### Motivation
The files inventory check was sometimes picking a wrong ancestor commit due to a shallow clone, producing spurious diffs.
Same issue fixed for the static quality gate by #44001 together with #46859.