### PR TITLE
Always run `bazel:test:windows-amd64` in CI

### DIFF
--- a/.gitlab/build/bazel/test.yml
+++ b/.gitlab/build/bazel/test.yml
@@ -25,9 +25,6 @@ bazel:test:macos-arm64:
 
 bazel:test:windows-amd64:
   extends: [ .bazel:test, .bazel:runner:windows-amd64 ]
-  rules:
-    - !reference [ .except_skip_windows ]
-    - when: on_success
   variables:
     POWERSHELL_SCRIPT: |-
       bazel test //bazel/tests/... //rtloader/...


### PR DESCRIPTION
### Motivation
This job is critical to ensure _any_ change, whether strictly `bazel`-related or in the source code being built/tested, doesn't break Windows builds.

It's the second time a breaking change is not gated properly (this time leading to #48207), so we're kindly asking to lift the Windows pipeline exclusion and always run this job in CI.