### PR TITLE
Also trigger Windows CI on `.bazel*` changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,6 +70,7 @@
   - tools/windows/**/*
 
   # Build/packaging
+  - .bazel*
   - MODULE.bazel*
   - omnibus/**/*
   - packages/**/*


### PR DESCRIPTION
### What does this PR do?
Add `.bazel*` to the `windows_path_2` change filter in `.gitlab-ci.yml`.

### Motivation
`.bazelrc` and `.bazelversion` live at the repo root, not under `bazel/**/*`.
Changes to those files can affect Windows builds and tests (#48207) without triggering Windows CI jobs, so
regressions go undetected until the change lands on `main`.

Follows #48087 - more to come?