### PR TITLE
feat(slapr): Prevent use out of main

### DIFF
--- a/.github/workflows/slapr.yml
+++ b/.github/workflows/slapr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run_slapr:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
### What does this PR do?
Do not run slapr on PR not targeting main

### Motivation
The workflow [is not meant to run on PR targeting releases](https://github.com/DataDog/datadog-agent/actions/runs/23347503103/attempts/1), so we just by-pass these calls until the activation of the workflow is requestedsd

### Describe how you validated your changes
n/a

### Additional Notes
