### PR TITLE
[observer] Export telemetry

### DIFF
--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -436,14 +436,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 		})
 
 		// Emit telemetry for the CoDisp score at every scored shingle
-		telemetry = append(telemetry, observer.ObserverTelemetry{
-			DetectorName: r.Name(),
-			Metric: &metricObs{
-				name:      "score",
-				value:     score,
-				timestamp: s.endTimestamp,
-			},
-		})
+		telemetry = append(telemetry, newTelemetryGauge(r.Name(), telemetryRRCFScore, score, s.endTimestamp))
 
 		// Skip warmup phase — scores are artificial during forest filling
 		if r.totalScored <= warmup {
@@ -455,14 +448,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 
 		// Emit telemetry for the dynamic threshold (only after warmup when threshold is meaningful)
 		if threshold > 0 {
-			telemetry = append(telemetry, observer.ObserverTelemetry{
-				DetectorName: r.Name(),
-				Metric: &metricObs{
-					name:      "threshold",
-					value:     threshold,
-					timestamp: s.endTimestamp,
-				},
-			})
+			telemetry = append(telemetry, newTelemetryGauge(r.Name(), telemetryRRCFThreshold, threshold, s.endTimestamp))
 		}
 
 		// Update rolling window (after computing threshold, so current score

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -18,6 +18,8 @@ import (
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
@@ -30,8 +32,9 @@ type Requires struct {
 	// When fields are nil, values are read from configuration defaults.
 	AgentInternalLogTap AgentInternalLogTapConfig
 
-	Config config.Component
-	Log    log.Component
+	Config    config.Component
+	Log       log.Component
+	Telemetry telemetry.Component
 
 	// Recorder is an optional component for transparent metric recording.
 	// If provided, all handles will be wrapped to record metrics to parquet files.
@@ -231,9 +234,15 @@ func NewComponent(deps Requires) Provides {
 		state:     eng.StateView(),
 	})
 
+	telemetryComp := deps.Telemetry
+	if telemetryComp == nil {
+		telemetryComp = noopsimpl.GetCompatComponent()
+	}
+
 	obs := &observerImpl{
-		engine: eng,
-		obsCh:  make(chan observation, 1000),
+		engine:           eng,
+		obsCh:            make(chan observation, 1000),
+		telemetryHandler: newTelemetryHandler(telemetryComp),
 	}
 
 	// Set up handle function based on recording and analysis configuration.
@@ -394,6 +403,8 @@ type observerImpl struct {
 
 	// fetcher pulls traces/profiles from remote trace-agents
 	fetcher *observerFetcher
+
+	telemetryHandler *telemetryHandler
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -413,7 +424,8 @@ func (o *observerImpl) run() {
 			o.processProfile(obs.source, obs.profile)
 		}
 		for _, req := range requests {
-			o.engine.advanceWithReason(req.upToSec, req.reason)
+			result := o.engine.advanceWithReason(req.upToSec, req.reason)
+			o.telemetryHandler.handleTelemetry(result.telemetry)
 		}
 	}
 }

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// RRCF detector
+	telemetryRRCFScore     = "observer.rrcf.score"
+	telemetryRRCFThreshold = "observer.rrcf.threshold"
+
+	// Log extractor
+	// TODO(celian): how to handle counters? We should have a unified interface between observer / internal telemetry
+	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
+)
+
+// This is used to:
+// 1. Enumerate all the telemetry metrics that are emitted by the observer
+// 2. Send them to the backend if we are running in observer mode (not testbench)
+type telemetryHandler struct {
+	telemetryGauges map[string]telemetry.Gauge
+}
+
+func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
+	gauges := make(map[string]telemetry.Gauge)
+
+	// Gauges
+	gauges[telemetryRRCFScore] = telemetryComp.NewGauge(
+		"observer",
+		telemetryRRCFScore,
+		[]string{"detector"},
+		"RRCF CoDisp score per scored shingle",
+	)
+	gauges[telemetryRRCFThreshold] = telemetryComp.NewGauge(
+		"observer",
+		telemetryRRCFThreshold,
+		[]string{"detector"},
+		"RRCF dynamic anomaly detection threshold (post-warmup)",
+	)
+	gauges[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewGauge(
+		"observer",
+		telemetryLogPatternExtractorPatternCount,
+		[]string{"detector"},
+		"Log pattern extractor pattern count",
+	)
+
+	return &telemetryHandler{
+		telemetryGauges: gauges,
+	}
+}
+
+// handleTelemetry handles the telemetry events by sending them to the telemetry backend.
+// Note 1: we don't forward the exact timestamp for each telemetry event but this is not a problem
+// because we use this only in the observer with realtime data
+// Note 2: we don't send logs to the backend
+func (h *telemetryHandler) handleTelemetry(events []observerdef.ObserverTelemetry) {
+	for _, event := range events {
+		if event.Metric != nil {
+			gauge, isGauge := h.telemetryGauges[event.Metric.GetName()]
+			if isGauge {
+				fmt.Printf("Sending telemetry: %v\n", event.Metric.GetName())
+				gauge.Set(event.Metric.GetValue(), append(event.Metric.GetRawTags(), "detector:"+event.DetectorName)...)
+				continue
+			}
+
+			pkglog.Warnf("[observer] telemetry gauge not found: %s", event.Metric.GetName())
+		}
+	}
+}
+
+// isMetricRegistered checks if a metric is registered in the telemetry handler
+func (h *telemetryHandler) isMetricRegistered(metricName string) bool {
+	_, isRegistered := h.telemetryGauges[metricName]
+
+	return isRegistered
+}
+
+// newTelemetryGauge creates a new telemetry gauge for the given telemetry name, detector name, and data time.
+// Warning: use a `telemetryName` that is defined in this file.
+func newTelemetryGauge(detectorName string, telemetryName string, value float64, dataTime int64) observerdef.ObserverTelemetry {
+	return observerdef.ObserverTelemetry{
+		DetectorName: detectorName,
+		Metric: &metricObs{
+			name:      telemetryName,
+			value:     value,
+			tags:      []string{"detector:" + detectorName},
+			timestamp: dataTime,
+		},
+	}
+}

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -6,8 +6,6 @@
 package observerimpl
 
 import (
-	"fmt"
-
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
@@ -57,7 +55,6 @@ func (h *telemetryHandler) handleTelemetry(events []observerdef.ObserverTelemetr
 		if event.Metric != nil {
 			gauge, isGauge := h.telemetryGauges[event.Metric.GetName()]
 			if isGauge {
-				fmt.Printf("Sending telemetry: %v\n", event.Metric.GetName())
 				gauge.Set(event.Metric.GetValue(), event.Metric.GetRawTags()...)
 				continue
 			}

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -17,10 +17,6 @@ const (
 	// RRCF detector
 	telemetryRRCFScore     = "observer.rrcf.score"
 	telemetryRRCFThreshold = "observer.rrcf.threshold"
-
-	// Log extractor
-	// TODO(celian): how to handle counters? We should have a unified interface between observer / internal telemetry
-	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
 )
 
 // This is used to:
@@ -46,12 +42,6 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 		[]string{"detector"},
 		"RRCF dynamic anomaly detection threshold (post-warmup)",
 	)
-	gauges[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewGauge(
-		"observer",
-		telemetryLogPatternExtractorPatternCount,
-		[]string{"detector"},
-		"Log pattern extractor pattern count",
-	)
 
 	return &telemetryHandler{
 		telemetryGauges: gauges,
@@ -68,7 +58,7 @@ func (h *telemetryHandler) handleTelemetry(events []observerdef.ObserverTelemetr
 			gauge, isGauge := h.telemetryGauges[event.Metric.GetName()]
 			if isGauge {
 				fmt.Printf("Sending telemetry: %v\n", event.Metric.GetName())
-				gauge.Set(event.Metric.GetValue(), append(event.Metric.GetRawTags(), "detector:"+event.DetectorName)...)
+				gauge.Set(event.Metric.GetValue(), event.Metric.GetRawTags()...)
 				continue
 			}
 

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -721,8 +721,6 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 
 			if !tb.telemetryHandler.isMetricRegistered(metric.name) {
 				fmt.Printf("ERROR: [observer] metric %s is not registered\n", metric.name)
-			} else {
-				fmt.Printf("metric %s is registered\n", metric.name)
 			}
 		}
 
@@ -866,9 +864,9 @@ func (tb *TestBench) GetMetricsAnomaliesForSeries(seriesID observerdef.SeriesID)
 func (tb *TestBench) resolveAnomalySeriesIDs(anomalies []observerdef.Anomaly) []observerdef.Anomaly {
 	for i := range anomalies {
 		a := &anomalies[i]
+		// This comes from the telemetry
 		if a.SourceSeriesID == "" && a.Source.Name != "" {
-			telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
-			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
+			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", a.Source.String()+":avg", nil))
 		}
 	}
 	return anomalies

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -20,6 +20,7 @@ import (
 	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
@@ -127,6 +128,9 @@ type TestBench struct {
 
 	// API server
 	api *TestBenchAPI
+
+	// This is not directly used, it's mostly to ensure that telemetry metrics are registered in the telemetry handler
+	telemetryHandler *telemetryHandler
 }
 
 // ScenarioInfo describes an available scenario.
@@ -200,6 +204,7 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 		logAnomaliesByDetector: make(map[string][]observerdef.Anomaly),
 		sse:                    hub,
 		sseStop:                stop,
+		telemetryHandler:       newTelemetryHandler(noopsimpl.GetCompatComponent()),
 	}
 
 	// Heartbeat goroutine — lets SSE clients detect stale connections.
@@ -712,7 +717,13 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				telemetryEvent.DetectorName = detectorName
 			}
 			// Save this for UI
-			tb.engine.Storage().Add("telemetry", "telemetry."+telemetryEvent.DetectorName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
+			tb.engine.Storage().Add("telemetry", metric.name, metric.value, metric.timestamp, metric.tags)
+
+			if !tb.telemetryHandler.isMetricRegistered(metric.name) {
+				fmt.Printf("ERROR: [observer] metric %s is not registered\n", metric.name)
+			} else {
+				fmt.Printf("metric %s is registered\n", metric.name)
+			}
 		}
 
 		if telemetryEvent.Log != nil {


### PR DESCRIPTION
### What does this PR do?

This exports the telemetry as internal datadog agent metrics.
It adds a handler to define all of the telemetry metrics.

### Motivation

### Describe how you validated your changes

### Additional Notes
