### PR TITLE
[Backport 7.77.x] macos: hide gui app from menu bar

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -6,7 +6,7 @@
 
 # Datadog Agent install script for macOS.
 set -e
-install_script_version=1.6.0
+install_script_version=1.7.0
 
 # Terminal color detection
 # Colors are enabled only when outputting to a terminal (not when piped/redirected)
@@ -63,6 +63,16 @@ fi
 agent_dist_channel=
 if [ -n "$DD_AGENT_DIST_CHANNEL" ]; then
     agent_dist_channel="$DD_AGENT_DIST_CHANNEL"
+fi
+
+# Per-user install only: show the menu bar icon. Unset/false keeps headless GUI (postinst adds
+# --headless; this script removes it from the plist and reloads launchd when enabled).
+# Truthy: 1, true, yes, on (case-insensitive).
+gui_app_menu_enabled=false
+if [ -n "$DD_GUI_APP_MENU_ENABLED" ]; then
+    case "$(printf '%s' "$DD_GUI_APP_MENU_ENABLED" | tr '[:upper:]' '[:lower:]')" in
+        1|true|yes|on) gui_app_menu_enabled=true ;;
+    esac
 fi
 
 if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
@@ -597,7 +607,7 @@ if [ -f "$user_plist_file" ] || [ -f "/Library/LaunchAgents/com.datadoghq.gui.pl
     max_wait=100  # 100 * 0.1s = 10 seconds
     count=0
     while [ $count -lt $max_wait ]; do
-        if ! pgrep -f "Datadog Agent.app/Contents/MacOS/gui" > /dev/null 2>&1; then
+        if ! pgrep -U "$user_uid" -f "Datadog Agent.app/Contents/MacOS/gui" > /dev/null 2>&1; then
             break
         fi
         sleep 0.1
@@ -659,10 +669,45 @@ else
     printf "${BLUE}\n* A datadog.yaml configuration file already exists. It will not be overwritten.\n${NC}\n"
 fi
 
-# Starting the app
-if [ "$systemdaemon_install" = false ]; then
-    $cmd_real_user open -a 'Datadog Agent.app'
-else
+# Per-user GUI: postinst always installs --headless; optionally strip it and reload launchd here
+user_gui_plist="${install_user_home}/Library/LaunchAgents/com.datadoghq.gui.plist"
+if [ "$systemdaemon_install" = false ] && [ "$gui_app_menu_enabled" = true ] && [ -f "$user_gui_plist" ]; then
+    printf "${BLUE}\n    - Enabling menu bar GUI (DD_GUI_APP_MENU_ENABLED)...\n${NC}"
+    $sudo_cmd sed -i '' '/<string>--headless<\/string>/d' "$user_gui_plist"
+    $cmd_launchctl bootout "gui/$user_uid/com.datadoghq.gui" 2>/dev/null || true
+
+    # Wait for the headless GUI process to stop before loading menu-bar mode.
+    # This avoids a race where a still-running instance causes the relaunched app to self-exit.
+    max_wait=100  # 100 * 0.1s = 10 seconds
+    count=0
+    while [ $count -lt $max_wait ]; do
+        if ! pgrep -f "Datadog Agent.app/Contents/MacOS/gui" > /dev/null 2>&1; then
+            break
+        fi
+        sleep 0.1
+        count=$((count + 1))
+    done
+
+    if [ $count -ge $max_wait ]; then
+        printf "${YELLOW}    Warning: GUI process still running after 10s, sending TERM and kickstarting job${NC}\n"
+
+        # Target only the current user's GUI process.
+        stale_gui_pid=$(pgrep -U "$user_uid" -f "Datadog Agent.app/Contents/MacOS/gui" | head -n 1)
+        if [ -n "$stale_gui_pid" ]; then
+            kill -TERM "$stale_gui_pid" 2>/dev/null || true
+        fi
+
+        # Ensure job is loaded, then kickstart to relaunch in menu-bar mode.
+        $cmd_launchctl load -w "$user_gui_plist" 2>/dev/null || true
+        $cmd_launchctl kickstart -k "gui/$user_uid/com.datadoghq.gui" 2>/dev/null || \
+            $cmd_launchctl kickstart "gui/$user_uid/com.datadoghq.gui" 2>/dev/null || true
+    else
+        $cmd_launchctl load -w "$user_gui_plist"
+    fi
+fi
+
+# Per-user: GUI is started by postinst (headless) or by launchctl load above (menu bar); no open needed
+if [ "$systemdaemon_install" != false ]; then
     printf "${BLUE}\n* Installing $service_name as a system-wide LaunchDaemon ...\n\n${NC}"
     # Remove the Agent login item and unload the agent for current user
     # if it is running - it's not running if the script was launched when

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -207,8 +207,14 @@ else
   sudo -Hu "$INSTALL_USER" ln -vs $CONF_DIR/datadog.yaml "$USER_HOME/.datadog-agent/datadog.yaml"
   sudo -Hu "$INSTALL_USER" ln -vs $CONF_DIR/checks.d "$USER_HOME/.datadog-agent/checks.d"
 
-  # Create the tray icon app launchctl service
+  # Tray app: headless by default (WiFi IPC only). install_mac_os.sh may remove --headless afterward
+  # if DD_GUI_APP_MENU_ENABLED is set (postinst does not see that env var from the installer).
   sudo -Hu "$INSTALL_USER" cp -vf "$CONF_DIR/com.datadoghq.gui.plist.example" "$USER_HOME/Library/LaunchAgents/com.datadoghq.gui.plist"
+
+  sed -i '' '/<\/array>/i\
+            <string>--headless<\/string>
+' "$USER_HOME/Library/LaunchAgents/com.datadoghq.gui.plist"
+
   sudo -Hu "$INSTALL_USER" launchctl load -w "$USER_HOME/Library/LaunchAgents/com.datadoghq.agent.plist"
 
   # Load the GUI LaunchAgent
@@ -219,6 +225,9 @@ else
   echo "=========================================="
   echo "Datadog Agent GUI"
   echo "=========================================="
+  echo "The menu bar icon is hidden by default (headless GUI for WiFi metrics)."
+  echo "When installing via install_mac_os.sh, set DD_GUI_APP_MENU_ENABLED=1 (or true, yes, on) to show it."
+  echo ""
   echo "To enable WiFi data collection (SSID/BSSID), grant Location permission:"
   echo "  System Settings -> Privacy & Security -> Location Services -> Enable 'Datadog Agent'"
   echo ""

--- a/releasenotes/notes/macos-hide-gui-app-icon-ad39600534c3a404.yaml
+++ b/releasenotes/notes/macos-hide-gui-app-icon-ad39600534c3a404.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Hide GUI app by default for MacOS agent per-user install.


### PR DESCRIPTION
Backport 6ffeeecbe1fe223b916cf827e8f221a9224573f4 from #48083.

 ___

### What does this PR do?
Per IT request, this PR hides the GUI app by default for MacOS agent per-user install.

### Motivation
[WINA-2506](https://datadoghq.atlassian.net/browse/WINA-2506)

### Describe how you validated your changes
Verification by inspecting installation logs and UI behavior with MacOS agent installations. Ensure all CI pipelines pass.

### Additional Notes