### PR TITLE
[ACTP] Remove rshell from DCA PAR registry

### DIFF
--- a/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
+++ b/pkg/privateactionrunner/bundles/registry_kubeapiserver.go
@@ -43,7 +43,6 @@ import (
 	com_datadoghq_kubernetes_customresources "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/customresources"
 	com_datadoghq_kubernetes_discovery "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/discovery"
 	com_datadoghq_mongodb "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/mongodb"
-	com_datadoghq_remoteaction_rshell "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/rshell"
 	com_datadoghq_script "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/script"
 	com_datadoghq_temporal "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/temporal"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
@@ -87,7 +86,6 @@ func NewRegistry(configuration *config.Config, traceroute traceroute.Component, 
 			"com.datadoghq.kubernetes.customresources": com_datadoghq_kubernetes_customresources.NewKubernetesCustomResources(),
 			"com.datadoghq.kubernetes.discovery":       com_datadoghq_kubernetes_discovery.NewKubernetesDiscovery(),
 			"com.datadoghq.mongodb":                    com_datadoghq_mongodb.NewMongoDB(),
-			"com.datadoghq.remoteaction.rshell":        com_datadoghq_remoteaction_rshell.NewRshellBundle(configuration.RShellAllowedPaths),
 			"com.datadoghq.script":                     com_datadoghq_script.NewScript(),
 			"com.datadoghq.temporal":                   com_datadoghq_temporal.NewTemporal(),
 		},


### PR DESCRIPTION
<!-- dd-meta {"pullId":"1d80c517-8a06-469d-99ff-efc06429dc44","source":"chat","resourceId":"7b0cb137-bbab-4b41-b488-4748f7887eab","workflowId":"361f1bff-ba74-4f5b-956b-fbebd365f4cc","codeChangeId":"361f1bff-ba74-4f5b-956b-fbebd365f4cc","sourceType":"slack"} -->
### What does this PR do?
Removes the rshell privateactionrunner bundle from the Cluster Agent (kubeapiserver build) registry so DCA no longer exposes rshell actions by default.

### Motivation
The DCA environment does not provide all capabilities and mounts expected by rshell actions (for example, limited capabilities and filesystem access), which can make those actions fail in practice. Excluding rshell from the kubeapiserver-specific registry keeps the initial DCA PAR surface aligned with supported runtime constraints.

### Describe how you validated your changes
- Ran `go test -tags kubeapiserver ./pkg/privateactionrunner/bundles/...` (passes)
- Ran formatter tooling (`goimports`, `gofmt`) via the formatting tool; no additional changes were needed
- Ran lint tooling via the lint tool; `golangci-lint` could not run in this environment because the installed binary was built with Go 1.24 while the repo targets Go 1.25.7

### Additional Notes
- Change is limited to `pkg/privateactionrunner/bundles/registry_kubeapiserver.go`
- The generic PAR registry remains unchanged; only the DCA (kubeapiserver-tagged) bundle set is affected

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/7b0cb137-bbab-4b41-b488-4748f7887eab)

Comment @datadog to request changes