### PR TITLE
Add excluded_ips config option for SNMP default scan

### DIFF
--- a/comp/snmpscanmanager/impl/snmpscanmanager.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager.go
@@ -73,6 +73,12 @@ type Provides struct {
 // NewComponent creates a new snmpscanmanager component
 func NewComponent(reqs Requires) (Provides, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	excludedIPs := make(ipSet)
+	for _, ip := range reqs.Config.GetStringSlice("network_devices.default_scan.excluded_ips") {
+		excludedIPs.add(ip)
+	}
+
 	scanManager := &snmpScanManagerImpl{
 		log:         reqs.Logger,
 		scanner:     reqs.Scanner,
@@ -84,6 +90,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 
 		scanQueue:       make(chan snmpscanmanager.ScanRequest, scanQueueSize),
 		allRequestedIPs: make(ipSet),
+		excludedIPs:     excludedIPs,
 		deviceScans:     make(deviceScansByIP),
 
 		ctx:        ctx,
@@ -120,6 +127,7 @@ type snmpScanManagerImpl struct {
 
 	scanQueue       chan snmpscanmanager.ScanRequest
 	allRequestedIPs ipSet
+	excludedIPs     ipSet
 	deviceScans     deviceScansByIP
 
 	ctx        context.Context
@@ -158,6 +166,11 @@ func (m *snmpScanManagerImpl) RequestScan(req snmpscanmanager.ScanRequest, force
 	}
 
 	if !m.agentConfig.GetBool("network_devices.default_scan.enabled") {
+		return
+	}
+
+	if m.excludedIPs.contains(req.DeviceIP) {
+		m.log.Debugf("Skipping default scan request for excluded device %s", req.DeviceIP)
 		return
 	}
 

--- a/comp/snmpscanmanager/impl/snmpscanmanager_test.go
+++ b/comp/snmpscanmanager/impl/snmpscanmanager_test.go
@@ -205,6 +205,61 @@ func TestRequestScan(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "excluded IPs are not scanned",
+			configContent: map[string]interface{}{
+				"network_devices.default_scan.enabled":      true,
+				"network_devices.default_scan.excluded_ips": []string{"192.168.0.1", "10.0.0.1"},
+			},
+			buildMockConfigProvider: func() *snmpConfigProviderMock {
+				mockConfigProvider := newSnmpConfigProviderMock()
+
+				// Only 192.168.0.2 should be scanned since 192.168.0.1 and 10.0.0.1 are excluded
+				mockConfigProvider.On("GetDeviceConfig",
+					"192.168.0.2", mock.Anything, mock.Anything).
+					Return(&snmpparse.SNMPConfig{
+						IPAddress:       "192.168.0.2",
+						Port:            161,
+						CommunityString: "public",
+					}, "namespace", nil).
+					Once()
+
+				return mockConfigProvider
+			},
+			buildMockScanner: func() *snmpscanmock.SnmpScanMock {
+				scanner := snmpscanmock.Mock(t)
+				mockScanner, ok := scanner.(*snmpscanmock.SnmpScanMock)
+				assert.True(t, ok)
+
+				mockScanner.On("ScanDeviceAndSendData",
+					mock.Anything, &snmpparse.SNMPConfig{
+						IPAddress:       "192.168.0.2",
+						Port:            161,
+						CommunityString: "public",
+					}, "namespace", mock.Anything, mock.Anything).
+					Return(nil).
+					Once()
+
+				return mockScanner
+			},
+			scanReqs: []snmpscanmanager.ScanRequest{
+				{
+					DeviceIP: "192.168.0.1", // Excluded
+				},
+				{
+					DeviceIP: "192.168.0.2", // Not excluded
+				},
+				{
+					DeviceIP: "10.0.0.1", // Excluded
+				},
+			},
+			expectedDeviceScans: deviceScansByIP{
+				"192.168.0.2": {
+					DeviceIP:   "192.168.0.2",
+					ScanStatus: successScan,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -3980,6 +3980,12 @@ api_key:
 #
 #     enabled: false
 
+#     # @param excluded_ips - list of strings - optional - default: []
+#     # List of IP addresses to exclude from automatic scanning.
+#     # Devices with these IP addresses will be skipped during default scan.
+#
+#     excluded_ips: []
+
 #   # @param autodiscovery - custom object - optional
 #   # Creates and schedules a listener to automatically discover your SNMP devices.
 #   # Discovered devices can then be monitored with the SNMP integration by using

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -225,6 +225,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("network_devices.autodiscovery.retries", 3)
 
 	config.BindEnvAndSetDefault("network_devices.default_scan.enabled", false)
+	config.BindEnvAndSetDefault("network_devices.default_scan.excluded_ips", []string{})
 
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.snmp_traps.forwarder.")
 	config.BindEnvAndSetDefault("network_devices.snmp_traps.enabled", false)


### PR DESCRIPTION
## Summary
- Add `network_devices.default_scan.excluded_ips` config option to allow customers to specify IP addresses to exclude from automatic SNMP device scanning
- Configurable via YAML config
- Only applies when `network_devices.default_scan.enabled: true`

## Test plan
- [x] Unit tests added for excluded IPs behavior
- [ ] Manual test: enable default scan, set excluded IPs, verify debug log shows "Skipping default scan request for excluded device"

🤖 Generated with [Claude Code](https://claude.com/claude-code)