### PR TITLE
remove unused `GetSecretSettingPaths` and add exclude node to `mergeLayers`

### DIFF
--- a/pkg/config/model/types.go
+++ b/pkg/config/model/types.go
@@ -171,9 +171,6 @@ type Reader interface {
 	// AllSettingsWithoutDefaultOrSecrets returns all non-default settings, excluding the secret backend
 	// layer as well.
 	AllSettingsWithoutDefaultOrSecrets() map[string]interface{}
-	// GetSecretSettingPaths returns the flattened key path that exist in the secrets layer.
-	// This allows the scrubber to know exactly which settings contain secrets
-	GetSecretSettingPaths() []string
 	// AllKeysLowercased returns all config keys in the config, no matter how they are set.
 	// Note that it returns the keys lowercased.
 	AllKeysLowercased() []string

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -975,33 +975,6 @@ func (c *ntmConfig) mergeWithoutSecrets() *nodeImpl {
 	return merged
 }
 
-// GetSecretSettingPaths returns the flattened key paths that exist in the secrets layer.
-func (c *ntmConfig) GetSecretSettingPaths() []string {
-	c.RLock()
-	defer c.RUnlock()
-
-	var keys []string
-	collectFlattenedKeysFromNode(c.secrets, "", &keys)
-	return keys
-}
-
-// collectFlattenedKeysFromNode recursively walks a node tree and collects flattened dotted key paths
-// for all leaf nodes.
-func collectFlattenedKeysFromNode(node *nodeImpl, prefix string, keys *[]string) {
-	for _, name := range node.ChildrenKeys() {
-		child, err := node.GetChild(name)
-		if err != nil {
-			continue
-		}
-		fullKey := joinKey(prefix, name)
-		if child.IsLeafNode() {
-			*keys = append(*keys, fullKey)
-		} else if child.IsInnerNode() {
-			collectFlattenedKeysFromNode(child, fullKey, keys)
-		}
-	}
-}
-
 // AllSettingsBySource returns the settings from each source (file, env vars, ...)
 func (c *ntmConfig) AllSettingsBySource() map[model.Source]interface{} {
 	c.maybeRebuild()

--- a/pkg/config/nodetreemodel/config.go
+++ b/pkg/config/nodetreemodel/config.go
@@ -486,7 +486,8 @@ func (c *ntmConfig) checkKnownKey(key string) {
 	log.Warnf("config key %v is unknown", key)
 }
 
-func (c *ntmConfig) mergeAllLayers() error {
+// mergeLayers merges all config layers in priority order. Layers passed as exclude are skipped.
+func (c *ntmConfig) mergeLayers(exclude ...*nodeImpl) (*nodeImpl, error) {
 	treeList := []*nodeImpl{
 		c.defaults,
 		c.unknown,
@@ -502,13 +503,23 @@ func (c *ntmConfig) mergeAllLayers() error {
 
 	merged := newInnerNode(nil)
 	for _, tree := range treeList {
+		if slices.Contains(exclude, tree) {
+			continue
+		}
 		next, err := merged.Merge(tree)
 		if err != nil {
-			return err
+			return merged, err
 		}
 		merged = next
 	}
+	return merged, nil
+}
 
+func (c *ntmConfig) mergeAllLayers() error {
+	merged, err := c.mergeLayers()
+	if err != nil {
+		return err
+	}
 	c.root = merged
 	return nil
 }
@@ -949,29 +960,10 @@ func (c *ntmConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} 
 
 // mergeWithoutSecrets returns a merged tree of all layers except the secrets layer.
 func (c *ntmConfig) mergeWithoutSecrets() *nodeImpl {
-	treeList := []*nodeImpl{
-		c.defaults,
-		c.unknown,
-		c.file,
-		c.envs,
-		c.fleetPolicies,
-		// secrets layer excluded
-		c.runtime,
-		c.localConfigProcess,
-		c.remoteConfig,
-		c.cli,
+	merged, err := c.mergeLayers(c.secrets)
+	if err != nil {
+		log.Errorf("error merging config layers without secrets: %s", err)
 	}
-
-	merged := newInnerNode(nil)
-	for _, tree := range treeList {
-		next, err := merged.Merge(tree)
-		if err != nil {
-			log.Errorf("error merging config layers without secrets: %s", err)
-			return merged
-		}
-		merged = next
-	}
-
 	return merged
 }
 

--- a/pkg/config/nodetreemodel/config_test.go
+++ b/pkg/config/nodetreemodel/config_test.go
@@ -416,22 +416,6 @@ func TestAllSettingsWithoutDefaultOrSecrets(t *testing.T) {
 	assert.False(t, found)
 }
 
-func TestGetSecretSettingPaths(t *testing.T) {
-	cfg := NewNodeTreeConfig("test", "TEST", nil)
-	cfg.SetDefault("api_key", "")
-	cfg.SetDefault("proxy.https", "")
-	cfg.SetDefault("proxy.http", "")
-	cfg.BuildSchema()
-
-	assert.Empty(t, cfg.GetSecretSettingPaths())
-
-	cfg.Set("api_key", "resolved_key", model.SourceSecretBackend)
-	cfg.Set("proxy.https", "resolved_proxy", model.SourceSecretBackend)
-
-	paths := cfg.GetSecretSettingPaths()
-	assert.ElementsMatch(t, []string{"api_key", "proxy.https"}, paths)
-}
-
 func TestIsSet(t *testing.T) {
 	cfg := NewNodeTreeConfig("test", "TEST", nil)
 	cfg.SetDefault("a", 0)

--- a/pkg/config/teeconfig/teeconfig.go
+++ b/pkg/config/teeconfig/teeconfig.go
@@ -524,11 +524,6 @@ func (t *teeConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{} 
 	return base
 }
 
-// GetSecretSettingPaths returns the flattened key paths that exist in the secrets layer
-func (t *teeConfig) GetSecretSettingPaths() []string {
-	return t.baseline.GetSecretSettingPaths()
-}
-
 // AllFlattenedSettingsWithSequenceID returns all settings as a flattened map of schema leaf keys
 // along with the sequence ID.
 func (t *teeConfig) AllFlattenedSettingsWithSequenceID() (map[string]interface{}, uint64) {

--- a/pkg/config/viperconfig/viper.go
+++ b/pkg/config/viperconfig/viper.go
@@ -842,11 +842,6 @@ func (c *safeConfig) AllSettingsWithoutDefaultOrSecrets() map[string]interface{}
 	return c.AllSettingsWithoutDefault()
 }
 
-// GetSecretSettingPaths does not exist in the viper impl
-func (c *safeConfig) GetSecretSettingPaths() []string {
-	return nil
-}
-
 // AllFlattenedSettingsWithSequenceID returns all settings as a flattened map of schema leaf keys
 // along with the sequence ID.
 // Keys are flattened (e.g., "logs_config.enabled" instead of nested {"logs_config": {"enabled": ...}}).


### PR DESCRIPTION
### What does this PR do?
removes the currently unused `GetSecretSettingPaths` - in the future it is unlikely to be used compared to just dumping the layers without secrets. 

also cleans up duplicated mergeLayers logic

### Motivation

tidying up

### Describe how you validated your changes

CI

### Additional Notes
