### PR TITLE
[autoscaling] Make initial sync indicator accurate

### DIFF
--- a/pkg/clusteragent/autoscaling/cluster/provider.go
+++ b/pkg/clusteragent/autoscaling/cluster/provider.go
@@ -64,7 +64,7 @@ func StartClusterAutoscaling(
 	// Start informers & controllers
 	apiCl.DynamicInformerFactory.Start(ctx.Done())
 
-	go controller.Run(ctx)
+	go controller.Run(ctx, 1)
 
 	return nil
 }

--- a/pkg/clusteragent/autoscaling/controller.go
+++ b/pkg/clusteragent/autoscaling/controller.go
@@ -10,24 +10,86 @@ package autoscaling
 import (
 	"context"
 	"fmt"
-	"time"
+	"sync"
+	"sync/atomic"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
+// initTracker tracks unique keys enqueued during the initial informer
+// list and signals completion when all of them have been processed at least once.
+//
+// Lifecycle: add (during initial list) → seal (after handler.HasSynced) → processed (by workers).
+type initTracker struct {
+	done    atomic.Bool
+	mu      sync.Mutex
+	pending map[string]struct{}
+}
+
+// add records a key from the initial informer list.
+func (t *initTracker) add(key string) {
+	if t.done.Load() {
+		return
+	}
+	t.mu.Lock()
+	if t.pending == nil {
+		t.pending = make(map[string]struct{})
+	}
+	t.pending[key] = struct{}{}
+	t.mu.Unlock()
+}
+
+// processed marks a key as processed. Returns true the single time all initial
+// items have been processed, so the caller can log once.
+func (t *initTracker) processed(key string) bool {
+	if t.done.Load() {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.pending, key)
+	if len(t.pending) == 0 {
+		t.pending = nil
+		t.done.Store(true)
+		return true
+	}
+	return false
+}
+
+// seal must be called once all add calls are done (i.e. after
+// handler.HasSynced). It handles the empty-resource case where no items were
+// enqueued. Returns true if this call caused completion.
+func (t *initTracker) seal() bool {
+	if t.done.Load() {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.pending) == 0 {
+		t.pending = nil
+		t.done.Store(true)
+		return true
+	}
+	return false
+}
+
+func (t *initTracker) isDone() bool {
+	return t.done.Load()
+}
+
 // Controller is a generic implementation of a Kubernetes controller processing objects that can be retrieved through Dynamic Client
 // User needs to implement the Processor interface to define the processing logic
 type Controller struct {
-	processor Processor
-	synced    cache.InformerSynced
-	context   context.Context
+	processor   Processor
+	synced      cache.InformerSynced
+	context     context.Context
+	initTracker initTracker
 
 	// Fields available to child controllers
 	ID        SenderID
@@ -54,20 +116,25 @@ func NewController(
 		ID:        controllerID,
 		Client:    client,
 		Lister:    mainInformer.Lister(),
-		synced:    mainInformer.Informer().HasSynced,
 		Workqueue: workqueue,
 		IsLeader:  isLeader,
 	}
 
-	if _, err := mainInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	handler, err := mainInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.enqueue,
 		DeleteFunc: c.enqueue,
-		UpdateFunc: func(_, new interface{}) {
+		UpdateFunc: func(_, new any) {
 			c.enqueue(new)
 		},
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, fmt.Errorf("cannot add event handler to informer: %v", err)
 	}
+
+	// Use handler.HasSynced rather than informer.HasSynced: it guarantees all
+	// initial-list events have been delivered to our callbacks, not just that the
+	// cache is populated.
+	c.synced = handler.HasSynced
 
 	// We use an observer on the store to propagate events as soon as possible
 	observable.RegisterObserver(Observer{
@@ -77,20 +144,23 @@ func NewController(
 	return c, nil
 }
 
-// HasSynced returns true when the underlying informer cache has been synced.
-func (c *Controller) HasSynced() bool {
-	return c.synced()
+// InitialSyncDone returns true when initial informer sync is done AND all items have been processed at least once.
+func (c *Controller) InitialSyncDone() bool {
+	return c.initTracker.isDone()
 }
 
-// Run starts the controller to handle objects
-func (c *Controller) Run(ctx context.Context) {
+// Run starts the controller to handle objects with the given number of workers.
+func (c *Controller) Run(ctx context.Context, numWorkers int) {
 	if ctx == nil {
 		log.Errorf("Cannot run with a nil context")
 		return
 	}
 	c.context = ctx
 
-	defer c.Workqueue.ShutDown()
+	if preStart, ok := c.processor.(ProcessorPreStart); ok {
+		preStart.PreStart(c.context)
+		log.Debugf("PreStart done for controller id: %s", c.ID)
+	}
 
 	log.Infof("Starting controller id: %s (waiting for cache sync)", c.ID)
 	if !cache.WaitForCacheSync(ctx.Done(), c.synced) {
@@ -99,28 +169,39 @@ func (c *Controller) Run(ctx context.Context) {
 	}
 	log.Infof("Started controller: %s (cache sync finished)", c.ID)
 
-	if preStart, ok := c.processor.(ProcessorPreStart); ok {
-		preStart.PreStart(c.context)
-		log.Debugf("PreStart done for controller id: %s", c.ID)
+	if c.initTracker.seal() {
+		log.Debugf("All initial items processed for controller id: %s (no initial items)", c.ID)
 	}
 
-	log.Debugf("Starting workers for controller id: %s", c.ID)
-	go wait.Until(c.worker, time.Second, ctx.Done())
+	log.Debugf("Starting %d workers for controller id: %s", numWorkers, c.ID)
+	for i := range numWorkers {
+		go c.worker(i)
+	}
 
 	<-ctx.Done()
 	log.Infof("Stopping controller id: %s", c.ID)
+	if c.IsLeader() {
+		c.Workqueue.ShutDownWithDrain()
+	} else {
+		c.Workqueue.ShutDown()
+	}
+	log.Infof("Controller stopped: %s", c.ID)
 }
 
-func (c *Controller) worker() {
+func (c *Controller) worker(workerID int) {
+	log.Debugf("Starting worker %d for controller id: %s", workerID, c.ID)
 	for c.process() {
 	}
 }
 
-func (c *Controller) enqueue(obj interface{}) {
+func (c *Controller) enqueue(obj any) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
 		log.Debugf("Couldn't get key for object %v: %v", obj, err)
 		return
+	}
+	if !c.InitialSyncDone() {
+		c.initTracker.add(key)
 	}
 	c.Workqueue.AddRateLimited(key)
 }
@@ -154,6 +235,10 @@ func (c *Controller) process() bool {
 		c.Workqueue.AddRateLimited(key)
 	} else { // no requeue
 		c.Workqueue.Forget(key)
+	}
+
+	if c.initTracker.processed(key) {
+		log.Infof("All initial items processed for controller id: %s", c.ID)
 	}
 
 	return true

--- a/pkg/clusteragent/autoscaling/controller_test.go
+++ b/pkg/clusteragent/autoscaling/controller_test.go
@@ -1,0 +1,190 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+
+package autoscaling
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/client-go/util/workqueue"
+)
+
+// testProcessor records every Process call and optionally blocks via onProcess.
+type testProcessor struct {
+	mu        sync.Mutex
+	calls     map[string]int
+	onProcess func(key string)
+}
+
+func (p *testProcessor) Process(_ context.Context, key, _, _ string) ProcessResult {
+	if p.onProcess != nil {
+		p.onProcess(key)
+	}
+	p.mu.Lock()
+	p.calls[key]++
+	p.mu.Unlock()
+	return NoRequeue
+}
+
+func (p *testProcessor) snapshot() map[string]int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make(map[string]int, len(p.calls))
+	for k, v := range p.calls {
+		out[k] = v
+	}
+	return out
+}
+
+// newTestController builds a Controller wired with a real workqueue and a
+// controllable synced gate. Items are enqueued and tracked before synced is
+// released, mirroring what the informer does during the initial list.
+// Run() is started in a background goroutine; t.Cleanup tears everything down.
+func newTestController(t *testing.T, keys []string, numWorkers int, proc *testProcessor) *Controller {
+	t.Helper()
+
+	wq := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedItemBasedRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+	)
+
+	synced := make(chan struct{})
+	c := &Controller{
+		processor: proc,
+		ID:        "test",
+		Workqueue: wq,
+		IsLeader:  func() bool { return true },
+		synced: func() bool {
+			select {
+			case <-synced:
+				return true
+			default:
+				return false
+			}
+		},
+	}
+
+	for _, key := range keys {
+		c.initTracker.add(key)
+		wq.Add(key)
+	}
+
+	close(synced)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Run(ctx, numWorkers)
+
+	t.Cleanup(cancel)
+
+	return c
+}
+
+// assertInitialSyncInvariant waits for InitialSyncDone and then verifies that
+// every unique key from the initial list has been processed at least once.
+func assertInitialSyncInvariant(t *testing.T, c *Controller, keys []string, proc *testProcessor) {
+	t.Helper()
+
+	require.Eventually(t, c.InitialSyncDone, 5*time.Second, time.Millisecond,
+		"InitialSyncDone should become true")
+
+	unique := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		unique[k] = struct{}{}
+	}
+	snap := proc.snapshot()
+	for key := range unique {
+		assert.GreaterOrEqual(t, snap[key], 1, "key %q should be processed at least once", key)
+	}
+}
+
+func TestControllerInitialSync(t *testing.T) {
+	tests := []struct {
+		name    string
+		keys    []string
+		workers int
+	}{
+		{"no items", nil, 1},
+		{"single item", []string{"ns/a"}, 1},
+		{"multiple items single worker", []string{"ns/a", "ns/b", "ns/c", "ns/d", "ns/e"}, 1},
+		{"multiple items multiple workers", []string{"ns/a", "ns/b", "ns/c", "ns/d", "ns/e"}, 4},
+		{"duplicate keys", []string{"ns/a", "ns/a", "ns/b", "ns/b", "ns/c"}, 2},
+		{"many items many workers", makeKeys(100), 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proc := &testProcessor{calls: make(map[string]int)}
+			c := newTestController(t, tt.keys, tt.workers, proc)
+			assertInitialSyncInvariant(t, c, tt.keys, proc)
+		})
+	}
+}
+
+func TestControllerInitialSync_WaitsForSlowItem(t *testing.T) {
+	gate := make(chan struct{})
+	proc := &testProcessor{
+		calls: make(map[string]int),
+		onProcess: func(key string) {
+			if key == "ns/slow" {
+				<-gate
+			}
+		},
+	}
+
+	keys := []string{"ns/fast-1", "ns/fast-2", "ns/slow"}
+	c := newTestController(t, keys, 3, proc)
+
+	require.Eventually(t, func() bool {
+		snap := proc.snapshot()
+		return snap["ns/fast-1"] > 0 && snap["ns/fast-2"] > 0
+	}, 5*time.Second, time.Millisecond)
+
+	assert.False(t, c.InitialSyncDone(),
+		"InitialSyncDone should be false while an initial item is still pending")
+
+	close(gate)
+
+	assertInitialSyncInvariant(t, c, keys, proc)
+}
+
+func FuzzControllerInitialSync(f *testing.F) {
+	f.Add(uint8(0), uint8(1), uint8(1))
+	f.Add(uint8(1), uint8(1), uint8(1))
+	f.Add(uint8(5), uint8(2), uint8(5))
+	f.Add(uint8(20), uint8(4), uint8(5))
+	f.Add(uint8(200), uint8(8), uint8(200))
+
+	f.Fuzz(func(t *testing.T, numItems, numWorkers, numUnique uint8) {
+		n := int(numItems)
+		w := max(int(numWorkers%8), 1)
+		u := max(int(numUnique), 1)
+
+		keys := make([]string, n)
+		for i := range keys {
+			keys[i] = fmt.Sprintf("ns/obj-%d", i%u)
+		}
+
+		proc := &testProcessor{calls: make(map[string]int)}
+		c := newTestController(t, keys, w, proc)
+		assertInitialSyncInvariant(t, c, keys, proc)
+	})
+}
+
+func makeKeys(n int) []string {
+	keys := make([]string, n)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("ns/obj-%d", i)
+	}
+	return keys
+}

--- a/pkg/clusteragent/autoscaling/processor.go
+++ b/pkg/clusteragent/autoscaling/processor.go
@@ -62,7 +62,7 @@ type Processor interface {
 	Process(ctx context.Context, key, ns, name string) ProcessResult
 }
 
-// ProcessorPreStart is an interface that can be implemented by the Processor to perform some initialization after informers are synced and before the controller starts
+// ProcessorPreStart is an interface that can be implemented by the Processor to perform some initialization before the informers and workers are started
 type ProcessorPreStart interface {
 	// PreStart is called by the controller before starting workers
 	PreStart(ctx context.Context)

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -491,7 +491,7 @@ func clampResourceList(rl corev1.ResourceList, minAllowed, maxAllowed corev1.Res
 
 // shouldEvictDeferred returns true if the time since the last action is greater than the resize pending period, false otherwise
 func shouldEvictDeferred(podAutoscaler *datadoghq.DatadogPodAutoscaler, now time.Time) bool {
-	var period = defaultResizePendingPeriod
+	period := defaultResizePendingPeriod
 	// If the DPA has a configured resize pending period, use that instead of the default
 	if podAutoscaler.Spec.ApplyPolicy != nil && podAutoscaler.Spec.ApplyPolicy.Update != nil && podAutoscaler.Spec.ApplyPolicy.Update.ResizePendingPeriod > 0 {
 		period = podAutoscaler.Spec.ApplyPolicy.Update.ResizePendingPeriod
@@ -511,7 +511,7 @@ func shouldFallbackToRollout(toEvict []classifiedPod, podAutoscaler *datadoghq.D
 		return true
 	}
 
-	var delay = defaultRolloutFallbackDelay
+	delay := defaultRolloutFallbackDelay
 	// If the DPA has a configured rollout fallback delay, use that instead of the default
 	if podAutoscaler.Spec.ApplyPolicy != nil && podAutoscaler.Spec.ApplyPolicy.Update != nil && podAutoscaler.Spec.ApplyPolicy.Update.RolloutFallbackDelay > 0 {
 		delay = podAutoscaler.Spec.ApplyPolicy.Update.RolloutFallbackDelay

--- a/pkg/clusteragent/autoscaling/workload/provider/provider.go
+++ b/pkg/clusteragent/autoscaling/workload/provider/provider.go
@@ -113,20 +113,21 @@ func StartWorkloadAutoscaling(
 		},
 	)
 
-	autoscalerSyncer := profile.NewAutoscalerSyncer(profileStore, store, isLeaderFunc, profileController.HasSynced, workloadWatcher.HasSynced)
+	autoscalerSyncer := profile.NewAutoscalerSyncer(profileStore, store, isLeaderFunc, profileController.InitialSyncDone, workloadWatcher.HasSynced)
 	builtinManager := profile.NewBuiltinProfileManager(apiCl.DynamicInformerCl, isLeaderFunc)
 
 	// Start informers & controllers (informers can be started multiple times)
 	apiCl.DynamicInformerFactory.Start(ctx.Done())
 	apiCl.InformerFactory.Start(ctx.Done())
 
+	dpaNumWorkers := pkgconfigsetup.Datadog().GetInt("autoscaling.workload.num_workers")
 	// TODO: Wait POD Watcher sync before running the controller
 	go builtinManager.Run(ctx)
-	go profileController.Run(ctx)
+	go profileController.Run(ctx, 1)
 	go workloadWatcher.Run(ctx)
 	go autoscalerSyncer.Run(ctx)
 	go podWatcher.Run(ctx)
-	go controller.Run(ctx)
+	go controller.Run(ctx, dpaNumWorkers)
 
 	// Only start the local recommender if failover metrics collection is enabled
 	if pkgconfigsetup.Datadog().GetBool("autoscaling.failover.enabled") {

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1247,6 +1247,7 @@ func autoscaling(config pkgconfigmodel.Setup) {
 	config.BindEnvAndSetDefault("autoscaling.workload.enabled", false)
 	config.BindEnvAndSetDefault("autoscaling.failover.enabled", false)
 	config.BindEnvAndSetDefault("autoscaling.workload.limit", 1000)
+	config.BindEnvAndSetDefault("autoscaling.workload.num_workers", 2)
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.ca_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.cert_file", "")
 	config.BindEnvAndSetDefault("autoscaling.workload.external_recommender.tls.key_file", "")


### PR DESCRIPTION
### What does this PR do?

In some cases code in #48061 may lead to deletion/re-creation of Autoscalers due to the cache readiness not always being accurate.

### Motivation

Improve reliability of new feature

### Describe how you validated your changes

The issues being a race, it's not easy to reproduce in live scenarios. Although checking `DELETE` operations on Autoscalers managed by profiles should show ~0 even with number of Cluster Agent pods restart.

### Additional Notes

Updating `datadog-operator` to fix a duplication in the CRD.
We're also adding a configuration field to allow testing with more concurrent workers