### PR TITLE
fix(installer): suppress stdout logging for status --json

### DIFF
--- a/pkg/fleet/installer/commands/command.go
+++ b/pkg/fleet/installer/commands/command.go
@@ -44,6 +44,14 @@ const (
 	AnnotationHumanReadableErrors = "human-readable-errors"
 )
 
+type cmdOption func(*cmdConfig)
+type cmdConfig struct{ quiet bool }
+
+// withQuiet suppresses stdout logging for the command (e.g. when outputting structured JSON).
+func withQuiet() cmdOption {
+	return func(c *cmdConfig) { c.quiet = true }
+}
+
 type cmd struct {
 	t              *telemetry.Telemetry
 	span           *telemetry.Span
@@ -66,9 +74,13 @@ func setupStdoutLogger(_ *env.Env) {
 }
 
 // newCmd creates a new command
-func newCmd(operation string) *cmd {
+func newCmd(operation string, opts ...cmdOption) *cmd {
+	cfg := &cmdConfig{}
+	for _, o := range opts {
+		o(cfg)
+	}
 	env := env.FromEnv()
-	if !env.IsFromDaemon {
+	if !env.IsFromDaemon && !cfg.quiet {
 		setupStdoutLogger(env)
 	}
 	t := newTelemetry(env)
@@ -114,8 +126,8 @@ type installerCmd struct {
 	installer.Installer
 }
 
-func newInstallerCmd(operation string) (_ *installerCmd, err error) {
-	cmd := newCmd(operation)
+func newInstallerCmd(operation string, opts ...cmdOption) (_ *installerCmd, err error) {
+	cmd := newCmd(operation, opts...)
 	defer func() {
 		if err != nil {
 			cmd.stop(err)
@@ -537,8 +549,8 @@ func isInstalledCommand() *cobra.Command {
 	return cmd
 }
 
-func getState() (*repository.PackageStates, error) {
-	i, err := newInstallerCmd("get_states")
+func getState(opts ...cmdOption) (*repository.PackageStates, error) {
+	i, err := newInstallerCmd("get_states", opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fleet/installer/commands/status.go
+++ b/pkg/fleet/installer/commands/status.go
@@ -70,7 +70,12 @@ func status(debug bool, jsonOutput bool) error {
 	}
 
 	// Get states & convert to map[string]packageState
-	packageStates, err := getState()
+	var stateOpts []cmdOption
+	if jsonOutput {
+		// Suppress regular logging when outputting JSON.
+		stateOpts = append(stateOpts, withQuiet())
+	}
+	packageStates, err := getState(stateOpts...)
 	if err != nil {
 		return fmt.Errorf("error getting package states: %w", err)
 	}


### PR DESCRIPTION
### What does this PR do?

When `datadog-installer status --json` is run, telemetry warning messages (e.g. `failed to send telemetry payload ... 403 Forbidden`) were written to stdout before the JSON output, corrupting it and causing parse failures in E2E tests.

Introduces a `withQuiet()` functional option for `newCmd` that skips `setupStdoutLogger` when invoked. The `status` command passes this option through `getState` → `newInstallerCmd` → `newCmd` when `--json` is set.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2282
Fixes a flake introduced in #46910 where logs were redirected to stdout for non-daemon calls. `status --json` is parsed programmatically and must produce clean JSON.

### Describe how you validated your changes

Covered by existing E2E test `TestAgentConfig/TestConfigCustomUser` which was flaking with `invalid character 'i' in literal false` due to `if (-not $?) { exit $LASTEXITCODE }` appearing before the JSON.

### Additional Notes

The functional options pattern (`withQuiet()`) leaves all other command call sites unchanged (variadic with zero args = original behavior).