### PR TITLE
Add panic recovery for gopsutil process parsing in system-probe container store

### DIFF
--- a/pkg/network/containers/container_item_linux.go
+++ b/pkg/network/containers/container_item_linux.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/funcs"
 	utilintern "github.com/DataDog/datadog-agent/pkg/util/intern"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var hostRoot = funcs.MemoizeNoError(func() string {
@@ -207,7 +208,14 @@ func errIsProcessNotRunning(err error) bool {
 		errors.Is(err, os.ErrNotExist)
 }
 
-func (cr *containerReader) isProcessStillRunningImpl(ctx context.Context, entry *events.Process) (bool, error) {
+func (cr *containerReader) isProcessStillRunningImpl(ctx context.Context, entry *events.Process) (running bool, retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Warnf("Recovered panic in isProcessStillRunningImpl for pid %d (likely malformed /proc stat): %v", entry.Pid, r)
+			running = false
+			retErr = nil
+		}
+	}()
 	_, err := process.NewProcessWithContext(ctx, int32(entry.Pid))
 	if errIsProcessNotRunning(err) {
 		return false, nil

--- a/pkg/network/containers/container_item_linux_test.go
+++ b/pkg/network/containers/container_item_linux_test.go
@@ -295,3 +295,24 @@ func TestReadContainerItemProcessRunningVsNotRunning(t *testing.T) {
 		})
 	}
 }
+
+// Validates the named-return + defer/recover pattern used in isProcessStillRunningImpl,
+// since we cannot reliably trigger the real gopsutil panic in a unit test.
+func TestIsProcessStillRunningImpl_PanicRecovery(t *testing.T) {
+	panicCaught := false
+
+	running, err := func() (running bool, retErr error) {
+		defer func() {
+			if r := recover(); r != nil {
+				panicCaught = true
+				running = false
+				retErr = nil
+			}
+		}()
+		panic("runtime error: slice bounds out of range [1:0]")
+	}()
+
+	require.True(t, panicCaught, "panic should have been caught by recover")
+	require.False(t, running, "should report process as not running after panic")
+	require.NoError(t, err, "should not return an error after panic recovery")
+}

--- a/releasenotes/notes/fix-gopsutil-panic-in-system-probe-container-store-11d690d68500595f.yaml
+++ b/releasenotes/notes/fix-gopsutil-panic-in-system-probe-container-store-11d690d68500595f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed a panic in the system-probe container store caused by gopsutil
+    parsing malformed /proc/[pid]/stat files during process termination
+    race conditions.


### PR DESCRIPTION
### What does this PR do?

Adds a `recover()` wrapper around `process.NewProcessWithContext` in `isProcessStillRunningImpl` in the system-probe's container store. On panic, the process is treated as not running (safe default).

### Motivation

Follow-up to escalation [NTWK-754](https://datadoghq.atlassian.net/browse/NTWK-754). A customer hit a panic in the system-probe on Agent 7.76.3 caused by gopsutil's `splitProcStat` encountering a malformed `/proc/[pid]/stat` file (race condition during process termination). This is the same root cause fixed in [PR #45288](https://github.com/DataDog/datadog-agent/pull/45288) for the gohai code path, but at a different call site (`pkg/network/containers/container_item_linux.go:199`).

Plan used for this change can be found in my comment [here](https://datadoghq.atlassian.net/browse/NTWK-754?focusedCommentId=3100576). 

### Describe how you validated your changes

- **Unit test**: `TestIsProcessStillRunningImpl_PanicRecovery` validates the named-return + `defer`/`recover` pattern returns `(false, nil)` on panic.
- **Smoke test**: Built and ran the system-probe in a devenv — clean startup and shutdown, no panics, exit code 0.
- **Code inspection**: The change only adds a `defer`/`recover` with no modifications to the existing logic. The normal code path is unchanged.

[NTWK-754]: https://datadoghq.atlassian.net/browse/NTWK-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ