### PR TITLE
NDMC-278: Mark IPs as processed immediately after device scan

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -198,12 +198,12 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 	for authIndex, authentication := range job.subnet.config.Authentications {
 		deviceFound = l.checkDeviceReachable(authentication, job.subnet.config.Port, deviceIP)
 
-		l.deviceDeduper.MarkIPAsProcessed(deviceIP)
-		l.registerDedupedDevices()
-
 		if !deviceFound {
+			l.deviceDeduper.DecrementIPCounter(deviceIP)
 			continue
 		}
+
+		l.deviceDeduper.MarkIPAsProcessed(deviceIP)
 
 		device, exists := job.subnet.devices[entityID]
 		if exists && device.Failures != 0 {
@@ -218,6 +218,9 @@ func (l *SNMPListener) checkDevice(job snmpJob) {
 
 		break
 	}
+
+	l.registerDedupedDevices()
+
 	if !deviceFound {
 		l.deleteService(entityID, job.subnet)
 	}

--- a/pkg/snmp/devicededuper/device_deduper.go
+++ b/pkg/snmp/devicededuper/device_deduper.go
@@ -48,6 +48,7 @@ func (d DeviceInfo) equal(other DeviceInfo) bool {
 
 // DeviceDeduper is an interface for deduplicating SNMP devices
 type DeviceDeduper interface {
+	DecrementIPCounter(ip string)
 	MarkIPAsProcessed(ip string)
 	AddPendingDevice(device PendingDevice)
 	GetDedupedDevices() []PendingDevice
@@ -58,7 +59,7 @@ type deviceDeduperImpl struct {
 	sync.RWMutex
 	deviceInfos    []DeviceInfo
 	pendingDevices []PendingDevice
-	ipsCounter     map[string]*atomic.Uint32
+	ipsCounter     map[string]*atomic.Int32
 	config         snmp.ListenerConfig
 }
 
@@ -67,7 +68,7 @@ func NewDeviceDeduper(config snmp.ListenerConfig) DeviceDeduper {
 	deduper := &deviceDeduperImpl{
 		deviceInfos:    make([]DeviceInfo, 0),
 		pendingDevices: make([]PendingDevice, 0),
-		ipsCounter:     make(map[string]*atomic.Uint32),
+		ipsCounter:     make(map[string]*atomic.Int32),
 		config:         config,
 	}
 
@@ -94,10 +95,10 @@ func (d *deviceDeduperImpl) initializeCounters() {
 			ipStr := currentIP.String()
 			counter, exists := d.ipsCounter[ipStr]
 			if !exists {
-				counter = &atomic.Uint32{}
+				counter = &atomic.Int32{}
 				d.ipsCounter[ipStr] = counter
 			}
-			counter.Add(uint32(len(config.Authentications)))
+			counter.Add(int32(len(config.Authentications)))
 		}
 	}
 }
@@ -175,14 +176,25 @@ func (d *deviceDeduperImpl) GetDedupedDevices() []PendingDevice {
 	return dedupedDevices
 }
 
-// MarkIPAsProcessed removes an IP from the counter, it is used to make sure we get the minimum IP for a device
+// DecrementIPCounter decrements the counter for an IP by 1, representing one completed auth attempt.
+func (d *deviceDeduperImpl) DecrementIPCounter(ip string) {
+	d.RLock()
+	defer d.RUnlock()
+	counter, exists := d.ipsCounter[ip]
+
+	if exists {
+		counter.Add(-1)
+	}
+}
+
+// MarkIPAsProcessed sets the counter for an IP to 0, signaling that the device was found and no further attempts are needed
 func (d *deviceDeduperImpl) MarkIPAsProcessed(ip string) {
 	d.RLock()
 	defer d.RUnlock()
 	counter, exists := d.ipsCounter[ip]
 
 	if exists {
-		counter.Add(^uint32(0)) // Subtract 1 using bitwise NOT of 0
+		counter.Store(0)
 	}
 }
 

--- a/pkg/snmp/devicededuper/device_deduper_test.go
+++ b/pkg/snmp/devicededuper/device_deduper_test.go
@@ -149,7 +149,7 @@ func TestDeviceDeduper_Contains(t *testing.T) {
 	deduper := &deviceDeduperImpl{
 		deviceInfos:    make([]DeviceInfo, 0),
 		pendingDevices: make([]PendingDevice, 0),
-		ipsCounter:     make(map[string]*atomic.Uint32),
+		ipsCounter:     make(map[string]*atomic.Int32),
 	}
 
 	now := time.Now().UnixMilli()
@@ -175,32 +175,53 @@ func TestDeviceDeduper_Contains(t *testing.T) {
 	assert.False(t, deduper.contains(differentDevice))
 }
 
+func TestDeviceDeduper_DecrementIPCounter(t *testing.T) {
+	deduper := &deviceDeduperImpl{
+		deviceInfos:    make([]DeviceInfo, 0),
+		pendingDevices: make([]PendingDevice, 0),
+		ipsCounter:     make(map[string]*atomic.Int32),
+	}
+
+	counter1 := &atomic.Int32{}
+	counter1.Store(2)
+	deduper.ipsCounter["192.168.1.1"] = counter1
+
+	counter2 := &atomic.Int32{}
+	counter2.Store(1)
+	deduper.ipsCounter["192.168.1.2"] = counter2
+
+	deduper.DecrementIPCounter("192.168.1.1")
+	count := deduper.ipsCounter["192.168.1.1"].Load()
+	assert.Equal(t, int32(1), count)
+
+	deduper.DecrementIPCounter("192.168.1.1")
+	count = deduper.ipsCounter["192.168.1.1"].Load()
+	assert.Equal(t, int32(0), count)
+
+	deduper.DecrementIPCounter("192.168.1.2")
+	count = deduper.ipsCounter["192.168.1.2"].Load()
+	assert.Equal(t, int32(0), count)
+
+	// Decrementing past 0 goes to -1, which checkPreviousIPs still treats as processed (count > 0 is false)
+	deduper.DecrementIPCounter("192.168.1.2")
+	count = deduper.ipsCounter["192.168.1.2"].Load()
+	assert.Equal(t, int32(-1), count)
+}
+
 func TestDeviceDeduper_MarkIPAsProcessed(t *testing.T) {
 	deduper := &deviceDeduperImpl{
 		deviceInfos:    make([]DeviceInfo, 0),
 		pendingDevices: make([]PendingDevice, 0),
-		ipsCounter:     make(map[string]*atomic.Uint32),
+		ipsCounter:     make(map[string]*atomic.Int32),
 	}
 
-	counter1 := &atomic.Uint32{}
-	counter1.Store(2)
+	counter1 := &atomic.Int32{}
+	counter1.Store(5)
 	deduper.ipsCounter["192.168.1.1"] = counter1
-
-	counter2 := &atomic.Uint32{}
-	counter2.Store(1)
-	deduper.ipsCounter["192.168.1.2"] = counter2
 
 	deduper.MarkIPAsProcessed("192.168.1.1")
 	count := deduper.ipsCounter["192.168.1.1"].Load()
-	assert.Equal(t, uint32(1), count)
-
-	deduper.MarkIPAsProcessed("192.168.1.1")
-	count = deduper.ipsCounter["192.168.1.1"].Load()
-	assert.Equal(t, uint32(0), count)
-
-	deduper.MarkIPAsProcessed("192.168.1.2")
-	count = deduper.ipsCounter["192.168.1.2"].Load()
-	assert.Equal(t, uint32(0), count)
+	assert.Equal(t, int32(0), count)
 }
 
 func TestDeviceDeduper_InitIPCounter(t *testing.T) {
@@ -226,9 +247,9 @@ func TestDeviceDeduper_InitIPCounter(t *testing.T) {
 	assert.True(t, ok)
 
 	count := deduperImpl.ipsCounter["192.168.1.1"].Load()
-	assert.Equal(t, uint32(2), count)
+	assert.Equal(t, int32(2), count)
 	count = deduperImpl.ipsCounter["192.168.1.2"].Load()
-	assert.Equal(t, uint32(2), count)
+	assert.Equal(t, int32(2), count)
 
 	_, ok = deduperImpl.ipsCounter["192.168.1.0"]
 	assert.False(t, ok)
@@ -240,22 +261,22 @@ func TestDeviceDeduper_CheckPreviousIPs(t *testing.T) {
 	deduper := &deviceDeduperImpl{
 		deviceInfos:    make([]DeviceInfo, 0),
 		pendingDevices: make([]PendingDevice, 0),
-		ipsCounter:     make(map[string]*atomic.Uint32),
+		ipsCounter:     make(map[string]*atomic.Int32),
 	}
 
-	counter1 := &atomic.Uint32{}
+	counter1 := &atomic.Int32{}
 	counter1.Store(0)
 	deduper.ipsCounter["192.168.1.1"] = counter1 // Already processed
 
-	counter2 := &atomic.Uint32{}
+	counter2 := &atomic.Int32{}
 	counter2.Store(1)
 	deduper.ipsCounter["192.168.1.2"] = counter2 // Not processed yet
 
-	counter3 := &atomic.Uint32{}
+	counter3 := &atomic.Int32{}
 	counter3.Store(0)
 	deduper.ipsCounter["192.168.1.3"] = counter3 // Already processed
 
-	counter4 := &atomic.Uint32{}
+	counter4 := &atomic.Int32{}
 	counter4.Store(0)
 	deduper.ipsCounter["192.168.1.4"] = counter4 // Already processed
 
@@ -277,7 +298,7 @@ func TestDeviceDeduper_AddPendingDevice(t *testing.T) {
 	deduper := &deviceDeduperImpl{
 		deviceInfos:    make([]DeviceInfo, 0),
 		pendingDevices: make([]PendingDevice, 0),
-		ipsCounter:     make(map[string]*atomic.Uint32),
+		ipsCounter:     make(map[string]*atomic.Int32),
 	}
 
 	now := time.Now().UnixMilli()
@@ -379,7 +400,7 @@ func TestDeviceDeduper_GetDedupedDevices(t *testing.T) {
 	deduper := &deviceDeduperImpl{
 		deviceInfos:    make([]DeviceInfo, 0),
 		pendingDevices: make([]PendingDevice, 0),
-		ipsCounter:     make(map[string]*atomic.Uint32),
+		ipsCounter:     make(map[string]*atomic.Int32),
 	}
 
 	now := time.Now().UnixMilli()
@@ -429,19 +450,19 @@ func TestDeviceDeduper_GetDedupedDevices(t *testing.T) {
 
 	// Set IP counter such that 192.168.1.1 has all previous IPs discovered
 	// but 192.168.1.3 does not
-	counter0 := &atomic.Uint32{}
+	counter0 := &atomic.Int32{}
 	counter0.Store(0)
 	deduper.ipsCounter["192.168.1.0"] = counter0 // Already scanned
 
-	counter1 := &atomic.Uint32{}
+	counter1 := &atomic.Int32{}
 	counter1.Store(0)
 	deduper.ipsCounter["192.168.1.1"] = counter1 // Current IP
 
-	counter2 := &atomic.Uint32{}
+	counter2 := &atomic.Int32{}
 	counter2.Store(1)
 	deduper.ipsCounter["192.168.1.2"] = counter2 // Pending IP
 
-	counter3 := &atomic.Uint32{}
+	counter3 := &atomic.Int32{}
 	counter3.Store(0)
 	deduper.ipsCounter["192.168.1.3"] = counter3 // Current IP
 
@@ -571,18 +592,18 @@ func TestDeviceDeduper_ResetCounters(t *testing.T) {
 
 	// Initially, all counters should be set to 2 (number of authentications)
 	count := deduperImpl.ipsCounter["192.168.1.1"].Load()
-	assert.Equal(t, uint32(2), count)
+	assert.Equal(t, int32(2), count)
 	count = deduperImpl.ipsCounter["192.168.1.2"].Load()
-	assert.Equal(t, uint32(2), count)
+	assert.Equal(t, int32(2), count)
 
 	// Process some IPs
-	deduper.MarkIPAsProcessed("192.168.1.1")
-	deduper.MarkIPAsProcessed("192.168.1.2")
+	deduper.DecrementIPCounter("192.168.1.1")
+	deduper.DecrementIPCounter("192.168.1.2")
 
 	count = deduperImpl.ipsCounter["192.168.1.1"].Load()
-	assert.Equal(t, uint32(1), count)
+	assert.Equal(t, int32(1), count)
 	count = deduperImpl.ipsCounter["192.168.1.2"].Load()
-	assert.Equal(t, uint32(1), count)
+	assert.Equal(t, int32(1), count)
 
 	// Add a discovered device
 	now := time.Now().UnixMilli()
@@ -600,9 +621,9 @@ func TestDeviceDeduper_ResetCounters(t *testing.T) {
 
 	// Verify counters are reset to initial value
 	count = deduperImpl.ipsCounter["192.168.1.1"].Load()
-	assert.Equal(t, uint32(2), count)
+	assert.Equal(t, int32(2), count)
 	count = deduperImpl.ipsCounter["192.168.1.2"].Load()
-	assert.Equal(t, uint32(2), count)
+	assert.Equal(t, int32(2), count)
 
 	// Verify device infos are cleared
 	assert.Len(t, deduperImpl.deviceInfos, 0)

--- a/releasenotes/notes/update-ip-processing-counter-0d86644aeeb173db.yaml
+++ b/releasenotes/notes/update-ip-processing-counter-0d86644aeeb173db.yaml
@@ -1,0 +1,12 @@
+---
+fixes:
+  - |
+    Fixed an issue in SNMP autodiscovery where the IP processing counter was not
+    reset to zero immediately after an IP was fully processed. When multiple
+    authentications were configured, the counter was only decremented once per
+    authentication attempted, meaning a successful first authentication would leave
+    the counter at a non-zero value. This caused the deduplication logic to treat
+    the IP as still in-progress, potentially delaying or preventing devices from
+    being registered correctly. The counter is now cleared immediately once an IP
+    has been fully processed. This only affects users with SNMP device deduplication
+    enabled.

--- a/releasenotes/notes/update-ip-processing-counter-0d86644aeeb173db.yaml
+++ b/releasenotes/notes/update-ip-processing-counter-0d86644aeeb173db.yaml
@@ -2,11 +2,5 @@
 fixes:
   - |
     Fixed an issue in SNMP autodiscovery where the IP processing counter was not
-    reset to zero immediately after an IP was fully processed. When multiple
-    authentications were configured, the counter was only decremented once per
-    authentication attempted, meaning a successful first authentication would leave
-    the counter at a non-zero value. This caused the deduplication logic to treat
-    the IP as still in-progress, potentially delaying or preventing devices from
-    being registered correctly. The counter is now cleared immediately once an IP
-    has been fully processed. This only affects users with SNMP device deduplication
-    enabled.
+    reset immediately after processing, potentially delaying or preventing device
+    registration when deduplication was enabled.

--- a/test/new-e2e/tests/ndm/snmp/autodiscovery_test.go
+++ b/test/new-e2e/tests/ndm/snmp/autodiscovery_test.go
@@ -80,6 +80,7 @@ func (v *autoDiscoverySuite) TestAuthenticationsConfig() {
 network_devices:
   autodiscovery:
     loader: core
+    use_deduplication: true
     configs:
       - network_address: 127.0.0.0/30
         port: 1161

--- a/test/new-e2e/tests/ndm/snmp/autodiscovery_test.go
+++ b/test/new-e2e/tests/ndm/snmp/autodiscovery_test.go
@@ -80,6 +80,41 @@ func (v *autoDiscoverySuite) TestAuthenticationsConfig() {
 network_devices:
   autodiscovery:
     loader: core
+    configs:
+      - network_address: 127.0.0.0/30
+        port: 1161
+        authentications:
+          - community_string: 'invalid1'
+          - community_string: 'cisco-nexus'
+          - community_string: 'invalid2'
+`
+	v.UpdateEnv(autoDiscoverySuiteProvisioner(agentConfig))
+
+	err := fakeIntake.Client().FlushServerAndResetAggregators()
+	v.Require().NoError(err)
+
+	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
+		checkBasicMetrics(c, fakeIntake)
+	}, 2*time.Minute, 10*time.Second)
+
+	require.EventuallyWithT(v.T(), func(c *assert.CollectT) {
+		ndmPayload := checkLastNDMPayload(c, fakeIntake, "default")
+		require.NotEmpty(c, ndmPayload.Devices)
+		checkCiscoNexusDeviceMetadata(c, ndmPayload.Devices[0])
+	}, 2*time.Minute, 10*time.Second)
+}
+
+func (v *autoDiscoverySuite) TestAuthenticationsConfigWithDeduplication() {
+	vm := v.Env().RemoteHost
+	fakeIntake := v.Env().FakeIntake
+
+	setupDevice(v.Require(), vm)
+
+	// language=yaml
+	agentConfig := `
+network_devices:
+  autodiscovery:
+    loader: core
     use_deduplication: true
     configs:
       - network_address: 127.0.0.0/30


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in SNMP autodiscovery where the IP processing counter was not cleared immediately after an IP was fully scanned. The counter was decremented once per authentication attempted, so if the first authentication succeeded, the counter would stop at numAuths - 1 instead of 0. This caused the deduplication logic to treat already-processed IPs as still in-progress.                                                     

Also refactors the counter from map[string]*atomic.Uint32 to a simpler set (map[string]struct{}), since the count value was never meaningfully used — only whether it was zero or not.      

### Motivation

When deduplication is enabled and multiple authentications are configured, devices could be delayed or never registered because previous IPs appeared to still be in-progress. The fix ensures the IP is marked as fully processed immediately after the scan completes, regardless of which authentication succeeded.

### Describe how you validated your changes

- Updated unit tests in pkg/snmp/devicededuper/ to cover the new logic, and updated the E2E test as well to go through this flow (by adding deduplication)
- Existing unit tests in should continue to pass.
- When testing locally, cached devices should show up as discovered even if the first authentication already succeeds.
-  When testing in staging, the number of devices should either stay the same or increase (to cover scenarios where devices did not get seen due to the bug)

### Additional Notes

This only affects users with SNMP device deduplication enabled.