### PR TITLE
Drop stale Go version guard in `inv update-go`

### DIFF
--- a/tasks/update_go.py
+++ b/tasks/update_go.py
@@ -90,21 +90,8 @@ def update_go(
 
     _update_references(warn, version)
     _update_go_mods(warn, version, include_otel_modules)
-
-    # check the installed go version before running tasks requiring the correct version
-    res = ctx.run("go version")
-    if res and res.stdout.startswith(f"go version go{version} "):
-        print("Updating the code in pkg/template...")
-        bazel(ctx, "run", "//pkg/template:generate")
-        print("Running the tidy task...")
-        tidy(ctx)
-    else:
-        print(
-            color_message(
-                "WARNING: did not run `dda inv tidy` nor `dda inv pkg-template.generate` as the version of your `go` binary doesn't match the requested version",
-                "orange",
-            )
-        )
+    bazel(ctx, "run", "//pkg/template:generate")
+    tidy(ctx)
 
     if release_note:
         releasenote_path = _create_releasenote(ctx, version)


### PR DESCRIPTION
### Motivation
The Go version check before running `//pkg/template:generate` and `inv tidy` was introduced when those tasks relied on the system `go` binary.

Since #47751 both operations go through Bazel's hermetic Go toolchain, making the system `go` version irrelevant.

### What does this PR do?
Remove the guard, which became dead code and should have been removed in the frame of #47751, sorry.