### PR TITLE
[Backport 7.77.x] [e2e] Pin argo-rollouts chart version for K8s < 1.25 (#48196)

### DIFF
--- a/test/e2e-framework/scenarios/aws/kindvm/run.go
+++ b/test/e2e-framework/scenarios/aws/kindvm/run.go
@@ -36,6 +36,7 @@ import (
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/aws/fakeintake"
 	"github.com/DataDog/datadog-agent/test/e2e-framework/scenarios/outputs"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -143,7 +144,14 @@ func RunWithEnv(ctx *pulumi.Context, awsEnv resAws.Environment, env outputs.Kube
 
 	var dependsOnArgoRollout pulumi.ResourceOption
 	if params.deployArgoRollout {
-		argoParams, err := argorollouts.NewParams()
+		var argoOpts []argorollouts.Option
+		// argo-rollouts chart >= 2.40.8 uses x-kubernetes-validations in CRDs,
+		// which requires K8s >= 1.25. Pin to last compatible version for older clusters.
+		kubeVer, err := semver.NewVersion(utils.ParseKubernetesVersion(awsEnv.KubernetesVersion()))
+		if err == nil && kubeVer.LessThan(semver.MustParse("1.25.0")) {
+			argoOpts = append(argoOpts, argorollouts.WithVersion("2.40.7"))
+		}
+		argoParams, err := argorollouts.NewParams(argoOpts...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

Pin the argo-rollouts Helm chart to version `2.40.7` for e2e test clusters running Kubernetes < 1.25, while leaving newer clusters unpinned so they continue using the latest chart.

### Motivation

Chart version `2.40.8` (released 2026-03-21) updated argo-rollouts to v1.9.0, which introduced CRDs using `x-kubernetes-validations` (CEL validation). This feature requires Kubernetes 1.25+ and breaks `TestKindSuite` on K8s 1.19 and 1.22 clusters — see [incident-51509](https://dd.slack.com/archives/C0AMS18K2HM).

The unpinned chart meant CI pulled the latest version automatically, causing consistent failures on the `main` branch since ~2026-03-22.

### Describe how you validated your changes

- `go vet ./scenarios/aws/kindvm/...` passes
- K8s 1.19/1.22 clusters will get chart `2.40.7` (last version before the breaking CRD change)
- K8s >= 1.25 clusters continue using the latest chart (no version constraint)
- Full validation via CI: `new-e2e-containers: [--run TestKindSuite]` jobs for all K8s versions

### Additional Notes

| Chart Version | Released | Change | K8s < 1.25 compatible? |
|---|---|---|---|
| `2.40.6` | 2026-02-14 | — | Yes |
| `2.40.7` | 2026-03-20 | Add `controller.createConfigmap` flag | Yes |
| `2.40.8` | 2026-03-21 | **Update argo-rollouts to v1.9.0** | **No** |

Manual cherry pick from #48096