### PR TITLE
Replace string-key reconstruction with QueryHandle for series identity

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -12,7 +12,6 @@ package observer
 
 import (
 	"sort"
-	"strconv"
 	"strings"
 )
 
@@ -269,9 +268,6 @@ type LogMetricsExtractorOutput struct {
 	Telemetry []ObserverTelemetry
 }
 
-// MetricName is a human-readable metric identifier (e.g., "cpu.user:avg").
-// Multiple series can share a MetricName if they differ by tags.
-type MetricName string
 
 // SeriesDescriptor is the fully resolved identity of a time series.
 // It carries namespace, metric name, tags, and aggregation — everything
@@ -323,43 +319,10 @@ func (sd SeriesDescriptor) Key() string {
 	return sd.Namespace + "|" + sd.Name + ":" + aggStr + "|" + tagStr
 }
 
-// AnomalySource is an alias for SeriesDescriptor for backward compatibility.
-// Deprecated: use SeriesDescriptor directly.
-type AnomalySource = SeriesDescriptor
-
 // SeriesRef is a compact numeric handle for a stored time series.
 // Storage assigns a SeriesRef when a series key is first created;
 // the ref remains stable for the lifetime of the storage instance.
-// Use NoSeriesRef as a sentinel for "no series".
 type SeriesRef int
-
-// NoSeriesRef is the sentinel value meaning "no series".
-const NoSeriesRef SeriesRef = -1
-
-// QueryHandle pairs a SeriesRef with an Aggregate, uniquely identifying
-// a view over a stored series (e.g. series 42 read as avg).
-// This type lives at the detector→engine boundary; it does NOT cross
-// into correlators, API serialization, or ActiveCorrelation.
-type QueryHandle struct {
-	Ref       SeriesRef
-	Aggregate Aggregate
-}
-
-// NoQueryHandle is the zero-value sentinel for "no query handle".
-var NoQueryHandle = QueryHandle{Ref: NoSeriesRef}
-
-// IsValid returns true if the QueryHandle refers to a real series.
-func (qh QueryHandle) IsValid() bool {
-	return qh.Ref != NoSeriesRef
-}
-
-// String returns "ref:agg" (e.g. "42:avg"). Returns "" for invalid handles.
-func (qh QueryHandle) String() string {
-	if qh.Ref == NoSeriesRef {
-		return ""
-	}
-	return strconv.Itoa(int(qh.Ref)) + ":" + AggregateString(qh.Aggregate)
-}
 
 // AnomalyType distinguishes the source type of an anomaly.
 type AnomalyType string

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -10,6 +10,8 @@
 // passed to data pipelines without adding significant overhead.
 package observer
 
+import "strconv"
+
 // team: agent-metric-pipelines
 
 // Component is the central observer that receives data via handles.
@@ -291,8 +293,39 @@ func (s AnomalySource) String() string {
 	return s.Name + ":" + AggregateString(s.Aggregate)
 }
 
-// SeriesID uniquely identifies a time series (namespace + name + tags).
-type SeriesID string
+// SeriesRef is a compact numeric handle for a stored time series.
+// Storage assigns a SeriesRef when a series key is first created;
+// the ref remains stable for the lifetime of the storage instance.
+// Use NoSeriesRef as a sentinel for "no series".
+type SeriesRef int
+
+// NoSeriesRef is the sentinel value meaning "no series".
+const NoSeriesRef SeriesRef = -1
+
+// QueryHandle pairs a SeriesRef with an Aggregate, uniquely identifying
+// a view over a stored series (e.g. series 42 read as avg).
+// This type lives at the detector→engine boundary; it does NOT cross
+// into correlators, API serialization, or ActiveCorrelation.
+type QueryHandle struct {
+	Ref       SeriesRef
+	Aggregate Aggregate
+}
+
+// NoQueryHandle is the zero-value sentinel for "no query handle".
+var NoQueryHandle = QueryHandle{Ref: NoSeriesRef}
+
+// IsValid returns true if the QueryHandle refers to a real series.
+func (qh QueryHandle) IsValid() bool {
+	return qh.Ref != NoSeriesRef
+}
+
+// String returns "ref:agg" (e.g. "42:avg"). Returns "" for invalid handles.
+func (qh QueryHandle) String() string {
+	if qh.Ref == NoSeriesRef {
+		return ""
+	}
+	return strconv.Itoa(int(qh.Ref)) + ":" + AggregateString(qh.Aggregate)
+}
 
 // AnomalyType distinguishes the source type of an anomaly.
 type AnomalyType string
@@ -313,9 +346,9 @@ type Anomaly struct {
 	Type AnomalyType
 	// Source identifies which metric/signal the anomaly is about.
 	Source AnomalySource
-	// SourceSeriesID uniquely identifies the source series (namespace + name + tags).
-	// Empty for log anomalies.
-	SourceSeriesID SeriesID
+	// SourceView identifies the concrete storage series + aggregate that produced
+	// this anomaly. Invalid (NoQueryHandle) for log anomalies.
+	SourceView QueryHandle
 	// DetectorName identifies which detector produced this anomaly.
 	DetectorName string
 	Title        string
@@ -433,8 +466,8 @@ type Reporter interface {
 type ActiveCorrelation struct {
 	Pattern string // pattern name, e.g. "kernel_bottleneck"
 	Title   string // display title, e.g. "Correlated: Kernel network bottleneck"
-	// MemberSeriesIDs are the concrete series identities participating in this correlation.
-	MemberSeriesIDs []SeriesID
+	// MemberRefs are the storage series refs participating in this correlation.
+	MemberRefs []SeriesRef
 	// MetricNames are display-oriented metric names participating in this correlation.
 	MetricNames []MetricName
 	Anomalies   []Anomaly // the actual anomalies that triggered this correlation
@@ -470,12 +503,10 @@ func WorkloadSeriesFilter() SeriesFilter {
 	return SeriesFilter{ExcludeNamespaces: []string{TelemetryNamespace}}
 }
 
-type SeriesHandle int
-
 // SeriesMeta describes a series discovered via ListSeries.
-// The Handle field is a stable numeric identifier for use in hot-path methods.
+// The Ref field is a stable numeric identifier for use in hot-path methods.
 type SeriesMeta struct {
-	Handle    SeriesHandle
+	Ref       SeriesRef
 	Namespace string
 	Name      string
 	Tags      []string
@@ -538,7 +569,7 @@ type MetricContext struct {
 // Detectors use this to pull whatever data they need.
 //
 // Use ListSeries to discover series and obtain their numeric handles.
-// All hot-path methods take a SeriesHandle for O(1) lookups.
+// All hot-path methods take a SeriesRef for O(1) lookups.
 //
 // Reading points: ForEachPoint and GetSeriesRange both read the same data;
 // they differ in allocation cost and ownership model.
@@ -562,27 +593,27 @@ type StorageReader interface {
 	// GetSeriesRange returns points within a time range (start, end].
 	// Start is exclusive, end is inclusive. Use start=0 to read from the beginning.
 	// Allocates a new []Point slice — see interface doc for when to prefer ForEachPoint.
-	GetSeriesRange(handle SeriesHandle, start, end int64, agg Aggregate) *Series
+	GetSeriesRange(handle SeriesRef, start, end int64, agg Aggregate) *Series
 
 	// ForEachPoint calls fn for every point in the time range (start, end].
 	// The Series pointer and its contents are valid only for the duration of
 	// the callback. Uses a pooled buffer internally so steady-state calls
 	// do not allocate. Returns false if the series was not found.
-	ForEachPoint(handle SeriesHandle, start, end int64, agg Aggregate, fn func(*Series, Point)) bool
+	ForEachPoint(handle SeriesRef, start, end int64, agg Aggregate, fn func(*Series, Point)) bool
 
 	// PointCount returns the number of raw data points for a series without
 	// loading or converting them. Returns 0 if the series is not found.
-	PointCount(handle SeriesHandle) int
+	PointCount(handle SeriesRef) int
 
 	// PointCountUpTo returns the number of raw data points with timestamp <= endTime.
 	// Uses binary search for efficiency. Returns 0 if the series is not found.
-	PointCountUpTo(handle SeriesHandle, endTime int64) int
+	PointCountUpTo(handle SeriesRef, endTime int64) int
 
 	// WriteGeneration returns a per-series counter that increments on every
 	// write to that series, including same-bucket merges. Use this to detect
 	// updates to an existing series even when its point count does not change.
 	// Returns 0 if the series is not found.
-	WriteGeneration(handle SeriesHandle) int64
+	WriteGeneration(handle SeriesRef) int64
 
 	// SeriesGeneration returns a global counter that increments only when the
 	// set of known series changes. Use this to cache ListSeries results and

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -380,9 +380,6 @@ type Anomaly struct {
 	Type AnomalyType
 	// Source is the fully resolved series identity (namespace, name, tags, aggregate).
 	Source SeriesDescriptor
-	// SourceView identifies the concrete storage series + aggregate that produced
-	// this anomaly. Invalid (NoQueryHandle) for log anomalies.
-	SourceView QueryHandle
 	// DetectorName identifies which detector produced this anomaly.
 	DetectorName string
 	Title        string

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -10,7 +10,11 @@
 // passed to data pipelines without adding significant overhead.
 package observer
 
-import "strconv"
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
 
 // team: agent-metric-pipelines
 
@@ -269,29 +273,59 @@ type LogMetricsExtractorOutput struct {
 // Multiple series can share a MetricName if they differ by tags.
 type MetricName string
 
-// AnomalySource identifies the metric that an anomaly is about using
-// structured fields rather than string concatenation.
-type AnomalySource struct {
+// SeriesDescriptor is the fully resolved identity of a time series.
+// It carries namespace, metric name, tags, and aggregation — everything
+// needed to display, key, and compare series across correlators and API.
+type SeriesDescriptor struct {
 	// Namespace identifies the component that produced this metric
 	// (e.g. an extractor name like "log_metrics_extractor", or "dogstatsd").
 	Namespace string
 	// Name is the base metric name (e.g. "log.pattern.<hash>.count", "cpu.user").
 	Name string
+	// Tags are the series-level tags (e.g. ["host:web-1", "env:prod"]).
+	Tags []string
 	// Aggregate is the aggregation applied when reading the series.
 	Aggregate Aggregate
 }
 
 // String returns a human-readable representation (e.g. "cpu.user:avg").
-// Namespace is structural and not included in the display string.
-func (s AnomalySource) String() string {
-	if s.Name == "" {
+// Namespace and tags are not included — use DisplayName() for that.
+func (sd SeriesDescriptor) String() string {
+	if sd.Name == "" {
 		return ""
 	}
-	if s.Aggregate == AggregateNone {
-		return s.Name
+	if sd.Aggregate == AggregateNone {
+		return sd.Name
 	}
-	return s.Name + ":" + AggregateString(s.Aggregate)
+	return sd.Name + ":" + AggregateString(sd.Aggregate)
 }
+
+// DisplayName returns a display string with tags (e.g. "cpu.user:avg{host:web-1}").
+func (sd SeriesDescriptor) DisplayName() string {
+	base := sd.String()
+	if len(sd.Tags) == 0 {
+		return base
+	}
+	return base + "{" + strings.Join(sd.Tags, ",") + "}"
+}
+
+// Key returns a stable string suitable for use as a map key.
+// Format: "namespace|name:agg|tag1,tag2,..."
+func (sd SeriesDescriptor) Key() string {
+	aggStr := AggregateString(sd.Aggregate)
+	var tagStr string
+	if len(sd.Tags) > 0 {
+		sorted := make([]string, len(sd.Tags))
+		copy(sorted, sd.Tags)
+		sort.Strings(sorted)
+		tagStr = strings.Join(sorted, ",")
+	}
+	return sd.Namespace + "|" + sd.Name + ":" + aggStr + "|" + tagStr
+}
+
+// AnomalySource is an alias for SeriesDescriptor for backward compatibility.
+// Deprecated: use SeriesDescriptor directly.
+type AnomalySource = SeriesDescriptor
 
 // SeriesRef is a compact numeric handle for a stored time series.
 // Storage assigns a SeriesRef when a series key is first created;
@@ -344,8 +378,8 @@ type Anomaly struct {
 	// Type distinguishes log-based anomalies from metric-based ones.
 	// Defaults to AnomalyTypeMetric if not set.
 	Type AnomalyType
-	// Source identifies which metric/signal the anomaly is about.
-	Source AnomalySource
+	// Source is the fully resolved series identity (namespace, name, tags, aggregate).
+	Source SeriesDescriptor
 	// SourceView identifies the concrete storage series + aggregate that produced
 	// this anomaly. Invalid (NoQueryHandle) for log anomalies.
 	SourceView QueryHandle
@@ -356,7 +390,6 @@ type Anomaly struct {
 	// Context carries optional enrichment about the originating signal, such as
 	// a synthesized pattern and example source data.
 	Context   *MetricContext
-	Tags      []string
 	Timestamp int64    // when the anomaly was detected (unix seconds)
 	Score     *float64 // confidence/severity score (nil if not available)
 	// DebugInfo contains detector-specific debug information explaining the detection.
@@ -466,10 +499,8 @@ type Reporter interface {
 type ActiveCorrelation struct {
 	Pattern string // pattern name, e.g. "kernel_bottleneck"
 	Title   string // display title, e.g. "Correlated: Kernel network bottleneck"
-	// MemberRefs are the storage series refs participating in this correlation.
-	MemberRefs []SeriesRef
-	// MetricNames are display-oriented metric names participating in this correlation.
-	MetricNames []MetricName
+	// Members are the fully resolved series descriptors participating in this correlation.
+	Members     []SeriesDescriptor
 	Anomalies   []Anomaly // the actual anomalies that triggered this correlation
 	FirstSeen   int64     // when pattern first matched (unix seconds, from data)
 	LastUpdated int64     // most recent contributing signal (unix seconds, from data)

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -12,6 +12,7 @@ package observer
 
 import (
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -324,6 +325,19 @@ func (sd SeriesDescriptor) Key() string {
 // the ref remains stable for the lifetime of the storage instance.
 type SeriesRef int
 
+// QueryHandle pairs a storage series ref with its aggregate, providing
+// enough information to produce the compact ID ("42:avg") that the API
+// uses as a join key across endpoints.
+type QueryHandle struct {
+	Ref       SeriesRef
+	Aggregate Aggregate
+}
+
+// CompactID returns the compact series identifier (e.g. "42:avg").
+func (q QueryHandle) CompactID() string {
+	return strconv.Itoa(int(q.Ref)) + ":" + AggregateString(q.Aggregate)
+}
+
 // AnomalyType distinguishes the source type of an anomaly.
 type AnomalyType string
 
@@ -343,6 +357,10 @@ type Anomaly struct {
 	Type AnomalyType
 	// Source is the fully resolved series identity (namespace, name, tags, aggregate).
 	Source SeriesDescriptor
+	// SourceRef is the storage handle for this anomaly's series, enabling
+	// direct compact ID lookups without string-key reconstruction. Nil for
+	// anomalies without a storage-backed series (e.g. log anomalies, RRCF).
+	SourceRef *QueryHandle
 	// DetectorName identifies which detector produced this anomaly.
 	DetectorName string
 	Title        string

--- a/comp/observer/impl/anomaly_correlator_identity_keys_test.go
+++ b/comp/observer/impl/anomaly_correlator_identity_keys_test.go
@@ -22,16 +22,16 @@ func TestLeadLagCorrelator_PreservesFullSeriesIDs(t *testing.T) {
 		WindowSeconds:       120,
 	})
 
-	seriesA := observer.SeriesID("parquet|cpu.user:avg|host:A,service:web")
-	seriesB := observer.SeriesID("parquet|cpu.user:avg|host:B,service:web")
+	seriesA := observer.SeriesRef(0)
+	seriesB := observer.SeriesRef(1)
 
-	c.ProcessAnomaly(observer.Anomaly{SourceSeriesID: seriesA, Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{SourceSeriesID: seriesB, Timestamp: 108})
+	c.ProcessAnomaly(observer.Anomaly{SourceView: observer.QueryHandle{Ref: seriesA, Aggregate: observer.AggregateAverage}, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{SourceView: observer.QueryHandle{Ref: seriesB, Aggregate: observer.AggregateAverage}, Timestamp: 108})
 
 	edges := c.GetEdges()
 	require.NotEmpty(t, edges)
-	assert.Contains(t, []string{string(seriesA), string(seriesB)}, edges[0].Leader)
-	assert.Contains(t, []string{string(seriesA), string(seriesB)}, edges[0].Follower)
+	assert.Contains(t, []string{"0", "1"}, edges[0].Leader)
+	assert.Contains(t, []string{"0", "1"}, edges[0].Follower)
 }
 
 func TestSurpriseCorrelator_PreservesFullSeriesIDs(t *testing.T) {
@@ -45,15 +45,15 @@ func TestSurpriseCorrelator_PreservesFullSeriesIDs(t *testing.T) {
 		EvictionWindowSeconds: 300,
 	})
 
-	seriesA := observer.SeriesID("parquet|net.retransmits:avg|host:A,az:1a")
-	seriesB := observer.SeriesID("parquet|net.retransmits:avg|host:B,az:1a")
+	seriesA := observer.SeriesRef(0)
+	seriesB := observer.SeriesRef(1)
 
-	c.ProcessAnomaly(observer.Anomaly{SourceSeriesID: seriesA, Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{SourceSeriesID: seriesB, Timestamp: 101})
+	c.ProcessAnomaly(observer.Anomaly{SourceView: observer.QueryHandle{Ref: seriesA, Aggregate: observer.AggregateAverage}, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{SourceView: observer.QueryHandle{Ref: seriesB, Aggregate: observer.AggregateAverage}, Timestamp: 101})
 	c.Advance(200) // finalize window
 
 	edges := c.GetEdges()
 	require.NotEmpty(t, edges)
-	assert.Contains(t, []string{string(seriesA), string(seriesB)}, edges[0].Source1)
-	assert.Contains(t, []string{string(seriesA), string(seriesB)}, edges[0].Source2)
+	assert.Contains(t, []string{"0", "1"}, edges[0].Source1)
+	assert.Contains(t, []string{"0", "1"}, edges[0].Source2)
 }

--- a/comp/observer/impl/anomaly_correlator_identity_keys_test.go
+++ b/comp/observer/impl/anomaly_correlator_identity_keys_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLeadLagCorrelator_PreservesFullSeriesIDs(t *testing.T) {
+func TestLeadLagCorrelator_PreservesDescriptorKeys(t *testing.T) {
 	c := NewLeadLagCorrelator(LeadLagConfig{
 		MaxLagSeconds:       30,
 		MinObservations:     1,
@@ -22,19 +22,19 @@ func TestLeadLagCorrelator_PreservesFullSeriesIDs(t *testing.T) {
 		WindowSeconds:       120,
 	})
 
-	seriesA := observer.SeriesRef(0)
-	seriesB := observer.SeriesRef(1)
+	srcA := observer.SeriesDescriptor{Name: "cpu.user", Aggregate: observer.AggregateAverage}
+	srcB := observer.SeriesDescriptor{Name: "mem.used", Aggregate: observer.AggregateAverage}
 
-	c.ProcessAnomaly(observer.Anomaly{SourceView: observer.QueryHandle{Ref: seriesA, Aggregate: observer.AggregateAverage}, Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{SourceView: observer.QueryHandle{Ref: seriesB, Aggregate: observer.AggregateAverage}, Timestamp: 108})
+	c.ProcessAnomaly(observer.Anomaly{Source: srcA, SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{Source: srcB, SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage}, Timestamp: 108})
 
 	edges := c.GetEdges()
 	require.NotEmpty(t, edges)
-	assert.Contains(t, []string{"0", "1"}, edges[0].Leader)
-	assert.Contains(t, []string{"0", "1"}, edges[0].Follower)
+	assert.Contains(t, []string{srcA.Key(), srcB.Key()}, edges[0].Leader)
+	assert.Contains(t, []string{srcA.Key(), srcB.Key()}, edges[0].Follower)
 }
 
-func TestSurpriseCorrelator_PreservesFullSeriesIDs(t *testing.T) {
+func TestSurpriseCorrelator_PreservesDescriptorKeys(t *testing.T) {
 	c := NewSurpriseCorrelator(SurpriseConfig{
 		WindowSizeSeconds:     10,
 		MinLift:               1.0,
@@ -45,15 +45,15 @@ func TestSurpriseCorrelator_PreservesFullSeriesIDs(t *testing.T) {
 		EvictionWindowSeconds: 300,
 	})
 
-	seriesA := observer.SeriesRef(0)
-	seriesB := observer.SeriesRef(1)
+	srcA := observer.SeriesDescriptor{Name: "cpu.user", Aggregate: observer.AggregateAverage}
+	srcB := observer.SeriesDescriptor{Name: "mem.used", Aggregate: observer.AggregateAverage}
 
-	c.ProcessAnomaly(observer.Anomaly{SourceView: observer.QueryHandle{Ref: seriesA, Aggregate: observer.AggregateAverage}, Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{SourceView: observer.QueryHandle{Ref: seriesB, Aggregate: observer.AggregateAverage}, Timestamp: 101})
+	c.ProcessAnomaly(observer.Anomaly{Source: srcA, SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{Source: srcB, SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage}, Timestamp: 101})
 	c.Advance(200) // finalize window
 
 	edges := c.GetEdges()
 	require.NotEmpty(t, edges)
-	assert.Contains(t, []string{"0", "1"}, edges[0].Source1)
-	assert.Contains(t, []string{"0", "1"}, edges[0].Source2)
+	assert.Contains(t, []string{srcA.Key(), srcB.Key()}, edges[0].Source1)
+	assert.Contains(t, []string{srcA.Key(), srcB.Key()}, edges[0].Source2)
 }

--- a/comp/observer/impl/anomaly_correlator_identity_keys_test.go
+++ b/comp/observer/impl/anomaly_correlator_identity_keys_test.go
@@ -25,8 +25,8 @@ func TestLeadLagCorrelator_PreservesDescriptorKeys(t *testing.T) {
 	srcA := observer.SeriesDescriptor{Name: "cpu.user", Aggregate: observer.AggregateAverage}
 	srcB := observer.SeriesDescriptor{Name: "mem.used", Aggregate: observer.AggregateAverage}
 
-	c.ProcessAnomaly(observer.Anomaly{Source: srcA, SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{Source: srcB, SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage}, Timestamp: 108})
+	c.ProcessAnomaly(observer.Anomaly{Source: srcA, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{Source: srcB, Timestamp: 108})
 
 	edges := c.GetEdges()
 	require.NotEmpty(t, edges)
@@ -48,8 +48,8 @@ func TestSurpriseCorrelator_PreservesDescriptorKeys(t *testing.T) {
 	srcA := observer.SeriesDescriptor{Name: "cpu.user", Aggregate: observer.AggregateAverage}
 	srcB := observer.SeriesDescriptor{Name: "mem.used", Aggregate: observer.AggregateAverage}
 
-	c.ProcessAnomaly(observer.Anomaly{Source: srcA, SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{Source: srcB, SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage}, Timestamp: 101})
+	c.ProcessAnomaly(observer.Anomaly{Source: srcA, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{Source: srcB, Timestamp: 101})
 	c.Advance(200) // finalize window
 
 	edges := c.GetEdges()

--- a/comp/observer/impl/anomaly_correlator_leadlag.go
+++ b/comp/observer/impl/anomaly_correlator_leadlag.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"sync"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
@@ -207,7 +208,7 @@ type LeadLagCorrelator struct {
 	config LeadLagConfig
 
 	// Recent anomaly timestamps per source
-	sourceTimestamps map[observer.SeriesID]*RingBuffer
+	sourceTimestamps map[observer.SeriesRef]*RingBuffer
 
 	// Lag histograms for series pairs: pair -> histogram of (B_time - A_time)
 	lagHistograms map[seriesPairKey]*LagHistogram
@@ -240,7 +241,7 @@ func NewLeadLagCorrelator(config LeadLagConfig) *LeadLagCorrelator {
 	}
 	return &LeadLagCorrelator{
 		config:           config,
-		sourceTimestamps: make(map[observer.SeriesID]*RingBuffer),
+		sourceTimestamps: make(map[observer.SeriesRef]*RingBuffer),
 		lagHistograms:    make(map[seriesPairKey]*LagHistogram),
 	}
 }
@@ -255,7 +256,7 @@ func (c *LeadLagCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	source := anomaly.SourceSeriesID
+	source := anomaly.SourceView.Ref
 	ts := anomaly.Timestamp
 
 	// Update current data time
@@ -335,7 +336,7 @@ func (c *LeadLagCorrelator) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.sourceTimestamps = make(map[observer.SeriesID]*RingBuffer)
+	c.sourceTimestamps = make(map[observer.SeriesRef]*RingBuffer)
 	c.lagHistograms = make(map[seriesPairKey]*LagHistogram)
 	c.recentAnomalies = c.recentAnomalies[:0]
 	c.currentDataTime = 0
@@ -360,7 +361,7 @@ func (c *LeadLagCorrelator) GetEdges() []LeadLagEdge {
 			continue
 		}
 
-		var leaderSource, followerSource observer.SeriesID
+		var leaderSource, followerSource observer.SeriesRef
 		if leader == "A" {
 			leaderSource = sourceA
 			followerSource = sourceB
@@ -372,8 +373,8 @@ func (c *LeadLagCorrelator) GetEdges() []LeadLagEdge {
 		}
 
 		edges = append(edges, LeadLagEdge{
-			Leader:       string(leaderSource),
-			Follower:     string(followerSource),
+			Leader:       strconv.Itoa(int(leaderSource)),
+			Follower:     strconv.Itoa(int(followerSource)),
 			TypicalLag:   int64(math.Abs(float64(typicalLag))),
 			Confidence:   confidence,
 			Observations: histogram.totalObservations,
@@ -400,20 +401,22 @@ func (c *LeadLagCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 
 	var result []observer.ActiveCorrelation
 
-	// Group anomalies by source for quick lookup
-	anomaliesBySource := make(map[observer.SeriesID][]observer.Anomaly)
+	// Group anomalies by source ref for quick lookup
+	anomaliesBySource := make(map[observer.SeriesRef][]observer.Anomaly)
 	for _, a := range c.recentAnomalies {
-		anomaliesBySource[a.SourceSeriesID] = append(anomaliesBySource[a.SourceSeriesID], a)
+		anomaliesBySource[a.SourceView.Ref] = append(anomaliesBySource[a.SourceView.Ref], a)
 	}
 
 	// Create a correlation for each significant lead-lag chain
 	for _, edge := range edges {
-		memberSeriesIDs := []observer.SeriesID{observer.SeriesID(edge.Leader), observer.SeriesID(edge.Follower)}
-
-		// Collect anomalies from both sources
+		// Collect anomalies from both sources by matching ref strings
 		var anomalies []observer.Anomaly
-		anomalies = append(anomalies, anomaliesBySource[observer.SeriesID(edge.Leader)]...)
-		anomalies = append(anomalies, anomaliesBySource[observer.SeriesID(edge.Follower)]...)
+		for ref, aa := range anomaliesBySource {
+			refStr := strconv.Itoa(int(ref))
+			if refStr == edge.Leader || refStr == edge.Follower {
+				anomalies = append(anomalies, aa...)
+			}
+		}
 
 		// Find time range
 		var firstSeen, lastUpdated int64
@@ -431,11 +434,11 @@ func (c *LeadLagCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 			Pattern: fmt.Sprintf("lead_lag_%s_to_%s", edge.Leader, edge.Follower),
 			Title: fmt.Sprintf("LeadLag: %s → %s (+%ds)",
 				edge.Leader, edge.Follower, edge.TypicalLag),
-			MemberSeriesIDs: memberSeriesIDs,
-			MetricNames:     metricNames,
-			Anomalies:       anomalies,
-			FirstSeen:       firstSeen,
-			LastUpdated:     lastUpdated,
+			MemberRefs:  sortedUniqueRefs(anomalies),
+			MetricNames: metricNames,
+			Anomalies:   anomalies,
+			FirstSeen:   firstSeen,
+			LastUpdated: lastUpdated,
 		})
 	}
 

--- a/comp/observer/impl/anomaly_correlator_leadlag.go
+++ b/comp/observer/impl/anomaly_correlator_leadlag.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
 	"sync"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
@@ -207,8 +206,8 @@ type LeadLagEdge struct {
 type LeadLagCorrelator struct {
 	config LeadLagConfig
 
-	// Recent anomaly timestamps per source
-	sourceTimestamps map[observer.SeriesRef]*RingBuffer
+	// Recent anomaly timestamps per source (keyed by descriptor key)
+	sourceTimestamps map[string]*RingBuffer
 
 	// Lag histograms for series pairs: pair -> histogram of (B_time - A_time)
 	lagHistograms map[seriesPairKey]*LagHistogram
@@ -241,7 +240,7 @@ func NewLeadLagCorrelator(config LeadLagConfig) *LeadLagCorrelator {
 	}
 	return &LeadLagCorrelator{
 		config:           config,
-		sourceTimestamps: make(map[observer.SeriesRef]*RingBuffer),
+		sourceTimestamps: make(map[string]*RingBuffer),
 		lagHistograms:    make(map[seriesPairKey]*LagHistogram),
 	}
 }
@@ -256,7 +255,7 @@ func (c *LeadLagCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	source := anomaly.SourceView.Ref
+	source := anomaly.Source.Key()
 	ts := anomaly.Timestamp
 
 	// Update current data time
@@ -336,7 +335,7 @@ func (c *LeadLagCorrelator) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.sourceTimestamps = make(map[observer.SeriesRef]*RingBuffer)
+	c.sourceTimestamps = make(map[string]*RingBuffer)
 	c.lagHistograms = make(map[seriesPairKey]*LagHistogram)
 	c.recentAnomalies = c.recentAnomalies[:0]
 	c.currentDataTime = 0
@@ -353,28 +352,25 @@ func (c *LeadLagCorrelator) GetEdges() []LeadLagEdge {
 		if histogram.totalObservations < c.config.MinObservations {
 			continue
 		}
-		sourceA := pair.A
-		sourceB := pair.B
-
 		leader, typicalLag, confidence := histogram.Detect()
 		if confidence < c.config.ConfidenceThreshold {
 			continue
 		}
 
-		var leaderSource, followerSource observer.SeriesRef
+		var leaderKey, followerKey string
 		if leader == "A" {
-			leaderSource = sourceA
-			followerSource = sourceB
+			leaderKey = pair.A
+			followerKey = pair.B
 		} else if leader == "B" {
-			leaderSource = sourceB
-			followerSource = sourceA
+			leaderKey = pair.B
+			followerKey = pair.A
 		} else {
 			continue // No clear direction
 		}
 
 		edges = append(edges, LeadLagEdge{
-			Leader:       strconv.Itoa(int(leaderSource)),
-			Follower:     strconv.Itoa(int(followerSource)),
+			Leader:       leaderKey,
+			Follower:     followerKey,
 			TypicalLag:   int64(math.Abs(float64(typicalLag))),
 			Confidence:   confidence,
 			Observations: histogram.totalObservations,
@@ -401,22 +397,18 @@ func (c *LeadLagCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 
 	var result []observer.ActiveCorrelation
 
-	// Group anomalies by source ref for quick lookup
-	anomaliesBySource := make(map[observer.SeriesRef][]observer.Anomaly)
+	// Group anomalies by source key for quick lookup
+	anomaliesBySource := make(map[string][]observer.Anomaly)
 	for _, a := range c.recentAnomalies {
-		anomaliesBySource[a.SourceView.Ref] = append(anomaliesBySource[a.SourceView.Ref], a)
+		anomaliesBySource[a.Source.Key()] = append(anomaliesBySource[a.Source.Key()], a)
 	}
 
 	// Create a correlation for each significant lead-lag chain
 	for _, edge := range edges {
-		// Collect anomalies from both sources by matching ref strings
+		// Collect anomalies from both sources
 		var anomalies []observer.Anomaly
-		for ref, aa := range anomaliesBySource {
-			refStr := strconv.Itoa(int(ref))
-			if refStr == edge.Leader || refStr == edge.Follower {
-				anomalies = append(anomalies, aa...)
-			}
-		}
+		anomalies = append(anomalies, anomaliesBySource[edge.Leader]...)
+		anomalies = append(anomalies, anomaliesBySource[edge.Follower]...)
 
 		// Find time range
 		var firstSeen, lastUpdated int64
@@ -428,14 +420,12 @@ func (c *LeadLagCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 				lastUpdated = a.Timestamp
 			}
 		}
-		metricNames := sortedUniqueMetricNames(anomalies)
 
 		result = append(result, observer.ActiveCorrelation{
 			Pattern: fmt.Sprintf("lead_lag_%s_to_%s", edge.Leader, edge.Follower),
 			Title: fmt.Sprintf("LeadLag: %s → %s (+%ds)",
 				edge.Leader, edge.Follower, edge.TypicalLag),
-			MemberRefs:  sortedUniqueRefs(anomalies),
-			MetricNames: metricNames,
+			Members:     sortedUniqueMembers(anomalies),
 			Anomalies:   anomalies,
 			FirstSeen:   firstSeen,
 			LastUpdated: lastUpdated,

--- a/comp/observer/impl/anomaly_correlator_passthrough.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough.go
@@ -88,13 +88,13 @@ func (c *DetectorPassthroughCorrelator) ActiveCorrelations() []observer.ActiveCo
 		for i, a := range sorted {
 			metricName := observer.MetricName(a.Source.String())
 			result = append(result, observer.ActiveCorrelation{
-				Pattern:         fmt.Sprintf("passthrough_%s_%d", detName, i),
-				Title:           fmt.Sprintf("Passthrough[%s]: %s", detName, a.Source),
-				MemberSeriesIDs: []observer.SeriesID{a.SourceSeriesID},
-				MetricNames:     []observer.MetricName{metricName},
-				Anomalies:       []observer.Anomaly{a},
-				FirstSeen:       a.Timestamp,
-				LastUpdated:     a.Timestamp,
+				Pattern:     fmt.Sprintf("passthrough_%s_%d", detName, i),
+				Title:       fmt.Sprintf("Passthrough[%s]: %s", detName, a.Source),
+				MemberRefs:  []observer.SeriesRef{a.SourceView.Ref},
+				MetricNames: []observer.MetricName{metricName},
+				Anomalies:   []observer.Anomaly{a},
+				FirstSeen:   a.Timestamp,
+				LastUpdated: a.Timestamp,
 			})
 		}
 	}

--- a/comp/observer/impl/anomaly_correlator_passthrough.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough.go
@@ -86,12 +86,10 @@ func (c *DetectorPassthroughCorrelator) ActiveCorrelations() []observer.ActiveCo
 		sort.Slice(sorted, func(i, j int) bool { return sorted[i].Timestamp < sorted[j].Timestamp })
 
 		for i, a := range sorted {
-			metricName := observer.MetricName(a.Source.String())
 			result = append(result, observer.ActiveCorrelation{
 				Pattern:     fmt.Sprintf("passthrough_%s_%d", detName, i),
 				Title:       fmt.Sprintf("Passthrough[%s]: %s", detName, a.Source),
-				MemberRefs:  []observer.SeriesRef{a.SourceView.Ref},
-				MetricNames: []observer.MetricName{metricName},
+				Members:     []observer.SeriesDescriptor{a.Source},
 				Anomalies:   []observer.Anomaly{a},
 				FirstSeen:   a.Timestamp,
 				LastUpdated: a.Timestamp,

--- a/comp/observer/impl/anomaly_correlator_passthrough_test.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough_test.go
@@ -20,9 +20,9 @@ func passthroughSource(name string) observer.AnomalySource {
 func TestDetectorPassthroughCorrelator_OnePerAnomaly(t *testing.T) {
 	c := NewDetectorPassthroughCorrelator()
 
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), SourceSeriesID: "s1", Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "bocpd", Source: passthroughSource("redis.cpu.sys"), SourceSeriesID: "s1", Timestamp: 105})
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.info.latency_ms"), SourceSeriesID: "s2", Timestamp: 110})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "bocpd", Source: passthroughSource("redis.cpu.sys"), SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 105})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.info.latency_ms"), SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage}, Timestamp: 110})
 
 	corrs := c.ActiveCorrelations()
 	// 3 anomalies = 3 correlations (one per anomaly)
@@ -59,11 +59,11 @@ func TestDetectorPassthroughCorrelator_TimestampOrdering(t *testing.T) {
 func TestDetectorPassthroughCorrelator_SeriesIDAndSource(t *testing.T) {
 	c := NewDetectorPassthroughCorrelator()
 
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), SourceSeriesID: "s1", Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 100})
 
 	corrs := c.ActiveCorrelations()
 	require.Len(t, corrs, 1)
-	assert.Equal(t, []observer.SeriesID{"s1"}, corrs[0].MemberSeriesIDs)
+	assert.Equal(t, []observer.SeriesRef{observer.SeriesRef(0)}, corrs[0].MemberRefs)
 	assert.Equal(t, []observer.MetricName{"redis.cpu.sys"}, corrs[0].MetricNames)
 }
 

--- a/comp/observer/impl/anomaly_correlator_passthrough_test.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough_test.go
@@ -20,9 +20,9 @@ func passthroughSource(name string) observer.SeriesDescriptor {
 func TestDetectorPassthroughCorrelator_OnePerAnomaly(t *testing.T) {
 	c := NewDetectorPassthroughCorrelator()
 
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 100})
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "bocpd", Source: passthroughSource("redis.cpu.sys"), SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 105})
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.info.latency_ms"), SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage}, Timestamp: 110})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "bocpd", Source: passthroughSource("redis.cpu.sys"), Timestamp: 105})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.info.latency_ms"), Timestamp: 110})
 
 	corrs := c.ActiveCorrelations()
 	// 3 anomalies = 3 correlations (one per anomaly)
@@ -59,7 +59,7 @@ func TestDetectorPassthroughCorrelator_TimestampOrdering(t *testing.T) {
 func TestDetectorPassthroughCorrelator_SeriesIDAndSource(t *testing.T) {
 	c := NewDetectorPassthroughCorrelator()
 
-	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage}, Timestamp: 100})
+	c.ProcessAnomaly(observer.Anomaly{DetectorName: "cusum", Source: passthroughSource("redis.cpu.sys"), Timestamp: 100})
 
 	corrs := c.ActiveCorrelations()
 	require.Len(t, corrs, 1)

--- a/comp/observer/impl/anomaly_correlator_passthrough_test.go
+++ b/comp/observer/impl/anomaly_correlator_passthrough_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func passthroughSource(name string) observer.AnomalySource {
-	return observer.AnomalySource{Name: name}
+func passthroughSource(name string) observer.SeriesDescriptor {
+	return observer.SeriesDescriptor{Name: name}
 }
 
 func TestDetectorPassthroughCorrelator_OnePerAnomaly(t *testing.T) {
@@ -63,8 +63,8 @@ func TestDetectorPassthroughCorrelator_SeriesIDAndSource(t *testing.T) {
 
 	corrs := c.ActiveCorrelations()
 	require.Len(t, corrs, 1)
-	assert.Equal(t, []observer.SeriesRef{observer.SeriesRef(0)}, corrs[0].MemberRefs)
-	assert.Equal(t, []observer.MetricName{"redis.cpu.sys"}, corrs[0].MetricNames)
+	require.Len(t, corrs[0].Members, 1)
+	assert.Equal(t, "redis.cpu.sys", corrs[0].Members[0].Name)
 }
 
 func TestDetectorPassthroughCorrelator_Reset(t *testing.T) {

--- a/comp/observer/impl/anomaly_correlator_surprise.go
+++ b/comp/observer/impl/anomaly_correlator_surprise.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
@@ -85,7 +86,7 @@ type SurpriseCorrelator struct {
 	config SurpriseConfig
 
 	// Marginal counts per source (how often each source has anomalies)
-	sourceCounts map[observer.SeriesID]int
+	sourceCounts map[observer.SeriesRef]int
 
 	// Joint counts for pairs (how often A and B co-occur in the same window)
 	pairCounts map[seriesPairKey]int
@@ -95,7 +96,7 @@ type SurpriseCorrelator struct {
 
 	// Current window tracking
 	currentWindowStart   int64
-	currentWindowSources map[observer.SeriesID]bool
+	currentWindowSources map[observer.SeriesRef]bool
 
 	// Recent anomalies for reporting
 	recentAnomalies []observer.Anomaly
@@ -131,9 +132,9 @@ func NewSurpriseCorrelator(config SurpriseConfig) *SurpriseCorrelator {
 	}
 	return &SurpriseCorrelator{
 		config:               config,
-		sourceCounts:         make(map[observer.SeriesID]int),
+		sourceCounts:         make(map[observer.SeriesRef]int),
 		pairCounts:           make(map[seriesPairKey]int),
-		currentWindowSources: make(map[observer.SeriesID]bool),
+		currentWindowSources: make(map[observer.SeriesRef]bool),
 	}
 }
 
@@ -147,7 +148,7 @@ func (c *SurpriseCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	source := anomaly.SourceSeriesID
+	source := anomaly.SourceView.Ref
 	ts := anomaly.Timestamp
 
 	// Update current data time
@@ -165,7 +166,7 @@ func (c *SurpriseCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	if windowStart > c.currentWindowStart {
 		c.finalizeWindow()
 		c.currentWindowStart = windowStart
-		c.currentWindowSources = make(map[observer.SeriesID]bool)
+		c.currentWindowSources = make(map[observer.SeriesRef]bool)
 	}
 
 	// Add this source to the current window
@@ -186,7 +187,7 @@ func (c *SurpriseCorrelator) finalizeWindow() {
 	}
 
 	// Update pair counts for all co-occurring sources
-	sources := make([]observer.SeriesID, 0, len(c.currentWindowSources))
+	sources := make([]observer.SeriesRef, 0, len(c.currentWindowSources))
 	for source := range c.currentWindowSources {
 		sources = append(sources, source)
 	}
@@ -231,11 +232,11 @@ func (c *SurpriseCorrelator) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.sourceCounts = make(map[observer.SeriesID]int)
+	c.sourceCounts = make(map[observer.SeriesRef]int)
 	c.pairCounts = make(map[seriesPairKey]int)
 	c.totalWindows = 0
 	c.currentWindowStart = 0
-	c.currentWindowSources = make(map[observer.SeriesID]bool)
+	c.currentWindowSources = make(map[observer.SeriesRef]bool)
 	c.recentAnomalies = c.recentAnomalies[:0]
 	c.currentDataTime = 0
 }
@@ -284,8 +285,8 @@ func (c *SurpriseCorrelator) GetEdges() []SurpriseEdge {
 		}
 
 		edges = append(edges, SurpriseEdge{
-			Source1:      string(source1),
-			Source2:      string(source2),
+			Source1:      strconv.Itoa(int(source1)),
+			Source2:      strconv.Itoa(int(source2)),
 			Lift:         lift,
 			Support:      pairCount,
 			Source1Count: count1,
@@ -322,20 +323,22 @@ func (c *SurpriseCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 
 	var result []observer.ActiveCorrelation
 
-	// Group anomalies by source for quick lookup
-	anomaliesBySource := make(map[observer.SeriesID][]observer.Anomaly)
+	// Group anomalies by source ref for quick lookup
+	anomaliesBySource := make(map[observer.SeriesRef][]observer.Anomaly)
 	for _, a := range c.recentAnomalies {
-		anomaliesBySource[a.SourceSeriesID] = append(anomaliesBySource[a.SourceSeriesID], a)
+		anomaliesBySource[a.SourceView.Ref] = append(anomaliesBySource[a.SourceView.Ref], a)
 	}
 
 	// Create a correlation for each significant surprise pattern
 	for _, edge := range edges {
-		memberSeriesIDs := []observer.SeriesID{observer.SeriesID(edge.Source1), observer.SeriesID(edge.Source2)}
-
-		// Collect anomalies from both sources
+		// Collect anomalies from both sources by matching ref strings
 		var anomalies []observer.Anomaly
-		anomalies = append(anomalies, anomaliesBySource[observer.SeriesID(edge.Source1)]...)
-		anomalies = append(anomalies, anomaliesBySource[observer.SeriesID(edge.Source2)]...)
+		for ref, aa := range anomaliesBySource {
+			refStr := strconv.Itoa(int(ref))
+			if refStr == edge.Source1 || refStr == edge.Source2 {
+				anomalies = append(anomalies, aa...)
+			}
+		}
 
 		// Find time range
 		var firstSeen, lastUpdated int64
@@ -362,13 +365,13 @@ func (c *SurpriseCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 		}
 
 		result = append(result, observer.ActiveCorrelation{
-			Pattern:         pattern,
-			Title:           title,
-			MemberSeriesIDs: memberSeriesIDs,
-			MetricNames:     metricNames,
-			Anomalies:       anomalies,
-			FirstSeen:       firstSeen,
-			LastUpdated:     lastUpdated,
+			Pattern:     pattern,
+			Title:       title,
+			MemberRefs:  sortedUniqueRefs(anomalies),
+			MetricNames: metricNames,
+			Anomalies:   anomalies,
+			FirstSeen:   firstSeen,
+			LastUpdated: lastUpdated,
 		})
 	}
 

--- a/comp/observer/impl/anomaly_correlator_surprise.go
+++ b/comp/observer/impl/anomaly_correlator_surprise.go
@@ -8,7 +8,6 @@ package observerimpl
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"sync"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
@@ -86,7 +85,7 @@ type SurpriseCorrelator struct {
 	config SurpriseConfig
 
 	// Marginal counts per source (how often each source has anomalies)
-	sourceCounts map[observer.SeriesRef]int
+	sourceCounts map[string]int
 
 	// Joint counts for pairs (how often A and B co-occur in the same window)
 	pairCounts map[seriesPairKey]int
@@ -96,7 +95,7 @@ type SurpriseCorrelator struct {
 
 	// Current window tracking
 	currentWindowStart   int64
-	currentWindowSources map[observer.SeriesRef]bool
+	currentWindowSources map[string]bool
 
 	// Recent anomalies for reporting
 	recentAnomalies []observer.Anomaly
@@ -132,9 +131,9 @@ func NewSurpriseCorrelator(config SurpriseConfig) *SurpriseCorrelator {
 	}
 	return &SurpriseCorrelator{
 		config:               config,
-		sourceCounts:         make(map[observer.SeriesRef]int),
+		sourceCounts:         make(map[string]int),
 		pairCounts:           make(map[seriesPairKey]int),
-		currentWindowSources: make(map[observer.SeriesRef]bool),
+		currentWindowSources: make(map[string]bool),
 	}
 }
 
@@ -148,7 +147,7 @@ func (c *SurpriseCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	source := anomaly.SourceView.Ref
+	source := anomaly.Source.Key()
 	ts := anomaly.Timestamp
 
 	// Update current data time
@@ -166,7 +165,7 @@ func (c *SurpriseCorrelator) ProcessAnomaly(anomaly observer.Anomaly) {
 	if windowStart > c.currentWindowStart {
 		c.finalizeWindow()
 		c.currentWindowStart = windowStart
-		c.currentWindowSources = make(map[observer.SeriesRef]bool)
+		c.currentWindowSources = make(map[string]bool)
 	}
 
 	// Add this source to the current window
@@ -187,11 +186,11 @@ func (c *SurpriseCorrelator) finalizeWindow() {
 	}
 
 	// Update pair counts for all co-occurring sources
-	sources := make([]observer.SeriesRef, 0, len(c.currentWindowSources))
+	sources := make([]string, 0, len(c.currentWindowSources))
 	for source := range c.currentWindowSources {
 		sources = append(sources, source)
 	}
-	sort.Slice(sources, func(i, j int) bool { return sources[i] < sources[j] }) // Ensure consistent ordering
+	sort.Strings(sources) // Ensure consistent ordering
 
 	// Track all pairs (limit to avoid memory explosion)
 	if len(c.pairCounts) < c.config.MaxPairsTracked {
@@ -232,11 +231,11 @@ func (c *SurpriseCorrelator) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.sourceCounts = make(map[observer.SeriesRef]int)
+	c.sourceCounts = make(map[string]int)
 	c.pairCounts = make(map[seriesPairKey]int)
 	c.totalWindows = 0
 	c.currentWindowStart = 0
-	c.currentWindowSources = make(map[observer.SeriesRef]bool)
+	c.currentWindowSources = make(map[string]bool)
 	c.recentAnomalies = c.recentAnomalies[:0]
 	c.currentDataTime = 0
 }
@@ -256,11 +255,8 @@ func (c *SurpriseCorrelator) GetEdges() []SurpriseEdge {
 		if pairCount < c.config.MinSupport {
 			continue
 		}
-		source1 := pair.A
-		source2 := pair.B
-
-		count1, ok1 := c.sourceCounts[source1]
-		count2, ok2 := c.sourceCounts[source2]
+		count1, ok1 := c.sourceCounts[pair.A]
+		count2, ok2 := c.sourceCounts[pair.B]
 		if !ok1 || !ok2 {
 			continue
 		}
@@ -285,8 +281,8 @@ func (c *SurpriseCorrelator) GetEdges() []SurpriseEdge {
 		}
 
 		edges = append(edges, SurpriseEdge{
-			Source1:      strconv.Itoa(int(source1)),
-			Source2:      strconv.Itoa(int(source2)),
+			Source1:      pair.A,
+			Source2:      pair.B,
 			Lift:         lift,
 			Support:      pairCount,
 			Source1Count: count1,
@@ -323,22 +319,18 @@ func (c *SurpriseCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 
 	var result []observer.ActiveCorrelation
 
-	// Group anomalies by source ref for quick lookup
-	anomaliesBySource := make(map[observer.SeriesRef][]observer.Anomaly)
+	// Group anomalies by source key for quick lookup
+	anomaliesBySource := make(map[string][]observer.Anomaly)
 	for _, a := range c.recentAnomalies {
-		anomaliesBySource[a.SourceView.Ref] = append(anomaliesBySource[a.SourceView.Ref], a)
+		anomaliesBySource[a.Source.Key()] = append(anomaliesBySource[a.Source.Key()], a)
 	}
 
 	// Create a correlation for each significant surprise pattern
 	for _, edge := range edges {
-		// Collect anomalies from both sources by matching ref strings
+		// Collect anomalies from both sources
 		var anomalies []observer.Anomaly
-		for ref, aa := range anomaliesBySource {
-			refStr := strconv.Itoa(int(ref))
-			if refStr == edge.Source1 || refStr == edge.Source2 {
-				anomalies = append(anomalies, aa...)
-			}
-		}
+		anomalies = append(anomalies, anomaliesBySource[edge.Source1]...)
+		anomalies = append(anomalies, anomaliesBySource[edge.Source2]...)
 
 		// Find time range
 		var firstSeen, lastUpdated int64
@@ -350,7 +342,6 @@ func (c *SurpriseCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 				lastUpdated = a.Timestamp
 			}
 		}
-		metricNames := sortedUniqueMetricNames(anomalies)
 
 		var title string
 		var pattern string
@@ -367,8 +358,7 @@ func (c *SurpriseCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 		result = append(result, observer.ActiveCorrelation{
 			Pattern:     pattern,
 			Title:       title,
-			MemberRefs:  sortedUniqueRefs(anomalies),
-			MetricNames: metricNames,
+			Members:     sortedUniqueMembers(anomalies),
 			Anomalies:   anomalies,
 			FirstSeen:   firstSeen,
 			LastUpdated: lastUpdated,

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -8,7 +8,6 @@ package observerimpl
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"sync"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
@@ -232,13 +231,13 @@ func (c *TimeClusterCorrelator) GetClusters() []TimeClusterInfo {
 		if c.config.MinClusterSize > 0 && len(cluster.anomalies) < c.config.MinClusterSize {
 			continue
 		}
-		seen := make(map[observer.SeriesRef]bool)
+		seen := make(map[string]bool)
 		for _, a := range cluster.anomalies {
-			seen[a.SourceView.Ref] = true
+			seen[a.Source.Key()] = true
 		}
 		sources := make([]string, 0, len(seen))
-		for ref := range seen {
-			sources = append(sources, strconv.Itoa(int(ref)))
+		for key := range seen {
+			sources = append(sources, key)
 		}
 		sort.Strings(sources)
 		result = append(result, TimeClusterInfo{
@@ -299,23 +298,10 @@ func (c *TimeClusterCorrelator) ActiveCorrelations() []observer.ActiveCorrelatio
 		if c.config.MinClusterSize > 0 && len(cluster.anomalies) < c.config.MinClusterSize {
 			continue
 		}
-		// Collect unique series refs
-		seen := make(map[observer.SeriesRef]bool)
-		for _, a := range cluster.anomalies {
-			seen[a.SourceView.Ref] = true
-		}
-		memberRefs := make([]observer.SeriesRef, 0, len(seen))
-		for ref := range seen {
-			memberRefs = append(memberRefs, ref)
-		}
-		sort.Slice(memberRefs, func(i, j int) bool { return memberRefs[i] < memberRefs[j] })
-		metricNames := sortedUniqueMetricNames(cluster.anomalies)
-
 		result = append(result, observer.ActiveCorrelation{
 			Pattern:     fmt.Sprintf("time_cluster_%d", cluster.id),
 			Title:       fmt.Sprintf("TimeCluster: %d anomalies", len(cluster.anomalies)),
-			MemberRefs:  memberRefs,
-			MetricNames: metricNames,
+			Members:     sortedUniqueMembers(cluster.anomalies),
 			Anomalies:   cluster.anomalies,
 			FirstSeen:   cluster.minTimestamp,
 			LastUpdated: cluster.maxTimestamp,

--- a/comp/observer/impl/anomaly_correlator_time_cluster.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster.go
@@ -8,6 +8,7 @@ package observerimpl
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
@@ -231,13 +232,13 @@ func (c *TimeClusterCorrelator) GetClusters() []TimeClusterInfo {
 		if c.config.MinClusterSize > 0 && len(cluster.anomalies) < c.config.MinClusterSize {
 			continue
 		}
-		seen := make(map[observer.SeriesID]bool)
+		seen := make(map[observer.SeriesRef]bool)
 		for _, a := range cluster.anomalies {
-			seen[a.SourceSeriesID] = true
+			seen[a.SourceView.Ref] = true
 		}
 		sources := make([]string, 0, len(seen))
-		for sid := range seen {
-			sources = append(sources, string(sid))
+		for ref := range seen {
+			sources = append(sources, strconv.Itoa(int(ref)))
 		}
 		sort.Strings(sources)
 		result = append(result, TimeClusterInfo{
@@ -298,26 +299,26 @@ func (c *TimeClusterCorrelator) ActiveCorrelations() []observer.ActiveCorrelatio
 		if c.config.MinClusterSize > 0 && len(cluster.anomalies) < c.config.MinClusterSize {
 			continue
 		}
-		// Collect unique series IDs
-		seen := make(map[observer.SeriesID]bool)
+		// Collect unique series refs
+		seen := make(map[observer.SeriesRef]bool)
 		for _, a := range cluster.anomalies {
-			seen[a.SourceSeriesID] = true
+			seen[a.SourceView.Ref] = true
 		}
-		memberSeriesIDs := make([]observer.SeriesID, 0, len(seen))
-		for sid := range seen {
-			memberSeriesIDs = append(memberSeriesIDs, sid)
+		memberRefs := make([]observer.SeriesRef, 0, len(seen))
+		for ref := range seen {
+			memberRefs = append(memberRefs, ref)
 		}
-		sort.Slice(memberSeriesIDs, func(i, j int) bool { return memberSeriesIDs[i] < memberSeriesIDs[j] })
+		sort.Slice(memberRefs, func(i, j int) bool { return memberRefs[i] < memberRefs[j] })
 		metricNames := sortedUniqueMetricNames(cluster.anomalies)
 
 		result = append(result, observer.ActiveCorrelation{
-			Pattern:         fmt.Sprintf("time_cluster_%d", cluster.id),
-			Title:           fmt.Sprintf("TimeCluster: %d anomalies", len(cluster.anomalies)),
-			MemberSeriesIDs: memberSeriesIDs,
-			MetricNames:     metricNames,
-			Anomalies:       cluster.anomalies,
-			FirstSeen:       cluster.minTimestamp,
-			LastUpdated:     cluster.maxTimestamp,
+			Pattern:     fmt.Sprintf("time_cluster_%d", cluster.id),
+			Title:       fmt.Sprintf("TimeCluster: %d anomalies", len(cluster.anomalies)),
+			MemberRefs:  memberRefs,
+			MetricNames: metricNames,
+			Anomalies:   cluster.anomalies,
+			FirstSeen:   cluster.minTimestamp,
+			LastUpdated: cluster.maxTimestamp,
 		})
 	}
 

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -167,23 +167,20 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 	// Same metric name, different tags = different Source descriptors
 	// Both should be separate members in the cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-
-		Title:      "Anomaly from host A",
-		Timestamp:  100,
+		Source:    observer.SeriesDescriptor{Name: "metric.a", Tags: []string{"host:A"}},
+		Title:     "Anomaly from host A",
+		Timestamp: 100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-
-		Title:      "Anomaly from host B",
-		Timestamp:  102,
+		Source:    observer.SeriesDescriptor{Name: "metric.a", Tags: []string{"host:B"}},
+		Title:     "Anomaly from host B",
+		Timestamp: 102,
 	})
 
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
 	assert.Len(t, correlations[0].Anomalies, 2)
-	// Same Source descriptor (both have same name, no tags) = 1 unique member
-	assert.Len(t, correlations[0].Members, 1)
+	assert.Len(t, correlations[0].Members, 2)
 }
 
 func TestTimeClusterCorrelator_Eviction(t *testing.T) {

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -21,16 +21,16 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 
 	// Two anomalies with nearby timestamps should cluster together
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.a"},
+		Source: observer.SeriesDescriptor{Name: "metric.a"},
 
-		Title:      "Anomaly A",
-		Timestamp:  100,
+		Title:     "Anomaly A",
+		Timestamp: 100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.b"},
+		Source: observer.SeriesDescriptor{Name: "metric.b"},
 
-		Title:      "Anomaly B",
-		Timestamp:  105, // 5 seconds later, within 10s proximity
+		Title:     "Anomaly B",
+		Timestamp: 105, // 5 seconds later, within 10s proximity
 	})
 
 	correlations := c.ActiveCorrelations()
@@ -47,16 +47,16 @@ func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 
 	// Anomalies within proximity window should cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.a"},
+		Source: observer.SeriesDescriptor{Name: "metric.a"},
 
-		Title:      "Anomaly A",
-		Timestamp:  100,
+		Title:     "Anomaly A",
+		Timestamp: 100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.b"},
+		Source: observer.SeriesDescriptor{Name: "metric.b"},
 
-		Title:      "Anomaly B",
-		Timestamp:  108, // 8 seconds later, within 10s proximity
+		Title:     "Anomaly B",
+		Timestamp: 108, // 8 seconds later, within 10s proximity
 	})
 
 	correlations := c.ActiveCorrelations()
@@ -72,16 +72,16 @@ func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 
 	// Anomalies outside proximity window should form separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.a"},
+		Source: observer.SeriesDescriptor{Name: "metric.a"},
 
-		Title:      "Anomaly A",
-		Timestamp:  100,
+		Title:     "Anomaly A",
+		Timestamp: 100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.b"},
+		Source: observer.SeriesDescriptor{Name: "metric.b"},
 
-		Title:      "Anomaly B",
-		Timestamp:  150, // 50 seconds later, outside 10s proximity
+		Title:     "Anomaly B",
+		Timestamp: 150, // 50 seconds later, outside 10s proximity
 	})
 
 	correlations := c.ActiveCorrelations()
@@ -99,16 +99,16 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Create two separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.a"},
+		Source: observer.SeriesDescriptor{Name: "metric.a"},
 
-		Title:      "Anomaly A",
-		Timestamp:  100,
+		Title:     "Anomaly A",
+		Timestamp: 100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.b"},
+		Source: observer.SeriesDescriptor{Name: "metric.b"},
 
-		Title:      "Anomaly B",
-		Timestamp:  120, // Far enough to be separate (20s apart)
+		Title:     "Anomaly B",
+		Timestamp: 120, // Far enough to be separate (20s apart)
 	})
 
 	// Verify two separate clusters
@@ -116,10 +116,10 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Add anomaly that bridges both clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.c"},
+		Source: observer.SeriesDescriptor{Name: "metric.c"},
 
-		Title:      "Anomaly C",
-		Timestamp:  110, // Near both clusters
+		Title:     "Anomaly C",
+		Timestamp: 110, // Near both clusters
 	})
 
 	// Should now be merged into one cluster
@@ -137,14 +137,14 @@ func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 
 	// Multiple anomalies from the same series should all be kept
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.SeriesDescriptor{Name: "metric.a"},
+		Source: observer.SeriesDescriptor{Name: "metric.a"},
 
 		Title:       "Anomaly A v1",
 		Description: "first",
 		Timestamp:   100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.SeriesDescriptor{Name: "metric.a"},
+		Source: observer.SeriesDescriptor{Name: "metric.a"},
 
 		Title:       "Anomaly A v2",
 		Description: "second",
@@ -191,18 +191,18 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	// Add old anomaly
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.old"},
+		Source: observer.SeriesDescriptor{Name: "metric.old"},
 
-		Title:      "Old Anomaly",
-		Timestamp:  100,
+		Title:     "Old Anomaly",
+		Timestamp: 100,
 	})
 
 	// Add recent anomaly (advances currentDataTime)
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.new"},
+		Source: observer.SeriesDescriptor{Name: "metric.new"},
 
-		Title:      "New Anomaly",
-		Timestamp:  200, // 100 seconds later, old one should be evicted
+		Title:     "New Anomaly",
+		Timestamp: 200, // 100 seconds later, old one should be evicted
 	})
 
 	// Flush should evict the old cluster
@@ -221,9 +221,9 @@ func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 
 	// A single anomaly should form a cluster of one
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.a"},
+		Source: observer.SeriesDescriptor{Name: "metric.a"},
 
-		Timestamp:  100,
+		Timestamp: 100,
 	})
 
 	correlations := c.ActiveCorrelations()
@@ -240,30 +240,30 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Create a cluster of 2 and a cluster of 3
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.a"},
+		Source: observer.SeriesDescriptor{Name: "metric.a"},
 
-		Timestamp:  100,
+		Timestamp: 100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.b"},
+		Source: observer.SeriesDescriptor{Name: "metric.b"},
 
-		Timestamp:  105,
+		Timestamp: 105,
 	})
 
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.c"},
+		Source: observer.SeriesDescriptor{Name: "metric.c"},
 
-		Timestamp:  200,
+		Timestamp: 200,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.d"},
+		Source: observer.SeriesDescriptor{Name: "metric.d"},
 
-		Timestamp:  205,
+		Timestamp: 205,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.e"},
+		Source: observer.SeriesDescriptor{Name: "metric.e"},
 
-		Timestamp:  208,
+		Timestamp: 208,
 	})
 
 	// Internally both clusters exist
@@ -280,9 +280,9 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Once the small cluster grows to meet threshold, it should appear
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.SeriesDescriptor{Name: "metric.f"},
+		Source: observer.SeriesDescriptor{Name: "metric.f"},
 
-		Timestamp:  103,
+		Timestamp: 103,
 	})
 	correlations = c.ActiveCorrelations()
 	assert.Len(t, correlations, 2)

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -22,13 +22,13 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 	// Two anomalies with nearby timestamps should cluster together
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.b"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly B",
 		Timestamp:  105, // 5 seconds later, within 10s proximity
 	})
@@ -48,13 +48,13 @@ func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 	// Anomalies within proximity window should cluster
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.b"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly B",
 		Timestamp:  108, // 8 seconds later, within 10s proximity
 	})
@@ -73,13 +73,13 @@ func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 	// Anomalies outside proximity window should form separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.b"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly B",
 		Timestamp:  150, // 50 seconds later, outside 10s proximity
 	})
@@ -100,13 +100,13 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 	// Create two separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.b"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly B",
 		Timestamp:  120, // Far enough to be separate (20s apart)
 	})
@@ -117,7 +117,7 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 	// Add anomaly that bridges both clusters
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.c"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(2), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly C",
 		Timestamp:  110, // Near both clusters
 	})
@@ -138,14 +138,14 @@ func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 	// Multiple anomalies from the same series should all be kept
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:      observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView:  observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+
 		Title:       "Anomaly A v1",
 		Description: "first",
 		Timestamp:   100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:      observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView:  observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+
 		Title:       "Anomaly A v2",
 		Description: "second",
 		Timestamp:   105,
@@ -164,17 +164,17 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 		WindowSeconds:    60,
 	})
 
-	// Same metric name, different tags = different SourceView refs
+	// Same metric name, different tags = different Source descriptors
 	// Both should be separate members in the cluster
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(6), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly from host A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(7), Aggregate: observer.AggregateAverage},
+
 		Title:      "Anomaly from host B",
 		Timestamp:  102,
 	})
@@ -195,7 +195,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 	// Add old anomaly
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.old"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(8), Aggregate: observer.AggregateAverage},
+
 		Title:      "Old Anomaly",
 		Timestamp:  100,
 	})
@@ -203,7 +203,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 	// Add recent anomaly (advances currentDataTime)
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.new"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(9), Aggregate: observer.AggregateAverage},
+
 		Title:      "New Anomaly",
 		Timestamp:  200, // 100 seconds later, old one should be evicted
 	})
@@ -225,7 +225,7 @@ func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 	// A single anomaly should form a cluster of one
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+
 		Timestamp:  100,
 	})
 
@@ -244,28 +244,28 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 	// Create a cluster of 2 and a cluster of 3
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.a"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.b"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+
 		Timestamp:  105,
 	})
 
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.c"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(2), Aggregate: observer.AggregateAverage},
+
 		Timestamp:  200,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.d"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(3), Aggregate: observer.AggregateAverage},
+
 		Timestamp:  205,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.e"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(4), Aggregate: observer.AggregateAverage},
+
 		Timestamp:  208,
 	})
 
@@ -284,7 +284,7 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 	// Once the small cluster grows to meet threshold, it should appear
 	c.ProcessAnomaly(observer.Anomaly{
 		Source:     observer.SeriesDescriptor{Name: "metric.f"},
-		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(5), Aggregate: observer.AggregateAverage},
+
 		Timestamp:  103,
 	})
 	correlations = c.ActiveCorrelations()

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -21,13 +21,13 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 
 	// Two anomalies with nearby timestamps should cluster together
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.a"},
+		Source:     observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.b"},
+		Source:     observer.SeriesDescriptor{Name: "metric.b"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly B",
 		Timestamp:  105, // 5 seconds later, within 10s proximity
@@ -36,8 +36,7 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
 	assert.Len(t, correlations[0].Anomalies, 2)
-	assert.Contains(t, correlations[0].MemberRefs, observer.SeriesRef(0))
-	assert.Contains(t, correlations[0].MemberRefs, observer.SeriesRef(1))
+	assert.Len(t, correlations[0].Members, 2)
 }
 
 func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
@@ -48,13 +47,13 @@ func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 
 	// Anomalies within proximity window should cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.a"},
+		Source:     observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.b"},
+		Source:     observer.SeriesDescriptor{Name: "metric.b"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly B",
 		Timestamp:  108, // 8 seconds later, within 10s proximity
@@ -73,13 +72,13 @@ func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 
 	// Anomalies outside proximity window should form separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.a"},
+		Source:     observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.b"},
+		Source:     observer.SeriesDescriptor{Name: "metric.b"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly B",
 		Timestamp:  150, // 50 seconds later, outside 10s proximity
@@ -100,13 +99,13 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Create two separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.a"},
+		Source:     observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.b"},
+		Source:     observer.SeriesDescriptor{Name: "metric.b"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly B",
 		Timestamp:  120, // Far enough to be separate (20s apart)
@@ -117,7 +116,7 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Add anomaly that bridges both clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.c"},
+		Source:     observer.SeriesDescriptor{Name: "metric.c"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(2), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly C",
 		Timestamp:  110, // Near both clusters
@@ -138,14 +137,14 @@ func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 
 	// Multiple anomalies from the same series should all be kept
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "metric.a"},
+		Source:      observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView:  observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
 		Title:       "Anomaly A v1",
 		Description: "first",
 		Timestamp:   100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "metric.a"},
+		Source:      observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView:  observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
 		Title:       "Anomaly A v2",
 		Description: "second",
@@ -155,8 +154,8 @@ func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
 	assert.Len(t, correlations[0].Anomalies, 2)
-	// Single unique series
-	assert.Len(t, correlations[0].MemberRefs, 1)
+	// Single unique series (same Source descriptor)
+	assert.Len(t, correlations[0].Members, 1)
 }
 
 func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
@@ -168,13 +167,13 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 	// Same metric name, different tags = different SourceView refs
 	// Both should be separate members in the cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.a"},
+		Source:     observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(6), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly from host A",
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.a"},
+		Source:     observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(7), Aggregate: observer.AggregateAverage},
 		Title:      "Anomaly from host B",
 		Timestamp:  102,
@@ -183,8 +182,8 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
 	assert.Len(t, correlations[0].Anomalies, 2)
-	assert.Contains(t, correlations[0].MemberRefs, observer.SeriesRef(6))
-	assert.Contains(t, correlations[0].MemberRefs, observer.SeriesRef(7))
+	// Same Source descriptor (both have same name, no tags) = 1 unique member
+	assert.Len(t, correlations[0].Members, 1)
 }
 
 func TestTimeClusterCorrelator_Eviction(t *testing.T) {
@@ -195,7 +194,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	// Add old anomaly
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.old"},
+		Source:     observer.SeriesDescriptor{Name: "metric.old"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(8), Aggregate: observer.AggregateAverage},
 		Title:      "Old Anomaly",
 		Timestamp:  100,
@@ -203,7 +202,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	// Add recent anomaly (advances currentDataTime)
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.new"},
+		Source:     observer.SeriesDescriptor{Name: "metric.new"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(9), Aggregate: observer.AggregateAverage},
 		Title:      "New Anomaly",
 		Timestamp:  200, // 100 seconds later, old one should be evicted
@@ -214,7 +213,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
-	assert.Equal(t, observer.SeriesRef(9), correlations[0].MemberRefs[0])
+	assert.Equal(t, "metric.new", correlations[0].Members[0].Name)
 }
 
 func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
@@ -225,7 +224,7 @@ func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 
 	// A single anomaly should form a cluster of one
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.a"},
+		Source:     observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
 		Timestamp:  100,
 	})
@@ -244,28 +243,28 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Create a cluster of 2 and a cluster of 3
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.a"},
+		Source:     observer.SeriesDescriptor{Name: "metric.a"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
 		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.b"},
+		Source:     observer.SeriesDescriptor{Name: "metric.b"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
 		Timestamp:  105,
 	})
 
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.c"},
+		Source:     observer.SeriesDescriptor{Name: "metric.c"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(2), Aggregate: observer.AggregateAverage},
 		Timestamp:  200,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.d"},
+		Source:     observer.SeriesDescriptor{Name: "metric.d"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(3), Aggregate: observer.AggregateAverage},
 		Timestamp:  205,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.e"},
+		Source:     observer.SeriesDescriptor{Name: "metric.e"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(4), Aggregate: observer.AggregateAverage},
 		Timestamp:  208,
 	})
@@ -284,7 +283,7 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Once the small cluster grows to meet threshold, it should appear
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:     observer.AnomalySource{Name: "metric.f"},
+		Source:     observer.SeriesDescriptor{Name: "metric.f"},
 		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(5), Aggregate: observer.AggregateAverage},
 		Timestamp:  103,
 	})

--- a/comp/observer/impl/anomaly_correlator_time_cluster_test.go
+++ b/comp/observer/impl/anomaly_correlator_time_cluster_test.go
@@ -21,23 +21,23 @@ func TestTimeClusterCorrelator_BasicClustering(t *testing.T) {
 
 	// Two anomalies with nearby timestamps should cluster together
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|",
-		Title:          "Anomaly A",
-		Timestamp:      100,
+		Source:     observer.AnomalySource{Name: "metric.a"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly A",
+		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.b"},
-		SourceSeriesID: "ns|metric.b|",
-		Title:          "Anomaly B",
-		Timestamp:      105, // 5 seconds later, within 10s proximity
+		Source:     observer.AnomalySource{Name: "metric.b"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly B",
+		Timestamp:  105, // 5 seconds later, within 10s proximity
 	})
 
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
 	assert.Len(t, correlations[0].Anomalies, 2)
-	assert.Contains(t, correlations[0].MemberSeriesIDs, observer.SeriesID("ns|metric.a|"))
-	assert.Contains(t, correlations[0].MemberSeriesIDs, observer.SeriesID("ns|metric.b|"))
+	assert.Contains(t, correlations[0].MemberRefs, observer.SeriesRef(0))
+	assert.Contains(t, correlations[0].MemberRefs, observer.SeriesRef(1))
 }
 
 func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
@@ -48,16 +48,16 @@ func TestTimeClusterCorrelator_ProximityWindow(t *testing.T) {
 
 	// Anomalies within proximity window should cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|",
-		Title:          "Anomaly A",
-		Timestamp:      100,
+		Source:     observer.AnomalySource{Name: "metric.a"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly A",
+		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.b"},
-		SourceSeriesID: "ns|metric.b|",
-		Title:          "Anomaly B",
-		Timestamp:      108, // 8 seconds later, within 10s proximity
+		Source:     observer.AnomalySource{Name: "metric.b"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly B",
+		Timestamp:  108, // 8 seconds later, within 10s proximity
 	})
 
 	correlations := c.ActiveCorrelations()
@@ -73,16 +73,16 @@ func TestTimeClusterCorrelator_NotNearby(t *testing.T) {
 
 	// Anomalies outside proximity window should form separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|",
-		Title:          "Anomaly A",
-		Timestamp:      100,
+		Source:     observer.AnomalySource{Name: "metric.a"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly A",
+		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.b"},
-		SourceSeriesID: "ns|metric.b|",
-		Title:          "Anomaly B",
-		Timestamp:      150, // 50 seconds later, outside 10s proximity
+		Source:     observer.AnomalySource{Name: "metric.b"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly B",
+		Timestamp:  150, // 50 seconds later, outside 10s proximity
 	})
 
 	correlations := c.ActiveCorrelations()
@@ -100,16 +100,16 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Create two separate clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|",
-		Title:          "Anomaly A",
-		Timestamp:      100,
+		Source:     observer.AnomalySource{Name: "metric.a"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly A",
+		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.b"},
-		SourceSeriesID: "ns|metric.b|",
-		Title:          "Anomaly B",
-		Timestamp:      120, // Far enough to be separate (20s apart)
+		Source:     observer.AnomalySource{Name: "metric.b"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly B",
+		Timestamp:  120, // Far enough to be separate (20s apart)
 	})
 
 	// Verify two separate clusters
@@ -117,10 +117,10 @@ func TestTimeClusterCorrelator_MergeClusters(t *testing.T) {
 
 	// Add anomaly that bridges both clusters
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.c"},
-		SourceSeriesID: "ns|metric.c|",
-		Title:          "Anomaly C",
-		Timestamp:      110, // Near both clusters
+		Source:     observer.AnomalySource{Name: "metric.c"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(2), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly C",
+		Timestamp:  110, // Near both clusters
 	})
 
 	// Should now be merged into one cluster
@@ -138,25 +138,25 @@ func TestTimeClusterCorrelator_SameSeriesMultipleAnomalies(t *testing.T) {
 
 	// Multiple anomalies from the same series should all be kept
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|",
-		Title:          "Anomaly A v1",
-		Description:    "first",
-		Timestamp:      100,
+		Source:      observer.AnomalySource{Name: "metric.a"},
+		SourceView:  observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+		Title:       "Anomaly A v1",
+		Description: "first",
+		Timestamp:   100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|",
-		Title:          "Anomaly A v2",
-		Description:    "second",
-		Timestamp:      105,
+		Source:      observer.AnomalySource{Name: "metric.a"},
+		SourceView:  observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+		Title:       "Anomaly A v2",
+		Description: "second",
+		Timestamp:   105,
 	})
 
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
 	assert.Len(t, correlations[0].Anomalies, 2)
 	// Single unique series
-	assert.Len(t, correlations[0].MemberSeriesIDs, 1)
+	assert.Len(t, correlations[0].MemberRefs, 1)
 }
 
 func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
@@ -165,26 +165,26 @@ func TestTimeClusterCorrelator_TaggedVariants(t *testing.T) {
 		WindowSeconds:    60,
 	})
 
-	// Same metric name, different tags = different SourceSeriesIDs
+	// Same metric name, different tags = different SourceView refs
 	// Both should be separate members in the cluster
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|host:A",
-		Title:          "Anomaly from host A",
-		Timestamp:      100,
+		Source:     observer.AnomalySource{Name: "metric.a"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(6), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly from host A",
+		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|host:B",
-		Title:          "Anomaly from host B",
-		Timestamp:      102,
+		Source:     observer.AnomalySource{Name: "metric.a"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(7), Aggregate: observer.AggregateAverage},
+		Title:      "Anomaly from host B",
+		Timestamp:  102,
 	})
 
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
 	assert.Len(t, correlations[0].Anomalies, 2)
-	assert.Contains(t, correlations[0].MemberSeriesIDs, observer.SeriesID("ns|metric.a|host:A"))
-	assert.Contains(t, correlations[0].MemberSeriesIDs, observer.SeriesID("ns|metric.a|host:B"))
+	assert.Contains(t, correlations[0].MemberRefs, observer.SeriesRef(6))
+	assert.Contains(t, correlations[0].MemberRefs, observer.SeriesRef(7))
 }
 
 func TestTimeClusterCorrelator_Eviction(t *testing.T) {
@@ -195,18 +195,18 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	// Add old anomaly
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.old"},
-		SourceSeriesID: "ns|metric.old|",
-		Title:          "Old Anomaly",
-		Timestamp:      100,
+		Source:     observer.AnomalySource{Name: "metric.old"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(8), Aggregate: observer.AggregateAverage},
+		Title:      "Old Anomaly",
+		Timestamp:  100,
 	})
 
 	// Add recent anomaly (advances currentDataTime)
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.new"},
-		SourceSeriesID: "ns|metric.new|",
-		Title:          "New Anomaly",
-		Timestamp:      200, // 100 seconds later, old one should be evicted
+		Source:     observer.AnomalySource{Name: "metric.new"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(9), Aggregate: observer.AggregateAverage},
+		Title:      "New Anomaly",
+		Timestamp:  200, // 100 seconds later, old one should be evicted
 	})
 
 	// Flush should evict the old cluster
@@ -214,7 +214,7 @@ func TestTimeClusterCorrelator_Eviction(t *testing.T) {
 
 	correlations := c.ActiveCorrelations()
 	require.Len(t, correlations, 1)
-	assert.Equal(t, observer.SeriesID("ns|metric.new|"), correlations[0].MemberSeriesIDs[0])
+	assert.Equal(t, observer.SeriesRef(9), correlations[0].MemberRefs[0])
 }
 
 func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
@@ -225,9 +225,9 @@ func TestTimeClusterCorrelator_SingletonCluster(t *testing.T) {
 
 	// A single anomaly should form a cluster of one
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|",
-		Timestamp:      100,
+		Source:     observer.AnomalySource{Name: "metric.a"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+		Timestamp:  100,
 	})
 
 	correlations := c.ActiveCorrelations()
@@ -244,30 +244,30 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Create a cluster of 2 and a cluster of 3
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.a"},
-		SourceSeriesID: "ns|metric.a|",
-		Timestamp:      100,
+		Source:     observer.AnomalySource{Name: "metric.a"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(0), Aggregate: observer.AggregateAverage},
+		Timestamp:  100,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.b"},
-		SourceSeriesID: "ns|metric.b|",
-		Timestamp:      105,
+		Source:     observer.AnomalySource{Name: "metric.b"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(1), Aggregate: observer.AggregateAverage},
+		Timestamp:  105,
 	})
 
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.c"},
-		SourceSeriesID: "ns|metric.c|",
-		Timestamp:      200,
+		Source:     observer.AnomalySource{Name: "metric.c"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(2), Aggregate: observer.AggregateAverage},
+		Timestamp:  200,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.d"},
-		SourceSeriesID: "ns|metric.d|",
-		Timestamp:      205,
+		Source:     observer.AnomalySource{Name: "metric.d"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(3), Aggregate: observer.AggregateAverage},
+		Timestamp:  205,
 	})
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.e"},
-		SourceSeriesID: "ns|metric.e|",
-		Timestamp:      208,
+		Source:     observer.AnomalySource{Name: "metric.e"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(4), Aggregate: observer.AggregateAverage},
+		Timestamp:  208,
 	})
 
 	// Internally both clusters exist
@@ -284,9 +284,9 @@ func TestTimeClusterCorrelator_MinClusterSize(t *testing.T) {
 
 	// Once the small cluster grows to meet threshold, it should appear
 	c.ProcessAnomaly(observer.Anomaly{
-		Source:         observer.AnomalySource{Name: "metric.f"},
-		SourceSeriesID: "ns|metric.f|",
-		Timestamp:      103,
+		Source:     observer.AnomalySource{Name: "metric.f"},
+		SourceView: observer.QueryHandle{Ref: observer.SeriesRef(5), Aggregate: observer.AggregateAverage},
+		Timestamp:  103,
 	})
 	correlations = c.ActiveCorrelations()
 	assert.Len(t, correlations, 2)

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -6,8 +6,6 @@
 package observerimpl
 
 import (
-	"sort"
-
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
@@ -160,18 +158,16 @@ func (c *CrossSignalCorrelator) Advance(dataTime int64) {
 				// Pattern already active - update LastUpdated and Anomalies
 				existing.LastUpdated = c.currentDataTime
 				existing.Anomalies = matchingAnomalies
-				existing.MemberRefs = sortedUniqueRefs(matchingAnomalies)
-				existing.MetricNames = c.getSortedMetricNames(sourceSet)
+				existing.Members = sortedUniqueMembers(matchingAnomalies)
 			} else {
 				// New pattern match - create ActiveCorrelation
 				c.activeCorrelations[pattern.name] = &observer.ActiveCorrelation{
-					Pattern:         pattern.name,
-					Title:           pattern.reportTitle,
-					MemberRefs: sortedUniqueRefs(matchingAnomalies),
-					MetricNames:     c.getSortedMetricNames(sourceSet),
-					Anomalies:       matchingAnomalies,
-					FirstSeen:       c.currentDataTime,
-					LastUpdated:     c.currentDataTime,
+					Pattern:     pattern.name,
+					Title:       pattern.reportTitle,
+					Members:     sortedUniqueMembers(matchingAnomalies),
+					Anomalies:   matchingAnomalies,
+					FirstSeen:   c.currentDataTime,
+					LastUpdated: c.currentDataTime,
 				}
 			}
 		}
@@ -235,15 +231,6 @@ func (c *CrossSignalCorrelator) getBuffer() []timestampedAnomaly {
 	return c.buffer
 }
 
-// getSortedMetricNames returns a sorted slice of metric names from a source set.
-func (c *CrossSignalCorrelator) getSortedMetricNames(sources map[observer.MetricName]struct{}) []observer.MetricName {
-	sourceList := make([]observer.MetricName, 0, len(sources))
-	for source := range sources {
-		sourceList = append(sourceList, source)
-	}
-	sort.Slice(sourceList, func(i, j int) bool { return sourceList[i] < sourceList[j] })
-	return sourceList
-}
 
 // ActiveCorrelations returns a copy of the currently active correlation patterns.
 func (c *CrossSignalCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
@@ -253,8 +240,7 @@ func (c *CrossSignalCorrelator) ActiveCorrelations() []observer.ActiveCorrelatio
 		result = append(result, observer.ActiveCorrelation{
 			Pattern:     ac.Pattern,
 			Title:       ac.Title,
-			MemberRefs:  append([]observer.SeriesRef(nil), ac.MemberRefs...),
-			MetricNames: append([]observer.MetricName(nil), ac.MetricNames...),
+			Members:     append([]observer.SeriesDescriptor(nil), ac.Members...),
 			Anomalies:   ac.Anomalies,
 			FirstSeen:   ac.FirstSeen,
 			LastUpdated: ac.LastUpdated,

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -160,14 +160,14 @@ func (c *CrossSignalCorrelator) Advance(dataTime int64) {
 				// Pattern already active - update LastUpdated and Anomalies
 				existing.LastUpdated = c.currentDataTime
 				existing.Anomalies = matchingAnomalies
-				existing.MemberSeriesIDs = sortedUniqueSeriesIDs(matchingAnomalies)
+				existing.MemberRefs = sortedUniqueRefs(matchingAnomalies)
 				existing.MetricNames = c.getSortedMetricNames(sourceSet)
 			} else {
 				// New pattern match - create ActiveCorrelation
 				c.activeCorrelations[pattern.name] = &observer.ActiveCorrelation{
 					Pattern:         pattern.name,
 					Title:           pattern.reportTitle,
-					MemberSeriesIDs: sortedUniqueSeriesIDs(matchingAnomalies),
+					MemberRefs: sortedUniqueRefs(matchingAnomalies),
 					MetricNames:     c.getSortedMetricNames(sourceSet),
 					Anomalies:       matchingAnomalies,
 					FirstSeen:       c.currentDataTime,
@@ -251,13 +251,13 @@ func (c *CrossSignalCorrelator) ActiveCorrelations() []observer.ActiveCorrelatio
 	for _, ac := range c.activeCorrelations {
 		// Return a copy to prevent external modification
 		result = append(result, observer.ActiveCorrelation{
-			Pattern:         ac.Pattern,
-			Title:           ac.Title,
-			MemberSeriesIDs: append([]observer.SeriesID(nil), ac.MemberSeriesIDs...),
-			MetricNames:     append([]observer.MetricName(nil), ac.MetricNames...),
-			Anomalies:       ac.Anomalies,
-			FirstSeen:       ac.FirstSeen,
-			LastUpdated:     ac.LastUpdated,
+			Pattern:     ac.Pattern,
+			Title:       ac.Title,
+			MemberRefs:  append([]observer.SeriesRef(nil), ac.MemberRefs...),
+			MetricNames: append([]observer.MetricName(nil), ac.MetricNames...),
+			Anomalies:   ac.Anomalies,
+			FirstSeen:   ac.FirstSeen,
+			LastUpdated: ac.LastUpdated,
 		})
 	}
 	return result

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -33,7 +33,7 @@ type timestampedAnomaly struct {
 // correlationPattern defines a known pattern of correlated signals.
 type correlationPattern struct {
 	name            string
-	requiredSources []observer.MetricName
+	requiredSources []string
 	reportTitle     string
 }
 
@@ -44,19 +44,19 @@ var knownPatterns = []correlationPattern{
 	{
 		// Most specific: all 3 signals indicate kernel-level issue
 		name:            "kernel_bottleneck",
-		requiredSources: []observer.MetricName{"network.retransmits:avg", "ebpf.lock_contention_ns:avg", "connection.errors:count"},
+		requiredSources: []string{"network.retransmits:avg", "ebpf.lock_contention_ns:avg", "connection.errors:count"},
 		reportTitle:     "Correlated: Kernel network bottleneck",
 	},
 	{
 		// Less specific: network issues without clear kernel involvement
 		name:            "network_degradation",
-		requiredSources: []observer.MetricName{"network.retransmits:avg", "connection.errors:count"},
+		requiredSources: []string{"network.retransmits:avg", "connection.errors:count"},
 		reportTitle:     "Correlated: Network degradation",
 	},
 	{
 		// Lock contention causing downstream failures
 		name:            "lock_contention_cascade",
-		requiredSources: []observer.MetricName{"ebpf.lock_contention_ns:avg", "connection.errors:count"},
+		requiredSources: []string{"ebpf.lock_contention_ns:avg", "connection.errors:count"},
 		reportTitle:     "Correlated: Lock contention cascade",
 	},
 }
@@ -138,9 +138,9 @@ func (c *CrossSignalCorrelator) Advance(dataTime int64) {
 	c.evictOldEntries()
 
 	// Extract unique signal sources from anomalies (display names for pattern matching)
-	sourceSet := make(map[observer.MetricName]struct{})
+	sourceSet := make(map[string]struct{})
 	for _, entry := range c.buffer {
-		sourceSet[observer.MetricName(entry.anomaly.Source.String())] = struct{}{}
+		sourceSet[entry.anomaly.Source.String()] = struct{}{}
 	}
 
 	// Track which patterns are currently active
@@ -189,7 +189,7 @@ func (c *CrossSignalCorrelator) Reset() {
 }
 
 // patternMatches checks if all required sources for a pattern are present.
-func (c *CrossSignalCorrelator) patternMatches(pattern correlationPattern, sources map[observer.MetricName]struct{}) bool {
+func (c *CrossSignalCorrelator) patternMatches(pattern correlationPattern, sources map[string]struct{}) bool {
 	for _, required := range pattern.requiredSources {
 		if _, ok := sources[required]; !ok {
 			return false
@@ -202,10 +202,10 @@ func (c *CrossSignalCorrelator) patternMatches(pattern correlationPattern, sourc
 // deduped by source - keeping only the most recent anomaly per source.
 func (c *CrossSignalCorrelator) collectMatchingAnomalies(pattern correlationPattern) []observer.Anomaly {
 	// Map from source to most recent anomaly for that source
-	bySource := make(map[observer.MetricName]observer.Anomaly)
+	bySource := make(map[string]observer.Anomaly)
 
 	for _, entry := range c.buffer {
-		display := observer.MetricName(entry.anomaly.Source.String())
+		display := entry.anomaly.Source.String()
 		for _, src := range pattern.requiredSources {
 			if display == src {
 				existing, exists := bySource[src]

--- a/comp/observer/impl/anomaly_processor_correlator.go
+++ b/comp/observer/impl/anomaly_processor_correlator.go
@@ -231,7 +231,6 @@ func (c *CrossSignalCorrelator) getBuffer() []timestampedAnomaly {
 	return c.buffer
 }
 
-
 // ActiveCorrelations returns a copy of the currently active correlation patterns.
 func (c *CrossSignalCorrelator) ActiveCorrelations() []observer.ActiveCorrelation {
 	result := make([]observer.ActiveCorrelation, 0, len(c.activeCorrelations))

--- a/comp/observer/impl/anomaly_processor_correlator_test.go
+++ b/comp/observer/impl/anomaly_processor_correlator_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func avgSource(name string) observer.AnomalySource {
-	return observer.AnomalySource{Name: name, Aggregate: observer.AggregateAverage}
+func avgSource(name string) observer.SeriesDescriptor {
+	return observer.SeriesDescriptor{Name: name, Aggregate: observer.AggregateAverage}
 }
 
-func countSource(name string) observer.AnomalySource {
-	return observer.AnomalySource{Name: name, Aggregate: observer.AggregateCount}
+func countSource(name string) observer.SeriesDescriptor {
+	return observer.SeriesDescriptor{Name: name, Aggregate: observer.AggregateCount}
 }
 
 func TestCorrelator_SingleAnomalyNoReport(t *testing.T) {
@@ -150,12 +150,15 @@ func TestCorrelator_ActiveCorrelationListsAllSignals(t *testing.T) {
 	found := findCorrelation(activeCorrs, "kernel_bottleneck")
 	require.NotNil(t, found)
 
-	// Sources should contain all three sources (sorted alphabetically)
-	sources := found.MetricNames
-	require.Len(t, sources, 3)
-	assert.Contains(t, sources, observer.MetricName("network.retransmits:avg"))
-	assert.Contains(t, sources, observer.MetricName("ebpf.lock_contention_ns:avg"))
-	assert.Contains(t, sources, observer.MetricName("connection.errors:count"))
+	// Members should contain all three sources
+	require.Len(t, found.Members, 3)
+	memberNames := make([]string, len(found.Members))
+	for i, m := range found.Members {
+		memberNames[i] = m.String()
+	}
+	assert.Contains(t, memberNames, "network.retransmits:avg")
+	assert.Contains(t, memberNames, "ebpf.lock_contention_ns:avg")
+	assert.Contains(t, memberNames, "connection.errors:count")
 }
 
 func TestCorrelator_ActiveCorrelationContainsPatternName(t *testing.T) {
@@ -225,7 +228,7 @@ func TestCorrelator_ExtraSignalsStillMatch(t *testing.T) {
 	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("network.retransmits")})
 	correlator.ProcessAnomaly(observer.Anomaly{Source: avgSource("ebpf.lock_contention_ns")})
 	correlator.ProcessAnomaly(observer.Anomaly{Source: countSource("connection.errors")})
-	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.AnomalySource{Name: "extra.signal"}})
+	correlator.ProcessAnomaly(observer.Anomaly{Source: observer.SeriesDescriptor{Name: "extra.signal"}})
 
 	correlator.Advance(0)
 	activeCorrs := correlator.ActiveCorrelations()
@@ -318,7 +321,7 @@ func TestCorrelator_ActiveCorrelationCleared(t *testing.T) {
 	// Add an anomaly at data time 1035 (35 seconds later), which advances currentDataTime
 	// and causes all previous signals to expire (1000 < 1035 - 30 = 1005)
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:    observer.AnomalySource{Name: "some.other.signal"},
+		Source:    observer.SeriesDescriptor{Name: "some.other.signal"},
 		Timestamp: 1035,
 	})
 	correlator.Advance(0)
@@ -429,7 +432,7 @@ func TestCorrelator_DedupesBySourceKeepingMostRecent(t *testing.T) {
 		Timestamp:   1025,                 // latest timestamp
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "network.retransmits"},
+		Source:      observer.SeriesDescriptor{Name: "network.retransmits"},
 		Description: "middle retransmits",
 		Timestamp:   1015,
 	})
@@ -483,7 +486,7 @@ func TestCorrelator_AnomaliesOnlyIncludesMatchingSignals(t *testing.T) {
 		Description: "connection errors anomaly",
 	})
 	correlator.ProcessAnomaly(observer.Anomaly{
-		Source:      observer.AnomalySource{Name: "extra.signal"},
+		Source:      observer.SeriesDescriptor{Name: "extra.signal"},
 		Description: "extra signal anomaly",
 	})
 

--- a/comp/observer/impl/correlation_identity.go
+++ b/comp/observer/impl/correlation_identity.go
@@ -28,18 +28,35 @@ func sortedUniqueMetricNames(anomalies []observer.Anomaly) []observer.MetricName
 	return names
 }
 
-func sortedUniqueSeriesIDs(anomalies []observer.Anomaly) []observer.SeriesID {
-	seen := make(map[observer.SeriesID]struct{})
+func sortedUniqueRefs(anomalies []observer.Anomaly) []observer.SeriesRef {
+	seen := make(map[observer.SeriesRef]struct{})
 	for _, a := range anomalies {
-		if a.SourceSeriesID == "" {
+		if a.SourceView.Ref == observer.NoSeriesRef {
 			continue
 		}
-		seen[a.SourceSeriesID] = struct{}{}
+		seen[a.SourceView.Ref] = struct{}{}
 	}
-	ids := make([]observer.SeriesID, 0, len(seen))
-	for id := range seen {
-		ids = append(ids, id)
+	refs := make([]observer.SeriesRef, 0, len(seen))
+	for ref := range seen {
+		refs = append(refs, ref)
 	}
-	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
-	return ids
+	sort.Slice(refs, func(i, j int) bool { return refs[i] < refs[j] })
+	return refs
+}
+
+func uniqueViewStrings(anomalies []observer.Anomaly) []string {
+	seen := make(map[string]struct{})
+	for _, a := range anomalies {
+		s := a.SourceView.String()
+		if s == "" {
+			continue
+		}
+		seen[s] = struct{}{}
+	}
+	views := make([]string, 0, len(seen))
+	for v := range seen {
+		views = append(views, v)
+	}
+	sort.Strings(views)
+	return views
 }

--- a/comp/observer/impl/correlation_identity.go
+++ b/comp/observer/impl/correlation_identity.go
@@ -11,52 +11,20 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-func sortedUniqueMetricNames(anomalies []observer.Anomaly) []observer.MetricName {
-	seen := make(map[observer.MetricName]struct{})
+// sortedUniqueMembers extracts unique SeriesDescriptors from anomalies' Source
+// fields, deduplicating by Key() and sorting by String() for deterministic output.
+func sortedUniqueMembers(anomalies []observer.Anomaly) []observer.SeriesDescriptor {
+	seen := make(map[string]observer.SeriesDescriptor)
 	for _, a := range anomalies {
-		display := observer.MetricName(a.Source.String())
-		if display == "" {
-			continue
+		key := a.Source.Key()
+		if _, ok := seen[key]; !ok {
+			seen[key] = a.Source
 		}
-		seen[display] = struct{}{}
 	}
-	names := make([]observer.MetricName, 0, len(seen))
-	for n := range seen {
-		names = append(names, n)
+	members := make([]observer.SeriesDescriptor, 0, len(seen))
+	for _, sd := range seen {
+		members = append(members, sd)
 	}
-	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
-	return names
-}
-
-func sortedUniqueRefs(anomalies []observer.Anomaly) []observer.SeriesRef {
-	seen := make(map[observer.SeriesRef]struct{})
-	for _, a := range anomalies {
-		if a.SourceView.Ref == observer.NoSeriesRef {
-			continue
-		}
-		seen[a.SourceView.Ref] = struct{}{}
-	}
-	refs := make([]observer.SeriesRef, 0, len(seen))
-	for ref := range seen {
-		refs = append(refs, ref)
-	}
-	sort.Slice(refs, func(i, j int) bool { return refs[i] < refs[j] })
-	return refs
-}
-
-func uniqueViewStrings(anomalies []observer.Anomaly) []string {
-	seen := make(map[string]struct{})
-	for _, a := range anomalies {
-		s := a.SourceView.String()
-		if s == "" {
-			continue
-		}
-		seen[s] = struct{}{}
-	}
-	views := make([]string, 0, len(seen))
-	for v := range seen {
-		views = append(views, v)
-	}
-	sort.Strings(views)
-	return views
+	sort.Slice(members, func(i, j int) bool { return members[i].Key() < members[j].Key() })
+	return members
 }

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -66,10 +66,10 @@ type engine struct {
 	rawAnomalies         []observerdef.Anomaly
 	rawAnomalyIndex      map[anomalyDedupKey]int // O(1) dedup lookup
 	rawAnomalyMu         sync.RWMutex
-	rawAnomalyWindow     int64                              // seconds to keep (0 = unlimited)
-	maxRawAnomalies      int                                // max count to keep (0 = unlimited)
-	currentDataTime      int64                              // latest anomaly timestamp seen
-	totalAnomalyCount    int                                // total count ever (no cap)
+	rawAnomalyWindow     int64           // seconds to keep (0 = unlimited)
+	maxRawAnomalies      int             // max count to keep (0 = unlimited)
+	currentDataTime      int64           // latest anomaly timestamp seen
+	totalAnomalyCount    int             // total count ever (no cap)
 	uniqueAnomalySources map[string]bool // unique sources that had anomalies (keyed by SeriesDescriptor.Key())
 
 	// Accumulated correlations from all advance cycles.

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -18,7 +18,7 @@ import (
 
 // anomalyDedupKey is a map key for O(1) anomaly deduplication.
 type anomalyDedupKey struct {
-	seriesID     observerdef.SeriesID
+	sourceView   observerdef.QueryHandle
 	detectorName string
 	timestamp    int64
 	title        string
@@ -47,7 +47,7 @@ type engine struct {
 	detectors        []observerdef.Detector
 	correlators      []observerdef.Correlator
 	contextProviders map[string]observerdef.ContextProvider // namespace → provider
-	contextRefs      map[observerdef.SeriesID]seriesContextRef
+	contextRefs      map[string]seriesContextRef
 
 	// scheduler decides when the engine should advance analysis.
 	scheduler schedulerPolicy
@@ -125,7 +125,7 @@ func newEngine(cfg engineConfig) *engine {
 		detectors:        cfg.detectors,
 		correlators:      cfg.correlators,
 		contextProviders: cfg.contextProviders,
-		contextRefs:      make(map[observerdef.SeriesID]seriesContextRef),
+		contextRefs:      make(map[string]seriesContextRef),
 		scheduler:        sched,
 
 		rawAnomalyWindow: cfg.rawAnomalyWindow,
@@ -200,8 +200,8 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 			}
 			e.storage.Add(extractor.Name(), m.Name, m.Value, l.timestampMs/1000, tags)
 			if m.ContextKey != "" {
-				seriesID := observerdef.SeriesID(seriesKey(extractor.Name(), m.Name, tags))
-				e.contextRefs[seriesID] = seriesContextRef{
+				sk := seriesKey(extractor.Name(), m.Name, tags)
+				e.contextRefs[sk] = seriesContextRef{
 					namespace:  extractor.Name(),
 					contextKey: m.ContextKey,
 				}
@@ -351,13 +351,20 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 // enrichAnomaly decorates an anomaly with context from the originating
 // extractor, if available. This runs automatically on every anomaly so
 // detectors don't need to be aware of context providers.
-// Lookup is keyed by the anomaly's concrete SourceSeriesID, which the engine
-// maps to a provider namespace and opaque extractor-owned context key.
+// Lookup resolves the anomaly's SourceView (QueryHandle) to an internal
+// storage key, then maps that to a provider namespace and context key.
 func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
-	if a.SourceSeriesID == "" {
+	if !a.SourceView.IsValid() {
 		return
 	}
-	ref, ok := e.contextRefs[a.SourceSeriesID]
+	fullKey, ok := e.storage.FullKeyForNumericID(a.SourceView.Ref)
+	if !ok {
+		return
+	}
+	// Resolve aggregate from SourceView into Source.
+	a.Source.Aggregate = a.SourceView.Aggregate
+
+	ref, ok := e.contextRefs[fullKey]
 	if !ok {
 		return
 	}
@@ -384,7 +391,7 @@ func (e *engine) processAnomaly(anomaly observerdef.Anomaly) {
 }
 
 // captureRawAnomaly stores a raw anomaly for telemetry and testbench display.
-// Deduplicates by SourceSeriesID+DetectorName+Timestamp+Title.
+// Deduplicates by SourceView+DetectorName+Timestamp+Title.
 // Returns true if the anomaly was new, false if it was a duplicate.
 func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 	e.rawAnomalyMu.Lock()
@@ -404,9 +411,9 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 		e.currentDataTime = anomaly.Timestamp
 	}
 
-	// Deduplicate by SourceSeriesID+DetectorName+Timestamp
+	// Deduplicate by SourceView+DetectorName+Timestamp+Title
 	key := anomalyDedupKey{
-		seriesID:     anomaly.SourceSeriesID,
+		sourceView:   anomaly.SourceView,
 		detectorName: anomaly.DetectorName,
 		timestamp:    anomaly.Timestamp,
 		title:        anomaly.Title,
@@ -447,7 +454,7 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 		e.rawAnomalyIndex = make(map[anomalyDedupKey]int, len(e.rawAnomalies))
 		for i, a := range e.rawAnomalies {
 			e.rawAnomalyIndex[anomalyDedupKey{
-				seriesID:     a.SourceSeriesID,
+				sourceView:   a.SourceView,
 				detectorName: a.DetectorName,
 				timestamp:    a.Timestamp,
 				title:        a.Title,
@@ -563,7 +570,7 @@ func (e *engine) SetExtractors(extractors []observerdef.LogMetricsExtractor) {
 	validateUniqueExtractorNames(extractors)
 	e.extractors = extractors
 	e.contextProviders = collectContextProviders(extractors)
-	e.contextRefs = make(map[observerdef.SeriesID]seriesContextRef)
+	e.contextRefs = make(map[string]seriesContextRef)
 }
 
 // Reset clears analysis state so detectors will re-analyze from scratch.
@@ -591,7 +598,7 @@ func (e *engine) Reset() {
 		}
 	}
 
-	e.contextRefs = make(map[observerdef.SeriesID]seriesContextRef)
+	e.contextRefs = make(map[string]seriesContextRef)
 }
 
 // resetRawAnomalies clears the raw anomaly tracking state.

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -70,7 +70,7 @@ type engine struct {
 	maxRawAnomalies      int                                // max count to keep (0 = unlimited)
 	currentDataTime      int64                              // latest anomaly timestamp seen
 	totalAnomalyCount    int                                // total count ever (no cap)
-	uniqueAnomalySources map[observerdef.AnomalySource]bool // unique sources that had anomalies
+	uniqueAnomalySources map[string]bool // unique sources that had anomalies (keyed by SeriesDescriptor.Key())
 
 	// Accumulated correlations from all advance cycles.
 	// Correlators maintain sliding windows that evict old state, but for
@@ -400,11 +400,11 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 	e.totalAnomalyCount++
 
 	if e.uniqueAnomalySources == nil {
-		e.uniqueAnomalySources = make(map[observerdef.AnomalySource]bool)
+		e.uniqueAnomalySources = make(map[string]bool)
 	}
 	const maxUniqueSources = 500
 	if len(e.uniqueAnomalySources) < maxUniqueSources {
-		e.uniqueAnomalySources[anomaly.Source] = true
+		e.uniqueAnomalySources[anomaly.Source.Key()] = true
 	}
 
 	if anomaly.Timestamp > e.currentDataTime {

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -18,7 +18,7 @@ import (
 
 // anomalyDedupKey is a map key for O(1) anomaly deduplication.
 type anomalyDedupKey struct {
-	sourceView   observerdef.QueryHandle
+	sourceKey    string // SeriesDescriptor.Key()
 	detectorName string
 	timestamp    int64
 	title        string
@@ -351,18 +351,13 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 // enrichAnomaly decorates an anomaly with context from the originating
 // extractor, if available. This runs automatically on every anomaly so
 // detectors don't need to be aware of context providers.
-// Lookup resolves the anomaly's SourceView (QueryHandle) to an internal
-// storage key, then maps that to a provider namespace and context key.
+// Lookup builds the storage key from Source fields (namespace, name, tags)
+// and maps that to a provider namespace and context key.
 func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
-	if !a.SourceView.IsValid() {
+	if a.Source.Name == "" {
 		return
 	}
-	fullKey, ok := e.storage.FullKeyForNumericID(a.SourceView.Ref)
-	if !ok {
-		return
-	}
-	// Resolve aggregate from SourceView into Source.
-	a.Source.Aggregate = a.SourceView.Aggregate
+	fullKey := seriesKey(a.Source.Namespace, a.Source.Name, a.Source.Tags)
 
 	ref, ok := e.contextRefs[fullKey]
 	if !ok {
@@ -391,7 +386,7 @@ func (e *engine) processAnomaly(anomaly observerdef.Anomaly) {
 }
 
 // captureRawAnomaly stores a raw anomaly for telemetry and testbench display.
-// Deduplicates by SourceView+DetectorName+Timestamp+Title.
+// Deduplicates by Source+DetectorName+Timestamp+Title.
 // Returns true if the anomaly was new, false if it was a duplicate.
 func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 	e.rawAnomalyMu.Lock()
@@ -411,9 +406,9 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 		e.currentDataTime = anomaly.Timestamp
 	}
 
-	// Deduplicate by SourceView+DetectorName+Timestamp+Title
+	// Deduplicate by Source+DetectorName+Timestamp+Title
 	key := anomalyDedupKey{
-		sourceView:   anomaly.SourceView,
+		sourceKey:    anomaly.Source.Key(),
 		detectorName: anomaly.DetectorName,
 		timestamp:    anomaly.Timestamp,
 		title:        anomaly.Title,
@@ -454,7 +449,7 @@ func (e *engine) captureRawAnomaly(anomaly observerdef.Anomaly) bool {
 		e.rawAnomalyIndex = make(map[anomalyDedupKey]int, len(e.rawAnomalies))
 		for i, a := range e.rawAnomalies {
 			e.rawAnomalyIndex[anomalyDedupKey{
-				sourceView:   a.SourceView,
+				sourceKey:    a.Source.Key(),
 				detectorName: a.DetectorName,
 				timestamp:    a.Timestamp,
 				title:        a.Title,

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -170,6 +170,25 @@ func (c *resettableCorrelator) ActiveCorrelations() []observerdef.ActiveCorrelat
 }
 func (c *resettableCorrelator) Reset() { c.resetCount++ }
 
+type emitOnSeriesDetector struct {
+	name string
+}
+
+func (d *emitOnSeriesDetector) Name() string { return d.name }
+
+func (d *emitOnSeriesDetector) Detect(series observerdef.Series) observerdef.DetectionResult {
+	if len(series.Points) == 0 {
+		return observerdef.DetectionResult{}
+	}
+	return observerdef.DetectionResult{
+		Anomalies: []observerdef.Anomaly{{
+			Title:       "detected",
+			Description: "detected from series",
+			Timestamp:   series.Points[len(series.Points)-1].Timestamp,
+		}},
+	}
+}
+
 func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
 	e := newEngine(engineConfig{
 		storage:   newTimeSeriesStorage(),
@@ -336,6 +355,40 @@ func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing
 	assert.Equal(t, "GET /users/123 returned 500", anomaly.Context.Example)
 	assert.Contains(t, anomaly.Context.Pattern, "*")
 	assert.NotContains(t, anomaly.Context.Example, "456")
+}
+
+func TestAdvance_LogMetricAnomalyIsEnrichedViaMatchingSeriesIdentity(t *testing.T) {
+	extractor := NewLogMetricsExtractor(LogMetricsExtractorConfig{})
+	detector := newSeriesDetectorAdapter(&emitOnSeriesDetector{name: "test_series_detector"}, []observerdef.Aggregate{observerdef.AggregateCount})
+	e := newEngine(engineConfig{
+		storage:          newTimeSeriesStorage(),
+		extractors:       []observerdef.LogMetricsExtractor{extractor},
+		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{extractor}),
+		detectors:        []observerdef.Detector{detector},
+	})
+
+	e.IngestLog("source-a", &logObs{
+		content:     []byte("GET /users/123 returned 500"),
+		tags:        []string{"service:api"},
+		timestampMs: 1_000,
+	})
+
+	result := e.Advance(1)
+	require.Len(t, result.anomalies, 1)
+
+	anomaly := result.anomalies[0]
+	assert.Equal(t, "log_metrics_extractor", anomaly.Source.Namespace)
+	assert.Equal(t, observerdef.AggregateCount, anomaly.Source.Aggregate)
+	assert.Contains(t, anomaly.Source.Name, "log.pattern.")
+	assert.Contains(t, anomaly.Source.Tags, "observer_source:source-a")
+	assert.Contains(t, anomaly.Source.Tags, "service:api")
+	require.NotNil(t, anomaly.SourceRef)
+	assert.Equal(t, observerdef.AggregateCount, anomaly.SourceRef.Aggregate)
+
+	require.NotNil(t, anomaly.Context)
+	assert.Equal(t, "log_metrics_extractor", anomaly.Context.Source)
+	assert.Equal(t, "GET /users/123 returned 500", anomaly.Context.Example)
+	assert.Equal(t, logSignature([]byte("GET /users/123 returned 500"), extractor.config.MaxEvalBytes), anomaly.Context.Pattern)
 }
 
 func containsTag(tags []string, want string) bool {

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -191,8 +191,8 @@ func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
 
 func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
-		{Source: observerdef.AnomalySource{Name: "cpu"}, DetectorName: "test", Timestamp: 99, SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}},
-		{Source: observerdef.AnomalySource{Name: "mem"}, DetectorName: "test", Timestamp: 99, SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(1), Aggregate: observerdef.AggregateAverage}},
+		{Source: observerdef.SeriesDescriptor{Name: "cpu"}, DetectorName: "test", Timestamp: 99, SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}},
+		{Source: observerdef.SeriesDescriptor{Name: "mem"}, DetectorName: "test", Timestamp: 99, SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(1), Aggregate: observerdef.AggregateAverage}},
 	}
 
 	e := newEngine(engineConfig{
@@ -223,16 +223,16 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 		ok: true,
 	}
 	anomalies := []observerdef.Anomaly{{
-		Source: observerdef.AnomalySource{
+		Source: observerdef.SeriesDescriptor{
 			Namespace: "log_metrics_extractor",
 			Name:      "log.pattern.abc.count",
+			Tags:      []string{"observer_source:source-a", "service:api"},
 			Aggregate: observerdef.AggregateCount,
 		},
-		DetectorName:   "test",
-		Description:    "detector-authored description",
-		Tags:           []string{"observer_source:source-a", "service:api"},
-		Timestamp:      99,
-		SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateCount},
+		DetectorName: "test",
+		Description:  "detector-authored description",
+		Timestamp:    99,
+		SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateCount},
 	}}
 
 	storage := newTimeSeriesStorage()
@@ -281,8 +281,7 @@ func TestSetExtractorsRefreshesContextProviders(t *testing.T) {
 		extractors:       []observerdef.LogMetricsExtractor{first},
 		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{first}),
 		detectors: []observerdef.Detector{&anomalyDetector{name: "test", anomalies: []observerdef.Anomaly{{
-			Source:     observerdef.AnomalySource{Namespace: "second", Name: "metric"},
-			Tags:       []string{"service:api"},
+			Source:     observerdef.SeriesDescriptor{Namespace: "second", Name: "metric", Tags: []string{"service:api"}},
 			Timestamp:  1,
 			SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
 		}}}},
@@ -322,11 +321,11 @@ func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing
 	for _, meta := range e.storage.ListSeries(observerdef.SeriesFilter{Namespace: extractor.Name()}) {
 		if len(meta.Tags) == 2 && containsTag(meta.Tags, "observer_source:source-a") && containsTag(meta.Tags, "service:api") {
 			anomaly = observerdef.Anomaly{
-				Source: observerdef.AnomalySource{
+				Source: observerdef.SeriesDescriptor{
 					Namespace: extractor.Name(),
 					Name:      meta.Name,
+					Tags:      meta.Tags,
 				},
-				Tags:           meta.Tags,
 				SourceView: observerdef.QueryHandle{Ref: meta.Ref, Aggregate: observerdef.AggregateCount},
 			}
 			break
@@ -489,7 +488,7 @@ func TestReporterEventSink(t *testing.T) {
 		kind:      eventAnomalyCreated,
 		timestamp: 100,
 		anomalyCreated: &anomalyCreatedEvent{
-			anomaly: observerdef.Anomaly{Source: observerdef.AnomalySource{Name: "cpu"}},
+			anomaly: observerdef.Anomaly{Source: observerdef.SeriesDescriptor{Name: "cpu"}},
 		},
 	})
 	assert.Equal(t, 1, reported, "anomaly events should not trigger reporter")
@@ -507,7 +506,7 @@ func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 	cpuView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:       observerdef.AnomalySource{Name: "cpu"},
+			Source:       observerdef.SeriesDescriptor{Name: "cpu"},
 			SourceView:   cpuView,
 			DetectorName: "test_detector",
 			Title:        "Spike detected",
@@ -515,7 +514,7 @@ func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 			Timestamp:    100,
 		},
 		{
-			Source:       observerdef.AnomalySource{Name: "cpu"},
+			Source:       observerdef.SeriesDescriptor{Name: "cpu"},
 			SourceView:   cpuView,
 			DetectorName: "test_detector",
 			Title:        "Trend change detected",
@@ -543,7 +542,7 @@ func TestFindingM2_EmptySourceViewCollision(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
 		{
 			Type:         observerdef.AnomalyTypeLog,
-			Source:       observerdef.AnomalySource{Name: "logs"},
+			Source:       observerdef.SeriesDescriptor{Name: "logs"},
 			SourceView:   observerdef.NoQueryHandle, // invalid for log anomalies
 			DetectorName: "log_detector",
 			Title:        "Error pattern A detected",
@@ -552,7 +551,7 @@ func TestFindingM2_EmptySourceViewCollision(t *testing.T) {
 		},
 		{
 			Type:         observerdef.AnomalyTypeLog,
-			Source:       observerdef.AnomalySource{Name: "logs"},
+			Source:       observerdef.SeriesDescriptor{Name: "logs"},
 			SourceView:   observerdef.NoQueryHandle, // invalid for log anomalies
 			DetectorName: "log_detector",
 			Title:        "Error pattern B detected",
@@ -581,14 +580,14 @@ func TestFindingM3_DedupAsymmetry(t *testing.T) {
 	cpuView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:       observerdef.AnomalySource{Name: "cpu"},
+			Source:       observerdef.SeriesDescriptor{Name: "cpu"},
 			SourceView:   cpuView,
 			DetectorName: "test_detector",
 			Title:        "Spike",
 			Timestamp:    100,
 		},
 		{
-			Source:       observerdef.AnomalySource{Name: "cpu"},
+			Source:       observerdef.SeriesDescriptor{Name: "cpu"},
 			SourceView:   cpuView,
 			DetectorName: "test_detector",
 			Title:        "Spike",

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -191,8 +191,8 @@ func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
 
 func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
-		{Source: observerdef.SeriesDescriptor{Name: "cpu"}, DetectorName: "test", Timestamp: 99, SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}},
-		{Source: observerdef.SeriesDescriptor{Name: "mem"}, DetectorName: "test", Timestamp: 99, SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(1), Aggregate: observerdef.AggregateAverage}},
+		{Source: observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage}, DetectorName: "test", Timestamp: 99},
+		{Source: observerdef.SeriesDescriptor{Name: "mem", Aggregate: observerdef.AggregateAverage}, DetectorName: "test", Timestamp: 99},
 	}
 
 	e := newEngine(engineConfig{
@@ -209,8 +209,8 @@ func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 
 	anomalyEvents := sink.eventsOfKind(eventAnomalyCreated)
 	assert.Len(t, anomalyEvents, 2)
-	assert.Equal(t, "cpu", anomalyEvents[0].anomalyCreated.anomaly.Source.String())
-	assert.Equal(t, "mem", anomalyEvents[1].anomalyCreated.anomaly.Source.String())
+	assert.Equal(t, "cpu:avg", anomalyEvents[0].anomalyCreated.anomaly.Source.String())
+	assert.Equal(t, "mem:avg", anomalyEvents[1].anomalyCreated.anomaly.Source.String())
 }
 
 func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T) {
@@ -232,12 +232,11 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 		DetectorName: "test",
 		Description:  "detector-authored description",
 		Timestamp:    99,
-		SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateCount},
 	}}
 
 	storage := newTimeSeriesStorage()
-	// Add a series so that SeriesRef(0) maps to the correct storage key.
-	storage.Add("ns", "log.pattern.abc.count", 1.0, 1, nil)
+	// Add a series so that the storage key matches Source fields.
+	storage.Add("log_metrics_extractor", "log.pattern.abc.count", 1.0, 1, []string{"observer_source:source-a", "service:api"})
 	e := newEngine(engineConfig{
 		storage: storage,
 		detectors: []observerdef.Detector{
@@ -247,7 +246,7 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 			"log_metrics_extractor": provider,
 		},
 	})
-	e.contextRefs["ns|log.pattern.abc.count|"] = seriesContextRef{
+	e.contextRefs["log_metrics_extractor|log.pattern.abc.count|observer_source:source-a,service:api"] = seriesContextRef{
 		namespace:  "log_metrics_extractor",
 		contextKey: "ctx-1",
 	}
@@ -274,21 +273,20 @@ func TestSetExtractorsRefreshesContextProviders(t *testing.T) {
 		"ctx-2": {Pattern: "p2", Example: "e2", Source: "second"},
 	}}
 	storage := newTimeSeriesStorage()
-	// Add a series so that SeriesRef(0) maps to the correct storage key.
-	storage.Add("ns", "metric", 1.0, 1, []string{"service:api"})
+	// Add a series so that the storage key matches Source fields.
+	storage.Add("second", "metric", 1.0, 1, []string{"service:api"})
 	e := newEngine(engineConfig{
 		storage:          storage,
 		extractors:       []observerdef.LogMetricsExtractor{first},
 		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{first}),
 		detectors: []observerdef.Detector{&anomalyDetector{name: "test", anomalies: []observerdef.Anomaly{{
-			Source:     observerdef.SeriesDescriptor{Namespace: "second", Name: "metric", Tags: []string{"service:api"}},
-			Timestamp:  1,
-			SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
+			Source:    observerdef.SeriesDescriptor{Namespace: "second", Name: "metric", Tags: []string{"service:api"}},
+			Timestamp: 1,
 		}}}},
 	})
 
 	e.SetExtractors([]observerdef.LogMetricsExtractor{second})
-	e.contextRefs["ns|metric|service:api"] = seriesContextRef{
+	e.contextRefs["second|metric|service:api"] = seriesContextRef{
 		namespace:  "second",
 		contextKey: "ctx-2",
 	}
@@ -326,7 +324,6 @@ func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing
 					Name:      meta.Name,
 					Tags:      meta.Tags,
 				},
-				SourceView: observerdef.QueryHandle{Ref: meta.Ref, Aggregate: observerdef.AggregateCount},
 			}
 			break
 		}
@@ -503,19 +500,16 @@ func (r *countingReporter) Name() string                      { return "counting
 func (r *countingReporter) Report(_ observerdef.ReportOutput) { *r.count++ }
 
 func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
-	cpuView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:       observerdef.SeriesDescriptor{Name: "cpu"},
-			SourceView:   cpuView,
+			Source:       observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage},
 			DetectorName: "test_detector",
 			Title:        "Spike detected",
 			Description:  "CPU spike",
 			Timestamp:    100,
 		},
 		{
-			Source:       observerdef.SeriesDescriptor{Name: "cpu"},
-			SourceView:   cpuView,
+			Source:       observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage},
 			DetectorName: "test_detector",
 			Title:        "Trend change detected",
 			Description:  "CPU trend shift",
@@ -535,15 +529,14 @@ func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 	sv := e.StateView()
 	raw := sv.Anomalies()
 	assert.Len(t, raw, 2,
-		"two anomalies with same SourceView+detector+timestamp but different titles should both survive dedup")
+		"two anomalies with same Source+detector+timestamp but different titles should both survive dedup")
 }
 
-func TestFindingM2_EmptySourceViewCollision(t *testing.T) {
+func TestFindingM2_EmptySourceCollision(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
 		{
 			Type:         observerdef.AnomalyTypeLog,
 			Source:       observerdef.SeriesDescriptor{Name: "logs"},
-			SourceView:   observerdef.NoQueryHandle, // invalid for log anomalies
 			DetectorName: "log_detector",
 			Title:        "Error pattern A detected",
 			Description:  "Pattern A",
@@ -552,7 +545,6 @@ func TestFindingM2_EmptySourceViewCollision(t *testing.T) {
 		{
 			Type:         observerdef.AnomalyTypeLog,
 			Source:       observerdef.SeriesDescriptor{Name: "logs"},
-			SourceView:   observerdef.NoQueryHandle, // invalid for log anomalies
 			DetectorName: "log_detector",
 			Title:        "Error pattern B detected",
 			Description:  "Pattern B",
@@ -572,23 +564,20 @@ func TestFindingM2_EmptySourceViewCollision(t *testing.T) {
 	sv := e.StateView()
 	raw := sv.Anomalies()
 	assert.Len(t, raw, 2,
-		"two log anomalies with invalid SourceView but different content should both survive dedup")
+		"two log anomalies with same Source but different titles should both survive dedup")
 }
 
 func TestFindingM3_DedupAsymmetry(t *testing.T) {
 	// Two identical anomalies (same dedup key) -- one will be deduped from rawAnomalies.
-	cpuView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:       observerdef.SeriesDescriptor{Name: "cpu"},
-			SourceView:   cpuView,
+			Source:       observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage},
 			DetectorName: "test_detector",
 			Title:        "Spike",
 			Timestamp:    100,
 		},
 		{
-			Source:       observerdef.SeriesDescriptor{Name: "cpu"},
-			SourceView:   cpuView,
+			Source:       observerdef.SeriesDescriptor{Name: "cpu", Aggregate: observerdef.AggregateAverage},
 			DetectorName: "test_detector",
 			Title:        "Spike",
 			Timestamp:    100,

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -191,8 +191,8 @@ func TestAdvanceEmitsAdvanceCompletedEvent(t *testing.T) {
 
 func TestAdvanceEmitsAnomalyCreatedEvents(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
-		{Source: observerdef.AnomalySource{Name: "cpu"}, DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|cpu|"},
-		{Source: observerdef.AnomalySource{Name: "mem"}, DetectorName: "test", Timestamp: 99, SourceSeriesID: "ns|mem|"},
+		{Source: observerdef.AnomalySource{Name: "cpu"}, DetectorName: "test", Timestamp: 99, SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}},
+		{Source: observerdef.AnomalySource{Name: "mem"}, DetectorName: "test", Timestamp: 99, SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(1), Aggregate: observerdef.AggregateAverage}},
 	}
 
 	e := newEngine(engineConfig{
@@ -232,11 +232,14 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 		Description:    "detector-authored description",
 		Tags:           []string{"observer_source:source-a", "service:api"},
 		Timestamp:      99,
-		SourceSeriesID: "ns|log.pattern.abc.count|",
+		SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateCount},
 	}}
 
+	storage := newTimeSeriesStorage()
+	// Add a series so that SeriesRef(0) maps to the correct storage key.
+	storage.Add("ns", "log.pattern.abc.count", 1.0, 1, nil)
 	e := newEngine(engineConfig{
-		storage: newTimeSeriesStorage(),
+		storage: storage,
 		detectors: []observerdef.Detector{
 			&anomalyDetector{name: "test", anomalies: anomalies},
 		},
@@ -244,7 +247,7 @@ func TestAdvanceEnrichesAnomalyContextWithoutOverwritingDescription(t *testing.T
 			"log_metrics_extractor": provider,
 		},
 	})
-	e.contextRefs[observerdef.SeriesID("ns|log.pattern.abc.count|")] = seriesContextRef{
+	e.contextRefs["ns|log.pattern.abc.count|"] = seriesContextRef{
 		namespace:  "log_metrics_extractor",
 		contextKey: "ctx-1",
 	}
@@ -270,20 +273,23 @@ func TestSetExtractorsRefreshesContextProviders(t *testing.T) {
 	second := &stubExtractor{name: "second", contextByKey: map[string]observerdef.MetricContext{
 		"ctx-2": {Pattern: "p2", Example: "e2", Source: "second"},
 	}}
+	storage := newTimeSeriesStorage()
+	// Add a series so that SeriesRef(0) maps to the correct storage key.
+	storage.Add("ns", "metric", 1.0, 1, []string{"service:api"})
 	e := newEngine(engineConfig{
-		storage:          newTimeSeriesStorage(),
+		storage:          storage,
 		extractors:       []observerdef.LogMetricsExtractor{first},
 		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{first}),
 		detectors: []observerdef.Detector{&anomalyDetector{name: "test", anomalies: []observerdef.Anomaly{{
-			Source:         observerdef.AnomalySource{Namespace: "second", Name: "metric"},
-			Tags:           []string{"service:api"},
-			Timestamp:      1,
-			SourceSeriesID: "ns|metric|service:api",
+			Source:     observerdef.AnomalySource{Namespace: "second", Name: "metric"},
+			Tags:       []string{"service:api"},
+			Timestamp:  1,
+			SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
 		}}}},
 	})
 
 	e.SetExtractors([]observerdef.LogMetricsExtractor{second})
-	e.contextRefs[observerdef.SeriesID("ns|metric|service:api")] = seriesContextRef{
+	e.contextRefs["ns|metric|service:api"] = seriesContextRef{
 		namespace:  "second",
 		contextKey: "ctx-2",
 	}
@@ -321,7 +327,7 @@ func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing
 					Name:      meta.Name,
 				},
 				Tags:           meta.Tags,
-				SourceSeriesID: observerdef.SeriesID(seriesKey(meta.Namespace, meta.Name, meta.Tags)),
+				SourceView: observerdef.QueryHandle{Ref: meta.Ref, Aggregate: observerdef.AggregateCount},
 			}
 			break
 		}
@@ -498,22 +504,23 @@ func (r *countingReporter) Name() string                      { return "counting
 func (r *countingReporter) Report(_ observerdef.ReportOutput) { *r.count++ }
 
 func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
+	cpuView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:         observerdef.AnomalySource{Name: "cpu"},
-			SourceSeriesID: "ns|cpu:avg|",
-			DetectorName:   "test_detector",
-			Title:          "Spike detected",
-			Description:    "CPU spike",
-			Timestamp:      100,
+			Source:       observerdef.AnomalySource{Name: "cpu"},
+			SourceView:   cpuView,
+			DetectorName: "test_detector",
+			Title:        "Spike detected",
+			Description:  "CPU spike",
+			Timestamp:    100,
 		},
 		{
-			Source:         observerdef.AnomalySource{Name: "cpu"},
-			SourceSeriesID: "ns|cpu:avg|",
-			DetectorName:   "test_detector",
-			Title:          "Trend change detected",
-			Description:    "CPU trend shift",
-			Timestamp:      100,
+			Source:       observerdef.AnomalySource{Name: "cpu"},
+			SourceView:   cpuView,
+			DetectorName: "test_detector",
+			Title:        "Trend change detected",
+			Description:  "CPU trend shift",
+			Timestamp:    100,
 		},
 	}
 
@@ -529,28 +536,28 @@ func TestFindingM1_DedupKeyTooCoarse(t *testing.T) {
 	sv := e.StateView()
 	raw := sv.Anomalies()
 	assert.Len(t, raw, 2,
-		"two anomalies with same seriesID+detector+timestamp but different titles should both survive dedup")
+		"two anomalies with same SourceView+detector+timestamp but different titles should both survive dedup")
 }
 
-func TestFindingM2_EmptySourceSeriesIDCollision(t *testing.T) {
+func TestFindingM2_EmptySourceViewCollision(t *testing.T) {
 	anomalies := []observerdef.Anomaly{
 		{
-			Type:           observerdef.AnomalyTypeLog,
-			Source:         observerdef.AnomalySource{Name: "logs"},
-			SourceSeriesID: "", // empty for log anomalies
-			DetectorName:   "log_detector",
-			Title:          "Error pattern A detected",
-			Description:    "Pattern A",
-			Timestamp:      100,
+			Type:         observerdef.AnomalyTypeLog,
+			Source:       observerdef.AnomalySource{Name: "logs"},
+			SourceView:   observerdef.NoQueryHandle, // invalid for log anomalies
+			DetectorName: "log_detector",
+			Title:        "Error pattern A detected",
+			Description:  "Pattern A",
+			Timestamp:    100,
 		},
 		{
-			Type:           observerdef.AnomalyTypeLog,
-			Source:         observerdef.AnomalySource{Name: "logs"},
-			SourceSeriesID: "", // empty for log anomalies
-			DetectorName:   "log_detector",
-			Title:          "Error pattern B detected",
-			Description:    "Pattern B",
-			Timestamp:      100,
+			Type:         observerdef.AnomalyTypeLog,
+			Source:       observerdef.AnomalySource{Name: "logs"},
+			SourceView:   observerdef.NoQueryHandle, // invalid for log anomalies
+			DetectorName: "log_detector",
+			Title:        "Error pattern B detected",
+			Description:  "Pattern B",
+			Timestamp:    100,
 		},
 	}
 
@@ -566,25 +573,26 @@ func TestFindingM2_EmptySourceSeriesIDCollision(t *testing.T) {
 	sv := e.StateView()
 	raw := sv.Anomalies()
 	assert.Len(t, raw, 2,
-		"two log anomalies with empty SourceSeriesID but different content should both survive dedup")
+		"two log anomalies with invalid SourceView but different content should both survive dedup")
 }
 
 func TestFindingM3_DedupAsymmetry(t *testing.T) {
 	// Two identical anomalies (same dedup key) -- one will be deduped from rawAnomalies.
+	cpuView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage}
 	anomalies := []observerdef.Anomaly{
 		{
-			Source:         observerdef.AnomalySource{Name: "cpu"},
-			SourceSeriesID: "ns|cpu:avg|",
-			DetectorName:   "test_detector",
-			Title:          "Spike",
-			Timestamp:      100,
+			Source:       observerdef.AnomalySource{Name: "cpu"},
+			SourceView:   cpuView,
+			DetectorName: "test_detector",
+			Title:        "Spike",
+			Timestamp:    100,
 		},
 		{
-			Source:         observerdef.AnomalySource{Name: "cpu"},
-			SourceSeriesID: "ns|cpu:avg|",
-			DetectorName:   "test_detector",
-			Title:          "Spike",
-			Timestamp:      100,
+			Source:       observerdef.AnomalySource{Name: "cpu"},
+			SourceView:   cpuView,
+			DetectorName: "test_detector",
+			Title:        "Spike",
+			Timestamp:    100,
 		},
 	}
 

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -221,6 +221,7 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 			}
 
 			pointsSeen := false
+			prevLen := len(allAnomalies)
 			storage.ForEachPoint(meta.Ref, startTime, dataTime, agg, func(series *observer.Series, p observer.Point) {
 				pointsSeen = true
 				anomaly := b.processPoint(state, p, series, agg)
@@ -229,6 +230,10 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 				}
 				state.lastProcessedTime = p.Timestamp
 			})
+			// Set SourceRef on any anomalies produced in this iteration.
+			for k := prevLen; k < len(allAnomalies); k++ {
+				allAnomalies[k].SourceRef = &observer.QueryHandle{Ref: meta.Ref, Aggregate: agg}
+			}
 
 			if !pointsSeen && mergeOccurred {
 				state.lastWriteGen = currentGen

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -223,7 +223,7 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 			pointsSeen := false
 			storage.ForEachPoint(meta.Ref, startTime, dataTime, agg, func(series *observer.Series, p observer.Point) {
 				pointsSeen = true
-				anomaly := b.processPoint(state, p, series, agg, sk.ref)
+				anomaly := b.processPoint(state, p, series, agg)
 				if anomaly != nil {
 					allAnomalies = append(allAnomalies, *anomaly)
 				}
@@ -253,7 +253,7 @@ func (b *BOCPDDetector) Reset() {
 
 // processPoint handles a single new observation for a series.
 // Returns an anomaly pointer if this point triggers a new alert onset.
-func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef) *observer.Anomaly {
+func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate) *observer.Anomaly {
 	x := p.Value
 
 	if !state.initialized {
@@ -267,7 +267,7 @@ func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, 
 		if !state.inAlert {
 			state.inAlert = true
 			state.alertStart = p.Timestamp
-			return b.makeAnomaly(state, p, series, agg, ref, cpProb, shortRunMass)
+			return b.makeAnomaly(state, p, series, agg, cpProb, shortRunMass)
 		}
 		return nil
 	}
@@ -393,7 +393,7 @@ func (b *BOCPDDetector) updatePosterior(state *bocpdSeriesState, x float64) (boo
 }
 
 // makeAnomaly constructs an Anomaly for a new alert onset.
-func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef, cpProb, shortRunMass float64) *observer.Anomaly {
+func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, cpProb, shortRunMass float64) *observer.Anomaly {
 	source := observer.SeriesDescriptor{
 		Namespace: series.Namespace,
 		Name:      series.Name,
@@ -415,7 +415,6 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 	return &observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
 		Source:         source,
-		SourceView: observer.QueryHandle{Ref: ref, Aggregate: agg},
 		DetectorName:   b.Name(),
 		Title:          "BOCPD changepoint detected: " + displayName,
 		Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -394,9 +394,10 @@ func (b *BOCPDDetector) updatePosterior(state *bocpdSeriesState, x float64) (boo
 
 // makeAnomaly constructs an Anomaly for a new alert onset.
 func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef, cpProb, shortRunMass float64) *observer.Anomaly {
-	source := observer.AnomalySource{
+	source := observer.SeriesDescriptor{
 		Namespace: series.Namespace,
 		Name:      series.Name,
+		Tags:      series.Tags,
 		Aggregate: agg,
 	}
 	deviation := (p.Value - state.baselineMean) / state.baselineStddev
@@ -419,7 +420,6 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 		Title:          "BOCPD changepoint detected: " + displayName,
 		Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",
 			displayName, triggerType, triggerValue, triggerThreshold, cpProb, b.config.ShortRunLength, shortRunMass),
-		Tags:      series.Tags,
 		Timestamp: p.Timestamp,
 		DebugInfo: &observer.AnomalyDebugInfo{
 			BaselineMean:   state.baselineMean,

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -418,10 +418,10 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 
 	displayName := source.String()
 	return &observer.Anomaly{
-		Type:           observer.AnomalyTypeMetric,
-		Source:         source,
-		DetectorName:   b.Name(),
-		Title:          "BOCPD changepoint detected: " + displayName,
+		Type:         observer.AnomalyTypeMetric,
+		Source:       source,
+		DetectorName: b.Name(),
+		Title:        "BOCPD changepoint detected: " + displayName,
 		Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",
 			displayName, triggerType, triggerValue, triggerThreshold, cpProb, b.config.ShortRunLength, shortRunMass),
 		Timestamp: p.Timestamp,

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -14,8 +14,8 @@ import (
 
 // bocpdStateKey uniquely identifies a (series, aggregation) pair for BOCPD state.
 type bocpdStateKey struct {
-	seriesHandle observer.SeriesHandle
-	agg          observer.Aggregate
+	ref observer.SeriesRef
+	agg observer.Aggregate
 }
 
 // bocpdSeriesState holds per-series streaming BOCPD state.
@@ -197,7 +197,7 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 
 	for _, meta := range b.cachedSeries {
 		for _, agg := range b.config.Aggregations {
-			sk := bocpdStateKey{seriesHandle: meta.Handle, agg: agg}
+			sk := bocpdStateKey{ref: meta.Ref, agg: agg}
 
 			state, exists := b.series[sk]
 			if !exists {
@@ -205,8 +205,8 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 				b.series[sk] = state
 			}
 
-			visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
-			currentGen := storage.WriteGeneration(meta.Handle)
+			visibleCount := storage.PointCountUpTo(meta.Ref, dataTime)
+			currentGen := storage.WriteGeneration(meta.Ref)
 			mergeOccurred := visibleCount == state.lastProcessedCount && currentGen != state.lastWriteGen
 			if visibleCount <= state.lastProcessedCount && !mergeOccurred {
 				continue
@@ -221,9 +221,9 @@ func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) o
 			}
 
 			pointsSeen := false
-			storage.ForEachPoint(meta.Handle, startTime, dataTime, agg, func(series *observer.Series, p observer.Point) {
+			storage.ForEachPoint(meta.Ref, startTime, dataTime, agg, func(series *observer.Series, p observer.Point) {
 				pointsSeen = true
-				anomaly := b.processPoint(state, p, series, agg)
+				anomaly := b.processPoint(state, p, series, agg, sk.ref)
 				if anomaly != nil {
 					allAnomalies = append(allAnomalies, *anomaly)
 				}
@@ -253,7 +253,7 @@ func (b *BOCPDDetector) Reset() {
 
 // processPoint handles a single new observation for a series.
 // Returns an anomaly pointer if this point triggers a new alert onset.
-func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate) *observer.Anomaly {
+func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef) *observer.Anomaly {
 	x := p.Value
 
 	if !state.initialized {
@@ -267,7 +267,7 @@ func (b *BOCPDDetector) processPoint(state *bocpdSeriesState, p observer.Point, 
 		if !state.inAlert {
 			state.inAlert = true
 			state.alertStart = p.Timestamp
-			return b.makeAnomaly(state, p, series, agg, cpProb, shortRunMass)
+			return b.makeAnomaly(state, p, series, agg, ref, cpProb, shortRunMass)
 		}
 		return nil
 	}
@@ -393,7 +393,7 @@ func (b *BOCPDDetector) updatePosterior(state *bocpdSeriesState, x float64) (boo
 }
 
 // makeAnomaly constructs an Anomaly for a new alert onset.
-func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, cpProb, shortRunMass float64) *observer.Anomaly {
+func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef, cpProb, shortRunMass float64) *observer.Anomaly {
 	source := observer.AnomalySource{
 		Namespace: series.Namespace,
 		Name:      series.Name,
@@ -414,7 +414,7 @@ func (b *BOCPDDetector) makeAnomaly(state *bocpdSeriesState, p observer.Point, s
 	return &observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
 		Source:         source,
-		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, series.Name+":"+aggSuffix(agg), series.Tags)),
+		SourceView: observer.QueryHandle{Ref: ref, Aggregate: agg},
 		DetectorName:   b.Name(),
 		Title:          "BOCPD changepoint detected: " + displayName,
 		Description: fmt.Sprintf("%s %s %.2f exceeded threshold %.2f (cp=%.2f, short-run<=%d mass=%.2f)",

--- a/comp/observer/impl/metrics_detector_bocpd_test.go
+++ b/comp/observer/impl/metrics_detector_bocpd_test.go
@@ -368,7 +368,7 @@ func TestFindingM6_BOCPDSkipsSameBucketValueMerges(t *testing.T) {
 	storage.Add("ns", "metric", 200.0, 5, nil)
 
 	// Verify storage actually merged: average should be 150, not 100.
-	series := storage.GetSeriesRange(observer.SeriesHandle(0), 4, 5, observer.AggregateAverage)
+	series := storage.GetSeriesRange(observer.SeriesRef(0), 4, 5, observer.AggregateAverage)
 	require.NotNil(t, series)
 	require.Len(t, series.Points, 1)
 	assert.Equal(t, 150.0, series.Points[0].Value,
@@ -401,9 +401,9 @@ func TestFindingM6_BOCPDSkipsSameBucketValueMerges(t *testing.T) {
 	}
 	genAfter := stateAfter.lastWriteGen
 
-	pointCount := storage.PointCountUpTo(observer.SeriesHandle(0), 5)
+	pointCount := storage.PointCountUpTo(observer.SeriesRef(0), 5)
 	t.Logf("genBefore=%d, genAfter=%d, PointCountUpTo=%d, writeGen=%d",
-		genBefore, genAfter, pointCount, storage.WriteGeneration(observer.SeriesHandle(0)))
+		genBefore, genAfter, pointCount, storage.WriteGeneration(observer.SeriesRef(0)))
 
 	// The detector should notice the merge via writeGeneration even though
 	// PointCountUpTo didn't change. If it re-processed, genAfter > genBefore.

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -179,7 +179,6 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ above baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
-				Tags:      series.Tags,
 				Timestamp: series.Points[i].Timestamp,
 				DebugInfo: debugInfo,
 			}
@@ -200,7 +199,6 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 				Title:  "CUSUM shift detected: " + series.Name,
 				Description: fmt.Sprintf("%s shifted to %.2f (%.1fσ below baseline of %.2f)",
 					series.Name, p.Value, deviation, baselineMean),
-				Tags:      series.Tags,
 				Timestamp: series.Points[i].Timestamp,
 				DebugInfo: debugInfo,
 			}

--- a/comp/observer/impl/metrics_detector_cusum.go
+++ b/comp/observer/impl/metrics_detector_cusum.go
@@ -208,16 +208,16 @@ func runCUSUM(series observer.Series, baselineMean, baselineStddev, k, h float64
 	return nil
 }
 
-func anomalySourceFromSeriesName(name string) observer.AnomalySource {
+func anomalySourceFromSeriesName(name string) observer.SeriesDescriptor {
 	if idx := strings.LastIndex(name, ":"); idx != -1 {
 		if agg, ok := parseAggregateSuffix(name[idx+1:]); ok {
-			return observer.AnomalySource{
+			return observer.SeriesDescriptor{
 				Name:      name[:idx],
 				Aggregate: agg,
 			}
 		}
 	}
-	return observer.AnomalySource{Name: name}
+	return observer.SeriesDescriptor{Name: name}
 }
 
 func parseAggregateSuffix(s string) (observer.Aggregate, bool) {

--- a/comp/observer/impl/metrics_detector_cusum_test.go
+++ b/comp/observer/impl/metrics_detector_cusum_test.go
@@ -212,7 +212,8 @@ func TestCUSUMDetector_SourceAndTags(t *testing.T) {
 	assert.Equal(t, "my.metric", anomaly.Source.Name, "Source name should exclude the aggregate suffix")
 	assert.Equal(t, observer.AggregateAverage, anomaly.Source.Aggregate, "Source aggregate should be parsed from the series name")
 	assert.Equal(t, "my.metric:avg", anomaly.Source.String(), "Source display should round-trip to the original series name")
-	assert.Equal(t, []string{"env:prod", "service:api"}, anomaly.Tags, "Tags should be preserved")
+	// Tags are folded into Source by the adapter; direct detect call doesn't set them
+	assert.Nil(t, anomaly.Source.Tags, "Tags are set by the adapter, not the detector directly")
 }
 
 func TestCUSUMDetector_EmitsAtThresholdCrossing(t *testing.T) {

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -113,7 +113,7 @@ type RRCFDetector struct {
 
 	// resolvedKeys caches the numeric series ID for each metric.
 	// Populated lazily on first Detect call via ListSeries discovery.
-	resolvedKeys map[string]observer.SeriesHandle
+	resolvedKeys map[string]observer.SeriesRef
 
 	// cursors tracks read position per metric for incremental reads.
 	cursors map[string]int64
@@ -153,7 +153,7 @@ func NewRRCFDetector(config RRCFConfig) *RRCFDetector {
 	return &RRCFDetector{
 		config:       config,
 		metrics:      metrics,
-		resolvedKeys: make(map[string]observer.SeriesHandle),
+		resolvedKeys: make(map[string]observer.SeriesRef),
 		cursors:      make(map[string]int64),
 		forest:       forest,
 		recentScores: make([]float64, 0, 100),
@@ -202,7 +202,7 @@ func (r *RRCFDetector) Detect(storage observer.StorageReader, dataTime int64) ob
 
 // resolveKey returns the cached numeric series ID for a metric definition.
 // Keys are populated by resolveAllKeys on the first Detect call.
-func (r *RRCFDetector) resolveKey(m RRCFMetricDef) (observer.SeriesHandle, bool) {
+func (r *RRCFDetector) resolveKey(m RRCFMetricDef) (observer.SeriesRef, bool) {
 	cursorKey := m.Namespace + "|" + m.Name
 	id, ok := r.resolvedKeys[cursorKey]
 	return id, ok
@@ -265,7 +265,7 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 		// Count total points across all metrics for this tag set
 		pc := 0
 		for _, meta := range metricsMap {
-			pc += storage.PointCount(meta.Handle)
+			pc += storage.PointCount(meta.Ref)
 		}
 		if mc > bestMetricCount || (mc == bestMetricCount && pc > bestPointCount) {
 			bestMetricCount = mc
@@ -285,7 +285,7 @@ func (r *RRCFDetector) resolveAllKeys(storage observer.StorageReader) bool {
 
 	// Resolve all metrics to this tag set
 	for cursorKey, meta := range tagSetMetrics[bestSig] {
-		r.resolvedKeys[cursorKey] = meta.Handle
+		r.resolvedKeys[cursorKey] = meta.Ref
 	}
 
 	return true
@@ -524,7 +524,7 @@ func (r *RRCFDetector) scoreShingle(s shingle) float64 {
 
 // Reset clears all state, useful for testing or after major regime changes.
 func (r *RRCFDetector) Reset() {
-	r.resolvedKeys = make(map[string]observer.SeriesHandle)
+	r.resolvedKeys = make(map[string]observer.SeriesRef)
 	r.cursors = make(map[string]int64)
 	r.recentScores = r.recentScores[:0]
 	r.allScores = r.allScores[:0]

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -460,7 +460,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 
 		if r.config.ThresholdSigma > 0 && threshold > 0 && score > threshold {
 			anomaly := observer.Anomaly{
-				Source:       observer.AnomalySource{Namespace: "rrcf", Name: "score"},
+				Source:       observer.SeriesDescriptor{Namespace: "rrcf", Name: "score"},
 				DetectorName: r.Name(),
 				Title:        "RRCF multivariate anomaly",
 				Description:  fmt.Sprintf("Unusual system metric combination (CoDisp=%.1f, threshold=%.1f)", score, threshold),

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -170,7 +170,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 				continue
 			}
 
-			anomaly, changeIdx, found := d.scanMW(state.buf, seriesMeta, agg, sk.ref)
+			anomaly, changeIdx, found := d.scanMW(state.buf, seriesMeta, agg)
 			if found {
 				allAnomalies = append(allAnomalies, anomaly)
 				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
@@ -186,7 +186,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 
 // scanMW runs the scan algorithm on points within the current segment.
 // Returns (anomaly, changeIndex, found). Pure function over the input data.
-func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef) (observer.Anomaly, int, bool) {
+func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series, agg observer.Aggregate) (observer.Anomaly, int, bool) {
 	n := len(points)
 
 	values := make([]float64, n)
@@ -294,7 +294,6 @@ func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series
 	anomaly := observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
 		Source:         observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
-		SourceView: observer.QueryHandle{Ref: ref, Aggregate: agg},
 		DetectorName:   d.Name(),
 		Title:          "ScanMW changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, p=%.2e, effect=%.2f, %.1f MADs)",

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -13,10 +13,10 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-// scanmwStateKey identifies per-series state by handle and aggregation.
+// scanmwStateKey identifies per-series state by ref and aggregation.
 type scanmwStateKey struct {
-	handle observer.SeriesHandle
-	agg    observer.Aggregate
+	ref observer.SeriesRef
+	agg observer.Aggregate
 }
 
 // scanmwSeriesState holds per-series streaming state for the ScanMW detector.
@@ -71,7 +71,7 @@ type ScanMWDetector struct {
 	// Aggregations to run detection on. Default: [Average, Count]
 	Aggregations []observer.Aggregate
 
-	// per-series state keyed by handle+agg
+	// per-series state keyed by ref+agg
 	series map[scanmwStateKey]*scanmwSeriesState
 
 	// Cache the discovered series list across Detect calls.
@@ -123,11 +123,11 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 	}
 
 	// Bulk-fetch point counts and write generations in a single lock acquisition.
-	handles := make([]observer.SeriesHandle, len(d.cachedSeries))
+	refs := make([]observer.SeriesRef, len(d.cachedSeries))
 	for i, meta := range d.cachedSeries {
-		handles[i] = meta.Handle
+		refs[i] = meta.Ref
 	}
-	bulkStatus := bulkSeriesStatus(storage, handles, dataTime)
+	bulkStatus := bulkSeriesStatus(storage, refs, dataTime)
 
 	var allAnomalies []observer.Anomaly
 
@@ -135,7 +135,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 		status := bulkStatus[i]
 
 		for _, agg := range d.Aggregations {
-			sk := scanmwStateKey{handle: meta.Handle, agg: agg}
+			sk := scanmwStateKey{ref: meta.Ref, agg: agg}
 
 			state, exists := d.series[sk]
 			if !exists {
@@ -156,7 +156,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 			// Collect points into reusable buffer to avoid per-call allocation.
 			state.buf = state.buf[:0]
 			var seriesMeta *observer.Series
-			storage.ForEachPoint(meta.Handle, state.segmentStartTime, dataTime, agg, func(s *observer.Series, p observer.Point) {
+			storage.ForEachPoint(meta.Ref, state.segmentStartTime, dataTime, agg, func(s *observer.Series, p observer.Point) {
 				if seriesMeta == nil {
 					sCopy := *s
 					seriesMeta = &sCopy
@@ -170,7 +170,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 				continue
 			}
 
-			anomaly, changeIdx, found := d.scanMW(state.buf, seriesMeta, agg)
+			anomaly, changeIdx, found := d.scanMW(state.buf, seriesMeta, agg, sk.ref)
 			if found {
 				allAnomalies = append(allAnomalies, anomaly)
 				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
@@ -186,7 +186,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 
 // scanMW runs the scan algorithm on points within the current segment.
 // Returns (anomaly, changeIndex, found). Pure function over the input data.
-func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series, agg observer.Aggregate) (observer.Anomaly, int, bool) {
+func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef) (observer.Anomaly, int, bool) {
 	n := len(points)
 
 	values := make([]float64, n)
@@ -294,7 +294,7 @@ func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series
 	anomaly := observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
 		Source:         observer.AnomalySource{Namespace: series.Namespace, Name: series.Name, Aggregate: agg},
-		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
+		SourceView: observer.QueryHandle{Ref: ref, Aggregate: agg},
 		DetectorName:   d.Name(),
 		Title:          "ScanMW changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, p=%.2e, effect=%.2f, %.1f MADs)",

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -172,6 +172,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 
 			anomaly, changeIdx, found := d.scanMW(state.buf, seriesMeta, agg)
 			if found {
+				anomaly.SourceRef = &observer.QueryHandle{Ref: meta.Ref, Aggregate: agg}
 				allAnomalies = append(allAnomalies, anomaly)
 				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
 			}

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -293,10 +293,10 @@ func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series
 
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
-		Type:           observer.AnomalyTypeMetric,
-		Source:         observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
-		DetectorName:   d.Name(),
-		Title:          "ScanMW changepoint: " + seriesName,
+		Type:         observer.AnomalyTypeMetric,
+		Source:       observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
+		DetectorName: d.Name(),
+		Title:        "ScanMW changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, p=%.2e, effect=%.2f, %.1f MADs)",
 			seriesName, direction, preMedian, postMedian, bestPValue, effectSize, deviation),
 		Timestamp: changePtTime,

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -293,13 +293,12 @@ func (d *ScanMWDetector) scanMW(points []observer.Point, series *observer.Series
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
-		Source:         observer.AnomalySource{Namespace: series.Namespace, Name: series.Name, Aggregate: agg},
+		Source:         observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
 		SourceView: observer.QueryHandle{Ref: ref, Aggregate: agg},
 		DetectorName:   d.Name(),
 		Title:          "ScanMW changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, p=%.2e, effect=%.2f, %.1f MADs)",
 			seriesName, direction, preMedian, postMedian, bestPValue, effectSize, deviation),
-		Tags:      series.Tags,
 		Timestamp: changePtTime,
 		Score:     &score,
 		DebugInfo: &observer.AnomalyDebugInfo{

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -12,10 +12,10 @@ import (
 	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
-// scanwelchStateKey identifies per-series state by handle and aggregation.
+// scanwelchStateKey identifies per-series state by ref and aggregation.
 type scanwelchStateKey struct {
-	handle observer.SeriesHandle
-	agg    observer.Aggregate
+	ref observer.SeriesRef
+	agg observer.Aggregate
 }
 
 // scanwelchSeriesState holds per-series streaming state for the ScanWelch detector.
@@ -63,7 +63,7 @@ type ScanWelchDetector struct {
 	// Aggregations to run detection on. Default: [Average, Count]
 	Aggregations []observer.Aggregate
 
-	// per-series state keyed by handle+agg
+	// per-series state keyed by ref+agg
 	series map[scanwelchStateKey]*scanwelchSeriesState
 
 	// Cache the discovered series list across Detect calls.
@@ -113,11 +113,11 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 
 	// Bulk-fetch point counts and write generations in a single lock acquisition.
 	// This avoids 2×len(series) individual RLock/RUnlock calls per Detect() call.
-	handles := make([]observer.SeriesHandle, len(d.cachedSeries))
+	refs := make([]observer.SeriesRef, len(d.cachedSeries))
 	for i, meta := range d.cachedSeries {
-		handles[i] = meta.Handle
+		refs[i] = meta.Ref
 	}
-	bulkStatus := bulkSeriesStatus(storage, handles, dataTime)
+	bulkStatus := bulkSeriesStatus(storage, refs, dataTime)
 
 	var allAnomalies []observer.Anomaly
 
@@ -125,7 +125,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 		status := bulkStatus[i]
 
 		for _, agg := range d.Aggregations {
-			sk := scanwelchStateKey{handle: meta.Handle, agg: agg}
+			sk := scanwelchStateKey{ref: meta.Ref, agg: agg}
 
 			state, exists := d.series[sk]
 			if !exists {
@@ -148,7 +148,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 			// state.buf which grows once and is reused across scans.
 			state.buf = state.buf[:0]
 			var seriesMeta *observer.Series
-			storage.ForEachPoint(meta.Handle, state.segmentStartTime, dataTime, agg, func(s *observer.Series, p observer.Point) {
+			storage.ForEachPoint(meta.Ref, state.segmentStartTime, dataTime, agg, func(s *observer.Series, p observer.Point) {
 				if seriesMeta == nil {
 					// Capture series metadata on first point (valid during callback).
 					sCopy := *s
@@ -163,7 +163,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 				continue
 			}
 
-			anomaly, changeIdx, found := d.scanWelch(state.buf, seriesMeta, agg)
+			anomaly, changeIdx, found := d.scanWelch(state.buf, seriesMeta, agg, sk.ref)
 			if found {
 				allAnomalies = append(allAnomalies, anomaly)
 				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
@@ -179,7 +179,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 
 // scanWelch runs the hybrid Welch/MW scan on points within the current segment.
 // Returns (anomaly, changeIndex, found).
-func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.Series, agg observer.Aggregate) (observer.Anomaly, int, bool) {
+func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef) (observer.Anomaly, int, bool) {
 	n := len(points)
 
 	values := make([]float64, n)
@@ -303,7 +303,7 @@ func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.
 	anomaly := observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
 		Source:         observer.AnomalySource{Namespace: series.Namespace, Name: series.Name, Aggregate: agg},
-		SourceSeriesID: observer.SeriesID(seriesKey(series.Namespace, seriesName, series.Tags)),
+		SourceView: observer.QueryHandle{Ref: ref, Aggregate: agg},
 		DetectorName:   d.Name(),
 		Title:          "ScanWelch changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, t=%.2f, p=%.2e, effect=%.2f, %.1f MADs)",

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -302,13 +302,12 @@ func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
-		Source:         observer.AnomalySource{Namespace: series.Namespace, Name: series.Name, Aggregate: agg},
+		Source:         observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
 		SourceView: observer.QueryHandle{Ref: ref, Aggregate: agg},
 		DetectorName:   d.Name(),
 		Title:          "ScanWelch changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, t=%.2f, p=%.2e, effect=%.2f, %.1f MADs)",
 			seriesName, direction, preMedian, postMedian, bestTAbs, pValue, effectSize, deviation),
-		Tags:      series.Tags,
 		Timestamp: changePtTime,
 		Score:     &score,
 		DebugInfo: &observer.AnomalyDebugInfo{

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -165,6 +165,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 
 			anomaly, changeIdx, found := d.scanWelch(state.buf, seriesMeta, agg)
 			if found {
+				anomaly.SourceRef = &observer.QueryHandle{Ref: meta.Ref, Aggregate: agg}
 				allAnomalies = append(allAnomalies, anomaly)
 				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
 			}

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -302,10 +302,10 @@ func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.
 
 	seriesName := series.Name + ":" + aggSuffix(agg)
 	anomaly := observer.Anomaly{
-		Type:           observer.AnomalyTypeMetric,
-		Source:         observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
-		DetectorName:   d.Name(),
-		Title:          "ScanWelch changepoint: " + seriesName,
+		Type:         observer.AnomalyTypeMetric,
+		Source:       observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
+		DetectorName: d.Name(),
+		Title:        "ScanWelch changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, t=%.2f, p=%.2e, effect=%.2f, %.1f MADs)",
 			seriesName, direction, preMedian, postMedian, bestTAbs, pValue, effectSize, deviation),
 		Timestamp: changePtTime,

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -163,7 +163,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 				continue
 			}
 
-			anomaly, changeIdx, found := d.scanWelch(state.buf, seriesMeta, agg, sk.ref)
+			anomaly, changeIdx, found := d.scanWelch(state.buf, seriesMeta, agg)
 			if found {
 				allAnomalies = append(allAnomalies, anomaly)
 				state.segmentStartTime = state.buf[changeIdx].Timestamp - 1
@@ -179,7 +179,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 
 // scanWelch runs the hybrid Welch/MW scan on points within the current segment.
 // Returns (anomaly, changeIndex, found).
-func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.Series, agg observer.Aggregate, ref observer.SeriesRef) (observer.Anomaly, int, bool) {
+func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.Series, agg observer.Aggregate) (observer.Anomaly, int, bool) {
 	n := len(points)
 
 	values := make([]float64, n)
@@ -303,7 +303,6 @@ func (d *ScanWelchDetector) scanWelch(points []observer.Point, series *observer.
 	anomaly := observer.Anomaly{
 		Type:           observer.AnomalyTypeMetric,
 		Source:         observer.SeriesDescriptor{Namespace: series.Namespace, Name: series.Name, Tags: series.Tags, Aggregate: agg},
-		SourceView: observer.QueryHandle{Ref: ref, Aggregate: agg},
 		DetectorName:   d.Name(),
 		Title:          "ScanWelch changepoint: " + seriesName,
 		Description: fmt.Sprintf("%s %s (pre_median=%.4f, post_median=%.4f, t=%.2f, p=%.2e, effect=%.2f, %.1f MADs)",

--- a/comp/observer/impl/metrics_detector_util.go
+++ b/comp/observer/impl/metrics_detector_util.go
@@ -22,20 +22,20 @@ type seriesStatus struct {
 // bulkStatusReader is an optional optimization interface for StorageReader
 // implementations that support batch status queries in a single lock acquisition.
 type bulkStatusReader interface {
-	BulkSeriesStatus(handles []observer.SeriesHandle, endTime int64) []seriesStatus
+	BulkSeriesStatus(refs []observer.SeriesRef, endTime int64) []seriesStatus
 }
 
-// bulkSeriesStatus returns the point count and write generation for each handle.
+// bulkSeriesStatus returns the point count and write generation for each ref.
 // If storage implements bulkStatusReader (e.g. timeSeriesStorage), it uses a
 // single lock acquisition. Otherwise falls back to individual PointCountUpTo +
-// WriteGeneration calls per handle.
-func bulkSeriesStatus(storage observer.StorageReader, handles []observer.SeriesHandle, endTime int64) []seriesStatus {
+// WriteGeneration calls per ref.
+func bulkSeriesStatus(storage observer.StorageReader, refs []observer.SeriesRef, endTime int64) []seriesStatus {
 	if br, ok := storage.(bulkStatusReader); ok {
-		return br.BulkSeriesStatus(handles, endTime)
+		return br.BulkSeriesStatus(refs, endTime)
 	}
-	// Fallback: individual calls (2 lock acquisitions per handle).
-	result := make([]seriesStatus, len(handles))
-	for i, h := range handles {
+	// Fallback: individual calls (2 lock acquisitions per ref).
+	result := make([]seriesStatus, len(refs))
+	for i, h := range refs {
 		result[i] = seriesStatus{
 			pointCount:      storage.PointCountUpTo(h, endTime),
 			writeGeneration: storage.WriteGeneration(h),

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -521,7 +521,6 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 					Tags:      series.Tags,
 					Aggregate: agg,
 				}
-				result.Anomalies[j].SourceView = observerdef.QueryHandle{Ref: meta.Ref, Aggregate: agg}
 			}
 			allAnomalies = append(allAnomalies, result.Anomalies...)
 			allTelemetry = append(allTelemetry, result.Telemetry...)

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -515,9 +515,10 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 			for j := range result.Anomalies {
 				result.Anomalies[j].Type = observerdef.AnomalyTypeMetric
 				result.Anomalies[j].DetectorName = a.detector.Name()
-				result.Anomalies[j].Source = observerdef.AnomalySource{
+				result.Anomalies[j].Source = observerdef.SeriesDescriptor{
 					Namespace: series.Namespace,
 					Name:      series.Name,
+					Tags:      series.Tags,
 					Aggregate: agg,
 				}
 				result.Anomalies[j].SourceView = observerdef.QueryHandle{Ref: meta.Ref, Aggregate: agg}

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -492,7 +492,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 
 	for _, meta := range allSeries {
 		keyStr := seriesKey(meta.Namespace, meta.Name, meta.Tags)
-		visibleCount := storage.PointCountUpTo(meta.Handle, dataTime)
+		visibleCount := storage.PointCountUpTo(meta.Ref, dataTime)
 		if prev, ok := a.lastVisibleCount[keyStr]; ok && prev == visibleCount {
 			continue
 		}
@@ -503,7 +503,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 			if a.windowSec > 0 {
 				start = dataTime - a.windowSec
 			}
-			series := storage.GetSeriesRange(meta.Handle, start, dataTime, agg)
+			series := storage.GetSeriesRange(meta.Ref, start, dataTime, agg)
 			if series == nil || len(series.Points) == 0 {
 				continue
 			}
@@ -520,7 +520,7 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 					Name:      series.Name,
 					Aggregate: agg,
 				}
-				result.Anomalies[j].SourceSeriesID = observerdef.SeriesID(seriesKey(series.Namespace, seriesWithAgg.Name, series.Tags))
+				result.Anomalies[j].SourceView = observerdef.QueryHandle{Ref: meta.Ref, Aggregate: agg}
 			}
 			allAnomalies = append(allAnomalies, result.Anomalies...)
 			allTelemetry = append(allTelemetry, result.Telemetry...)

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -521,6 +521,10 @@ func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTi
 					Tags:      series.Tags,
 					Aggregate: agg,
 				}
+				result.Anomalies[j].SourceRef = &observerdef.QueryHandle{
+					Ref:       meta.Ref,
+					Aggregate: agg,
+				}
 			}
 			allAnomalies = append(allAnomalies, result.Anomalies...)
 			allTelemetry = append(allTelemetry, result.Telemetry...)

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -107,10 +107,14 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			}
 			oc.Anomalies = make([]ObserverAnomaly, len(corr.Anomalies))
 			for j, a := range corr.Anomalies {
+				sourceID := a.Source.Key()
+				if a.SourceRef != nil {
+					sourceID = a.SourceRef.CompactID()
+				}
 				oc.Anomalies[j] = ObserverAnomaly{
 					Timestamp:      a.Timestamp,
 					Source:         a.Source.String(),
-					SourceSeriesID: a.Source.DisplayName(),
+					SourceSeriesID: sourceID,
 					Detector:       a.DetectorName,
 				}
 			}

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -110,7 +110,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 				oc.Anomalies[j] = ObserverAnomaly{
 					Timestamp:      a.Timestamp,
 					Source:         a.Source.String(),
-					SourceSeriesID: a.SourceView.String(),
+					SourceSeriesID: a.Source.DisplayName(),
 					Detector:       a.DetectorName,
 				}
 			}

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 )
 
 // ObserverOutput is the top-level JSON structure produced by headless mode.
@@ -101,16 +102,16 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			oc.Title = corr.Title
 			oc.Message = correlationMessage(corr)
 			oc.Tags = []string{"source:agent-q-branch-observer", "pattern:" + corr.Pattern}
-			oc.MemberSeries = make([]string, len(corr.MemberSeriesIDs))
-			for j, sid := range corr.MemberSeriesIDs {
-				oc.MemberSeries[j] = string(sid)
+			oc.MemberSeries = make([]string, len(corr.MemberRefs))
+			for j, ref := range corr.MemberRefs {
+				oc.MemberSeries[j] = strconv.Itoa(int(ref))
 			}
 			oc.Anomalies = make([]ObserverAnomaly, len(corr.Anomalies))
 			for j, a := range corr.Anomalies {
 				oc.Anomalies[j] = ObserverAnomaly{
 					Timestamp:      a.Timestamp,
 					Source:         a.Source.String(),
-					SourceSeriesID: string(a.SourceSeriesID),
+					SourceSeriesID: a.SourceView.String(),
 					Detector:       a.DetectorName,
 				}
 			}

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strconv"
 )
 
 // ObserverOutput is the top-level JSON structure produced by headless mode.
@@ -102,9 +101,9 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			oc.Title = corr.Title
 			oc.Message = correlationMessage(corr)
 			oc.Tags = []string{"source:agent-q-branch-observer", "pattern:" + corr.Pattern}
-			oc.MemberSeries = make([]string, len(corr.MemberRefs))
-			for j, ref := range corr.MemberRefs {
-				oc.MemberSeries[j] = strconv.Itoa(int(ref))
+			oc.MemberSeries = make([]string, len(corr.Members))
+			for j, m := range corr.Members {
+				oc.MemberSeries[j] = m.DisplayName()
 			}
 			oc.Anomalies = make([]ObserverAnomaly, len(corr.Anomalies))
 			for j, a := range corr.Anomalies {

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -217,9 +217,9 @@ func TestWriteObserverOutput_ValidJSON(t *testing.T) {
 			LastUpdated: 200,
 			Anomalies: []observerdef.Anomaly{
 				{
-					Timestamp:    100,
-					Source:       observerdef.SeriesDescriptor{Name: "metric"},
-		
+					Timestamp: 100,
+					Source:    observerdef.SeriesDescriptor{Name: "metric"},
+
 					DetectorName: "cusum",
 				},
 			},

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -55,14 +55,14 @@ func testCorrelation() observerdef.ActiveCorrelation {
 			{
 				Timestamp:    1000,
 				Source:       observerdef.SeriesDescriptor{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
-				SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
+	
 				DetectorName: "cusum",
 				Description:  "CUSUM detected shift in cpu.user:avg",
 			},
 			{
 				Timestamp:    1200,
 				Source:       observerdef.SeriesDescriptor{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
-				SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(1), Aggregate: observerdef.AggregateAverage},
+	
 				DetectorName: "cusum",
 				Description:  "CUSUM detected shift in mem.used:avg",
 			},
@@ -179,7 +179,7 @@ func TestWriteObserverOutput_Verbose(t *testing.T) {
 	require.Len(t, corr.Anomalies, 2)
 	assert.Equal(t, int64(1000), corr.Anomalies[0].Timestamp)
 	assert.Equal(t, "cpu.user:avg", corr.Anomalies[0].Source)
-	assert.Equal(t, "0:avg", corr.Anomalies[0].SourceSeriesID)
+	assert.Equal(t, "cpu.user:avg", corr.Anomalies[0].SourceSeriesID)
 	assert.Equal(t, "cusum", corr.Anomalies[0].Detector)
 
 	assert.Equal(t, int64(1200), corr.Anomalies[1].Timestamp)
@@ -219,7 +219,7 @@ func TestWriteObserverOutput_ValidJSON(t *testing.T) {
 				{
 					Timestamp:    100,
 					Source:       observerdef.SeriesDescriptor{Name: "metric"},
-					SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
+		
 					DetectorName: "cusum",
 				},
 			},

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -43,25 +43,25 @@ func newTestBenchForOutput() *TestBench {
 // testCorrelation returns a test correlation with known values.
 func testCorrelation() observerdef.ActiveCorrelation {
 	return observerdef.ActiveCorrelation{
-		Pattern:         "cluster_1000",
-		Title:           "Correlated anomalies at 1000",
-		MemberSeriesIDs: []observerdef.SeriesID{"parquet|cpu.user:avg|host:a", "parquet|mem.used:avg|host:a"},
-		FirstSeen:       1000,
-		LastUpdated:     1500,
+		Pattern:     "cluster_1000",
+		Title:       "Correlated anomalies at 1000",
+		MemberRefs:  []observerdef.SeriesRef{observerdef.SeriesRef(0), observerdef.SeriesRef(1)},
+		FirstSeen:   1000,
+		LastUpdated: 1500,
 		Anomalies: []observerdef.Anomaly{
 			{
-				Timestamp:      1000,
-				Source:         observerdef.AnomalySource{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
-				SourceSeriesID: "parquet|cpu.user:avg|host:a",
-				DetectorName:   "cusum",
-				Description:    "CUSUM detected shift in cpu.user:avg",
+				Timestamp:    1000,
+				Source:       observerdef.AnomalySource{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
+				SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
+				DetectorName: "cusum",
+				Description:  "CUSUM detected shift in cpu.user:avg",
 			},
 			{
-				Timestamp:      1200,
-				Source:         observerdef.AnomalySource{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
-				SourceSeriesID: "parquet|mem.used:avg|host:a",
-				DetectorName:   "cusum",
-				Description:    "CUSUM detected shift in mem.used:avg",
+				Timestamp:    1200,
+				Source:       observerdef.AnomalySource{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
+				SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(1), Aggregate: observerdef.AggregateAverage},
+				DetectorName: "cusum",
+				Description:  "CUSUM detected shift in mem.used:avg",
 			},
 		},
 	}
@@ -170,13 +170,13 @@ func TestWriteObserverOutput_Verbose(t *testing.T) {
 	assert.Equal(t, []string{"source:agent-q-branch-observer", "pattern:cluster_1000"}, corr.Tags)
 	assert.Equal(t, int64(1000), corr.PeriodStart)
 	assert.Equal(t, int64(1500), corr.PeriodEnd)
-	assert.Equal(t, []string{"parquet|cpu.user:avg|host:a", "parquet|mem.used:avg|host:a"}, corr.MemberSeries)
+	assert.Equal(t, []string{"0", "1"}, corr.MemberSeries)
 
 	// Nested anomalies
 	require.Len(t, corr.Anomalies, 2)
 	assert.Equal(t, int64(1000), corr.Anomalies[0].Timestamp)
 	assert.Equal(t, "cpu.user:avg", corr.Anomalies[0].Source)
-	assert.Equal(t, "parquet|cpu.user:avg|host:a", corr.Anomalies[0].SourceSeriesID)
+	assert.Equal(t, "0:avg", corr.Anomalies[0].SourceSeriesID)
 	assert.Equal(t, "cusum", corr.Anomalies[0].Detector)
 
 	assert.Equal(t, int64(1200), corr.Anomalies[1].Timestamp)
@@ -207,17 +207,17 @@ func TestWriteObserverOutput_ValidJSON(t *testing.T) {
 	tb.loadedScenario = "json_validity_check"
 	tb.engine.SetCorrelators([]observerdef.Correlator{&staticCorrelator{correlations: []observerdef.ActiveCorrelation{
 		{
-			Pattern:         "p1",
-			Title:           "Title with \"quotes\" and\nnewlines",
-			MemberSeriesIDs: []observerdef.SeriesID{"s1"},
-			FirstSeen:       100,
-			LastUpdated:     200,
+			Pattern:     "p1",
+			Title:       "Title with \"quotes\" and\nnewlines",
+			MemberRefs:  []observerdef.SeriesRef{observerdef.SeriesRef(0)},
+			FirstSeen:   100,
+			LastUpdated: 200,
 			Anomalies: []observerdef.Anomaly{
 				{
-					Timestamp:      100,
-					Source:         observerdef.AnomalySource{Name: "metric"},
-					SourceSeriesID: "s1",
-					DetectorName:   "cusum",
+					Timestamp:    100,
+					Source:       observerdef.AnomalySource{Name: "metric"},
+					SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
+					DetectorName: "cusum",
 				},
 			},
 		},

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -43,22 +43,25 @@ func newTestBenchForOutput() *TestBench {
 // testCorrelation returns a test correlation with known values.
 func testCorrelation() observerdef.ActiveCorrelation {
 	return observerdef.ActiveCorrelation{
-		Pattern:     "cluster_1000",
-		Title:       "Correlated anomalies at 1000",
-		MemberRefs:  []observerdef.SeriesRef{observerdef.SeriesRef(0), observerdef.SeriesRef(1)},
+		Pattern: "cluster_1000",
+		Title:   "Correlated anomalies at 1000",
+		Members: []observerdef.SeriesDescriptor{
+			{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
+			{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
+		},
 		FirstSeen:   1000,
 		LastUpdated: 1500,
 		Anomalies: []observerdef.Anomaly{
 			{
 				Timestamp:    1000,
-				Source:       observerdef.AnomalySource{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
+				Source:       observerdef.SeriesDescriptor{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
 				SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
 				DetectorName: "cusum",
 				Description:  "CUSUM detected shift in cpu.user:avg",
 			},
 			{
 				Timestamp:    1200,
-				Source:       observerdef.AnomalySource{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
+				Source:       observerdef.SeriesDescriptor{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
 				SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(1), Aggregate: observerdef.AggregateAverage},
 				DetectorName: "cusum",
 				Description:  "CUSUM detected shift in mem.used:avg",
@@ -170,7 +173,7 @@ func TestWriteObserverOutput_Verbose(t *testing.T) {
 	assert.Equal(t, []string{"source:agent-q-branch-observer", "pattern:cluster_1000"}, corr.Tags)
 	assert.Equal(t, int64(1000), corr.PeriodStart)
 	assert.Equal(t, int64(1500), corr.PeriodEnd)
-	assert.Equal(t, []string{"0", "1"}, corr.MemberSeries)
+	assert.Equal(t, []string{"cpu.user:avg", "mem.used:avg"}, corr.MemberSeries)
 
 	// Nested anomalies
 	require.Len(t, corr.Anomalies, 2)
@@ -209,13 +212,13 @@ func TestWriteObserverOutput_ValidJSON(t *testing.T) {
 		{
 			Pattern:     "p1",
 			Title:       "Title with \"quotes\" and\nnewlines",
-			MemberRefs:  []observerdef.SeriesRef{observerdef.SeriesRef(0)},
+			Members:     []observerdef.SeriesDescriptor{{Name: "metric", Aggregate: observerdef.AggregateAverage}},
 			FirstSeen:   100,
 			LastUpdated: 200,
 			Anomalies: []observerdef.Anomaly{
 				{
 					Timestamp:    100,
-					Source:       observerdef.AnomalySource{Name: "metric"},
+					Source:       observerdef.SeriesDescriptor{Name: "metric"},
 					SourceView:   observerdef.QueryHandle{Ref: observerdef.SeriesRef(0), Aggregate: observerdef.AggregateAverage},
 					DetectorName: "cusum",
 				},

--- a/comp/observer/impl/output_test.go
+++ b/comp/observer/impl/output_test.go
@@ -46,23 +46,23 @@ func testCorrelation() observerdef.ActiveCorrelation {
 		Pattern: "cluster_1000",
 		Title:   "Correlated anomalies at 1000",
 		Members: []observerdef.SeriesDescriptor{
-			{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
-			{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
+			{Namespace: "parquet", Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
+			{Namespace: "parquet", Name: "mem.used", Aggregate: observerdef.AggregateAverage},
 		},
 		FirstSeen:   1000,
 		LastUpdated: 1500,
 		Anomalies: []observerdef.Anomaly{
 			{
 				Timestamp:    1000,
-				Source:       observerdef.SeriesDescriptor{Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
-	
+				Source:       observerdef.SeriesDescriptor{Namespace: "parquet", Name: "cpu.user", Aggregate: observerdef.AggregateAverage},
+				SourceRef:    &observerdef.QueryHandle{Ref: 0, Aggregate: observerdef.AggregateAverage},
 				DetectorName: "cusum",
 				Description:  "CUSUM detected shift in cpu.user:avg",
 			},
 			{
 				Timestamp:    1200,
-				Source:       observerdef.SeriesDescriptor{Name: "mem.used", Aggregate: observerdef.AggregateAverage},
-	
+				Source:       observerdef.SeriesDescriptor{Namespace: "parquet", Name: "mem.used", Aggregate: observerdef.AggregateAverage},
+				SourceRef:    &observerdef.QueryHandle{Ref: 1, Aggregate: observerdef.AggregateAverage},
 				DetectorName: "cusum",
 				Description:  "CUSUM detected shift in mem.used:avg",
 			},
@@ -179,7 +179,7 @@ func TestWriteObserverOutput_Verbose(t *testing.T) {
 	require.Len(t, corr.Anomalies, 2)
 	assert.Equal(t, int64(1000), corr.Anomalies[0].Timestamp)
 	assert.Equal(t, "cpu.user:avg", corr.Anomalies[0].Source)
-	assert.Equal(t, "cpu.user:avg", corr.Anomalies[0].SourceSeriesID)
+	assert.Equal(t, "0:avg", corr.Anomalies[0].SourceSeriesID)
 	assert.Equal(t, "cusum", corr.Anomalies[0].Detector)
 
 	assert.Equal(t, int64(1200), corr.Anomalies[1].Timestamp)

--- a/comp/observer/impl/profile_test.go
+++ b/comp/observer/impl/profile_test.go
@@ -106,7 +106,7 @@ func BenchmarkGetSeriesRange(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		storage.GetSeriesRange(observerdef.SeriesHandle(0), 0, 576, observerdef.AggregateAverage)
+		storage.GetSeriesRange(observerdef.SeriesRef(0), 0, 576, observerdef.AggregateAverage)
 	}
 }
 
@@ -118,7 +118,7 @@ func BenchmarkForEachPoint(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		storage.ForEachPoint(observerdef.SeriesHandle(0), 0, 576, observerdef.AggregateAverage, func(_ *observerdef.Series, _ observerdef.Point) {})
+		storage.ForEachPoint(observerdef.SeriesRef(0), 0, 576, observerdef.AggregateAverage, func(_ *observerdef.Series, _ observerdef.Point) {})
 	}
 }
 
@@ -130,7 +130,7 @@ func BenchmarkForEachPoint_Small(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		storage.ForEachPoint(observerdef.SeriesHandle(0), 570, 576, observerdef.AggregateAverage, func(_ *observerdef.Series, _ observerdef.Point) {})
+		storage.ForEachPoint(observerdef.SeriesRef(0), 570, 576, observerdef.AggregateAverage, func(_ *observerdef.Series, _ observerdef.Point) {})
 	}
 }
 
@@ -142,6 +142,6 @@ func BenchmarkPointCountUpTo(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		storage.PointCountUpTo(observerdef.SeriesHandle(0), 300)
+		storage.PointCountUpTo(observerdef.SeriesRef(0), 300)
 	}
 }

--- a/comp/observer/impl/reporter_html.go
+++ b/comp/observer/impl/reporter_html.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1135,10 +1136,23 @@ func (r *HTMLReporter) handleAPICorrelations(w http.ResponseWriter, _ *http.Requ
 					Score:       a.Score,
 				}
 			}
+			// Collect unique source view strings from anomalies.
+			sourceSet := make(map[string]struct{})
+			for _, a := range ac.Anomalies {
+				if s := a.SourceView.String(); s != "" {
+					sourceSet[s] = struct{}{}
+				}
+			}
+			sources := make([]string, 0, len(sourceSet))
+			for s := range sourceSet {
+				sources = append(sources, s)
+			}
+			sort.Strings(sources)
+
 			correlations[i] = correlationOutput{
 				Pattern:     ac.Pattern,
 				Title:       ac.Title,
-				Sources:     seriesIDsToStringSlice(ac.MemberSeriesIDs),
+				Sources:     sources,
 				Anomalies:   anomalies,
 				FirstSeen:   ac.FirstSeen,
 				LastUpdated: ac.LastUpdated,
@@ -1155,13 +1169,6 @@ func (r *HTMLReporter) handleAPICorrelations(w http.ResponseWriter, _ *http.Requ
 	}
 }
 
-func seriesIDsToStringSlice(ids []observer.SeriesID) []string {
-	out := make([]string, len(ids))
-	for i, id := range ids {
-		out[i] = string(id)
-	}
-	return out
-}
 
 // handleAPIRawAnomalies returns all raw anomalies from detector implementations.
 func (r *HTMLReporter) handleAPIRawAnomalies(w http.ResponseWriter, _ *http.Request) {

--- a/comp/observer/impl/reporter_html.go
+++ b/comp/observer/impl/reporter_html.go
@@ -1131,21 +1131,15 @@ func (r *HTMLReporter) handleAPICorrelations(w http.ResponseWriter, _ *http.Requ
 					Source:      a.Source.String(),
 					Title:       a.Title,
 					Description: a.Description,
-					Tags:        a.Tags,
+					Tags:        a.Source.Tags,
 					Timestamp:   a.Timestamp,
 					Score:       a.Score,
 				}
 			}
-			// Collect unique source view strings from anomalies.
-			sourceSet := make(map[string]struct{})
-			for _, a := range ac.Anomalies {
-				if s := a.SourceView.String(); s != "" {
-					sourceSet[s] = struct{}{}
-				}
-			}
-			sources := make([]string, 0, len(sourceSet))
-			for s := range sourceSet {
-				sources = append(sources, s)
+			// Collect unique source strings from members.
+			sources := make([]string, len(ac.Members))
+			for k, m := range ac.Members {
+				sources[k] = m.String()
 			}
 			sort.Strings(sources)
 
@@ -1186,7 +1180,7 @@ func (r *HTMLReporter) handleAPIRawAnomalies(w http.ResponseWriter, _ *http.Requ
 				DetectorName: a.DetectorName,
 				Title:        a.Title,
 				Description:  a.Description,
-				Tags:         a.Tags,
+				Tags:         a.Source.Tags,
 				Timestamp:    a.Timestamp,
 				Score:        a.Score,
 			}

--- a/comp/observer/impl/reporter_html.go
+++ b/comp/observer/impl/reporter_html.go
@@ -1163,7 +1163,6 @@ func (r *HTMLReporter) handleAPICorrelations(w http.ResponseWriter, _ *http.Requ
 	}
 }
 
-
 // handleAPIRawAnomalies returns all raw anomalies from detector implementations.
 func (r *HTMLReporter) handleAPIRawAnomalies(w http.ResponseWriter, _ *http.Request) {
 	r.mu.RLock()

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -28,7 +28,7 @@ func TestHTMLReporter_Report_AddsToBuffer(t *testing.T) {
 	r.Report(observer.ReportOutput{
 		AdvancedToSec: 100,
 		NewAnomalies: []observer.Anomaly{
-			{Source: observer.AnomalySource{Name: "cpu"}, DetectorName: "test"},
+			{Source: observer.SeriesDescriptor{Name: "cpu"}, DetectorName: "test"},
 		},
 		ActiveCorrelations: []observer.ActiveCorrelation{
 			{Pattern: "p1", Title: "Correlation 1"},
@@ -151,7 +151,7 @@ func TestHTMLReporter_APIReports_ReturnsJSON(t *testing.T) {
 	r.Report(observer.ReportOutput{
 		AdvancedToSec: 42,
 		NewAnomalies: []observer.Anomaly{
-			{Source: observer.AnomalySource{Name: "cpu"}},
+			{Source: observer.SeriesDescriptor{Name: "cpu"}},
 		},
 	})
 
@@ -408,12 +408,12 @@ func TestHTMLReporter_APICorrelations_ReturnsJSON(t *testing.T) {
 			{
 				Pattern: "test_pattern",
 				Title:   "Test Correlation",
-				MemberRefs: []observer.SeriesRef{
-					observer.SeriesRef(0),
-					observer.SeriesRef(1),
+				Members: []observer.SeriesDescriptor{
+					{Name: "signal1"},
+					{Name: "signal2"},
 				},
 				Anomalies: []observer.Anomaly{
-					{Source: observer.AnomalySource{Name: "signal1"}, Title: "Anomaly 1", Description: "Description 1"},
+					{Source: observer.SeriesDescriptor{Name: "signal1"}, Title: "Anomaly 1", Description: "Description 1"},
 				},
 			},
 		},

--- a/comp/observer/impl/reporter_html_test.go
+++ b/comp/observer/impl/reporter_html_test.go
@@ -408,9 +408,9 @@ func TestHTMLReporter_APICorrelations_ReturnsJSON(t *testing.T) {
 			{
 				Pattern: "test_pattern",
 				Title:   "Test Correlation",
-				MemberSeriesIDs: []observer.SeriesID{
-					observer.SeriesID("series|signal1|"),
-					observer.SeriesID("series|signal2|"),
+				MemberRefs: []observer.SeriesRef{
+					observer.SeriesRef(0),
+					observer.SeriesRef(1),
 				},
 				Anomalies: []observer.Anomaly{
 					{Source: observer.AnomalySource{Name: "signal1"}, Title: "Anomaly 1", Description: "Description 1"},

--- a/comp/observer/impl/series_pair_key.go
+++ b/comp/observer/impl/series_pair_key.go
@@ -5,17 +5,20 @@
 
 package observerimpl
 
-import "strconv"
-import observer "github.com/DataDog/datadog-agent/comp/observer/def"
+import (
+	"strconv"
 
-// seriesPairKey identifies an unordered relationship between two series IDs.
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// seriesPairKey identifies an unordered relationship between two series refs.
 // It is canonicalized so (A,B) and (B,A) map to the same key.
 type seriesPairKey struct {
-	A observer.SeriesID
-	B observer.SeriesID
+	A observer.SeriesRef
+	B observer.SeriesRef
 }
 
-func newSeriesPairKey(a, b observer.SeriesID) seriesPairKey {
+func newSeriesPairKey(a, b observer.SeriesRef) seriesPairKey {
 	if a <= b {
 		return seriesPairKey{A: a, B: b}
 	}
@@ -23,9 +26,6 @@ func newSeriesPairKey(a, b observer.SeriesID) seriesPairKey {
 }
 
 // hashKey returns a deterministic encoding used only for hashing/sketch updates.
-// Length-prefixing avoids delimiter ambiguity without requiring parse/split logic.
 func (k seriesPairKey) hashKey() string {
-	a := string(k.A)
-	b := string(k.B)
-	return strconv.Itoa(len(a)) + ":" + a + strconv.Itoa(len(b)) + ":" + b
+	return strconv.Itoa(int(k.A)) + "|" + strconv.Itoa(int(k.B))
 }

--- a/comp/observer/impl/series_pair_key.go
+++ b/comp/observer/impl/series_pair_key.go
@@ -5,20 +5,15 @@
 
 package observerimpl
 
-import (
-	"strconv"
-
-	observer "github.com/DataDog/datadog-agent/comp/observer/def"
-)
-
-// seriesPairKey identifies an unordered relationship between two series refs.
+// seriesPairKey identifies an unordered relationship between two series.
+// A and B are descriptor key strings (from SeriesDescriptor.Key()).
 // It is canonicalized so (A,B) and (B,A) map to the same key.
 type seriesPairKey struct {
-	A observer.SeriesRef
-	B observer.SeriesRef
+	A string
+	B string
 }
 
-func newSeriesPairKey(a, b observer.SeriesRef) seriesPairKey {
+func newSeriesPairKey(a, b string) seriesPairKey {
 	if a <= b {
 		return seriesPairKey{A: a, B: b}
 	}
@@ -27,5 +22,5 @@ func newSeriesPairKey(a, b observer.SeriesRef) seriesPairKey {
 
 // hashKey returns a deterministic encoding used only for hashing/sketch updates.
 func (k seriesPairKey) hashKey() string {
-	return strconv.Itoa(int(k.A)) + "|" + strconv.Itoa(int(k.B))
+	return k.A + "|" + k.B
 }

--- a/comp/observer/impl/series_pair_key_test.go
+++ b/comp/observer/impl/series_pair_key_test.go
@@ -8,13 +8,12 @@ package observerimpl
 import (
 	"testing"
 
-	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSeriesPairKeyCanonicalization(t *testing.T) {
-	a := observer.SeriesRef(0)
-	b := observer.SeriesRef(1)
+	a := "cpu.user:avg"
+	b := "mem.used:avg"
 
 	k1 := newSeriesPairKey(a, b)
 	k2 := newSeriesPairKey(b, a)
@@ -25,9 +24,8 @@ func TestSeriesPairKeyCanonicalization(t *testing.T) {
 }
 
 func TestSeriesPairKeyHashKeyAvoidsDelimiterAmbiguity(t *testing.T) {
-	// These pairs should have different hash keys since they are different refs
-	k1 := newSeriesPairKey(observer.SeriesRef(0), observer.SeriesRef(1))
-	k2 := newSeriesPairKey(observer.SeriesRef(2), observer.SeriesRef(3))
+	k1 := newSeriesPairKey("cpu.user:avg", "mem.used:avg")
+	k2 := newSeriesPairKey("disk.io:count", "net.tx:sum")
 
 	assert.NotEqual(t, k1.hashKey(), k2.hashKey())
 }

--- a/comp/observer/impl/series_pair_key_test.go
+++ b/comp/observer/impl/series_pair_key_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestSeriesPairKeyCanonicalization(t *testing.T) {
-	a := observer.SeriesID("parquet|cpu.user:avg|host:A")
-	b := observer.SeriesID("parquet|cpu.user:avg|host:B")
+	a := observer.SeriesRef(0)
+	b := observer.SeriesRef(1)
 
 	k1 := newSeriesPairKey(a, b)
 	k2 := newSeriesPairKey(b, a)
@@ -25,9 +25,9 @@ func TestSeriesPairKeyCanonicalization(t *testing.T) {
 }
 
 func TestSeriesPairKeyHashKeyAvoidsDelimiterAmbiguity(t *testing.T) {
-	// These pairs can collide under naive delimiter concatenation.
-	k1 := newSeriesPairKey(observer.SeriesID("a|b"), observer.SeriesID("c"))
-	k2 := newSeriesPairKey(observer.SeriesID("a"), observer.SeriesID("b|c"))
+	// These pairs should have different hash keys since they are different refs
+	k1 := newSeriesPairKey(observer.SeriesRef(0), observer.SeriesRef(1))
+	k2 := newSeriesPairKey(observer.SeriesRef(2), observer.SeriesRef(3))
 
 	assert.NotEqual(t, k1.hashKey(), k2.hashKey())
 }

--- a/comp/observer/impl/stateview.go
+++ b/comp/observer/impl/stateview.go
@@ -102,13 +102,14 @@ func (sv *stateView) AnomaliesByDetector() map[string][]observerdef.Anomaly {
 	return result
 }
 
-// AnomaliesForView returns anomalies matching a specific QueryHandle (series ref + aggregate).
+// AnomaliesForSource returns anomalies matching a specific SeriesDescriptor.
 // Computes on read from the raw anomaly set.
-func (sv *stateView) AnomaliesForView(qh observerdef.QueryHandle) []observerdef.Anomaly {
+func (sv *stateView) AnomaliesForSource(sd observerdef.SeriesDescriptor) []observerdef.Anomaly {
+	targetKey := sd.Key()
 	all := sv.engine.RawAnomalies()
 	var result []observerdef.Anomaly
 	for _, a := range all {
-		if a.SourceView == qh {
+		if a.Source.Key() == targetKey {
 			result = append(result, a)
 		}
 	}

--- a/comp/observer/impl/stateview.go
+++ b/comp/observer/impl/stateview.go
@@ -29,8 +29,8 @@ func (sv *stateView) ListSeries(filter observerdef.SeriesFilter) []observerdef.S
 }
 
 // GetSeriesRange returns points within a time range for a series.
-func (sv *stateView) GetSeriesRange(handle observerdef.SeriesHandle, start, end int64, agg observerdef.Aggregate) *observerdef.Series {
-	return sv.engine.storage.GetSeriesRange(handle, start, end, agg)
+func (sv *stateView) GetSeriesRange(ref observerdef.SeriesRef, start, end int64, agg observerdef.Aggregate) *observerdef.Series {
+	return sv.engine.storage.GetSeriesRange(ref, start, end, agg)
 }
 
 // ScenarioBounds returns the time bounds of stored data.
@@ -102,13 +102,13 @@ func (sv *stateView) AnomaliesByDetector() map[string][]observerdef.Anomaly {
 	return result
 }
 
-// AnomaliesForSeries returns anomalies associated with a specific series ID.
+// AnomaliesForView returns anomalies matching a specific QueryHandle (series ref + aggregate).
 // Computes on read from the raw anomaly set.
-func (sv *stateView) AnomaliesForSeries(id observerdef.SeriesID) []observerdef.Anomaly {
+func (sv *stateView) AnomaliesForView(qh observerdef.QueryHandle) []observerdef.Anomaly {
 	all := sv.engine.RawAnomalies()
 	var result []observerdef.Anomaly
 	for _, a := range all {
-		if a.SourceSeriesID == id {
+		if a.SourceView == qh {
 			result = append(result, a)
 		}
 	}

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -110,25 +110,27 @@ func TestStateView_Anomalies(t *testing.T) {
 		t.Fatalf("expected 1 bocpd anomaly, got %d", len(byDetector["bocpd"]))
 	}
 
-	// AnomaliesForView filters by SourceView (QueryHandle)
-	diskView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(42), Aggregate: observerdef.AggregateAverage}
+	// AnomaliesForSource filters by SeriesDescriptor
+	diskDesc := observerdef.SeriesDescriptor{Name: "disk", Aggregate: observerdef.AggregateAverage}
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:       observerdef.SeriesDescriptor{Name: "disk"},
+		Source:       diskDesc,
 		DetectorName: "cusum",
 		Timestamp:    102,
-		SourceView:   diskView,
 	})
-	diskAnomalies := sv.AnomaliesForView(diskView)
+	diskAnomalies := sv.AnomaliesForSource(diskDesc)
 	if len(diskAnomalies) != 1 {
 		t.Fatalf("expected 1 disk anomaly, got %d", len(diskAnomalies))
 	}
 	if diskAnomalies[0].Source.Name != "disk" {
 		t.Fatalf("expected disk source, got %s", diskAnomalies[0].Source.Name)
 	}
-	// Zero-value QueryHandle should match anomalies with no SourceView set
-	emptyAnomalies := sv.AnomaliesForView(observerdef.QueryHandle{})
-	if len(emptyAnomalies) != 2 {
-		t.Fatalf("expected 2 anomalies with no SourceView, got %d", len(emptyAnomalies))
+	// Matching by name should find the correct anomaly
+	cpuAnomalies := sv.AnomaliesForSource(observerdef.SeriesDescriptor{Name: "cpu"})
+	if len(cpuAnomalies) != 1 {
+		t.Fatalf("expected 1 cpu anomaly, got %d", len(cpuAnomalies))
+	}
+	if cpuAnomalies[0].Source.Name != "cpu" {
+		t.Fatalf("expected cpu source, got %s", cpuAnomalies[0].Source.Name)
 	}
 }
 

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -69,12 +69,12 @@ func TestStateView_Anomalies(t *testing.T) {
 
 	// Add some anomalies via the engine
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:       observerdef.AnomalySource{Name: "cpu"},
+		Source:       observerdef.SeriesDescriptor{Name: "cpu"},
 		DetectorName: "cusum",
 		Timestamp:    100,
 	})
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:       observerdef.AnomalySource{Name: "mem"},
+		Source:       observerdef.SeriesDescriptor{Name: "mem"},
 		DetectorName: "bocpd",
 		Timestamp:    101,
 	})
@@ -113,7 +113,7 @@ func TestStateView_Anomalies(t *testing.T) {
 	// AnomaliesForView filters by SourceView (QueryHandle)
 	diskView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(42), Aggregate: observerdef.AggregateAverage}
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:       observerdef.AnomalySource{Name: "disk"},
+		Source:       observerdef.SeriesDescriptor{Name: "disk"},
 		DetectorName: "cusum",
 		Timestamp:    102,
 		SourceView:   diskView,

--- a/comp/observer/impl/stateview_test.go
+++ b/comp/observer/impl/stateview_test.go
@@ -29,10 +29,10 @@ func TestStateView_StorageAccess(t *testing.T) {
 	}
 
 	// GetSeriesRange — find the "cpu" series ID from ListSeries
-	cpuHandle := observerdef.SeriesHandle(-1)
+	cpuHandle := observerdef.SeriesRef(-1)
 	for _, m := range keys {
 		if m.Name == "cpu" {
-			cpuHandle = m.Handle
+			cpuHandle = m.Ref
 		}
 	}
 	series := sv.GetSeriesRange(cpuHandle, 0, 200, observerdef.AggregateAverage)
@@ -110,24 +110,25 @@ func TestStateView_Anomalies(t *testing.T) {
 		t.Fatalf("expected 1 bocpd anomaly, got %d", len(byDetector["bocpd"]))
 	}
 
-	// AnomaliesForSeries filters by SourceSeriesID
+	// AnomaliesForView filters by SourceView (QueryHandle)
+	diskView := observerdef.QueryHandle{Ref: observerdef.SeriesRef(42), Aggregate: observerdef.AggregateAverage}
 	e.captureRawAnomaly(observerdef.Anomaly{
-		Source:         observerdef.AnomalySource{Name: "disk"},
-		DetectorName:   "cusum",
-		Timestamp:      102,
-		SourceSeriesID: "ns|disk:avg|",
+		Source:       observerdef.AnomalySource{Name: "disk"},
+		DetectorName: "cusum",
+		Timestamp:    102,
+		SourceView:   diskView,
 	})
-	diskAnomalies := sv.AnomaliesForSeries("ns|disk:avg|")
+	diskAnomalies := sv.AnomaliesForView(diskView)
 	if len(diskAnomalies) != 1 {
 		t.Fatalf("expected 1 disk anomaly, got %d", len(diskAnomalies))
 	}
 	if diskAnomalies[0].Source.Name != "disk" {
 		t.Fatalf("expected disk source, got %s", diskAnomalies[0].Source.Name)
 	}
-	// Empty SourceSeriesID should not match
-	emptyAnomalies := sv.AnomaliesForSeries("")
+	// Zero-value QueryHandle should match anomalies with no SourceView set
+	emptyAnomalies := sv.AnomaliesForView(observerdef.QueryHandle{})
 	if len(emptyAnomalies) != 2 {
-		t.Fatalf("expected 2 anomalies with empty SourceSeriesID, got %d", len(emptyAnomalies))
+		t.Fatalf("expected 2 anomalies with no SourceView, got %d", len(emptyAnomalies))
 	}
 }
 

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -505,6 +505,23 @@ func (s *timeSeriesStorage) resolveByID(ref observer.SeriesRef) *seriesStats {
 	return s.seriesIDStats[ref]
 }
 
+// GetSeriesMeta returns the metadata for a series by its numeric ref.
+// Returns nil if the ref is out of range.
+func (s *timeSeriesStorage) GetSeriesMeta(ref observer.SeriesRef) *observer.SeriesMeta {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ss := s.resolveByID(ref)
+	if ss == nil {
+		return nil
+	}
+	return &observer.SeriesMeta{
+		Ref:       ref,
+		Namespace: ss.Namespace,
+		Name:      ss.Name,
+		Tags:      ss.Tags,
+	}
+}
+
 // seriesMeta is lightweight series metadata including point count,
 // used for API listing without materializing point data.
 type seriesMeta struct {

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -30,8 +30,8 @@ type timeSeriesStorage struct {
 
 	// Compact numeric IDs for O(1) lookups and API responses.
 	seriesIDs     map[string]observer.SeriesRef // internal key → numeric ref
-	seriesIDKeys  []string                         // numeric ID → internal key (index = ID)
-	seriesIDStats []*seriesStats                   // numeric ID → *seriesStats (index = ID)
+	seriesIDKeys  []string                      // numeric ID → internal key (index = ID)
+	seriesIDStats []*seriesStats                // numeric ID → *seriesStats (index = ID)
 
 	// Global generation for the series catalog; increments only when a new
 	// series key is created, not on every write to an existing series.

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -29,7 +29,7 @@ type timeSeriesStorage struct {
 	observationTimestamps map[int64]struct{}
 
 	// Compact numeric IDs for O(1) lookups and API responses.
-	seriesIDs     map[string]observer.SeriesHandle // internal key → numeric handle
+	seriesIDs     map[string]observer.SeriesRef // internal key → numeric ref
 	seriesIDKeys  []string                         // numeric ID → internal key (index = ID)
 	seriesIDStats []*seriesStats                   // numeric ID → *seriesStats (index = ID)
 
@@ -165,7 +165,7 @@ func newTimeSeriesStorage() *timeSeriesStorage {
 	return &timeSeriesStorage{
 		series:                make(map[string]*seriesStats),
 		observationTimestamps: make(map[int64]struct{}),
-		seriesIDs:             make(map[string]observer.SeriesHandle),
+		seriesIDs:             make(map[string]observer.SeriesRef),
 		droppedByMetric:       make(map[string]int64),
 		sampledDrops:          make(map[string]int),
 	}
@@ -201,7 +201,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		}
 		s.series[key] = stats
 		// Assign a compact numeric ID.
-		id := observer.SeriesHandle(len(s.seriesIDKeys))
+		id := observer.SeriesRef(len(s.seriesIDKeys))
 		s.seriesIDs[key] = id
 		s.seriesIDKeys = append(s.seriesIDKeys, key)
 		s.seriesIDStats = append(s.seriesIDStats, stats)
@@ -498,17 +498,17 @@ func joinTags(tags []string) string {
 
 // resolveByID returns the seriesStats for a numeric series ID.
 // Returns nil for out-of-range IDs. Caller must hold s.mu (read or write).
-func (s *timeSeriesStorage) resolveByID(handle observer.SeriesHandle) *seriesStats {
-	if handle < 0 || int(handle) >= len(s.seriesIDStats) {
+func (s *timeSeriesStorage) resolveByID(ref observer.SeriesRef) *seriesStats {
+	if ref < 0 || int(ref) >= len(s.seriesIDStats) {
 		return nil
 	}
-	return s.seriesIDStats[handle]
+	return s.seriesIDStats[ref]
 }
 
 // seriesMeta is lightweight series metadata including point count,
 // used for API listing without materializing point data.
 type seriesMeta struct {
-	Handle     observer.SeriesHandle // compact numeric handle
+	Ref        observer.SeriesRef // compact numeric ref
 	Namespace  string
 	Name       string
 	Tags       []string
@@ -525,7 +525,7 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 	for key, stats := range s.series {
 		if stats.Namespace == namespace {
 			result = append(result, seriesMeta{
-				Handle:     s.seriesIDs[key],
+				Ref:        s.seriesIDs[key],
 				Namespace:  stats.Namespace,
 				Name:       stats.Name,
 				Tags:       copyTags(stats.Tags),
@@ -534,8 +534,8 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 		}
 	}
 	sort.Slice(result, func(i, j int) bool {
-		if result[i].Handle != result[j].Handle {
-			return result[i].Handle < result[j].Handle
+		if result[i].Ref != result[j].Ref {
+			return result[i].Ref < result[j].Ref
 		}
 		if result[i].Name != result[j].Name {
 			return result[i].Name < result[j].Name
@@ -547,14 +547,14 @@ func (s *timeSeriesStorage) ListSeriesMetadata(namespace string) []seriesMeta {
 
 // GetSeriesByNumericID looks up a series by its compact numeric ID and returns
 // the data using the specified aggregation.
-func (s *timeSeriesStorage) GetSeriesByNumericID(handle observer.SeriesHandle, agg Aggregate) *observer.Series {
+func (s *timeSeriesStorage) GetSeriesByNumericID(ref observer.SeriesRef, agg Aggregate) *observer.Series {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if handle < 0 || int(handle) >= len(s.seriesIDKeys) {
+	if ref < 0 || int(ref) >= len(s.seriesIDKeys) {
 		return nil
 	}
-	key := s.seriesIDKeys[handle]
+	key := s.seriesIDKeys[ref]
 	stats := s.series[key]
 	if stats == nil {
 		return nil
@@ -692,15 +692,23 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 	return strconv.Itoa(int(numID))
 }
 
+// LookupRef returns the SeriesRef for the given internal storage key, if it exists.
+func (s *timeSeriesStorage) LookupRef(key string) (observer.SeriesRef, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ref, ok := s.seriesIDs[key]
+	return ref, ok
+}
+
 // FullKeyForNumericID returns the internal storage key for a compact numeric ID.
-func (s *timeSeriesStorage) FullKeyForNumericID(handle observer.SeriesHandle) (string, bool) {
+func (s *timeSeriesStorage) FullKeyForNumericID(ref observer.SeriesRef) (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if handle < 0 || int(handle) >= len(s.seriesIDKeys) {
+	if ref < 0 || int(ref) >= len(s.seriesIDKeys) {
 		return "", false
 	}
-	return s.seriesIDKeys[handle], true
+	return s.seriesIDKeys[ref], true
 }
 
 // StorageReader interface implementation
@@ -731,7 +739,7 @@ listSeriesLoop:
 			continue
 		}
 		result = append(result, observer.SeriesMeta{
-			Handle:    s.seriesIDs[key],
+			Ref:       s.seriesIDs[key],
 			Namespace: stats.Namespace,
 			Name:      stats.Name,
 			Tags:      stats.Tags,
@@ -741,11 +749,11 @@ listSeriesLoop:
 }
 
 // PointCount returns the number of raw data points for a series.
-func (s *timeSeriesStorage) PointCount(handle observer.SeriesHandle) int {
+func (s *timeSeriesStorage) PointCount(ref observer.SeriesRef) int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if stats := s.resolveByID(handle); stats != nil {
+	if stats := s.resolveByID(ref); stats != nil {
 		return stats.pointCount()
 	}
 	return 0
@@ -753,11 +761,11 @@ func (s *timeSeriesStorage) PointCount(handle observer.SeriesHandle) int {
 
 // PointCountUpTo returns the number of raw data points with timestamp <= endTime.
 // Uses binary search since timestamps are sorted.
-func (s *timeSeriesStorage) PointCountUpTo(handle observer.SeriesHandle, endTime int64) int {
+func (s *timeSeriesStorage) PointCountUpTo(ref observer.SeriesRef, endTime int64) int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	stats := s.resolveByID(handle)
+	stats := s.resolveByID(ref)
 	if stats == nil || stats.pointCount() == 0 {
 		return 0
 	}
@@ -776,28 +784,28 @@ func (s *timeSeriesStorage) RecordObservationTime(timestamp int64) {
 // WriteGeneration returns a counter that increments on every Add call
 // (including same-bucket merges). Detectors use this to detect value
 // changes that don't create new buckets.
-func (s *timeSeriesStorage) WriteGeneration(handle observer.SeriesHandle) int64 {
+func (s *timeSeriesStorage) WriteGeneration(ref observer.SeriesRef) int64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	if stats := s.resolveByID(handle); stats != nil {
+	if stats := s.resolveByID(ref); stats != nil {
 		return stats.writeGeneration
 	}
 	return 0
 }
 
 // BulkSeriesStatus returns the point count (up to endTime) and write generation
-// for each handle in a single lock acquisition. This avoids the overhead of
-// 2×len(handles) individual RLock/RUnlock calls in hot detector loops.
+// for each ref in a single lock acquisition. This avoids the overhead of
+// 2×len(refs) individual RLock/RUnlock calls in hot detector loops.
 // Implements bulkStatusReader (metrics_detector_util.go).
-func (s *timeSeriesStorage) BulkSeriesStatus(handles []observer.SeriesHandle, endTime int64) []seriesStatus {
-	result := make([]seriesStatus, len(handles))
+func (s *timeSeriesStorage) BulkSeriesStatus(refs []observer.SeriesRef, endTime int64) []seriesStatus {
+	result := make([]seriesStatus, len(refs))
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	for i, handle := range handles {
-		stats := s.resolveByID(handle)
+	for i, ref := range refs {
+		stats := s.resolveByID(ref)
 		if stats == nil || stats.pointCount() == 0 {
 			continue
 		}
@@ -831,11 +839,11 @@ func matchTags(tags []string, matchers map[string]string) bool {
 // GetSeriesRange returns points within a time range (start, end].
 // Start is exclusive, end is inclusive. Use start=0 to read from the beginning.
 // Uses binary search on the timestamps column for O(log N) range lookup.
-func (s *timeSeriesStorage) GetSeriesRange(handle observer.SeriesHandle, start, end int64, agg Aggregate) *observer.Series {
+func (s *timeSeriesStorage) GetSeriesRange(ref observer.SeriesRef, start, end int64, agg Aggregate) *observer.Series {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	stats := s.resolveByID(handle)
+	stats := s.resolveByID(ref)
 	if stats == nil {
 		return nil
 	}
@@ -909,13 +917,13 @@ var pointBufPool = sync.Pool{
 // Points are copied under the read lock into a pooled buffer; the callback
 // runs outside the lock so callers cannot block writers.
 func (s *timeSeriesStorage) ForEachPoint(
-	handle observer.SeriesHandle, start, end int64, agg Aggregate,
+	ref observer.SeriesRef, start, end int64, agg Aggregate,
 	fn func(*observer.Series, observer.Point),
 ) bool {
 	bufp := pointBufPool.Get().(*[]observer.Point)
 	buf := *bufp
 
-	series, buf, ok := s.snapshotRange(handle, start, end, agg, buf)
+	series, buf, ok := s.snapshotRange(ref, start, end, agg, buf)
 	if !ok {
 		*bufp = buf
 		pointBufPool.Put(bufp)
@@ -935,13 +943,13 @@ func (s *timeSeriesStorage) ForEachPoint(
 // Returns the series metadata, the (potentially grown) buffer, and whether the
 // series was found.
 func (s *timeSeriesStorage) snapshotRange(
-	handle observer.SeriesHandle, start, end int64, agg Aggregate,
+	ref observer.SeriesRef, start, end int64, agg Aggregate,
 	buf []observer.Point,
 ) (observer.Series, []observer.Point, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	stats := s.resolveByID(handle)
+	stats := s.resolveByID(ref)
 	if stats == nil {
 		return observer.Series{}, buf, false
 	}

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -657,10 +657,10 @@ func (s *timeSeriesStorage) SeriesGeneration() uint64 {
 	return s.seriesGen
 }
 
-// CompactSeriesID translates a full series key (as used in SourceSeriesID) to its
-// compact numeric ID string. The full key format is "namespace|name:agg|tags" where
-// the storage key is "namespace|name|tags" (without the agg suffix). This method
-// strips the agg suffix, looks up the numeric ID, and returns "numericID:agg".
+// CompactSeriesID translates a full series key to its compact numeric ID string.
+// The full key format is "namespace|name:agg|tags" where the storage key is
+// "namespace|name|tags" (without the agg suffix). This method strips the agg
+// suffix, looks up the numeric ID, and returns "numericID:agg".
 // Returns the original key unchanged if no mapping exists.
 func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 	s.mu.RLock()
@@ -690,25 +690,6 @@ func (s *timeSeriesStorage) CompactSeriesID(fullKey string) string {
 		return fmt.Sprintf("%d:%s", numID, aggStr)
 	}
 	return strconv.Itoa(int(numID))
-}
-
-// LookupRef returns the SeriesRef for the given internal storage key, if it exists.
-func (s *timeSeriesStorage) LookupRef(key string) (observer.SeriesRef, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	ref, ok := s.seriesIDs[key]
-	return ref, ok
-}
-
-// FullKeyForNumericID returns the internal storage key for a compact numeric ID.
-func (s *timeSeriesStorage) FullKeyForNumericID(ref observer.SeriesRef) (string, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	if ref < 0 || int(ref) >= len(s.seriesIDKeys) {
-		return "", false
-	}
-	return s.seriesIDKeys[ref], true
 }
 
 // StorageReader interface implementation

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -260,11 +260,11 @@ func makeRangeStorage() *timeSeriesStorage {
 }
 
 // rangeID is the numeric ID for the first (and only) series added by makeRangeStorage.
-const rangeID = observer.SeriesHandle(0)
+const rangeID = observer.SeriesRef(0)
 
 func TestGetSeriesRange_EmptySeries(t *testing.T) {
 	s := newTimeSeriesStorage()
-	result := s.GetSeriesRange(observer.SeriesHandle(-1), 0, 100, AggregateSum)
+	result := s.GetSeriesRange(observer.SeriesRef(-1), 0, 100, AggregateSum)
 	assert.Nil(t, result)
 }
 
@@ -273,7 +273,7 @@ func TestGetSeriesRange_SinglePoint(t *testing.T) {
 	s.Add("ns", "m", 42.0, 100, nil)
 
 	// First series added gets ID 0
-	id := observer.SeriesHandle(0)
+	id := observer.SeriesRef(0)
 
 	// Range that includes the point: (0, 100]
 	result := s.GetSeriesRange(id, 0, 100, AggregateSum)
@@ -350,7 +350,7 @@ func TestGetSeriesRange_AllAggregates(t *testing.T) {
 	s.Add("ns", "m", 10.0, 100, nil)
 	s.Add("ns", "m", 20.0, 100, nil)
 
-	id := observer.SeriesHandle(0)
+	id := observer.SeriesRef(0)
 
 	for _, tc := range []struct {
 		agg      Aggregate
@@ -383,13 +383,13 @@ func TestPointCountUpTo_BinarySearch(t *testing.T) {
 	// Points <= 10: just one
 	assert.Equal(t, 1, s.PointCountUpTo(rangeID, 10))
 	// Non-existent series
-	assert.Equal(t, 0, s.PointCountUpTo(observer.SeriesHandle(999), 100)) // non-existent ID
+	assert.Equal(t, 0, s.PointCountUpTo(observer.SeriesRef(999), 100)) // non-existent ID
 }
 
 func TestPointCount_ColumnarLayout(t *testing.T) {
 	s := makeRangeStorage()
 	assert.Equal(t, 5, s.PointCount(rangeID))
-	assert.Equal(t, 0, s.PointCount(observer.SeriesHandle(999))) // non-existent ID
+	assert.Equal(t, 0, s.PointCount(observer.SeriesRef(999))) // non-existent ID
 }
 
 func TestGetSeriesRange_OutOfOrderInsert(t *testing.T) {
@@ -399,7 +399,7 @@ func TestGetSeriesRange_OutOfOrderInsert(t *testing.T) {
 	s.Add("ns", "m", 10.0, 10, nil)
 	s.Add("ns", "m", 20.0, 20, nil)
 
-	result := s.GetSeriesRange(observer.SeriesHandle(0), 0, 100, AggregateSum)
+	result := s.GetSeriesRange(observer.SeriesRef(0), 0, 100, AggregateSum)
 	require.NotNil(t, result)
 	require.Len(t, result.Points, 3)
 	assert.Equal(t, int64(10), result.Points[0].Timestamp)

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -39,7 +39,7 @@ func (d *dynamicAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime in
 		Anomalies: []observerdef.Anomaly{
 			{
 				Source:         observerdef.AnomalySource{Name: fmt.Sprintf("%s%d", d.prefix, d.currentIndex)},
-				SourceSeriesID: observerdef.SeriesID(fmt.Sprintf("ns|%s%d|", d.prefix, d.currentIndex)),
+				SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(d.currentIndex), Aggregate: observerdef.AggregateAverage},
 				DetectorName:   d.Name(),
 				Title:          fmt.Sprintf("anomaly_%d", d.currentIndex),
 				Timestamp:      dataTime,

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -38,11 +38,10 @@ func (d *dynamicAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime in
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{
 			{
-				Source:         observerdef.SeriesDescriptor{Name: fmt.Sprintf("%s%d", d.prefix, d.currentIndex)},
-				SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(d.currentIndex), Aggregate: observerdef.AggregateAverage},
-				DetectorName:   d.Name(),
-				Title:          fmt.Sprintf("anomaly_%d", d.currentIndex),
-				Timestamp:      dataTime,
+				Source:       observerdef.SeriesDescriptor{Name: fmt.Sprintf("%s%d", d.prefix, d.currentIndex), Aggregate: observerdef.AggregateAverage},
+				DetectorName: d.Name(),
+				Title:        fmt.Sprintf("anomaly_%d", d.currentIndex),
+				Timestamp:    dataTime,
 			},
 		},
 	}

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -38,7 +38,7 @@ func (d *dynamicAnomalyDetector) Detect(_ observerdef.StorageReader, dataTime in
 	return observerdef.DetectionResult{
 		Anomalies: []observerdef.Anomaly{
 			{
-				Source:         observerdef.AnomalySource{Name: fmt.Sprintf("%s%d", d.prefix, d.currentIndex)},
+				Source:         observerdef.SeriesDescriptor{Name: fmt.Sprintf("%s%d", d.prefix, d.currentIndex)},
 				SourceView: observerdef.QueryHandle{Ref: observerdef.SeriesRef(d.currentIndex), Aggregate: observerdef.AggregateAverage},
 				DetectorName:   d.Name(),
 				Title:          fmt.Sprintf("anomaly_%d", d.currentIndex),

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -841,33 +841,36 @@ func (tb *TestBench) GetMetricsAnomaliesByDetector() map[string][]observerdef.An
 	return byDetector
 }
 
-// GetMetricsAnomaliesForView returns metric anomalies associated with a specific QueryHandle.
-// Matches on exact SourceView equality first. For anomalies that don't populate
-// SourceView (e.g. RRCF), falls back to matching via the telemetry series naming
-// convention so that /api/series/... and /api/anomalies still show markers.
-func (tb *TestBench) GetMetricsAnomaliesForView(qh observerdef.QueryHandle) []observerdef.Anomaly {
+// GetMetricsAnomaliesForSource returns metric anomalies associated with a specific SeriesDescriptor.
+// Matches on Source.Key() equality. For anomalies from detectors that use a different
+// namespace (e.g. RRCF uses "rrcf" while the telemetry series uses "telemetry"),
+// falls back to matching via the telemetry series naming convention so that
+// /api/series/... and /api/anomalies still show markers.
+func (tb *TestBench) GetMetricsAnomaliesForSource(sd observerdef.SeriesDescriptor) []observerdef.Anomaly {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	storage := tb.engine.Storage()
+	targetKey := sd.Key()
 	all := filterMetricAnomalies(tb.engine.StateView().Anomalies())
 	var result []observerdef.Anomaly
 	for _, a := range all {
-		if a.SourceView == qh {
+		if a.Source.Key() == targetKey {
 			result = append(result, a)
 			continue
 		}
-		// Fallback: detectors like RRCF emit anomalies without SourceView.
-		// Resolve the telemetry series key and check if it matches the
-		// requested QueryHandle.
-		if !a.SourceView.IsValid() && a.Source.Name != "" {
+		// Fallback: detectors like RRCF emit anomalies with a different namespace
+		// (e.g. Source.Namespace="rrcf") while the telemetry series is stored as
+		// "telemetry.rrcf.score:avg" in namespace "telemetry". Map through the
+		// telemetry naming convention.
+		if a.Source.Namespace != sd.Namespace && a.Source.Name != "" {
 			telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
-			key := seriesKey("telemetry", telemetryName, nil)
-			if ref, ok := storage.LookupRef(key); ok && ref == qh.Ref {
-				// Aggregate defaults to avg for telemetry series.
-				if qh.Aggregate == observerdef.AggregateAverage {
-					result = append(result, a)
-				}
+			telemetrySD := observerdef.SeriesDescriptor{
+				Namespace: "telemetry",
+				Name:      telemetryName,
+				Aggregate: observerdef.AggregateAverage,
+			}
+			if telemetrySD.Key() == targetKey {
+				result = append(result, a)
 			}
 		}
 	}
@@ -973,17 +976,16 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 
 	var groups []CompressedGroup
 	for i, corr := range correlations {
-		// Resolve member series from anomaly SourceView handles
+		// Resolve member series from anomaly Source descriptors
 		memberSet := make(map[string]bool)
 		var members []seriesCompact
 		for _, a := range corr.Anomalies {
-			viewStr := a.SourceView.String()
-			if viewStr == "" || memberSet[viewStr] {
+			srcKey := a.Source.Key()
+			if srcKey == "" || memberSet[srcKey] {
 				continue
 			}
-			memberSet[viewStr] = true
-			// Build member info from Source fields and SourceView aggregate
-			aggStr := observerdef.AggregateString(a.SourceView.Aggregate)
+			memberSet[srcKey] = true
+			aggStr := observerdef.AggregateString(a.Source.Aggregate)
 			members = append(members, seriesCompact{
 				Namespace: a.Source.Namespace,
 				Name:      a.Source.Name + ":" + aggStr,

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -842,15 +842,33 @@ func (tb *TestBench) GetMetricsAnomaliesByDetector() map[string][]observerdef.An
 }
 
 // GetMetricsAnomaliesForView returns metric anomalies associated with a specific QueryHandle.
+// Matches on exact SourceView equality first. For anomalies that don't populate
+// SourceView (e.g. RRCF), falls back to matching via the telemetry series naming
+// convention so that /api/series/... and /api/anomalies still show markers.
 func (tb *TestBench) GetMetricsAnomaliesForView(qh observerdef.QueryHandle) []observerdef.Anomaly {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
+	storage := tb.engine.Storage()
 	all := filterMetricAnomalies(tb.engine.StateView().Anomalies())
 	var result []observerdef.Anomaly
 	for _, a := range all {
 		if a.SourceView == qh {
 			result = append(result, a)
+			continue
+		}
+		// Fallback: detectors like RRCF emit anomalies without SourceView.
+		// Resolve the telemetry series key and check if it matches the
+		// requested QueryHandle.
+		if !a.SourceView.IsValid() && a.Source.Name != "" {
+			telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
+			key := seriesKey("telemetry", telemetryName, nil)
+			if ref, ok := storage.LookupRef(key); ok && ref == qh.Ref {
+				// Aggregate defaults to avg for telemetry series.
+				if qh.Aggregate == observerdef.AggregateAverage {
+					result = append(result, a)
+				}
+			}
 		}
 	}
 	return result

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -821,7 +821,7 @@ func (tb *TestBench) GetMetricsAnomalies() []observerdef.Anomaly {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	return tb.resolveAnomalySeriesIDs(filterMetricAnomalies(tb.engine.StateView().Anomalies()))
+	return filterMetricAnomalies(tb.engine.StateView().Anomalies())
 }
 
 // GetMetricsAnomaliesByDetector returns metric anomalies grouped by detector name.
@@ -836,42 +836,24 @@ func (tb *TestBench) GetMetricsAnomaliesByDetector() map[string][]observerdef.An
 			delete(byDetector, k)
 			continue
 		}
-		byDetector[k] = tb.resolveAnomalySeriesIDs(filtered)
+		byDetector[k] = filtered
 	}
 	return byDetector
 }
 
-// GetMetricsAnomaliesForSeries returns metric anomalies associated with a specific series id.
-func (tb *TestBench) GetMetricsAnomaliesForSeries(seriesID observerdef.SeriesID) []observerdef.Anomaly {
+// GetMetricsAnomaliesForView returns metric anomalies associated with a specific QueryHandle.
+func (tb *TestBench) GetMetricsAnomaliesForView(qh observerdef.QueryHandle) []observerdef.Anomaly {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
 
-	// Resolve SourceSeriesIDs first, then filter by the requested series ID.
-	// We resolve all anomalies because the engine may store them with empty
-	// SourceSeriesID (e.g. RRCF anomalies) that resolve to the requested ID.
-	resolved := tb.resolveAnomalySeriesIDs(filterMetricAnomalies(tb.engine.StateView().Anomalies()))
+	all := filterMetricAnomalies(tb.engine.StateView().Anomalies())
 	var result []observerdef.Anomaly
-	for _, a := range resolved {
-		if a.SourceSeriesID == seriesID {
+	for _, a := range all {
+		if a.SourceView == qh {
 			result = append(result, a)
 		}
 	}
 	return result
-}
-
-// resolveAnomalySeriesIDs applies testbench-specific SourceSeriesID resolution
-// to anomalies that have an empty SourceSeriesID. Detectors like RRCF that
-// operate on the full storage don't set SourceSeriesID; this maps them to the
-// corresponding telemetry series using the naming convention from handleTelemetry.
-func (tb *TestBench) resolveAnomalySeriesIDs(anomalies []observerdef.Anomaly) []observerdef.Anomaly {
-	for i := range anomalies {
-		a := &anomalies[i]
-		// This comes from the telemetry
-		if a.SourceSeriesID == "" && a.Source.Name != "" {
-			a.SourceSeriesID = observerdef.SeriesID(seriesKey(observerdef.TelemetryNamespace, a.Source.String()+":avg", nil))
-		}
-	}
-	return anomalies
 }
 
 // GetLogAnomalies returns all anomalies emitted directly by log detectors.
@@ -973,27 +955,21 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 
 	var groups []CompressedGroup
 	for i, corr := range correlations {
-		// Resolve member series from anomaly SourceSeriesIDs
-		memberSet := make(map[string]struct{})
+		// Resolve member series from anomaly SourceView handles
+		memberSet := make(map[string]bool)
 		var members []seriesCompact
 		for _, a := range corr.Anomalies {
-			if a.SourceSeriesID == "" {
+			viewStr := a.SourceView.String()
+			if viewStr == "" || memberSet[viewStr] {
 				continue
 			}
-			sid := string(a.SourceSeriesID)
-			if _, seen := memberSet[sid]; seen {
-				continue
-			}
-			memberSet[sid] = struct{}{}
-
-			ns, name, tags, ok := parseSeriesKey(sid)
-			if !ok {
-				continue
-			}
+			memberSet[viewStr] = true
+			// Build member info from Source fields and SourceView aggregate
+			aggStr := observerdef.AggregateString(a.SourceView.Aggregate)
 			members = append(members, seriesCompact{
-				Namespace: ns,
-				Name:      name,
-				Tags:      tags,
+				Namespace: a.Source.Namespace,
+				Name:      a.Source.Name + ":" + aggStr,
+				Tags:      a.Tags,
 			})
 		}
 
@@ -1381,7 +1357,7 @@ func (tb *TestBench) GetLogPatterns() []LogPatternInfo {
 		if storage != nil {
 			for _, m := range storage.ListSeriesMetadata(extractor.Name()) {
 				if m.Name == metricName {
-					seriesIDs = append(seriesIDs, strconv.Itoa(int(m.Handle))+":count")
+					seriesIDs = append(seriesIDs, strconv.Itoa(int(m.Ref))+":count")
 				}
 			}
 		}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -969,7 +969,7 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 			members = append(members, seriesCompact{
 				Namespace: a.Source.Namespace,
 				Name:      a.Source.Name + ":" + aggStr,
-				Tags:      a.Tags,
+				Tags:      a.Source.Tags,
 			})
 		}
 
@@ -1295,13 +1295,12 @@ func (tb *TestBench) loadDemoScenario() error {
 	for _, a := range demoAnomalies {
 		anomaly := observerdef.Anomaly{
 			Type:         observerdef.AnomalyTypeLog,
-			Source:       observerdef.AnomalySource{Name: "logs"},
+			Source:       observerdef.SeriesDescriptor{Name: "logs", Tags: []string{"service:" + a.service}},
 			DetectorName: a.detectorName,
 			Title:        a.title,
 			Description:  a.description,
 			Timestamp:    a.ts,
 			Score:        a.score,
-			Tags:         []string{"service:" + a.service},
 		}
 		tb.logAnomalies = append(tb.logAnomalies, anomaly)
 		tb.logAnomaliesByDetector[a.detectorName] = append(tb.logAnomaliesByDetector[a.detectorName], anomaly)

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -981,7 +981,7 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 		var members []seriesCompact
 		for _, a := range corr.Anomalies {
 			srcKey := a.Source.Key()
-			if srcKey == "" || memberSet[srcKey] {
+			if memberSet[srcKey] {
 				continue
 			}
 			memberSet[srcKey] = true

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -985,11 +985,42 @@ func (tb *TestBench) GetCompressedCorrelations(threshold float64) []CompressedGr
 				continue
 			}
 			memberSet[srcKey] = true
+
+			// Use SourceRef to get the actual stored series identity when available.
+			if a.SourceRef != nil {
+				meta := storage.GetSeriesMeta(a.SourceRef.Ref)
+				if meta != nil {
+					aggStr := observerdef.AggregateString(a.SourceRef.Aggregate)
+					members = append(members, seriesCompact{
+						Namespace: meta.Namespace,
+						Name:      meta.Name + ":" + aggStr,
+						Tags:      meta.Tags,
+					})
+					continue
+				}
+			}
+
+			// Fallback for cross-namespace detectors (e.g. RRCF): remap to the
+			// telemetry naming convention so CompactSeriesID can resolve it.
+			ns := a.Source.Namespace
 			aggStr := observerdef.AggregateString(a.Source.Aggregate)
+			name := a.Source.Name + ":" + aggStr
+			tags := a.Source.Tags
+
+			if a.DetectorName != "" && a.Source.Name != "" {
+				telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
+				telemetryKey := seriesKey("telemetry", telemetryName+":avg", nil)
+				if storage.CompactSeriesID(telemetryKey) != telemetryKey {
+					ns = "telemetry"
+					name = telemetryName + ":avg"
+					tags = nil
+				}
+			}
+
 			members = append(members, seriesCompact{
-				Namespace: a.Source.Namespace,
-				Name:      a.Source.Name + ":" + aggStr,
-				Tags:      a.Source.Tags,
+				Namespace: ns,
+				Name:      name,
+				Tags:      tags,
 			})
 		}
 

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -541,9 +541,14 @@ func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericI
 
 	nameWithAgg := series.Name + ":" + aggStr
 
-	// Build a QueryHandle for anomaly lookup
-	qh := observerdef.QueryHandle{Ref: numericID, Aggregate: observerdef.Aggregate(agg)}
-	anomalies := api.tb.GetMetricsAnomaliesForView(qh)
+	// Build a SeriesDescriptor for anomaly lookup
+	sd := observerdef.SeriesDescriptor{
+		Namespace: series.Namespace,
+		Name:      series.Name,
+		Tags:      series.Tags,
+		Aggregate: observerdef.Aggregate(agg),
+	}
+	anomalies := api.tb.GetMetricsAnomaliesForSource(sd)
 
 	type anomalyMarker struct {
 		Timestamp         int64  `json:"timestamp"`
@@ -667,29 +672,31 @@ func (api *TestBenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namesp
 		Title             string `json:"title"`
 	}
 
-	// Build a QueryHandle for anomaly lookup using the storage's series ref.
+	// Build a SeriesDescriptor for anomaly lookup.
 	// Use the returned series identity (not the request params) so that
 	// nil-tag requests that match a tagged series still find the ref.
 	var markers []anomalyMarker
-	key := seriesKey(series.Namespace, name, series.Tags)
-	if ref, ok := storage.LookupRef(key); ok {
-		qh := observerdef.QueryHandle{Ref: ref, Aggregate: observerdef.Aggregate(agg)}
-		anomalies := api.tb.GetMetricsAnomaliesForView(qh)
-		detectorComponentMap := api.tb.GetDetectorComponentMap()
-		for _, a := range anomalies {
-			if a.DetectorName == "" || a.Timestamp == 0 {
-				log.Printf("skipping malformed anomaly marker for series %q: detector=%q ts=%d",
-					seriesID, a.DetectorName, a.Timestamp)
-				continue
-			}
-			markers = append(markers, anomalyMarker{
-				Timestamp:         a.Timestamp,
-				DetectorName:      a.DetectorName,
-				DetectorComponent: detectorComponentMap[a.DetectorName],
-				SourceSeriesID:    seriesID,
-				Title:             a.Title,
-			})
+	sd := observerdef.SeriesDescriptor{
+		Namespace: series.Namespace,
+		Name:      name,
+		Tags:      series.Tags,
+		Aggregate: observerdef.Aggregate(agg),
+	}
+	anomalies := api.tb.GetMetricsAnomaliesForSource(sd)
+	detectorComponentMap := api.tb.GetDetectorComponentMap()
+	for _, a := range anomalies {
+		if a.DetectorName == "" || a.Timestamp == 0 {
+			log.Printf("skipping malformed anomaly marker for series %q: detector=%q ts=%d",
+				seriesID, a.DetectorName, a.Timestamp)
+			continue
 		}
+		markers = append(markers, anomalyMarker{
+			Timestamp:         a.Timestamp,
+			DetectorName:      a.DetectorName,
+			DetectorComponent: detectorComponentMap[a.DetectorName],
+			SourceSeriesID:    seriesID,
+			Title:             a.Title,
+		})
 	}
 
 	type pointOutput struct {
@@ -763,10 +770,9 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 	detectorComponentMap := api.tb.GetDetectorComponentMap()
 
 	toResponse := func(a observerdef.Anomaly) anomalyResponse {
-		sourceSeriesID := a.SourceView.String()
 		resp := anomalyResponse{
 			Source:            a.Source.String(),
-			SourceSeriesID:    sourceSeriesID,
+			SourceSeriesID:    a.Source.DisplayName(),
 			DetectorName:      a.DetectorName,
 			DetectorComponent: detectorComponentMap[a.DetectorName],
 			Title:             a.Title,

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -768,11 +768,31 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 	}
 
 	detectorComponentMap := api.tb.GetDetectorComponentMap()
+	storage := api.tb.getStorage()
+
+	// resolveCompactID maps an anomaly to the compact numeric ID format
+	// ("42:avg") used by /api/series. Uses SourceRef when available (per-series
+	// detectors), falls back to telemetry remapping for cross-namespace
+	// detectors (e.g. RRCF), then Key() as a stable fallback.
+	resolveCompactID := func(a observerdef.Anomaly) string {
+		if a.SourceRef != nil {
+			return a.SourceRef.CompactID()
+		}
+		// Fallback for cross-namespace detectors (e.g. RRCF)
+		if storage != nil && a.DetectorName != "" && a.Source.Name != "" {
+			telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
+			telemetryKey := seriesKey("telemetry", telemetryName+":avg", nil)
+			if compactID := storage.CompactSeriesID(telemetryKey); compactID != telemetryKey {
+				return compactID
+			}
+		}
+		return a.Source.Key()
+	}
 
 	toResponse := func(a observerdef.Anomaly) anomalyResponse {
 		resp := anomalyResponse{
 			Source:            a.Source.String(),
-			SourceSeriesID:    a.Source.DisplayName(),
+			SourceSeriesID:    resolveCompactID(a),
 			DetectorName:      a.DetectorName,
 			DetectorComponent: detectorComponentMap[a.DetectorName],
 			Title:             a.Title,
@@ -1037,6 +1057,8 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 		LastUpdated     int64           `json:"lastUpdated"`
 	}
 
+	storage := api.tb.getStorage()
+
 	response := make([]correlationResponse, len(correlations))
 	for i, c := range correlations {
 		anomalies := make([]anomalyOutput, len(c.Anomalies))
@@ -1054,10 +1076,40 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 				Tags:        tags,
 			}
 		}
-		// Build member series IDs with tags for unique identification across tag variants.
+
+		// Build ref lookup from anomalies on this correlation.
+		refByKey := make(map[string]*observerdef.QueryHandle)
+		for _, a := range c.Anomalies {
+			if a.SourceRef != nil {
+				refByKey[a.Source.Key()] = a.SourceRef
+			}
+		}
+
+		// Build member series IDs as compact numeric IDs ("42:avg") matching /api/series format.
 		memberIDs := make([]string, len(c.Members))
 		for k, m := range c.Members {
-			memberIDs[k] = m.DisplayName()
+			if ref, ok := refByKey[m.Key()]; ok {
+				memberIDs[k] = ref.CompactID()
+			} else {
+				// Fallback for cross-namespace detectors (e.g. RRCF)
+				resolved := false
+				if storage != nil {
+					for _, a := range c.Anomalies {
+						if a.Source.Key() == m.Key() && a.DetectorName != "" {
+							telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
+							telemetryKey := seriesKey("telemetry", telemetryName+":avg", nil)
+							if compactID := storage.CompactSeriesID(telemetryKey); compactID != telemetryKey {
+								memberIDs[k] = compactID
+								resolved = true
+							}
+							break
+						}
+					}
+				}
+				if !resolved {
+					memberIDs[k] = m.Key()
+				}
+			}
 		}
 		// Build metric names (name:agg only, no tags) for display.
 		metricNames := make([]string, len(c.Members))

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -1130,7 +1130,6 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 	api.writeJSON(w, response)
 }
 
-
 // handleLeadLag returns lead-lag edges.
 func (api *TestBenchAPI) handleLeadLag(w http.ResponseWriter, _ *http.Request) {
 	edges, enabled := api.tb.GetLeadLagEdges()

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -770,7 +770,7 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 			DetectorComponent: detectorComponentMap[a.DetectorName],
 			Title:             a.Title,
 			Description:       a.Description,
-			Tags:              a.Tags,
+			Tags:              a.Source.Tags,
 			Timestamp:         a.Timestamp,
 		}
 		if a.DebugInfo != nil {
@@ -851,7 +851,7 @@ func (api *TestBenchAPI) handleLogAnomalies(w http.ResponseWriter, r *http.Reque
 			DetectorName: a.DetectorName,
 			Title:        a.Title,
 			Description:  a.Description,
-			Tags:         a.Tags,
+			Tags:         a.Source.Tags,
 			Timestamp:    a.Timestamp,
 			Score:        a.Score,
 		})
@@ -1034,7 +1034,7 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 	for i, c := range correlations {
 		anomalies := make([]anomalyOutput, len(c.Anomalies))
 		for j, a := range c.Anomalies {
-			tags := a.Tags
+			tags := a.Source.Tags
 			if tags == nil {
 				tags = []string{}
 			}
@@ -1047,16 +1047,21 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 				Tags:        tags,
 			}
 		}
-		// Build member series ID strings from MemberRefs
-		memberIDs := make([]string, len(c.MemberRefs))
-		for k, ref := range c.MemberRefs {
-			memberIDs[k] = strconv.Itoa(int(ref))
+		// Build member series strings from Members
+		memberIDs := make([]string, len(c.Members))
+		for k, m := range c.Members {
+			memberIDs[k] = m.String()
+		}
+		// Build metric names from Members for backward compatibility
+		metricNames := make([]string, len(c.Members))
+		for k, m := range c.Members {
+			metricNames[k] = m.String()
 		}
 		response[i] = correlationResponse{
 			Pattern:         c.Pattern,
 			Title:           c.Title,
 			MemberSeriesIDs: memberIDs,
-			MetricNames:     metricNamesToStrings(c.MetricNames),
+			MetricNames:     metricNames,
 			Anomalies:       anomalies,
 			FirstSeen:       c.FirstSeen,
 			LastUpdated:     c.LastUpdated,
@@ -1066,13 +1071,6 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 	api.writeJSON(w, response)
 }
 
-func metricNamesToStrings(names []observerdef.MetricName) []string {
-	out := make([]string, len(names))
-	for i, n := range names {
-		out[i] = string(n)
-	}
-	return out
-}
 
 // handleLeadLag returns lead-lag edges.
 func (api *TestBenchAPI) handleLeadLag(w http.ResponseWriter, _ *http.Request) {

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -668,9 +668,10 @@ func (api *TestBenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namesp
 	}
 
 	// Build a QueryHandle for anomaly lookup using the storage's series ref.
-	// If we can't resolve the ref, we skip anomaly matching for this path.
+	// Use the returned series identity (not the request params) so that
+	// nil-tag requests that match a tagged series still find the ref.
 	var markers []anomalyMarker
-	key := seriesKey(namespace, name, tags)
+	key := seriesKey(series.Namespace, name, series.Tags)
 	if ref, ok := storage.LookupRef(key); ok {
 		qh := observerdef.QueryHandle{Ref: ref, Aggregate: observerdef.Aggregate(agg)}
 		anomalies := api.tb.GetMetricsAnomaliesForView(qh)
@@ -1047,12 +1048,12 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 				Tags:        tags,
 			}
 		}
-		// Build member series strings from Members
+		// Build member series IDs with tags for unique identification across tag variants.
 		memberIDs := make([]string, len(c.Members))
 		for k, m := range c.Members {
-			memberIDs[k] = m.String()
+			memberIDs[k] = m.DisplayName()
 		}
-		// Build metric names from Members for backward compatibility
+		// Build metric names (name:agg only, no tags) for display.
 		metricNames := make([]string, len(c.Members))
 		for k, m := range c.Members {
 			metricNames[k] = m.String()

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -458,7 +458,7 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 		for _, m := range metas {
 			for _, agg := range []Aggregate{AggregateAverage, AggregateCount} {
 				nameWithAgg := m.Name + ":" + aggSuffix(agg)
-				compactID := strconv.Itoa(int(m.Handle)) + ":" + aggSuffix(agg)
+				compactID := strconv.Itoa(int(m.Ref)) + ":" + aggSuffix(agg)
 				_, virtual := extractorNs[m.Namespace]
 				allSeries = append(allSeries, seriesInfo{
 					ID:         compactID,
@@ -494,7 +494,7 @@ func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Req
 		prefix := seriesID[:colonIdx]
 		if numericID, parseErr := strconv.Atoi(prefix); parseErr == nil {
 			aggStr := seriesID[colonIdx+1:]
-			api.handleNumericSeriesData(w, observerdef.SeriesHandle(numericID), aggStr, seriesID)
+			api.handleNumericSeriesData(w, observerdef.SeriesRef(numericID), aggStr, seriesID)
 			return
 		}
 	}
@@ -505,11 +505,11 @@ func (api *TestBenchAPI) handleSeriesDataByID(w http.ResponseWriter, r *http.Req
 		api.writeError(w, http.StatusBadRequest, "invalid series id")
 		return
 	}
-	api.handleSeriesDataForSeries(w, namespace, nameWithAgg, tags, observerdef.SeriesID(seriesID))
+	api.handleSeriesDataForSeries(w, namespace, nameWithAgg, tags, seriesID)
 }
 
 // handleNumericSeriesData resolves a compact numeric ID to series data.
-func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID observerdef.SeriesHandle, aggStr string, originalID string) {
+func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericID observerdef.SeriesRef, aggStr string, originalID string) {
 	var agg Aggregate
 	switch aggStr {
 	case "avg":
@@ -540,20 +540,10 @@ func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericI
 	}
 
 	nameWithAgg := series.Name + ":" + aggStr
-	seriesID := observerdef.SeriesID(originalID)
 
-	// Look up anomalies using the full key format that detectors produce
-	// (e.g. "parquet|metric:avg|tags"), not the compact numeric ID.
-	fullKey, _ := storage.FullKeyForNumericID(numericID)
-	var fullKeyWithAgg string
-	if ns, name, tags, ok := parseSeriesKey(fullKey); ok {
-		fullKeyWithAgg = seriesKey(ns, name+":"+aggStr, tags)
-	}
-	anomalyLookupID := seriesID
-	if fullKeyWithAgg != "" {
-		anomalyLookupID = observerdef.SeriesID(fullKeyWithAgg)
-	}
-	anomalies := api.tb.GetMetricsAnomaliesForSeries(anomalyLookupID)
+	// Build a QueryHandle for anomaly lookup
+	qh := observerdef.QueryHandle{Ref: numericID, Aggregate: observerdef.Aggregate(agg)}
+	anomalies := api.tb.GetMetricsAnomaliesForView(qh)
 
 	type anomalyMarker struct {
 		Timestamp         int64  `json:"timestamp"`
@@ -573,7 +563,7 @@ func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericI
 			Timestamp:         a.Timestamp,
 			DetectorName:      a.DetectorName,
 			DetectorComponent: detectorComponentMap[a.DetectorName],
-			SourceSeriesID:    string(seriesID),
+			SourceSeriesID:    originalID,
 			Title:             a.Title,
 		})
 	}
@@ -593,7 +583,7 @@ func (api *TestBenchAPI) handleNumericSeriesData(w http.ResponseWriter, numericI
 	}
 
 	resp := seriesResponse{
-		ID:        string(seriesID),
+		ID:        originalID,
 		Namespace: series.Namespace,
 		Name:      nameWithAgg,
 		Tags:      series.Tags,
@@ -631,7 +621,7 @@ func (api *TestBenchAPI) handleSeriesData(w http.ResponseWriter, r *http.Request
 	api.handleSeriesDataForSeries(w, namespace, nameWithAgg, nil, "")
 }
 
-func (api *TestBenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namespace, nameWithAgg string, tags []string, requestedID observerdef.SeriesID) {
+func (api *TestBenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namespace, nameWithAgg string, tags []string, requestedID string) {
 	seriesID := requestedID
 
 	// Parse aggregation suffix (e.g., "metric:avg" or "metric:count")
@@ -666,11 +656,8 @@ func (api *TestBenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namesp
 		return
 	}
 	if seriesID == "" {
-		seriesID = observerdef.SeriesID(seriesKey(series.Namespace, nameWithAgg, series.Tags))
+		seriesID = seriesKey(series.Namespace, nameWithAgg, series.Tags)
 	}
-
-	// Get anomalies for this series to include in response
-	anomalies := api.tb.GetMetricsAnomaliesForSeries(seriesID)
 
 	type anomalyMarker struct {
 		Timestamp         int64  `json:"timestamp"`
@@ -680,21 +667,28 @@ func (api *TestBenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namesp
 		Title             string `json:"title"`
 	}
 
+	// Build a QueryHandle for anomaly lookup using the storage's series ref.
+	// If we can't resolve the ref, we skip anomaly matching for this path.
 	var markers []anomalyMarker
-	detectorComponentMap := api.tb.GetDetectorComponentMap()
-	for _, a := range anomalies {
-		if a.DetectorName == "" || a.Timestamp == 0 {
-			log.Printf("skipping malformed anomaly marker for series %q: detector=%q ts=%d",
-				string(seriesID), a.DetectorName, a.Timestamp)
-			continue
+	key := seriesKey(namespace, name, tags)
+	if ref, ok := storage.LookupRef(key); ok {
+		qh := observerdef.QueryHandle{Ref: ref, Aggregate: observerdef.Aggregate(agg)}
+		anomalies := api.tb.GetMetricsAnomaliesForView(qh)
+		detectorComponentMap := api.tb.GetDetectorComponentMap()
+		for _, a := range anomalies {
+			if a.DetectorName == "" || a.Timestamp == 0 {
+				log.Printf("skipping malformed anomaly marker for series %q: detector=%q ts=%d",
+					seriesID, a.DetectorName, a.Timestamp)
+				continue
+			}
+			markers = append(markers, anomalyMarker{
+				Timestamp:         a.Timestamp,
+				DetectorName:      a.DetectorName,
+				DetectorComponent: detectorComponentMap[a.DetectorName],
+				SourceSeriesID:    seriesID,
+				Title:             a.Title,
+			})
 		}
-		markers = append(markers, anomalyMarker{
-			Timestamp:         a.Timestamp,
-			DetectorName:      a.DetectorName,
-			DetectorComponent: detectorComponentMap[a.DetectorName],
-			SourceSeriesID:    string(seriesID),
-			Title:             a.Title,
-		})
 	}
 
 	type pointOutput struct {
@@ -712,7 +706,7 @@ func (api *TestBenchAPI) handleSeriesDataForSeries(w http.ResponseWriter, namesp
 	}
 
 	resp := seriesResponse{
-		ID:        string(seriesID),
+		ID:        seriesID,
 		Namespace: series.Namespace,
 		Name:      nameWithAgg,
 		Tags:      series.Tags,
@@ -766,13 +760,9 @@ func (api *TestBenchAPI) handleAnomalies(w http.ResponseWriter, r *http.Request)
 	}
 
 	detectorComponentMap := api.tb.GetDetectorComponentMap()
-	storage := api.tb.getStorage()
 
 	toResponse := func(a observerdef.Anomaly) anomalyResponse {
-		sourceSeriesID := string(a.SourceSeriesID)
-		if storage != nil {
-			sourceSeriesID = storage.CompactSeriesID(sourceSeriesID)
-		}
+		sourceSeriesID := a.SourceView.String()
 		resp := anomalyResponse{
 			Source:            a.Source.String(),
 			SourceSeriesID:    sourceSeriesID,
@@ -1020,7 +1010,6 @@ func (api *TestBenchAPI) handleLogsSummary(w http.ResponseWriter, r *http.Reques
 // handleCorrelations returns detected correlations.
 func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Request) {
 	correlations := api.tb.GetCorrelations()
-	storage := api.tb.getStorage()
 
 	type anomalyOutput struct {
 		Source      string   `json:"source"`
@@ -1058,11 +1047,10 @@ func (api *TestBenchAPI) handleCorrelations(w http.ResponseWriter, _ *http.Reque
 				Tags:        tags,
 			}
 		}
-		memberIDs := seriesIDsToStrings(c.MemberSeriesIDs)
-		if storage != nil {
-			for k, id := range memberIDs {
-				memberIDs[k] = storage.CompactSeriesID(id)
-			}
+		// Build member series ID strings from MemberRefs
+		memberIDs := make([]string, len(c.MemberRefs))
+		for k, ref := range c.MemberRefs {
+			memberIDs[k] = strconv.Itoa(int(ref))
 		}
 		response[i] = correlationResponse{
 			Pattern:         c.Pattern,
@@ -1082,14 +1070,6 @@ func metricNamesToStrings(names []observerdef.MetricName) []string {
 	out := make([]string, len(names))
 	for i, n := range names {
 		out[i] = string(n)
-	}
-	return out
-}
-
-func seriesIDsToStrings(ids []observerdef.SeriesID) []string {
-	out := make([]string, len(ids))
-	for i, id := range ids {
-		out[i] = string(id)
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

- Anomalies from per-series detectors now carry a `SourceRef *QueryHandle` (numeric storage ref + aggregate), so the API layer calls `CompactID()` directly instead of reconstructing string keys and parsing them back apart via `CompactSeriesID()`
- Replaces `AnomalySource` (no tags) + `SeriesID` (opaque string) + `SeriesHandle` with `SeriesDescriptor` (carries tags) + `SeriesRef` + `QueryHandle` — series identity is self-contained instead of split across multiple fields
- Collapses `ActiveCorrelation.MemberSeriesIDs` + `MetricNames` into a single `Members []SeriesDescriptor`

## Motivation

The `seriesDetectorAdapter` had access to the numeric series ref from `ListSeries()` at detection time, but discarded it. Anomalies were enriched with a `SourceSeriesID` string built by `seriesKey(namespace, nameWithAgg, tags)` — but storage keys don't include the agg suffix in the name. This format mismatch meant `CompactSeriesID()` had to parse the suffix back out, and any divergence in string format (tag ordering, missing tags) silently fell through to an unresolved fallback. Carrying the ref directly eliminates the round-trip.

## Test plan

- [ ] `go test ./comp/observer/impl/` — all existing tests pass
- [ ] `TestAdvance_LogMetricAnomalyIsEnrichedViaMatchingSeriesIdentity` — new end-to-end test covering the full log → extractor → storage → detector → enrichment path
- [ ] Load a scenario with RRCF in testbench, verify `/api/anomalies` and `/api/correlations` return compact IDs matching `/api/series`
- [ ] Verify RRCF anomalies (no `SourceRef`) still resolve via telemetry remapping fallback