### PR TITLE
static quality gates: adjust the MSI on disk threshold

### DIFF
--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -7,6 +7,10 @@ static_quality_gates:
     - !reference [.on_main_or_release_branch]
     - !reference [.on_mergequeue]
     - !reference [.on_dev_branches_with_artifact_changes]
+    - changes:
+        paths:
+          - test/static/static_quality_gates.yml
+        compare_to: $COMPARE_TO_BRANCH
     - when: manual
       allow_failure: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64

--- a/test/static/static_quality_gates.yml
+++ b/test/static/static_quality_gates.yml
@@ -8,7 +8,7 @@ static_quality_gate_agent_heroku_amd64:
   max_on_disk_size: 320.58 MiB
   max_on_wire_size: 79.97 MiB
 static_quality_gate_agent_msi:
-  max_on_disk_size: 1062.52 MiB
+  max_on_disk_size: 651.44 MiB
   max_on_wire_size: 146.22 MiB
 static_quality_gate_agent_rpm_amd64:
   max_on_disk_size: 753.35 MiB


### PR DESCRIPTION
### What does this PR do?

Reduce the MSI on disk threshold by 411.08MB

### Motivation

This accounts for the savings in #43993 that weren't reflected yet. 
Fix [ABLD-336](https://datadoghq.atlassian.net/browse/ABLD-336)

### Describe how you validated your changes

### Additional Notes


[ABLD-336]: https://datadoghq.atlassian.net/browse/ABLD-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ