### PR TITLE
CI: run the SQG job when the threshold file changes

### DIFF
--- a/.gitlab/test/functional_test/static_quality_gate.yml
+++ b/.gitlab/test/functional_test/static_quality_gate.yml
@@ -7,6 +7,10 @@ static_quality_gates:
     - !reference [.on_main_or_release_branch]
     - !reference [.on_mergequeue]
     - !reference [.on_dev_branches_with_artifact_changes]
+    - changes:
+        paths:
+          - test/static/static_quality_gates.yml
+        compare_to: $COMPARE_TO_BRANCH
     - when: manual
       allow_failure: true
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/docker_x64$CI_IMAGE_DOCKER_X64_SUFFIX:$CI_IMAGE_DOCKER_X64


### PR DESCRIPTION
### What does this PR do?

Ensure the SQG job triggers when changing the thresholds

### Motivation

We don't want to allow a threshold change that would cause all following SQG runs to fail

### Describe how you validated your changes

I realized that the SQG job didn't run on this PR: https://github.com/DataDog/datadog-agent/pull/48268
I'll rebase it on top of this change and ensure that it now runs by default

### Additional Notes
