### PR TITLE
[observer] Add telemetry support to LogMetricsExtractors

### DIFF
--- a/comp/observer/README.md
+++ b/comp/observer/README.md
@@ -112,9 +112,9 @@ Reporters query state interfaces like `Correlator` and `RawAnomalyState` to acce
 
 When a log is observed, two things happen:
 
-1. **LogMetricsExtractors** run synchronously, transforming the log into metrics:
+1. **LogMetricsExtractors** run synchronously, transforming the log into metrics (and optional telemetry for debugging):
    ```
-   ProcessLog(log LogView) → []MetricOutput
+   ProcessLog(log LogView) → LogMetricsExtractorOutput { Metrics, Telemetry }
    ```
    Each returned metric is stored under the extractor's component name as the namespace and flows through normal detection. Implementations should be stateless and fast.
 
@@ -224,14 +224,16 @@ type MyExtractor struct{}
 
 func (m *MyExtractor) Name() string { return "my_extractor" }
 
-func (m *MyExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
+func (m *MyExtractor) ProcessLog(log observer.LogView) observer.LogMetricsExtractorOutput {
     content := string(log.GetContent())
     // Extract what you need synchronously — don't store the view
-    return []observer.MetricOutput{{
-        Name:  "my.metric",    // stored under the extractor's name as namespace
-        Value: 1,
-        Tags:  log.GetTags(),
-    }}
+    return observer.LogMetricsExtractorOutput{
+        Metrics: []observer.MetricOutput{{
+            Name:  "my.metric",    // stored under the extractor's name as namespace
+            Value: 1,
+            Tags:  log.GetTags(),
+        }},
+    }
 }
 ```
 

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -237,7 +237,7 @@ type LogMetricsExtractor interface {
 	// Name returns the extractor name for debugging and logging.
 	Name() string
 	// ProcessLog examines a log and returns any derived metrics.
-	ProcessLog(log LogView) []MetricOutput
+	ProcessLog(log LogView) LogMetricsExtractorOutput
 }
 
 // LogObserver is an optional interface that Detectors can implement to
@@ -255,6 +255,12 @@ type MetricOutput struct {
 	Value      float64
 	Tags       []string
 	ContextKey string
+}
+
+// LogMetricsExtractorOutput is what we obtain when we process a log with a log metrics extractor.
+type LogMetricsExtractorOutput struct {
+	Metrics   []MetricOutput
+	Telemetry []ObserverTelemetry
 }
 
 // MetricName is a human-readable metric identifier (e.g., "cpu.user:avg").

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -187,12 +187,13 @@ func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
 // IngestLog processes a log observation: runs extractors to produce virtual metrics,
 // notifies log observers, and consults the scheduler policy to determine whether
 // detectors should advance. Returns advance requests that the caller should execute.
-func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
+func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observerdef.ObserverTelemetry) {
 	sourceTag := "observer_source:" + source
 	view := &logView{obs: l}
+	var logTelemetry []observerdef.ObserverTelemetry
 	for _, extractor := range e.extractors {
-		metrics := extractor.ProcessLog(view)
-		for _, m := range metrics {
+		out := extractor.ProcessLog(view)
+		for _, m := range out.Metrics {
 			tags := copyTags(m.Tags)
 			if !sliceContains(tags, sourceTag) {
 				tags = append(tags, sourceTag)
@@ -206,6 +207,14 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 				}
 			}
 		}
+		if len(out.Telemetry) > 0 {
+			logTelemetry = append(logTelemetry, out.Telemetry...)
+		}
+	}
+	if len(logTelemetry) > 0 {
+		e.telemetryMu.Lock()
+		e.accumulatedTelemetry = append(e.accumulatedTelemetry, logTelemetry...)
+		e.telemetryMu.Unlock()
 	}
 	for _, lo := range e.logObservers {
 		lo.ProcessLog(view)
@@ -213,7 +222,7 @@ func (e *engine) IngestLog(source string, l *logObs) []advanceRequest {
 	dataTimeSec := l.timestampMs / 1000
 	e.storage.RecordObservationTime(dataTimeSec)
 	e.trackLatestDataTime(dataTimeSec)
-	return e.scheduler.onObservation(dataTimeSec, e.schedulerState())
+	return e.scheduler.onObservation(dataTimeSec, e.schedulerState()), logTelemetry
 }
 
 func sliceContains(items []string, want string) bool {

--- a/comp/observer/impl/events_test.go
+++ b/comp/observer/impl/events_test.go
@@ -11,9 +11,10 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
 // collectingSink collects all events for test assertions.
@@ -132,8 +133,8 @@ type stubExtractor struct {
 
 func (e *stubExtractor) Name() string { return e.name }
 
-func (e *stubExtractor) ProcessLog(_ observerdef.LogView) []observerdef.MetricOutput {
-	return nil
+func (e *stubExtractor) ProcessLog(_ observerdef.LogView) observerdef.LogMetricsExtractorOutput {
+	return observerdef.LogMetricsExtractorOutput{}
 }
 
 func (e *stubExtractor) GetContextByKey(key string) (observerdef.MetricContext, bool) {
@@ -300,12 +301,12 @@ func TestEnrichAnomalyWithRealLogPatternExtractorUsesStoredSeriesTags(t *testing
 		contextProviders: collectContextProviders([]observerdef.LogMetricsExtractor{extractor}),
 	})
 
-	e.IngestLog("source-a", &logObs{
+	_, _ = e.IngestLog("source-a", &logObs{
 		content:     []byte("GET /users/123 returned 500"),
 		tags:        []string{"service:api"},
 		timestampMs: 1_000,
 	})
-	e.IngestLog("source-b", &logObs{
+	_, _ = e.IngestLog("source-b", &logObs{
 		content:     []byte("GET /users/456 returned 500"),
 		tags:        []string{"service:worker"},
 		timestampMs: 2_000,
@@ -803,7 +804,7 @@ func TestFindingM12_LogOnlyTimestampsSkippedInReplay(t *testing.T) {
 	}
 
 	// Ingest log at 103 (no virtual metrics produced)
-	logRequests := e.IngestLog("ns", &logObs{
+	logRequests, _ := e.IngestLog("ns", &logObs{
 		content:     []byte("error happened"),
 		status:      "error",
 		timestampMs: 103000, // 103 seconds in millis
@@ -869,7 +870,7 @@ func TestIngestLogCopiesMetricTagsBeforeInjectingObserverSource(t *testing.T) {
 		extractors: []observerdef.LogMetricsExtractor{&sharedTagsExtractor{}},
 	})
 
-	e.IngestLog("source-a", &logObs{
+	_, _ = e.IngestLog("source-a", &logObs{
 		content:     []byte("hello"),
 		tags:        []string{"env:test"},
 		timestampMs: 1000,

--- a/comp/observer/impl/log_detector_connection_errors.go
+++ b/comp/observer/impl/log_detector_connection_errors.go
@@ -40,18 +40,20 @@ func (c *ConnectionErrorExtractor) Name() string {
 
 // ProcessLog checks if a log contains connection error patterns and returns a metric if so.
 // Anomaly detection is handled by metrics detection on the count aggregation of the emitted metric.
-func (c *ConnectionErrorExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
+func (c *ConnectionErrorExtractor) ProcessLog(log observer.LogView) observer.LogMetricsExtractorOutput {
 	content := strings.ToLower(string(log.GetContent()))
 
 	for _, pattern := range connectionErrorPatterns {
 		if strings.Contains(content, pattern) {
-			return []observer.MetricOutput{{
-				Name:  "connection.errors",
-				Value: 1.0,
-				Tags:  log.GetTags(),
-			}}
+			return observer.LogMetricsExtractorOutput{
+				Metrics: []observer.MetricOutput{{
+					Name:  "connection.errors",
+					Value: 1.0,
+					Tags:  log.GetTags(),
+				}},
+			}
 		}
 	}
 
-	return nil
+	return observer.LogMetricsExtractorOutput{}
 }

--- a/comp/observer/impl/log_detector_connection_errors_test.go
+++ b/comp/observer/impl/log_detector_connection_errors_test.go
@@ -25,10 +25,10 @@ func TestConnectionErrorExtractor_Process_ConnectionRefused(t *testing.T) {
 
 	result := e.ProcessLog(log)
 
-	assert.Len(t, result, 1)
-	assert.Equal(t, "connection.errors", result[0].Name)
-	assert.Equal(t, 1.0, result[0].Value)
-	assert.Equal(t, []string{"env:prod", "service:api"}, result[0].Tags)
+	assert.Len(t, result.Metrics, 1)
+	assert.Equal(t, "connection.errors", result.Metrics[0].Name)
+	assert.Equal(t, 1.0, result.Metrics[0].Value)
+	assert.Equal(t, []string{"env:prod", "service:api"}, result.Metrics[0].Tags)
 }
 
 func TestConnectionErrorExtractor_Process_ECONNRESET(t *testing.T) {
@@ -40,10 +40,10 @@ func TestConnectionErrorExtractor_Process_ECONNRESET(t *testing.T) {
 
 	result := e.ProcessLog(log)
 
-	assert.Len(t, result, 1)
-	assert.Equal(t, "connection.errors", result[0].Name)
-	assert.Equal(t, 1.0, result[0].Value)
-	assert.Equal(t, []string{"env:staging"}, result[0].Tags)
+	assert.Len(t, result.Metrics, 1)
+	assert.Equal(t, "connection.errors", result.Metrics[0].Name)
+	assert.Equal(t, 1.0, result.Metrics[0].Value)
+	assert.Equal(t, []string{"env:staging"}, result.Metrics[0].Tags)
 }
 
 func TestConnectionErrorExtractor_Process_NoMatch(t *testing.T) {
@@ -55,7 +55,7 @@ func TestConnectionErrorExtractor_Process_NoMatch(t *testing.T) {
 
 	result := e.ProcessLog(log)
 
-	assert.Empty(t, result)
+	assert.Empty(t, result.Metrics)
 }
 
 func TestConnectionErrorExtractor_Process_CaseInsensitive(t *testing.T) {
@@ -67,10 +67,10 @@ func TestConnectionErrorExtractor_Process_CaseInsensitive(t *testing.T) {
 
 	result := e.ProcessLog(log)
 
-	assert.Len(t, result, 1)
-	assert.Equal(t, "connection.errors", result[0].Name)
-	assert.Equal(t, 1.0, result[0].Value)
-	assert.Equal(t, []string{"env:prod"}, result[0].Tags)
+	assert.Len(t, result.Metrics, 1)
+	assert.Equal(t, "connection.errors", result.Metrics[0].Name)
+	assert.Equal(t, 1.0, result.Metrics[0].Value)
+	assert.Equal(t, []string{"env:prod"}, result.Metrics[0].Tags)
 }
 
 func TestConnectionErrorExtractor_Process_TagsCopied(t *testing.T) {
@@ -83,8 +83,8 @@ func TestConnectionErrorExtractor_Process_TagsCopied(t *testing.T) {
 
 	result := e.ProcessLog(log)
 
-	assert.Len(t, result, 1)
-	assert.Equal(t, inputTags, result[0].Tags)
+	assert.Len(t, result.Metrics, 1)
+	assert.Equal(t, inputTags, result.Metrics[0].Tags)
 }
 
 func TestConnectionErrorExtractor_Process_AllPatterns(t *testing.T) {
@@ -111,9 +111,9 @@ func TestConnectionErrorExtractor_Process_AllPatterns(t *testing.T) {
 
 			result := e.ProcessLog(log)
 
-			assert.Len(t, result, 1, "Expected metric for pattern: %s", tc.name)
-			assert.Equal(t, "connection.errors", result[0].Name)
-			assert.Equal(t, 1.0, result[0].Value)
+			assert.Len(t, result.Metrics, 1, "Expected metric for pattern: %s", tc.name)
+			assert.Equal(t, "connection.errors", result.Metrics[0].Name)
+			assert.Equal(t, 1.0, result.Metrics[0].Value)
 		})
 	}
 }

--- a/comp/observer/impl/log_metrics_extractor.go
+++ b/comp/observer/impl/log_metrics_extractor.go
@@ -79,14 +79,14 @@ func (a *LogMetricsExtractor) GetContextByKey(key string) (observer.MetricContex
 	return ctx, ok
 }
 
-func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.MetricOutput {
+func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) observer.LogMetricsExtractorOutput {
 	content := log.GetContent()
 	tags := log.GetTags()
 
 	// Always emit pattern frequency metric for all logs
 	patternSig := logSignature(content, a.config.MaxEvalBytes)
 	if patternSig == "" {
-		return nil
+		return observer.LogMetricsExtractorOutput{}
 	}
 
 	metricName := patternCountMetricName(patternSig)
@@ -114,7 +114,7 @@ func (a *LogMetricsExtractor) ProcessLog(log observer.LogView) []observer.Metric
 		metrics = append(metrics, a.extractJSONFieldMetrics(content, tags)...)
 	}
 
-	return metrics
+	return observer.LogMetricsExtractorOutput{Metrics: metrics}
 }
 
 func isJSONObject(b []byte) bool {

--- a/comp/observer/impl/log_metrics_extractor_test.go
+++ b/comp/observer/impl/log_metrics_extractor_test.go
@@ -10,9 +10,10 @@ import (
 	"hash/fnv"
 	"testing"
 
-	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	observer "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
 func TestLogMetricsExtractor_JSONNumericExtraction(t *testing.T) {
@@ -29,11 +30,11 @@ func TestLogMetricsExtractor_JSONNumericExtraction(t *testing.T) {
 	}
 
 	res := a.ProcessLog(log)
-	assert.Len(t, res, 3) // 2 numeric fields + pattern count
+	assert.Len(t, res.Metrics, 3) // 2 numeric fields + pattern count
 
 	// Order is map iteration dependent; just assert set membership.
 	got := map[string]observer.MetricOutput{}
-	for _, m := range res {
+	for _, m := range res.Metrics {
 		got[m.Name] = m
 	}
 
@@ -66,15 +67,15 @@ func TestLogMetricsExtractor_UnstructuredPatternCount(t *testing.T) {
 	}
 
 	res := a.ProcessLog(log)
-	assert.Len(t, res, 1)
-	assert.Equal(t, float64(1), res[0].Value)
-	assert.Equal(t, []string{"service:web"}, res[0].Tags)
+	assert.Len(t, res.Metrics, 1)
+	assert.Equal(t, float64(1), res.Metrics[0].Value)
+	assert.Equal(t, []string{"service:web"}, res.Metrics[0].Tags)
 
 	// Compute expected metric name (hash of signature).
 	sig := logSignature([]byte("Request completed in 45ms"), 0)
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(sig))
-	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res[0].Name)
+	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res.Metrics[0].Name)
 }
 
 func TestLogMetricsExtractor_JSONIncludeFields(t *testing.T) {
@@ -90,10 +91,10 @@ func TestLogMetricsExtractor_JSONIncludeFields(t *testing.T) {
 	}
 
 	res := a.ProcessLog(log)
-	require.Len(t, res, 2) // selected numeric field + pattern count
+	require.Len(t, res.Metrics, 2) // selected numeric field + pattern count
 
 	got := map[string]observer.MetricOutput{}
-	for _, m := range res {
+	for _, m := range res.Metrics {
 		got[m.Name] = m
 	}
 
@@ -118,12 +119,12 @@ func TestLogMetricsExtractor_InvalidJSONFallsBackToUnstructured(t *testing.T) {
 	log := &mockLogView{content: input, tags: []string{"service:api"}}
 
 	res := a.ProcessLog(log)
-	require.Len(t, res, 1)
+	require.Len(t, res.Metrics, 1)
 
 	sig := logSignature(input, 0)
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(sig))
-	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res[0].Name)
+	assert.Equal(t, fmt.Sprintf("log.pattern.%x.count", h.Sum64()), res.Metrics[0].Name)
 }
 
 func TestLogMetricsExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
@@ -134,10 +135,10 @@ func TestLogMetricsExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
 	}
 
 	res := a.ProcessLog(log)
-	require.Len(t, res, 1)
-	require.NotEmpty(t, res[0].ContextKey)
+	require.Len(t, res.Metrics, 1)
+	require.NotEmpty(t, res.Metrics[0].ContextKey)
 
-	ctx, ok := a.GetContextByKey(res[0].ContextKey)
+	ctx, ok := a.GetContextByKey(res.Metrics[0].ContextKey)
 	require.True(t, ok)
 	assert.Equal(t, "log_metrics_extractor", ctx.Source)
 	assert.Equal(t, "Request completed in 45ms", ctx.Example)
@@ -156,14 +157,14 @@ func TestLogMetricsExtractor_ContextKeySeparatesSameMetricByTags(t *testing.T) {
 
 	resA := a.ProcessLog(logA)
 	resB := a.ProcessLog(logB)
-	require.Len(t, resA, 1)
-	require.Len(t, resB, 1)
-	require.Equal(t, resA[0].Name, resB[0].Name)
-	require.NotEqual(t, resA[0].ContextKey, resB[0].ContextKey)
+	require.Len(t, resA.Metrics, 1)
+	require.Len(t, resB.Metrics, 1)
+	require.Equal(t, resA.Metrics[0].Name, resB.Metrics[0].Name)
+	require.NotEqual(t, resA.Metrics[0].ContextKey, resB.Metrics[0].ContextKey)
 
-	ctxA, ok := a.GetContextByKey(resA[0].ContextKey)
+	ctxA, ok := a.GetContextByKey(resA.Metrics[0].ContextKey)
 	require.True(t, ok)
-	ctxB, ok := a.GetContextByKey(resB[0].ContextKey)
+	ctxB, ok := a.GetContextByKey(resB.Metrics[0].ContextKey)
 	require.True(t, ok)
 
 	assert.Equal(t, "Request completed in 45ms", ctxA.Example)

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -97,11 +97,11 @@ func (e *LogPatternExtractor) GetContextByKey(key string) (observerdef.MetricCon
 }
 
 // ProcessLog clusters the log message and emits a count metric for its pattern.
-func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) []observerdef.MetricOutput {
+func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.LogMetricsExtractorOutput {
 	message := string(log.GetContent())
 	clusterResult := e.PatternClusterer.Process(message)
 	if clusterResult == nil {
-		return nil
+		return observerdef.LogMetricsExtractorOutput{}
 	}
 
 	patternKey := NewPatternKeyInfo(clusterResult.Cluster.ID)
@@ -116,10 +116,15 @@ func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) []observerdef.
 		example: message,
 	}
 
-	return []observerdef.MetricOutput{{
-		Name:       metricName,
-		Value:      1,
-		Tags:       log.GetTags(),
-		ContextKey: contextKey,
-	}}
+	return observerdef.LogMetricsExtractorOutput{
+		Metrics: []observerdef.MetricOutput{{
+			Name:       metricName,
+			Value:      1,
+			Tags:       log.GetTags(),
+			ContextKey: contextKey,
+		}},
+		Telemetry: []observerdef.ObserverTelemetry{
+			newTelemetryGauge(e.Name(), telemetryLogPatternExtractorPatternCount, float64(e.PatternClusterer.NumClusters()), log.GetTimestampUnixMilli()/1000),
+		},
+	}
 }

--- a/comp/observer/impl/log_pattern_extractor_test.go
+++ b/comp/observer/impl/log_pattern_extractor_test.go
@@ -21,10 +21,10 @@ func TestLogPatternExtractor_GetContextByKeyUsesOutputContextKey(t *testing.T) {
 	}
 
 	res := e.ProcessLog(log)
-	require.Len(t, res, 1)
-	require.NotEmpty(t, res[0].ContextKey)
+	require.Len(t, res.Metrics, 1)
+	require.NotEmpty(t, res.Metrics[0].ContextKey)
 
-	ctx, ok := e.GetContextByKey(res[0].ContextKey)
+	ctx, ok := e.GetContextByKey(res.Metrics[0].ContextKey)
 	require.True(t, ok)
 	assert.Equal(t, "log_pattern_extractor", ctx.Source)
 	assert.Equal(t, "GET /users/123 returned 500", ctx.Example)
@@ -45,14 +45,14 @@ func TestLogPatternExtractor_ContextKeySeparatesSameMetricByTags(t *testing.T) {
 
 	resA := e.ProcessLog(logA)
 	resB := e.ProcessLog(logB)
-	require.Len(t, resA, 1)
-	require.Len(t, resB, 1)
-	require.Equal(t, resA[0].Name, resB[0].Name)
-	require.NotEqual(t, resA[0].ContextKey, resB[0].ContextKey)
+	require.Len(t, resA.Metrics, 1)
+	require.Len(t, resB.Metrics, 1)
+	require.Equal(t, resA.Metrics[0].Name, resB.Metrics[0].Name)
+	require.NotEqual(t, resA.Metrics[0].ContextKey, resB.Metrics[0].ContextKey)
 
-	ctxA, ok := e.GetContextByKey(resA[0].ContextKey)
+	ctxA, ok := e.GetContextByKey(resA.Metrics[0].ContextKey)
 	require.True(t, ok)
-	ctxB, ok := e.GetContextByKey(resB[0].ContextKey)
+	ctxB, ok := e.GetContextByKey(resB.Metrics[0].ContextKey)
 	require.True(t, ok)
 
 	assert.Equal(t, "GET /users/123 returned 500", ctxA.Example)
@@ -69,13 +69,13 @@ func TestLogPatternExtractor_ResetClearsContext(t *testing.T) {
 	}
 
 	res := e.ProcessLog(log)
-	require.Len(t, res, 1)
+	require.Len(t, res.Metrics, 1)
 
-	_, ok := e.GetContextByKey(res[0].ContextKey)
+	_, ok := e.GetContextByKey(res.Metrics[0].ContextKey)
 	require.True(t, ok)
 
 	e.Reset()
 
-	_, ok = e.GetContextByKey(res[0].ContextKey)
+	_, ok = e.GetContextByKey(res.Metrics[0].ContextKey)
 	assert.False(t, ok)
 }

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -436,14 +436,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 		})
 
 		// Emit telemetry for the CoDisp score at every scored shingle
-		telemetry = append(telemetry, observer.ObserverTelemetry{
-			DetectorName: r.Name(),
-			Metric: &metricObs{
-				name:      "score",
-				value:     score,
-				timestamp: s.endTimestamp,
-			},
-		})
+		telemetry = append(telemetry, newTelemetryGauge(r.Name(), telemetryRRCFScore, score, s.endTimestamp))
 
 		// Skip warmup phase — scores are artificial during forest filling
 		if r.totalScored <= warmup {
@@ -455,14 +448,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 
 		// Emit telemetry for the dynamic threshold (only after warmup when threshold is meaningful)
 		if threshold > 0 {
-			telemetry = append(telemetry, observer.ObserverTelemetry{
-				DetectorName: r.Name(),
-				Metric: &metricObs{
-					name:      "threshold",
-					value:     threshold,
-					timestamp: s.endTimestamp,
-				},
-			})
+			telemetry = append(telemetry, newTelemetryGauge(r.Name(), telemetryRRCFThreshold, threshold, s.endTimestamp))
 		}
 
 		// Update rolling window (after computing threshold, so current score

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -415,7 +415,11 @@ func (o *observerImpl) run() {
 			requests = o.engine.IngestMetric(obs.source, obs.metric)
 		}
 		if obs.log != nil {
-			requests = append(requests, o.engine.IngestLog(obs.source, obs.log)...)
+			logRequests, logTelemetry := o.engine.IngestLog(obs.source, obs.log)
+			requests = append(requests, logRequests...)
+			if len(logTelemetry) > 0 {
+				o.telemetryHandler.handleTelemetry(logTelemetry)
+			}
 		}
 		if obs.trace != nil {
 			o.processTrace(obs.source, obs.trace)

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -18,6 +18,8 @@ import (
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
 	remoteagentregistry "github.com/DataDog/datadog-agent/comp/core/remoteagentregistry/def"
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
@@ -30,8 +32,9 @@ type Requires struct {
 	// When fields are nil, values are read from configuration defaults.
 	AgentInternalLogTap AgentInternalLogTapConfig
 
-	Config config.Component
-	Log    log.Component
+	Config    config.Component
+	Log       log.Component
+	Telemetry telemetry.Component
 
 	// Recorder is an optional component for transparent metric recording.
 	// If provided, all handles will be wrapped to record metrics to parquet files.
@@ -231,9 +234,15 @@ func NewComponent(deps Requires) Provides {
 		state:     eng.StateView(),
 	})
 
+	telemetryComp := deps.Telemetry
+	if telemetryComp == nil {
+		telemetryComp = noopsimpl.GetCompatComponent()
+	}
+
 	obs := &observerImpl{
-		engine: eng,
-		obsCh:  make(chan observation, 1000),
+		engine:           eng,
+		obsCh:            make(chan observation, 1000),
+		telemetryHandler: newTelemetryHandler(telemetryComp),
 	}
 
 	// Set up handle function based on recording and analysis configuration.
@@ -394,6 +403,8 @@ type observerImpl struct {
 
 	// fetcher pulls traces/profiles from remote trace-agents
 	fetcher *observerFetcher
+
+	telemetryHandler *telemetryHandler
 }
 
 // run is the main dispatch loop, processing all observations sequentially.
@@ -413,7 +424,8 @@ func (o *observerImpl) run() {
 			o.processProfile(obs.source, obs.profile)
 		}
 		for _, req := range requests {
-			o.engine.advanceWithReason(req.upToSec, req.reason)
+			result := o.engine.advanceWithReason(req.upToSec, req.reason)
+			o.telemetryHandler.handleTelemetry(result.telemetry)
 		}
 	}
 }

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"fmt"
+
+	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	// RRCF detector
+	telemetryRRCFScore     = "observer.rrcf.score"
+	telemetryRRCFThreshold = "observer.rrcf.threshold"
+
+	// Log extractor
+	// TODO(celian): how to handle counters? We should have a unified interface between observer / internal telemetry
+	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
+)
+
+// This is used to:
+// 1. Enumerate all the telemetry metrics that are emitted by the observer
+// 2. Send them to the backend if we are running in observer mode (not testbench)
+type telemetryHandler struct {
+	telemetryGauges map[string]telemetry.Gauge
+}
+
+func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
+	gauges := make(map[string]telemetry.Gauge)
+
+	// Gauges
+	gauges[telemetryRRCFScore] = telemetryComp.NewGauge(
+		"observer",
+		telemetryRRCFScore,
+		[]string{"detector"},
+		"RRCF CoDisp score per scored shingle",
+	)
+	gauges[telemetryRRCFThreshold] = telemetryComp.NewGauge(
+		"observer",
+		telemetryRRCFThreshold,
+		[]string{"detector"},
+		"RRCF dynamic anomaly detection threshold (post-warmup)",
+	)
+	gauges[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewGauge(
+		"observer",
+		telemetryLogPatternExtractorPatternCount,
+		[]string{"detector"},
+		"Log pattern extractor pattern count",
+	)
+
+	return &telemetryHandler{
+		telemetryGauges: gauges,
+	}
+}
+
+// handleTelemetry handles the telemetry events by sending them to the telemetry backend.
+// Note 1: we don't forward the exact timestamp for each telemetry event but this is not a problem
+// because we use this only in the observer with realtime data
+// Note 2: we don't send logs to the backend
+func (h *telemetryHandler) handleTelemetry(events []observerdef.ObserverTelemetry) {
+	for _, event := range events {
+		if event.Metric != nil {
+			gauge, isGauge := h.telemetryGauges[event.Metric.GetName()]
+			if isGauge {
+				fmt.Printf("Sending telemetry: %v\n", event.Metric.GetName())
+				gauge.Set(event.Metric.GetValue(), append(event.Metric.GetRawTags(), "detector:"+event.DetectorName)...)
+				continue
+			}
+
+			pkglog.Warnf("[observer] telemetry gauge not found: %s", event.Metric.GetName())
+		}
+	}
+}
+
+// isMetricRegistered checks if a metric is registered in the telemetry handler
+func (h *telemetryHandler) isMetricRegistered(metricName string) bool {
+	_, isRegistered := h.telemetryGauges[metricName]
+
+	return isRegistered
+}
+
+// newTelemetryGauge creates a new telemetry gauge for the given telemetry name, detector name, and data time.
+// Warning: use a `telemetryName` that is defined in this file.
+func newTelemetryGauge(detectorName string, telemetryName string, value float64, dataTime int64) observerdef.ObserverTelemetry {
+	return observerdef.ObserverTelemetry{
+		DetectorName: detectorName,
+		Metric: &metricObs{
+			name:      telemetryName,
+			value:     value,
+			tags:      []string{"detector:" + detectorName},
+			timestamp: dataTime,
+		},
+	}
+}

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -6,8 +6,6 @@
 package observerimpl
 
 import (
-	"fmt"
-
 	telemetry "github.com/DataDog/datadog-agent/comp/core/telemetry"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 	pkglog "github.com/DataDog/datadog-agent/pkg/util/log"
@@ -57,7 +55,6 @@ func (h *telemetryHandler) handleTelemetry(events []observerdef.ObserverTelemetr
 		if event.Metric != nil {
 			gauge, isGauge := h.telemetryGauges[event.Metric.GetName()]
 			if isGauge {
-				fmt.Printf("Sending telemetry: %v\n", event.Metric.GetName())
 				gauge.Set(event.Metric.GetValue(), event.Metric.GetRawTags()...)
 				continue
 			}

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -17,10 +17,6 @@ const (
 	// RRCF detector
 	telemetryRRCFScore     = "observer.rrcf.score"
 	telemetryRRCFThreshold = "observer.rrcf.threshold"
-
-	// Log extractor
-	// TODO(celian): how to handle counters? We should have a unified interface between observer / internal telemetry
-	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
 )
 
 // This is used to:
@@ -46,12 +42,6 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 		[]string{"detector"},
 		"RRCF dynamic anomaly detection threshold (post-warmup)",
 	)
-	gauges[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewGauge(
-		"observer",
-		telemetryLogPatternExtractorPatternCount,
-		[]string{"detector"},
-		"Log pattern extractor pattern count",
-	)
 
 	return &telemetryHandler{
 		telemetryGauges: gauges,
@@ -68,7 +58,7 @@ func (h *telemetryHandler) handleTelemetry(events []observerdef.ObserverTelemetr
 			gauge, isGauge := h.telemetryGauges[event.Metric.GetName()]
 			if isGauge {
 				fmt.Printf("Sending telemetry: %v\n", event.Metric.GetName())
-				gauge.Set(event.Metric.GetValue(), append(event.Metric.GetRawTags(), "detector:"+event.DetectorName)...)
+				gauge.Set(event.Metric.GetValue(), event.Metric.GetRawTags()...)
 				continue
 			}
 

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -15,6 +15,9 @@ const (
 	// RRCF detector
 	telemetryRRCFScore     = "observer.rrcf.score"
 	telemetryRRCFThreshold = "observer.rrcf.threshold"
+
+	// Log pattern extractor
+	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
 )
 
 // This is used to:
@@ -39,6 +42,12 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 		telemetryRRCFThreshold,
 		[]string{"detector"},
 		"RRCF dynamic anomaly detection threshold (post-warmup)",
+	)
+	gauges[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewGauge(
+		"observer",
+		telemetryLogPatternExtractorPatternCount,
+		[]string{"detector"},
+		"Log pattern extractor pattern count",
 	)
 
 	return &telemetryHandler{
@@ -73,14 +82,14 @@ func (h *telemetryHandler) isMetricRegistered(metricName string) bool {
 
 // newTelemetryGauge creates a new telemetry gauge for the given telemetry name, detector name, and data time.
 // Warning: use a `telemetryName` that is defined in this file.
-func newTelemetryGauge(detectorName string, telemetryName string, value float64, dataTime int64) observerdef.ObserverTelemetry {
+func newTelemetryGauge(detectorName string, telemetryName string, value float64, dataTimeSec int64) observerdef.ObserverTelemetry {
 	return observerdef.ObserverTelemetry{
 		DetectorName: detectorName,
 		Metric: &metricObs{
 			name:      telemetryName,
 			value:     value,
 			tags:      []string{"detector:" + detectorName},
-			timestamp: dataTime,
+			timestamp: dataTimeSec,
 		},
 	}
 }

--- a/comp/observer/impl/test_helpers_test.go
+++ b/comp/observer/impl/test_helpers_test.go
@@ -73,17 +73,19 @@ func (c *dynamicCorrelator) Reset() { c.currentIndex = 0 }
 type noopLogExtractor struct{}
 
 func (e *noopLogExtractor) Name() string { return "noop_extractor" }
-func (e *noopLogExtractor) ProcessLog(_ observerdef.LogView) []observerdef.MetricOutput {
-	return nil
+func (e *noopLogExtractor) ProcessLog(_ observerdef.LogView) observerdef.LogMetricsExtractorOutput {
+	return observerdef.LogMetricsExtractorOutput{}
 }
 
 type sharedTagsExtractor struct{}
 
 func (e *sharedTagsExtractor) Name() string { return "shared_tags_extractor" }
-func (e *sharedTagsExtractor) ProcessLog(log observerdef.LogView) []observerdef.MetricOutput {
+func (e *sharedTagsExtractor) ProcessLog(log observerdef.LogView) observerdef.LogMetricsExtractorOutput {
 	tags := log.GetTags()
-	return []observerdef.MetricOutput{
-		{Name: "metric.a", Value: 1, Tags: tags},
-		{Name: "metric.b", Value: 1, Tags: tags},
+	return observerdef.LogMetricsExtractorOutput{
+		Metrics: []observerdef.MetricOutput{
+			{Name: "metric.a", Value: 1, Tags: tags},
+			{Name: "metric.b", Value: 1, Tags: tags},
+		},
 	}
 }

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -721,8 +721,6 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 
 			if !tb.telemetryHandler.isMetricRegistered(metric.name) {
 				fmt.Printf("ERROR: [observer] metric %s is not registered\n", metric.name)
-			} else {
-				fmt.Printf("metric %s is registered\n", metric.name)
 			}
 		}
 
@@ -866,9 +864,9 @@ func (tb *TestBench) GetMetricsAnomaliesForSeries(seriesID observerdef.SeriesID)
 func (tb *TestBench) resolveAnomalySeriesIDs(anomalies []observerdef.Anomaly) []observerdef.Anomaly {
 	for i := range anomalies {
 		a := &anomalies[i]
+		// This comes from the telemetry
 		if a.SourceSeriesID == "" && a.Source.Name != "" {
-			telemetryName := "telemetry." + a.DetectorName + "." + a.Source.String()
-			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", telemetryName+":avg", nil))
+			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", a.Source.String()+":avg", nil))
 		}
 	}
 	return anomalies

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -20,6 +20,7 @@ import (
 	recorderdef "github.com/DataDog/datadog-agent/comp/anomalydetection/recorder/def"
 	config "github.com/DataDog/datadog-agent/comp/core/config"
 	log "github.com/DataDog/datadog-agent/comp/core/log/def"
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
 
@@ -127,6 +128,9 @@ type TestBench struct {
 
 	// API server
 	api *TestBenchAPI
+
+	// This is not directly used, it's mostly to ensure that telemetry metrics are registered in the telemetry handler
+	telemetryHandler *telemetryHandler
 }
 
 // ScenarioInfo describes an available scenario.
@@ -200,6 +204,7 @@ func NewTestBench(config TestBenchConfig) (*TestBench, error) {
 		logAnomaliesByDetector: make(map[string][]observerdef.Anomaly),
 		sse:                    hub,
 		sseStop:                stop,
+		telemetryHandler:       newTelemetryHandler(noopsimpl.GetCompatComponent()),
 	}
 
 	// Heartbeat goroutine — lets SSE clients detect stale connections.
@@ -712,7 +717,13 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				telemetryEvent.DetectorName = detectorName
 			}
 			// Save this for UI
-			tb.engine.Storage().Add("telemetry", "telemetry."+telemetryEvent.DetectorName+"."+metric.name, metric.value, metric.timestamp, metric.tags)
+			tb.engine.Storage().Add("telemetry", metric.name, metric.value, metric.timestamp, metric.tags)
+
+			if !tb.telemetryHandler.isMetricRegistered(metric.name) {
+				fmt.Printf("ERROR: [observer] metric %s is not registered\n", metric.name)
+			} else {
+				fmt.Printf("metric %s is registered\n", metric.name)
+			}
 		}
 
 		if telemetryEvent.Log != nil {

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -650,6 +650,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// log observers, and timestamp tracking all use the same code path as
 	// live ingestion. We ignore the returned advance requests because
 	// ReplayStoredData (below) will handle scheduling after all data is loaded.
+	var ingestTelemetry []observerdef.ObserverTelemetry
 	for _, log := range tb.rawLogs {
 		obs := &logObs{
 			content:     log.GetContent(),
@@ -658,7 +659,8 @@ func (tb *TestBench) rerunDetectorsLocked() {
 			hostname:    log.GetHostname(),
 			timestampMs: log.GetTimestampUnixMilli(),
 		}
-		tb.engine.IngestLog("parquet", obs)
+		_, tel := tb.engine.IngestLog("parquet", obs)
+		ingestTelemetry = append(ingestTelemetry, tel...)
 	}
 
 	// Replay all stored data through the scheduler policy.
@@ -669,7 +671,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 
 	// Handle telemetry (write telemetry metrics to storage for UI)
 	dataTime := tb.engine.Storage().MaxTimestamp()
-	for _, t := range result.telemetry {
+	for _, t := range append(ingestTelemetry, result.telemetry...) {
 		detName := t.DetectorName
 		if detName == "" {
 			detName = "unknown"

--- a/comp/observer/impl/testbench_api_test.go
+++ b/comp/observer/impl/testbench_api_test.go
@@ -94,7 +94,7 @@ func TestHandleSeriesListMarksLogPatternExtractorSeriesAsVirtual(t *testing.T) {
 	require.NoError(t, err)
 	api := NewTestBenchAPI(tb)
 
-	tb.engine.IngestLog("test-source", &logObs{
+	_, _ = tb.engine.IngestLog("test-source", &logObs{
 		content:     []byte("GET /users/123 returned 500"),
 		tags:        []string{"service:api"},
 		timestampMs: 2_000,


### PR DESCRIPTION
Adds telemetry output to the LogMetricsExtractorOutput struct, enabling extractors to emit telemetry alongside metrics.

Adds:
- `LogMetricsExtractorOutput` struct: replaces `[]MetricOutput` return type with a struct carrying both `Metrics` and `Telemetry` fields
- Log pattern extractor telemetry: emits `observer.log_pattern_extractor.pattern_count` gauge on each log processed