### PR TITLE
[PROF-14098] Add dd_evp_origin and dd_evp_origin_version to all profiles uploaded by the agent-based full host profiler

### DIFF
--- a/comp/host-profiler/collector/impl/agentprovider/config_builder.go
+++ b/comp/host-profiler/collector/impl/agentprovider/config_builder.go
@@ -55,7 +55,9 @@ func buildExporters(conf confMap, agent configManager) []any {
 			"profiles_endpoint": fmt.Sprintf(profilesEndpointFormat, site),
 			"metrics_endpoint":  fmt.Sprintf(metricsEndpointFormat, site),
 			"headers": confMap{
-				"dd-api-key": key,
+				"dd-api-key":            key,
+				"dd-evp-origin":         version.ProfilerName,
+				"dd-evp-origin-version": version.ProfilerVersion,
 			},
 		}
 	}

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: eu_key_1
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: eu_key_1
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: test_api_key_123
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
@@ -2,11 +2,15 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: additional_api_key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.com_1:
         headers:
             dd-api-key: main_api_key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
@@ -2,14 +2,14 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: additional_api_key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.com_1:
         headers:
             dd-api-key: main_api_key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
@@ -2,11 +2,15 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: test_api_key_123
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/us3.datadoghq.com_0:
         headers:
             dd-api-key: us3_api_key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
@@ -2,14 +2,14 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/us3.datadoghq.com_0:
         headers:
             dd-api-key: us3_api_key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp/us3.datadoghq.com_0:
         headers:
             dd-api-key: test_api_key_123
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp/us3.datadoghq.com_0:
         headers:
             dd-api-key: test_api_key_123
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.us3.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.us3.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
@@ -2,11 +2,15 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: main_key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: eu_key_1
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
@@ -2,14 +2,14 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: main_key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: eu_key_1
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
@@ -2,28 +2,28 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: main_key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: eu_key_1
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
     otlphttp/datadoghq.eu_1:
         headers:
             dd-api-key: eu_key_2
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
     otlphttp/datadoghq.eu_2:
         headers:
             dd-api-key: eu_key_3
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
@@ -2,21 +2,29 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: main_key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: eu_key_1
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
     otlphttp/datadoghq.eu_1:
         headers:
             dd-api-key: eu_key_2
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
     otlphttp/datadoghq.eu_2:
         headers:
             dd-api-key: eu_key_3
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: test_api_key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp/datadoghq.com_0:
         headers:
             dd-api-key: test_api_key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.com/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.com/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: test_key_123
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: test_key_123
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: test_api_key_456
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp/datadoghq.eu_0:
         headers:
             dd-api-key: test_api_key_456
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
         metrics_endpoint: https://otlp.datadoghq.eu/v1/metrics
         profiles_endpoint: https://intake.profile.datadoghq.eu/v1development/profiles
 extensions:

--- a/comp/host-profiler/collector/impl/converters/converter_table_test.go
+++ b/comp/host-profiler/collector/impl/converters/converter_table_test.go
@@ -248,6 +248,11 @@ func TestConverterWithoutAgent(t *testing.T) {
 			provided: "no_agent/preserve-res-attrs-no-system/in.yaml",
 			expected: "no_agent/preserve-res-attrs-no-system/out.yaml",
 		},
+		{
+			name:     "preserve-user-evp-headers",
+			provided: "no_agent/preserve-evp-headers/in.yaml",
+			expected: "no_agent/preserve-evp-headers/out.yaml",
+		},
 	}
 
 	runSuccessTests(t, newConverterWithoutAgent(confmap.ConverterSettings{Logger: zap.NewNop()}), tests)

--- a/comp/host-profiler/collector/impl/converters/converter_without_agent.go
+++ b/comp/host-profiler/collector/impl/converters/converter_without_agent.go
@@ -15,6 +15,7 @@ import (
 	"log/slog"
 	"slices"
 
+	"github.com/DataDog/datadog-agent/comp/host-profiler/version"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
 	"go.uber.org/zap/exp/zapslog"
@@ -338,6 +339,12 @@ func (c *converterWithoutAgent) ensureOtlpHTTPExporterConfig(conf confMap, expor
 
 			if !ensureKeyStringValue(headers, fieldDDAPIKey) {
 				return fmt.Errorf("%s exporter missing required dd-api-key header", name)
+			}
+			if _, err := SetDefault(headers, fieldDDEVPOrigin, version.ProfilerName); err != nil {
+				return err
+			}
+			if _, err := SetDefault(headers, fieldDDEVPOriginVersion, version.ProfilerVersion); err != nil {
+				return err
 			}
 		}
 	}

--- a/comp/host-profiler/collector/impl/converters/converters.go
+++ b/comp/host-profiler/collector/impl/converters/converters.go
@@ -56,6 +56,8 @@ const (
 const (
 	fieldAllowHostnameOverride = "allow_hostname_override"
 	fieldDDAPIKey              = "dd-api-key"
+	fieldDDEVPOrigin           = "dd-evp-origin"
+	fieldDDEVPOriginVersion    = "dd-evp-origin-version"
 	fieldAPIKey                = "api_key"
 	fieldAppKey                = "app_key"
 )

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: "12345"
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: "12345"
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -4,6 +4,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -4,7 +4,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -3,9 +3,13 @@ exporters:
     otlphttp/prod:
         headers:
             dd-api-key: "11111"
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
     otlphttp/staging:
         headers:
             dd-api-key: staging-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -3,12 +3,12 @@ exporters:
     otlphttp/prod:
         headers:
             dd-api-key: "11111"
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
     otlphttp/staging:
         headers:
             dd-api-key: staging-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/in.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/in.yaml
@@ -1,0 +1,12 @@
+exporters:
+  otlphttp:
+    headers:
+      dd-api-key: test-api-key
+      dd-evp-origin: custom-origin
+      dd-evp-origin-version: custom-version
+service:
+  pipelines:
+    profiles:
+      processors: []
+      receivers: []
+      exporters: [otlphttp]

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/out.yaml
@@ -1,15 +1,15 @@
 exporters:
     otlphttp:
         headers:
-            dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
-            dd-evp-origin-version: 7.0.0-test
+            dd-api-key: test-api-key
+            dd-evp-origin: custom-origin
+            dd-evp-origin-version: custom-version
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:
             - action: upsert
               key: profiler_name
-              value: host-profiler
+              value: full-host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test
@@ -36,7 +36,6 @@ service:
             exporters:
                 - otlphttp
             processors:
-                - batch
                 - resourcedetection/default
                 - resource/dd-profiler-internal-metadata
             receivers:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-evp-headers/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     batch:
         timeout: 10s

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     batch:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -3,6 +3,8 @@ exporters:
         endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 extensions:
     custom:
         config: value

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -3,7 +3,7 @@ exporters:
         endpoint: http://localhost:4318
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 extensions:
     custom:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     batch:
         timeout: 10s

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     batch:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -2,7 +2,7 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
-            dd-evp-origin: full-host-profiler
+            dd-evp-origin: host-profiler
             dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -2,6 +2,8 @@ exporters:
     otlphttp:
         headers:
             dd-api-key: test-api-key
+            dd-evp-origin: full-host-profiler
+            dd-evp-origin-version: 7.0.0-test
 processors:
     resource/dd-profiler-internal-metadata:
         attributes:


### PR DESCRIPTION
### What does this PR do?

Add EVP headers for both bundle/standalone.
Ensure "don't override" policy in order to keep user-set values if defined for standalone.

### Motivation

Add HTTP header as was done in dd-otel-host-profiler.

### Describe how you validated your changes

- Add/fix golden tests
- Make sure that metrics from EVP intake now contain the right tags: https://ddstaging.datadoghq.com/s/c894ecec5/cyf-67p-8k8

<img width="2962" height="1746" alt="image" src="https://github.com/user-attachments/assets/c10478d5-516d-40a9-9f44-da79fb2ec952" />


### Additional Notes
