### PR TITLE
Break the dependency cycle between create and structure

### DIFF
--- a/pkg/config/create/go.mod
+++ b/pkg/config/create/go.mod
@@ -5,7 +5,6 @@ go 1.25.0
 require (
 	github.com/DataDog/datadog-agent/pkg/config/model v0.72.2
 	github.com/DataDog/datadog-agent/pkg/config/nodetreemodel v0.64.1
-	github.com/DataDog/datadog-agent/pkg/config/structure v0.77.0-devel.0.20260211235139-a5361978c2b6
 	github.com/DataDog/datadog-agent/pkg/config/teeconfig v0.64.1
 	github.com/DataDog/datadog-agent/pkg/config/viperconfig v0.72.2
 	github.com/DataDog/datadog-agent/pkg/util/log v0.72.2

--- a/pkg/config/create/read_config_file_fuzz_test.go
+++ b/pkg/config/create/read_config_file_fuzz_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config/nodetreemodel"
-	"github.com/DataDog/datadog-agent/pkg/config/structure"
 )
 
 func FuzzReadConfig(f *testing.F) {
@@ -143,13 +142,8 @@ other: value`) // Null value (YAML parses as nil)
 
 		// Test error conditions don't crash
 		if err == nil {
-			// Only test additional operations if ReadConfig succeeded
-			// Test unmarshal functionality on valid configs
-			var result map[string]interface{}
-			structure.UnmarshalKey(cfg, "", &result)
-			structure.UnmarshalKey(cfg, "c", &result)
-
-			// Test settings retrieval with sequence ID
+			cfg.AllSettings()
+			cfg.Get("c")
 			_, _ = cfg.AllFlattenedSettingsWithSequenceID()
 		}
 	})


### PR DESCRIPTION
### What does this PR do?
Breaks the Go module dependency cycle between `pkg/config/create` and `pkg/config/structure` by removing test-only cross-imports. The cycle existed because tests in each module happened to use a convenience function from the other for test setup. No production code is changed.

### Motivation
The `datadog-agent` repository has ~190 internal Go modules. Bazel is using a Direct Acyclic Graph (**DAG**) — it cannot build modules with cyclic dependencies. A module dependency graph analysis identified 4 cycles blocking 73 modules from Bazel migration. This cycle blocks 57 downstream modules.

### Describe how you validated your changes
```shell
cd pkg/config/structure && go test ./...
cd pkg/config/create && go test ./...
cd pkg/config/create && go test -fuzz=FuzzReadConfig -fuzztime=5s ./...
go mod tidy # on both modules confirms config/create is no longer in structure/go.mod requires and vice versa
dda inv modules.add-all-replace
```

### Additional Notes
This is one of the 3 cycles to break for the Bazel migration.