### PR TITLE
[ACTP] Add remote action connection

### DIFF
--- a/pkg/privateactionrunner/adapters/config/constants.go
+++ b/pkg/privateactionrunner/adapters/config/constants.go
@@ -42,4 +42,5 @@ var BundleInheritedAllowedActions = []BundleInheritedAllowedAction{
 	{ActionFQN: "com.datadoghq.script.testConnection", ExpectedPrefix: "com.datadoghq.script"},
 	{ActionFQN: "com.datadoghq.script.enrichScript", ExpectedPrefix: "com.datadoghq.script"},
 	{ActionFQN: "com.datadoghq.ddagent.testConnection", ExpectedPrefix: "com.datadoghq.ddagent"},
+	{ActionFQN: "com.datadoghq.remoteaction.testConnection", ExpectedPrefix: "com.datadoghq.remoteaction"},
 }

--- a/pkg/privateactionrunner/autoconnections/allowed_connections.go
+++ b/pkg/privateactionrunner/autoconnections/allowed_connections.go
@@ -30,6 +30,14 @@ var supportedConnections = map[string]ConnectionDefinition{
 			},
 		},
 	},
+	"remoteaction": {
+		FQNPrefix:       "com.datadoghq.remoteaction",
+		IntegrationType: "RemoteAction",
+		Credentials: CredentialConfig{
+			Type:             "RemoteAction",
+			AdditionalFields: nil,
+		},
+	},
 }
 
 func actionsAllowlistContainsBundle(actionsAllowlist []string, fqnPrefix string) bool {

--- a/pkg/privateactionrunner/bundles/registry.go
+++ b/pkg/privateactionrunner/bundles/registry.go
@@ -42,6 +42,7 @@ import (
 	com_datadoghq_kubernetes_customresources "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/customresources"
 	com_datadoghq_kubernetes_discovery "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/kubernetes/discovery"
 	com_datadoghq_mongodb "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/mongodb"
+	com_datadoghq_remoteaction "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction"
 	com_datadoghq_remoteaction_rshell "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/remoteaction/rshell"
 	com_datadoghq_script "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/script"
 	com_datadoghq_temporal "github.com/DataDog/datadog-agent/pkg/privateactionrunner/bundles/temporal"
@@ -86,6 +87,7 @@ func NewRegistry(configuration *config.Config, traceroute traceroute.Component, 
 			"com.datadoghq.kubernetes.customresources": com_datadoghq_kubernetes_customresources.NewKubernetesCustomResources(),
 			"com.datadoghq.kubernetes.discovery":       com_datadoghq_kubernetes_discovery.NewKubernetesDiscovery(),
 			"com.datadoghq.mongodb":                    com_datadoghq_mongodb.NewMongoDB(),
+			"com.datadoghq.remoteaction":               com_datadoghq_remoteaction.NewRemoteAction(),
 			"com.datadoghq.remoteaction.rshell":        com_datadoghq_remoteaction_rshell.NewRshellBundle(configuration.RShellAllowedPaths),
 			"com.datadoghq.script":                     com_datadoghq_script.NewScript(),
 			"com.datadoghq.temporal":                   com_datadoghq_temporal.NewTemporal(),

--- a/pkg/privateactionrunner/bundles/remoteaction/entrypoint.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/entrypoint.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_remoteaction
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+type RemoteAction struct {
+	actions map[string]types.Action
+}
+
+func NewRemoteAction() *RemoteAction {
+	return &RemoteAction{
+		actions: map[string]types.Action{
+			"testConnection": NewTestConnectionHandler(),
+		},
+	}
+}
+
+func (h *RemoteAction) GetAction(actionName string) types.Action {
+	return h.actions[actionName]
+}

--- a/pkg/privateactionrunner/bundles/remoteaction/test_connection.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/test_connection.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_remoteaction
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/adapters/parversion"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
+	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+)
+
+type TestConnectionHandler struct {
+}
+
+func NewTestConnectionHandler() *TestConnectionHandler {
+	return &TestConnectionHandler{}
+}
+
+type TestConnectionInputs struct {
+	// No inputs required for this test action
+}
+
+type TestConnectionOutputs struct {
+	Success   bool      `json:"success"`
+	AgentInfo AgentInfo `json:"version"`
+}
+
+type AgentInfo struct {
+	Version string `json:"version"`
+}
+
+func (h *TestConnectionHandler) Run(
+	ctx context.Context,
+	task *types.Task,
+	credentials *privateconnection.PrivateCredentials,
+) (interface{}, error) {
+	return &TestConnectionOutputs{
+		Success: true,
+		AgentInfo: AgentInfo{
+			Version: parversion.RunnerVersion,
+		},
+	}, nil
+}

--- a/pkg/privateactionrunner/bundles/remoteaction/test_connection.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/test_connection.go
@@ -26,7 +26,7 @@ type TestConnectionInputs struct {
 
 type TestConnectionOutputs struct {
 	Success   bool      `json:"success"`
-	AgentInfo AgentInfo `json:"version"`
+	AgentInfo AgentInfo `json:"agentInfo"`
 }
 
 type AgentInfo struct {
@@ -37,7 +37,7 @@ func (h *TestConnectionHandler) Run(
 	ctx context.Context,
 	task *types.Task,
 	credentials *privateconnection.PrivateCredentials,
-) (interface{}, error) {
+) (any, error) {
 	return &TestConnectionOutputs{
 		Success: true,
 		AgentInfo: AgentInfo{


### PR DESCRIPTION
### What does this PR do?

Adds a `remoteaction` connection type to the Private Action Runner (PAR). This includes:
- A new `remoteaction` entry in the auto-connections allowlist (`allowed_connections.go`) with FQN prefix `com.datadoghq.remoteaction` and integration type `RemoteAction`
- A new `com.datadoghq.remoteaction` bundle registered in the bundle registry
- A `testConnection` action that returns agent version info, used to verify the connection is alive

### Motivation

Enable the PAR to auto-create and expose a `RemoteAction` connection, allowing Datadog workflows to verify connectivity to the runner and retrieve basic agent metadata.

### Describe how you validated your changes

Ran the PAR locally — connections were automatically created as expected.

<img width="1220" height="661" alt="Screenshot 2026-03-24 at 10 57 40" src="https://github.com/user-attachments/assets/12817ed4-6d1f-40d3-8154-85f18835363a" />


### Additional Notes

The `testConnection` action requires no credentials and simply returns `{ success: true, version: "<runner_version>" }`.