### PR TITLE
[observer] Don't process telemetry metrics

### DIFF
--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -449,11 +449,25 @@ type RawAnomalyState interface {
 	RawAnomalies() []Anomaly
 }
 
+// TelemetryNamespace is the storage namespace used for observer-internal debug
+// metrics (e.g. testbench UI charts). Detectors must not treat it as workload data.
+const TelemetryNamespace = "telemetry"
+
 // SeriesFilter specifies criteria for selecting series.
 type SeriesFilter struct {
 	Namespace   string            // exact match (empty = any)
 	NamePattern string            // prefix match (empty = any)
 	TagMatchers map[string]string // required tag key=value pairs
+	// ExcludeNamespaces skips series whose namespace is in this list. It is only
+	// applied when Namespace is empty (list-all mode). An explicit Namespace match
+	// ignores ExcludeNamespaces so callers can still list internal series when needed.
+	ExcludeNamespaces []string
+}
+
+// WorkloadSeriesFilter returns a filter for anomaly detectors: all namespaces
+// except TelemetryNamespace.
+func WorkloadSeriesFilter() SeriesFilter {
+	return SeriesFilter{ExcludeNamespaces: []string{TelemetryNamespace}}
 }
 
 type SeriesHandle int

--- a/comp/observer/impl/metrics_detector_bocpd.go
+++ b/comp/observer/impl/metrics_detector_bocpd.go
@@ -189,7 +189,7 @@ func (b *BOCPDDetector) Name() string {
 func (b *BOCPDDetector) Detect(storage observer.StorageReader, dataTime int64) observer.DetectionResult {
 	gen := storage.SeriesGeneration()
 	if b.cachedSeries == nil || gen != b.cachedGen {
-		b.cachedSeries = storage.ListSeries(observer.SeriesFilter{})
+		b.cachedSeries = storage.ListSeries(observer.WorkloadSeriesFilter())
 		b.cachedGen = gen
 	}
 

--- a/comp/observer/impl/metrics_detector_scanmw.go
+++ b/comp/observer/impl/metrics_detector_scanmw.go
@@ -118,7 +118,7 @@ func (d *ScanMWDetector) Detect(storage observer.StorageReader, dataTime int64) 
 
 	gen := storage.SeriesGeneration()
 	if d.cachedSeries == nil || gen != d.cachedGen {
-		d.cachedSeries = storage.ListSeries(observer.SeriesFilter{})
+		d.cachedSeries = storage.ListSeries(observer.WorkloadSeriesFilter())
 		d.cachedGen = gen
 	}
 

--- a/comp/observer/impl/metrics_detector_scanwelch.go
+++ b/comp/observer/impl/metrics_detector_scanwelch.go
@@ -107,7 +107,7 @@ func (d *ScanWelchDetector) Detect(storage observer.StorageReader, dataTime int6
 
 	gen := storage.SeriesGeneration()
 	if d.cachedSeries == nil || gen != d.cachedGen {
-		d.cachedSeries = storage.ListSeries(observer.SeriesFilter{})
+		d.cachedSeries = storage.ListSeries(observer.WorkloadSeriesFilter())
 		d.cachedGen = gen
 	}
 

--- a/comp/observer/impl/observer.go
+++ b/comp/observer/impl/observer.go
@@ -485,7 +485,7 @@ func (a *seriesDetectorAdapter) Reset() {
 }
 
 func (a *seriesDetectorAdapter) Detect(storage observerdef.StorageReader, dataTime int64) observerdef.DetectionResult {
-	allSeries := storage.ListSeries(observerdef.SeriesFilter{})
+	allSeries := storage.ListSeries(observerdef.WorkloadSeriesFilter())
 
 	var allAnomalies []observerdef.Anomaly
 	var allTelemetry []observerdef.ObserverTelemetry

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -711,9 +711,18 @@ func (s *timeSeriesStorage) ListSeries(filter observer.SeriesFilter) []observer.
 	defer s.mu.RUnlock()
 
 	var result []observer.SeriesMeta
+listSeriesLoop:
 	for key, stats := range s.series {
-		if filter.Namespace != "" && stats.Namespace != filter.Namespace {
-			continue
+		if filter.Namespace != "" {
+			if stats.Namespace != filter.Namespace {
+				continue
+			}
+		} else {
+			for _, ex := range filter.ExcludeNamespaces {
+				if stats.Namespace == ex {
+					continue listSeriesLoop
+				}
+			}
 		}
 		if filter.NamePattern != "" && !strings.HasPrefix(stats.Name, filter.NamePattern) {
 			continue

--- a/comp/observer/impl/storage_test.go
+++ b/comp/observer/impl/storage_test.go
@@ -560,3 +560,20 @@ func TestTimeBoundsSkipsNonPositivePrefixOnly(t *testing.T) {
 	assert.Equal(t, int64(10), minTs)
 	assert.Equal(t, int64(20), maxTs)
 }
+
+func TestTimeSeriesStorage_ListSeries_ExcludeNamespaces(t *testing.T) {
+	s := newTimeSeriesStorage()
+	s.Add(observer.TelemetryNamespace, "internal.gauge", 1, 1000, nil)
+	s.Add("work", "cpu", 2, 1000, nil)
+
+	all := s.ListSeries(observer.SeriesFilter{})
+	require.Len(t, all, 2)
+
+	workload := s.ListSeries(observer.WorkloadSeriesFilter())
+	require.Len(t, workload, 1)
+	assert.Equal(t, "work", workload[0].Namespace)
+
+	onlyTel := s.ListSeries(observer.SeriesFilter{Namespace: observer.TelemetryNamespace})
+	require.Len(t, onlyTel, 1)
+	assert.Equal(t, observer.TelemetryNamespace, onlyTel[0].Namespace)
+}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -719,7 +719,7 @@ func (tb *TestBench) handleTelemetry(telemetry []observerdef.ObserverTelemetry, 
 				telemetryEvent.DetectorName = detectorName
 			}
 			// Save this for UI
-			tb.engine.Storage().Add("telemetry", metric.name, metric.value, metric.timestamp, metric.tags)
+			tb.engine.Storage().Add(observerdef.TelemetryNamespace, metric.name, metric.value, metric.timestamp, metric.tags)
 
 			if !tb.telemetryHandler.isMetricRegistered(metric.name) {
 				fmt.Printf("ERROR: [observer] metric %s is not registered\n", metric.name)
@@ -868,7 +868,7 @@ func (tb *TestBench) resolveAnomalySeriesIDs(anomalies []observerdef.Anomaly) []
 		a := &anomalies[i]
 		// This comes from the telemetry
 		if a.SourceSeriesID == "" && a.Source.Name != "" {
-			a.SourceSeriesID = observerdef.SeriesID(seriesKey("telemetry", a.Source.String()+":avg", nil))
+			a.SourceSeriesID = observerdef.SeriesID(seriesKey(observerdef.TelemetryNamespace, a.Source.String()+":avg", nil))
 		}
 	}
 	return anomalies


### PR DESCRIPTION
Prevent anomaly detectors from processing observer-internal telemetry metrics stored under the "telemetry" namespace.

Adds:
- `TelemetryNamespace` constant: names the internal namespace so it can be referenced consistently
- `WorkloadSeriesFilter()`: helper returning a filter that excludes the telemetry namespace, used by all detectors
- `ExcludeNamespaces` on `SeriesFilter`: allows callers to skip specific namespaces when listing in list-all mode

Tested using unit tests + manually checked in the UI we don't have anomalies on telemetry anymore