### PR TITLE
Emit Spot rebalance recommendations events for AWS

### DIFF
--- a/pkg/collector/corechecks/cloud/hostinfo/hostinfo.go
+++ b/pkg/collector/corechecks/cloud/hostinfo/hostinfo.go
@@ -31,6 +31,9 @@ const CheckName = "cloud_hostinfo"
 // PreemptionEventType is the event type for preemption events
 const PreemptionEventType = "HostPreemption"
 
+// PreemptionRiskEventType is the event type for rebalance recommendation events
+const PreemptionRiskEventType = "HostPreemptionRisk"
+
 // Check collects host information from cloud provider metadata services
 type Check struct {
 	core.CheckBase
@@ -38,14 +41,16 @@ type Check struct {
 	cloudProvider         string
 	cloudProviderOnce     sync.Once
 	terminationTime       time.Time
+	rebalanceNoticeTime   time.Time
 	preemptionUnsupported bool // Set to true when preemption detection is not supported or instance is not preemptible
 }
 
 // For testing purposes
 var (
-	detectCloudProviderFn      = cloudproviders.DetectCloudProvider
-	getPreemptionTerminationFn = cloudproviders.GetPreemptionTerminationTime
-	uptime                     = host.Uptime
+	detectCloudProviderFn        = cloudproviders.DetectCloudProvider
+	getPreemptionTerminationFn   = cloudproviders.GetPreemptionTerminationTime
+	getRebalanceRecommendationFn = cloudproviders.GetRebalanceRecommendationTime
+	uptime                       = host.Uptime
 )
 
 // Factory creates a new check factory
@@ -68,6 +73,7 @@ func (c *Check) Run() error {
 
 	// Check for preemption events (e.g., AWS Spot, GCE Preemptible, Azure Spot)
 	c.checkPreemptionEvents(sender)
+	c.checkRebalanceRecommendation(sender)
 
 	sender.Commit()
 
@@ -134,4 +140,48 @@ func (c *Check) checkPreemptionEvents(sender sender.Sender) {
 	}
 	sender.Event(ev)
 	log.Infof("Instance preemption detected, will terminate at: %s", terminationTime.UTC().Format(time.RFC3339))
+}
+
+// checkRebalanceRecommendation checks for an AWS rebalance recommendation and emits an event if found.
+// Skipped when a termination time is already known (termination supersedes the recommendation).
+func (c *Check) checkRebalanceRecommendation(sender sender.Sender) {
+	if c.cloudProvider == "" || c.preemptionUnsupported {
+		return
+	}
+
+	// If termination is already scheduled, a rebalance recommendation is redundant
+	if !c.terminationTime.IsZero() {
+		return
+	}
+
+	// If rebalance recommendation was already emitted, don't emit again
+	if !c.rebalanceNoticeTime.IsZero() {
+		return
+	}
+
+	noticeTime, err := getRebalanceRecommendationFn(context.Background(), c.cloudProvider)
+	if err != nil {
+		log.Tracef("Rebalance recommendation check returned an error (usually expected), cloud provider: %s, error: %s", c.cloudProvider, err)
+		return
+	}
+
+	c.rebalanceNoticeTime = noticeTime
+
+	// Get current uptime for the event text
+	uptimeSeconds, err := uptime()
+	if err != nil {
+		log.Warnf("Could not retrieve uptime to enrich preemption event, error: %s", err)
+		uptimeSeconds = 0
+	}
+
+	ev := event.Event{
+		Title:          "Elevated risk of Instance Preemption",
+		Text:           fmt.Sprintf("This instance received a rebalance recommendation event (elevated risk of preemption) at: %s, uptime: %d seconds", noticeTime.UTC().Format(time.RFC3339), uptimeSeconds),
+		Priority:       event.PriorityNormal,
+		AlertType:      event.AlertTypeInfo,
+		SourceTypeName: "system",
+		EventType:      PreemptionRiskEventType,
+	}
+	sender.Event(ev)
+	log.Infof("Instance rebalance recommendation detected at: %s", noticeTime.UTC().Format(time.RFC3339))
 }

--- a/pkg/collector/corechecks/cloud/hostinfo/hostinfo_test.go
+++ b/pkg/collector/corechecks/cloud/hostinfo/hostinfo_test.go
@@ -27,6 +27,7 @@ func uptimeSampler() (uint64, error) {
 func resetTestVars() {
 	detectCloudProviderFn = cloudproviders.DetectCloudProvider
 	getPreemptionTerminationFn = cloudproviders.GetPreemptionTerminationTime
+	getRebalanceRecommendationFn = cloudproviders.GetRebalanceRecommendationTime
 	uptime = host.Uptime
 }
 
@@ -105,6 +106,10 @@ func TestHostInfoCheckNoPreemptionScheduled(t *testing.T) {
 	// Mock preemption termination to return no termination scheduled
 	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
 		return time.Time{}, errors.New("no preemption scheduled")
+	}
+
+	getRebalanceRecommendationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, errors.New("no rebalance recommendation")
 	}
 
 	mockSender := mocksender.NewMockSender(CheckName)
@@ -247,4 +252,162 @@ func TestHostInfoCheckPreemptionUnsupportedStopsPolling(t *testing.T) {
 	if callCount != 1 {
 		t.Errorf("expected getPreemptionTerminationFn to be called 1 time, got %d", callCount)
 	}
+}
+
+func TestHostInfoCheckWithRebalanceRecommendation(t *testing.T) {
+	defer resetTestVars()
+
+	noticeTime := time.Date(2020, 10, 27, 8, 22, 0, 0, time.UTC)
+
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	// No termination scheduled
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, errors.New("no preemption scheduled")
+	}
+
+	getRebalanceRecommendationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return noticeTime, nil
+	}
+
+	uptime = uptimeSampler
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	mockSender.On("Event", mock.MatchedBy(func(ev event.Event) bool {
+		return ev.Title == "Elevated risk of Instance Preemption" &&
+			ev.AlertType == event.AlertTypeInfo &&
+			ev.EventType == PreemptionRiskEventType
+	})).Return().Times(1)
+	mockSender.On("Commit").Return().Times(1)
+
+	check.Run()
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+}
+
+func TestHostInfoCheckRebalanceEventSentOnlyOnce(t *testing.T) {
+	defer resetTestVars()
+
+	noticeTime := time.Date(2020, 10, 27, 8, 22, 0, 0, time.UTC)
+
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, errors.New("no preemption scheduled")
+	}
+
+	getRebalanceRecommendationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return noticeTime, nil
+	}
+
+	uptime = uptimeSampler
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	mockSender.On("Event", mock.MatchedBy(func(ev event.Event) bool {
+		return ev.EventType == PreemptionRiskEventType
+	})).Return().Times(1)
+	mockSender.On("Commit").Return()
+
+	// Run the check twice — event should only be sent once
+	check.Run()
+	check.Run()
+
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 2)
+}
+
+func TestHostInfoCheckRebalanceSkippedWhenTerminationSet(t *testing.T) {
+	defer resetTestVars()
+
+	terminationTime := time.Now().Add(2 * time.Minute).UTC().Truncate(time.Second)
+
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return terminationTime, nil
+	}
+
+	rebalanceCalled := false
+	getRebalanceRecommendationFn = func(_ context.Context, _ string) (time.Time, error) {
+		rebalanceCalled = true
+		return time.Date(2020, 10, 27, 8, 22, 0, 0, time.UTC), nil
+	}
+
+	uptime = uptimeSampler
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	// Only preemption event should be sent, not rebalance
+	mockSender.On("Event", mock.MatchedBy(func(ev event.Event) bool {
+		return ev.EventType == PreemptionEventType
+	})).Return().Times(1)
+	mockSender.On("Commit").Return().Times(1)
+
+	check.Run()
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 1)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
+
+	if rebalanceCalled {
+		t.Error("rebalance recommendation should not be checked when termination is already scheduled")
+	}
+}
+
+func TestHostInfoCheckNoRebalanceRecommendation(t *testing.T) {
+	defer resetTestVars()
+
+	detectCloudProviderFn = func(_ context.Context, _ bool) (string, string) {
+		return "AWS", ""
+	}
+
+	getPreemptionTerminationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, errors.New("no preemption scheduled")
+	}
+
+	getRebalanceRecommendationFn = func(_ context.Context, _ string) (time.Time, error) {
+		return time.Time{}, errors.New("no rebalance recommendation")
+	}
+
+	mockSender := mocksender.NewMockSender(CheckName)
+	mockSender.On("FinalizeCheckServiceTag").Return()
+
+	check := newCheck().(*Check)
+	check.Configure(mockSender.GetSenderManager(), integration.FakeConfigHash, nil, nil, "test", "provider")
+
+	mocksender.SetSender(mockSender, check.ID())
+
+	mockSender.On("Commit").Return().Times(1)
+
+	check.Run()
+	mockSender.AssertExpectations(t)
+	mockSender.AssertNumberOfCalls(t, "Event", 0)
+	mockSender.AssertNumberOfCalls(t, "Commit", 1)
 }

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -305,6 +305,10 @@ var preemptionDetectors = map[string]cloudProviderPreemptionDetector{
 	ec2.CloudProviderName: ec2.GetSpotTerminationTime,
 }
 
+var rebalanceDetectors = map[string]cloudProviderPreemptionDetector{
+	ec2.CloudProviderName: ec2.GetRebalanceRecommendationTime,
+}
+
 // ErrNotPreemptible is returned when the instance is not a preemptible instance
 // (e.g., not an AWS Spot instance, not a GCE Preemptible instance).
 // When this error is returned, callers should stop polling for preemption events.
@@ -334,4 +338,24 @@ func GetPreemptionTerminationTime(ctx context.Context, cloudProviderName string)
 		return time.Time{}, err
 	}
 	return terminationTime, nil
+}
+
+// GetRebalanceRecommendationTime returns the time a rebalance recommendation was issued
+// for a preemptible instance (e.g., AWS Spot rebalance recommendation).
+// Returns ErrNotPreemptible if the instance is not preemptible.
+// Returns ErrPreemptionUnsupported if the cloud provider doesn't support rebalance detection.
+func GetRebalanceRecommendationTime(ctx context.Context, cloudProviderName string) (time.Time, error) {
+	callback, found := rebalanceDetectors[cloudProviderName]
+	if !found {
+		return time.Time{}, ErrPreemptionUnsupported
+	}
+
+	noticeTime, err := callback(ctx)
+	if err != nil {
+		if errors.Is(err, ec2.ErrNotSpotInstance) {
+			return time.Time{}, ErrNotPreemptible
+		}
+		return time.Time{}, err
+	}
+	return noticeTime, nil
 }

--- a/pkg/util/ec2/spot.go
+++ b/pkg/util/ec2/spot.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	imdsSpotInstanceAction = "/spot/instance-action"
-	imdsInstanceLifeCycle  = "/instance-life-cycle"
-	instanceLifeCycleSpot  = "spot"
+	imdsSpotInstanceAction      = "/spot/instance-action"
+	imdsRebalanceRecommendation = "/events/recommendations/rebalance"
+	imdsInstanceLifeCycle       = "/instance-life-cycle"
+	instanceLifeCycleSpot       = "spot"
 )
 
 // ErrNotSpotInstance is returned when the instance is not a spot instance
@@ -29,6 +30,11 @@ var ErrNotSpotInstance = errors.New("instance is not a spot instance")
 type spotInstanceAction struct {
 	Action string `json:"action"`
 	Time   string `json:"time"`
+}
+
+// rebalanceRecommendation represents the response from the events/recommendations/rebalance IMDS endpoint
+type rebalanceRecommendation struct {
+	NoticeTime string `json:"noticeTime"`
 }
 
 var instanceLifeCycleFetcher = cachedfetch.Fetcher{
@@ -77,4 +83,35 @@ func GetSpotTerminationTime(ctx context.Context) (time.Time, error) {
 	}
 
 	return terminationTime, nil
+}
+
+// GetRebalanceRecommendationTime returns the time an EC2 rebalance recommendation was issued for a spot instance.
+// If the instance is not a spot instance, it returns ErrNotSpotInstance.
+// If no recommendation is active, it returns an error (typically a 404 from IMDS).
+// Docs: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/rebalance-recommendations.html
+func GetRebalanceRecommendationTime(ctx context.Context) (time.Time, error) {
+	isSpot, err := IsSpotInstance(ctx)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to determine instance type: %w", err)
+	}
+	if !isSpot {
+		return time.Time{}, ErrNotSpotInstance
+	}
+
+	res, err := ec2internal.GetMetadataItem(ctx, imdsRebalanceRecommendation, ec2internal.UseIMDSv2(), false)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to retrieve rebalance recommendation from IMDS: %w", err)
+	}
+
+	var rec rebalanceRecommendation
+	if err := json.Unmarshal([]byte(res), &rec); err != nil {
+		return time.Time{}, fmt.Errorf("unable to parse rebalance recommendation response: %w", err)
+	}
+
+	noticeTime, err := time.Parse(time.RFC3339, rec.NoticeTime)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("unable to parse rebalance notice time %q: %w", rec.NoticeTime, err)
+	}
+
+	return noticeTime, nil
 }

--- a/pkg/util/ec2/spot_test.go
+++ b/pkg/util/ec2/spot_test.go
@@ -102,6 +102,105 @@ func TestIsSpotInstance(t *testing.T) {
 	}
 }
 
+func TestGetRebalanceRecommendationTime(t *testing.T) {
+	ctx := context.Background()
+	configmock.New(t)
+
+	tests := []struct {
+		name               string
+		instanceLifeCycle  string
+		rebalanceCode      int
+		rebalanceBody      string
+		expectedTime       time.Time
+		expectError        bool
+		expectNotSpotError bool
+		errorContains      string
+	}{
+		{
+			name:              "valid rebalance recommendation",
+			instanceLifeCycle: "spot",
+			rebalanceCode:     http.StatusOK,
+			rebalanceBody:     `{"noticeTime": "2020-10-27T08:22:00Z"}`,
+			expectedTime:      time.Date(2020, 10, 27, 8, 22, 0, 0, time.UTC),
+			expectError:       false,
+		},
+		{
+			name:              "no rebalance recommendation (404)",
+			instanceLifeCycle: "spot",
+			rebalanceCode:     http.StatusNotFound,
+			rebalanceBody:     "",
+			expectError:       true,
+			errorContains:     "unable to retrieve rebalance recommendation",
+		},
+		{
+			name:              "invalid JSON response",
+			instanceLifeCycle: "spot",
+			rebalanceCode:     http.StatusOK,
+			rebalanceBody:     `not valid json`,
+			expectError:       true,
+			errorContains:     "unable to parse rebalance recommendation response",
+		},
+		{
+			name:              "invalid time format",
+			instanceLifeCycle: "spot",
+			rebalanceCode:     http.StatusOK,
+			rebalanceBody:     `{"noticeTime": "invalid-time"}`,
+			expectError:       true,
+			errorContains:     "unable to parse rebalance notice time",
+		},
+		{
+			name:               "not a spot instance",
+			instanceLifeCycle:  "on-demand",
+			rebalanceCode:      http.StatusOK,
+			rebalanceBody:      `{"noticeTime": "2020-10-27T08:22:00Z"}`,
+			expectError:        true,
+			expectNotSpotError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.Method {
+				case http.MethodPut:
+					io.WriteString(w, testIMDSToken)
+				case http.MethodGet:
+					if strings.HasSuffix(r.URL.Path, "/instance-life-cycle") {
+						io.WriteString(w, tt.instanceLifeCycle)
+					} else if strings.HasSuffix(r.URL.Path, "/events/recommendations/rebalance") {
+						if tt.rebalanceCode != http.StatusOK {
+							w.WriteHeader(tt.rebalanceCode)
+							return
+						}
+						io.WriteString(w, tt.rebalanceBody)
+					}
+				}
+			}))
+			defer ts.Close()
+
+			ec2internal.MetadataURL = ts.URL
+			ec2internal.TokenURL = ts.URL
+			ec2internal.Token = httputils.NewAPIToken(ec2internal.GetToken)
+			defer resetSpotTestVars()
+
+			noticeTime, err := GetRebalanceRecommendationTime(ctx)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.expectNotSpotError {
+					assert.True(t, errors.Is(err, ErrNotSpotInstance), "expected ErrNotSpotInstance, got: %v", err)
+				} else {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedTime, noticeTime)
+			}
+		})
+	}
+}
+
 func TestGetSpotTerminationTime(t *testing.T) {
 	ctx := context.Background()
 	configmock.New(t)


### PR DESCRIPTION
### What does this PR do?

Add collection of Spot rebalance recommendations events on top of Spot termination events.

### Motivation

Reflect insights from cloud provider

### Describe how you validated your changes

While it is possible to simulate a Spot disruption, it's not possible to simulate a recommendation live.
Trying new/demanded instance types can allow to have an event in a 1-3h window.

### Additional Notes
