### PR TITLE
Remove redundant `gazelle` exclusions (`**/build`) and fix setup inconsistencies

### DIFF
--- a/.gitlab/build/bazel/lint.yml
+++ b/.gitlab/build/bazel/lint.yml
@@ -43,7 +43,7 @@ bazel:run-buildifier-test:
 bazel:run-gazelle:
   extends: [ .bazel:lint, .bazel:runner:linux-amd64 ]
   script:
-    - bazel run //:gazelle -- -mode=diff -strict
+    - bazel run //:gazelle -- -mode=diff
   variables:
     FIX_COMMAND: "bazel run //:gazelle"
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -489,11 +489,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/util/workqueue
 # gazelle:exclude pkg/util/xc
 # gazelle:exclude pkg/windowsdriver
-# TODO(agent-build): This exclusion is ready for removal, blocked by issues caused by the interaction of
-# Bazel with directories named `build` created by the CMake builds. We can remove this once we remove CMake
-# support or we upgrade to a Bazel version containing a fix: https://github.com/bazelbuild/bazel/pull/26842
-# In the meantime, temporarily remove this exclusion locally if regeneration of BUILD files is required
-# gazelle:exclude rtloader
 # gazelle:exclude tasks
 # gazelle:exclude test
 # gazelle:exclude tools/NamedPipeCmd
@@ -505,16 +500,16 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude tools/host-profiler
 # gazelle:exclude tools/retry_file_dump
 # gazelle:exclude tools/windows
-# gazelle:exclude .gitlab
-# gazelle:prefix github.com/DataDog/datadog-agent
 gazelle(
     name = "gazelle",
-    args = [
-        "-build_file_name=BUILD.bazel",  # avoid BUILD/build mess: https://github.com/docker/desktop-feedback/issues/251
-        "-external=static",  # don't use the network: https://github.com/bazel-contrib/bazel-gazelle/issues/1385
-    ],
     build_tags = ALL_BUILD_TAGS,
+    external = "static",  # don't use the network: https://github.com/bazel-contrib/bazel-gazelle/issues/1385
+    extra_args = [
+        "-build_file_name=BUILD.bazel",  # avoid BUILD/build mess: https://github.com/docker/desktop-feedback/issues/251
+        "-strict",  # don't swallow syntax errors or unknown directives
+    ],
     gazelle = ":gazelle_binary",
+    prefix = "github.com/DataDog/datadog-agent",
 )
 
 gazelle_binary(


### PR DESCRIPTION
### What does this PR do?
Remove `gazelle` exclusions that had to be put in place pending a fix for `gazelle` confused by `build` directories on "broken" case-insensitive filesystem stacks (docker/desktop-feedback#251).
Doing so, I realized there were inconsistencies in the `gazelle` setup and took the opportunity to fix them.

### Motivation
#48455 indeed allows to get rid of the following exclusions:
```
# TODO(agent-build): This exclusion is ready for removal, blocked by issues caused by the interaction of
# Bazel with directories named `build` created by the CMake builds. We can remove this once we remove CMake
# support or we upgrade to a Bazel version containing a fix: https://github.com/bazelbuild/bazel/pull/26842
# In the meantime, temporarily remove this exclusion locally if regeneration of BUILD files is required
# gazelle:exclude rtloader
...
# gazelle:exclude .gitlab
```

Nearby inconsistencies in the `gazelle` setup:
- `build_tags` is passed by attribute (`build_tags = ALL_BUILD_TAGS`) => OK (**canonical**),
- `external` was passed by `args` (`-external=static`) => pass by attribute (`external = "static"`),
- `prefix` was passed by directive (`# gazelle:prefix github.com/DataDog/datadog-agent`) => pass by attribute (`prefix = "github.com/DataDog/datadog-agent"`),
- `args` happens to be a [compatibility shim](https://github.com/bazel-contrib/bazel-gazelle/pull/62) => use `extra_args` (**canonical**) when there's no corresponding attribute yet:
   - `build_file_name` was passed by `args` and doesn't have a corresponding attribute yet => pass by `extra_args`,
   - `strict` was passed from a single GitLab job and doesn't have a corresponding attribute yet => pass by `extra_args`.

### Describe how you validated your changes
Kind assistance of @alopezz and/or @JSGette who run Linux containers on their macOS-powered laptop.