### PR TITLE
Provide `PYTHON_FOR_BUILD` to CPython's Windows build

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -65,6 +65,7 @@ run_binary(
             "libffi_win_dir",
             "openssl-bin_win_dir",
             "tcltk_win_dir",
+            "@python_3_12//:python3",
             "@visual_studio//:msbuild",
         ]
     ),
@@ -84,6 +85,7 @@ run_binary(
         "TCLTK_DIR": r"$(location tcltk_win_dir)\amd64",
         "TCL_VERSION": python_externals["tcltk"],
         "MSBUILD": "$(location @visual_studio//:msbuild)",
+        "PYTHON_FOR_BUILD": "$(location @python_3_12//:python3)",
     },
     outs = [
         "build/{}".format(file)

--- a/deps/cpython/build_python.bat
+++ b/deps/cpython/build_python.bat
@@ -3,6 +3,7 @@ for %%F in (%SRCFILE%) do set sourcedir=%%~dpF
 :: Make sure input paths are proper Windows paths as needed
 for %%F in (%OUTDIR%) do set destdir=%%~fF\\
 for %%F in (%MSBUILD%) do set MSBUILD=%%~fF
+for %%F in (%PYTHON_FOR_BUILD%) do set PYTHON_FOR_BUILD=%%~fF
 
 set build_outdir=%sourcedir%\PCbuild\amd64
 


### PR DESCRIPTION
### What does this PR do?
- add `@python_3_12//:python3` (current `rules_python`'s hermetic interpreter) to `python_win`'s srcs and expose it as [PYTHON_FOR_BUILD](https://github.com/python/cpython/blob/3.13/PCbuild/readme.txt#L236),
- resolve it to an absolute path in `build_python.bat` before `build.bat` is called, so `MSBuild` can use it regardless of its working directory.

### Motivation
CPython's `PCbuild/find_python.bat` looks for a Python interpreter to perform pre-compilation code generation (opcodes, grammar, token tables) and to orchestrate PGO training runs.

When `PYTHON_FOR_BUILD` is not set, [find_python.bat](https://github.com/python/cpython/blob/3.13/PCbuild/find_python.bat) falls back through the following chain, each of which fails in a Bazel action running under `--incompatible_strict_action_env` (Bazel 9's default BTW):
1. `VIRTUAL_ENV`,
2. `externals` directory,
3. `HOST_PYTHON`,
4. `py.exe` launcher,
5. `NuGet` download: **failed for me**... which surfaced the hermeticity issue.

`PYTHON_FOR_BUILD` is CPython's dedicated variable for the ([`3.6+`](https://github.com/python/cpython/blob/3.13/PCbuild/readme.txt#L6)) interpreter **used to build** CPython itself, as opposed to the one **being built** (i.e. `3.13.12` as of today).

### Describe how you validated your changes
Confirmed on a local Windows VM that `find_python.bat` reports "found as PYTHON_FOR_BUILD" and proceeds past code generation.

### Additional Notes
Found while making progress towards #48206; split out so it can be reviewed/merged/reverted independently.