### PR TITLE
Add GPU detection for AMD and Intel processes

### DIFF
--- a/pkg/discovery/module/rust/src/procfs/fd.rs
+++ b/pkg/discovery/module/rust/src/procfs/fd.rs
@@ -205,6 +205,12 @@ fn is_gpu_device(link: &Path) -> bool {
 
     let bytes = link.as_os_str().as_encoded_bytes();
 
+    // AMD ROCm: checked before the NVIDIA prefix guard to ensure it is always reachable.
+    if bytes == b"/dev/kfd" {
+        return true;
+    }
+
+    // NVIDIA devices: /dev/nvidia{N}, /dev/nvidiactl, /dev/nvidia-uvm, etc.
     let Some(suffix) = bytes.strip_prefix(NVIDIA_DEV_PREFIX) else {
         return false;
     };
@@ -677,6 +683,37 @@ mod tests {
             assert!(!is_gpu_device(Path::new("nvidia0")));
             assert!(!is_gpu_device(Path::new("/dev/nvidia 0")));
             assert!(!is_gpu_device(Path::new("/dev/NVIDIA0")));
+        }
+
+        #[test]
+        fn test_amd_kfd_device() {
+            assert!(is_gpu_device(Path::new("/dev/kfd")));
+        }
+
+        #[test]
+        fn test_amd_and_nvidia_coexist() {
+            // Both AMD and NVIDIA devices must be detected independently.
+            assert!(is_gpu_device(Path::new("/dev/kfd")));
+            assert!(is_gpu_device(Path::new("/dev/nvidia0")));
+            assert!(is_gpu_device(Path::new("/dev/nvidiactl")));
+        }
+
+        #[test]
+        fn test_amd_kfd_partial_or_similar_not_detected() {
+            assert!(!is_gpu_device(Path::new("/dev/kfd0")));
+            assert!(!is_gpu_device(Path::new("/dev/kfd1")));
+            assert!(!is_gpu_device(Path::new("/dev/kfdd")));
+            assert!(!is_gpu_device(Path::new("kfd")));
+            assert!(!is_gpu_device(Path::new("/dev/KFD")));
+        }
+
+        #[test]
+        fn test_dri_render_nodes_not_detected() {
+            // /dev/dri/renderD* is shared between AMD and Intel display/compute,
+            // too noisy for device-based detection — must be excluded.
+            assert!(!is_gpu_device(Path::new("/dev/dri/renderD128")));
+            assert!(!is_gpu_device(Path::new("/dev/dri/renderD129")));
+            assert!(!is_gpu_device(Path::new("/dev/dri/card0")));
         }
     }
 }

--- a/pkg/discovery/module/rust/src/procfs/maps.rs
+++ b/pkg/discovery/module/rust/src/procfs/maps.rs
@@ -20,7 +20,7 @@ pub fn get_reader_for_pid(pid: i32) -> Result<BufReader<Take<File>>, std::io::Er
 }
 
 // Pre-built finders for NVIDIA-specific GPU libraries using memchr for fast substring search
-static GPU_LIB_FINDERS: LazyLock<[Finder<'static>; 7]> = LazyLock::new(|| {
+static GPU_NVIDIA_LIB_FINDERS: LazyLock<[Finder<'static>; 7]> = LazyLock::new(|| {
     [
         Finder::new(b"libcuda.so"),
         Finder::new(b"libcudart.so"),
@@ -32,21 +32,43 @@ static GPU_LIB_FINDERS: LazyLock<[Finder<'static>; 7]> = LazyLock::new(|| {
     ]
 });
 
-/// Internal function to check for GPU libraries given a reader
-fn check_for_gpu_libraries<R: BufRead>(reader: R) -> bool {
-    reader
-        .split(b'\n')
-        .map_while(|line_result| line_result.ok())
-        .any(|line| GPU_LIB_FINDERS.iter().any(|f| f.find(&line).is_some()))
+// Pre-built finders for AMD ROCm GPU compute libraries
+static GPU_AMD_LIB_FINDERS: LazyLock<[Finder<'static>; 6]> = LazyLock::new(|| {
+    [
+        Finder::new(b"libamdhip64.so"),
+        Finder::new(b"librocblas.so"),
+        Finder::new(b"libMIOpen.so"),
+        Finder::new(b"librocm_smi64.so"),
+        Finder::new(b"librccl.so"),
+        Finder::new(b"libhipblas.so"),
+    ]
+});
+
+// Pre-built finders for Intel GPU compute libraries (Level Zero)
+static GPU_INTEL_LIB_FINDERS: LazyLock<[Finder<'static>; 1]> =
+    LazyLock::new(|| [Finder::new(b"libze_intel_gpu.so")]);
+
+/// Scans a reader for any GPU library fingerprint in a single pass over its lines.
+/// Shared by the public API and test helpers to avoid logic duplication.
+fn check_for_any_gpu_libraries<R: BufRead>(reader: R) -> bool {
+    reader.split(b'\n').map_while(Result::ok).any(|line| {
+        GPU_NVIDIA_LIB_FINDERS
+            .iter()
+            .any(|f| f.find(&line).is_some())
+            || GPU_AMD_LIB_FINDERS.iter().any(|f| f.find(&line).is_some())
+            || GPU_INTEL_LIB_FINDERS
+                .iter()
+                .any(|f| f.find(&line).is_some())
+    })
 }
 
-/// Detects if a process is using NVIDIA GPU libraries by checking /proc/[pid]/maps
-pub fn has_gpu_nvidia_libraries(pid: i32) -> bool {
+/// Detects if a process is using any GPU libraries by scanning /proc/[pid]/maps once.
+/// Checks NVIDIA, AMD ROCm, and Intel GPU compute libraries in a single pass.
+pub fn has_any_gpu_libraries(pid: i32) -> bool {
     let Ok(reader) = get_reader_for_pid(pid) else {
         return false;
     };
-
-    check_for_gpu_libraries(reader)
+    check_for_any_gpu_libraries(reader)
 }
 
 #[cfg(test)]
@@ -55,9 +77,31 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn test_with_mock_maps(maps_content: &str) -> bool {
+    fn check_for_gpu_libraries<R: BufRead>(reader: R, finders: &[Finder<'static>]) -> bool {
+        reader
+            .split(b'\n')
+            .map_while(|line_result| line_result.ok())
+            .any(|line| finders.iter().any(|f| f.find(&line).is_some()))
+    }
+
+    fn test_nvidia_with_mock_maps(maps_content: &str) -> bool {
         let reader = BufReader::new(maps_content.as_bytes());
-        check_for_gpu_libraries(reader)
+        check_for_gpu_libraries(reader, &*GPU_NVIDIA_LIB_FINDERS)
+    }
+
+    fn test_amd_with_mock_maps(maps_content: &str) -> bool {
+        let reader = BufReader::new(maps_content.as_bytes());
+        check_for_gpu_libraries(reader, &*GPU_AMD_LIB_FINDERS)
+    }
+
+    fn test_intel_with_mock_maps(maps_content: &str) -> bool {
+        let reader = BufReader::new(maps_content.as_bytes());
+        check_for_gpu_libraries(reader, &*GPU_INTEL_LIB_FINDERS)
+    }
+
+    fn test_has_any_gpu_with_mock_maps(maps_content: &str) -> bool {
+        let reader = BufReader::new(maps_content.as_bytes());
+        check_for_any_gpu_libraries(reader)
     }
 
     #[test]
@@ -67,7 +111,7 @@ mod tests {
 7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libm.so.6
 7f8e4c400000-7f8e4c500000 r--p 00000000 08:01 123456 /usr/lib/libpthread.so.0
 ";
-        assert!(!test_with_mock_maps(maps_content));
+        assert!(!test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
@@ -78,21 +122,21 @@ mod tests {
 7f8e4c400000-7f8e4c500000 r--p 00000000 08:01 123456 /usr/lib/libcudnn.so.8
 7f8e4c500000-7f8e4c600000 r--p 00000000 08:01 123456 /usr/lib/libnccl.so.2
 ";
-        assert!(test_with_mock_maps(maps_content));
+        assert!(test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
     fn test_has_gpu_nvidia_libraries_empty_maps() {
         let maps_content = "";
-        assert!(!test_with_mock_maps(maps_content));
+        assert!(!test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
-    fn test_has_gpu_nvidia_libraries_invalid_pid() {
+    fn test_has_any_gpu_libraries_invalid_pid() {
         // Test with PID that doesn't have a maps file
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         temp_env::with_var("HOST_PROC", Some(temp_dir.path()), || {
-            assert!(!has_gpu_nvidia_libraries(999999));
+            assert!(!has_any_gpu_libraries(999999));
         });
     }
 
@@ -112,7 +156,7 @@ mod tests {
 7f8e4c021000-7f8e4e400000 r-xp 00021000 08:01 456789 /usr/lib/x86_64-linux-gnu/libcuda.so.535.129.03
 7f8e50000000-7f8e50001000 r--p 00000000 08:01 567890 /usr/lib/x86_64-linux-gnu/libpthread.so.0
 ";
-        assert!(test_with_mock_maps(maps_content));
+        assert!(test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
@@ -122,7 +166,7 @@ mod tests {
 7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/LIBCUDA.SO
 7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/LIBCUDART.SO
 ";
-        assert!(!test_with_mock_maps(maps_content));
+        assert!(!test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
@@ -132,7 +176,7 @@ mod tests {
 7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456    /usr/lib/libcuda.so.535
 7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456    /usr/lib/libc.so.6
 ";
-        assert!(test_with_mock_maps(maps_content));
+        assert!(test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
@@ -142,14 +186,14 @@ mod tests {
 7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /opt/cuda/lib64/libcublas.so.11.10.3.66
 7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /opt/cuda/extras/CUPTI/lib64/libnvrtc.so.11.2.152
 ";
-        assert!(test_with_mock_maps(maps_content));
+        assert!(test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
     fn test_has_gpu_nvidia_libraries_with_newlines() {
         let maps_content =
             "\n\n7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libcuda.so\n\n";
-        assert!(test_with_mock_maps(maps_content));
+        assert!(test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
@@ -168,7 +212,7 @@ mod tests {
             "7f8eff000000-7f8eff021000 r--p 00000000 08:01 123456 /usr/lib/libcuda.so.535\n",
         );
 
-        assert!(test_with_mock_maps(&maps_content));
+        assert!(test_nvidia_with_mock_maps(&maps_content));
     }
 
     #[test]
@@ -187,14 +231,14 @@ mod tests {
             ));
         }
 
-        assert!(test_with_mock_maps(&maps_content));
+        assert!(test_nvidia_with_mock_maps(&maps_content));
     }
 
     #[test]
     fn test_has_gpu_nvidia_libraries_no_newline_at_end() {
         let maps_content =
             "7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libcuda.so.535";
-        assert!(test_with_mock_maps(maps_content));
+        assert!(test_nvidia_with_mock_maps(maps_content));
     }
 
     #[test]
@@ -204,7 +248,7 @@ mod tests {
 7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libnvidia-ml.so.535
 7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libnvidia-ml.so.535
 ";
-        assert!(test_with_mock_maps(maps_content));
+        assert!(test_nvidia_with_mock_maps(maps_content));
     }
 
     /// Verify that check_for_gpu_libraries terminates on I/O error instead
@@ -216,17 +260,17 @@ mod tests {
         // No GPU libraries before the error — should return false, not hang.
         let content = b"7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libc.so.6\n";
         let reader = BufReader::new(ErrorAfterReader::new(&content[..]));
-        assert!(!check_for_gpu_libraries(reader));
+        assert!(!check_for_any_gpu_libraries(reader));
 
         // GPU library present before error — should find it and return true.
         let content =
             b"7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libcuda.so.535\n";
         let reader = BufReader::new(ErrorAfterReader::new(&content[..]));
-        assert!(check_for_gpu_libraries(reader));
+        assert!(check_for_any_gpu_libraries(reader));
 
         // Empty content, immediate error — should return false, not hang.
         let reader = BufReader::new(ErrorAfterReader::new(&b""[..]));
-        assert!(!check_for_gpu_libraries(reader));
+        assert!(!check_for_any_gpu_libraries(reader));
     }
 
     #[test]
@@ -246,10 +290,162 @@ mod tests {
                 lib
             );
             assert!(
-                !test_with_mock_maps(&maps_content),
+                !test_nvidia_with_mock_maps(&maps_content),
                 "Should NOT detect library: {}",
                 lib
             );
         }
+    }
+
+    #[test]
+    fn test_has_gpu_amd_libraries_detected() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /opt/rocm/lib/libamdhip64.so.5
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /opt/rocm/lib/librocblas.so.3
+";
+        assert!(test_amd_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_gpu_amd_libraries_miopen() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /opt/rocm/lib/libMIOpen.so.1
+";
+        assert!(test_amd_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_gpu_amd_libraries_rocm_smi() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /opt/rocm/lib/librocm_smi64.so.5
+";
+        assert!(test_amd_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_gpu_amd_libraries_not_detected_without_amd_libs() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libcuda.so.535
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libc.so.6
+";
+        assert!(!test_amd_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_gpu_amd_libraries_rccl() {
+        // librccl.so is the AMD distributed-training comms library (ROCm equivalent of libnccl.so)
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /opt/rocm/lib/librccl.so.1
+";
+        assert!(test_amd_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_gpu_amd_libraries_hipblas() {
+        // libhipblas.so is the HIP BLAS library, used in ROCm ML workloads
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /opt/rocm/lib/libhipblas.so.2
+";
+        assert!(test_amd_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_gpu_intel_libraries_level_zero() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/x86_64-linux-gnu/libze_intel_gpu.so.1
+";
+        assert!(test_intel_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_gpu_intel_libraries_not_detected_without_intel_libs() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libamdhip64.so.5
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libc.so.6
+";
+        assert!(!test_intel_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_amd_libs_not_detected_by_nvidia_finder() {
+        // AMD libraries must not trigger NVIDIA detection
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /opt/rocm/lib/libamdhip64.so.5
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /opt/rocm/lib/librocblas.so.3
+";
+        assert!(!test_nvidia_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_intel_libs_not_detected_by_nvidia_finder() {
+        // Intel libraries must not trigger NVIDIA detection
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libze_intel_gpu.so.1
+";
+        assert!(!test_nvidia_with_mock_maps(maps_content));
+    }
+
+    // --- Direct tests for the public has_any_gpu_libraries function ---
+
+    #[test]
+    fn test_has_any_gpu_libraries_nvidia_only() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libcuda.so.535
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libc.so.6
+";
+        assert!(test_has_any_gpu_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_any_gpu_libraries_amd_only() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /opt/rocm/lib/libamdhip64.so.5
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libc.so.6
+";
+        assert!(test_has_any_gpu_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_any_gpu_libraries_intel_only() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libze_intel_gpu.so.1
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libc.so.6
+";
+        assert!(test_has_any_gpu_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_any_gpu_libraries_mixed_nvidia_and_amd() {
+        // A process using both NVIDIA and AMD libraries (e.g. heterogeneous node) must be detected
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libcuda.so.535
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /opt/rocm/lib/libamdhip64.so.5
+";
+        assert!(test_has_any_gpu_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_any_gpu_libraries_mixed_nvidia_and_intel() {
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libcuda.so.535
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libze_intel_gpu.so.1
+";
+        assert!(test_has_any_gpu_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_any_gpu_libraries_no_gpu_libs() {
+        // A process with only standard system libraries must not be detected
+        let maps_content = "
+7f8e4c000000-7f8e4c021000 r--p 00000000 08:01 123456 /usr/lib/libc.so.6
+7f8e4c021000-7f8e4c400000 r-xp 00021000 08:01 123456 /usr/lib/libm.so.6
+7f8e4c400000-7f8e4c500000 r--p 00000000 08:01 123456 /usr/lib/libpthread.so.0
+";
+        assert!(!test_has_any_gpu_with_mock_maps(maps_content));
+    }
+
+    #[test]
+    fn test_has_any_gpu_libraries_empty_maps() {
+        assert!(!test_has_any_gpu_with_mock_maps(""));
     }
 }

--- a/pkg/discovery/module/rust/src/services.rs
+++ b/pkg/discovery/module/rust/src/services.rs
@@ -102,7 +102,7 @@ pub fn get_services(params: Params) -> ServicesResponse {
 }
 
 fn is_using_gpu(pid: i32, open_files_info: &OpenFilesInfo) -> bool {
-    open_files_info.has_gpu_device || procfs::maps::has_gpu_nvidia_libraries(pid)
+    open_files_info.has_gpu_device || procfs::maps::has_any_gpu_libraries(pid)
 }
 
 fn get_service(


### PR DESCRIPTION
### What does this PR do?

Extends the existing GPU detection mechanism (introduced for NVIDIA in #46538) to also identify processes using AMD ROCm and Intel GPU compute libraries.

Detection uses the same two-layer strategy as the NVIDIA implementation:

**Device file detection** (`/proc/[pid]/fd`):
- AMD ROCm: `/dev/kfd` (AMD Kernel Fusion Driver — exclusive to ROCm compute)

**Library detection** (`/proc/[pid]/maps`):
- AMD ROCm: `libamdhip64.so`, `librocblas.so`, `libMIOpen.so`, `librocm_smi64.so` , `librccl.so`, `libhipblas.so`
- Intel (Level Zero): `libze_intel_gpu.so`

Both checks are combined in a single pass over `/proc/[pid]/maps`.

`/dev/dri/renderD*` is intentionally excluded  because it is opened by display compositors, browsers, and video players, which would cause false positives.

`libze_loader.so` is intentionally excluded: the detection goal is "is this process doing Intel GPU compute?", and `libze_intel_gpu.so` answers that directly. Any process that loads the GPU backend will also have loaded the loader, so there are no true positives lost — only false positives avoided.

### Motivation
[DSCVR-364](https://datadoghq.atlassian.net/browse/DSCVR-364) and [DSCVR-405](https://datadoghq.atlassian.net/browse/DSCVR-405)

Follow-up to #46538, which only covered NVIDIA GPUs. AMD and Intel GPUs are increasingly common in ML/HPC workloads and should be detected in the same discovery pipeline.

### Describe how you validated your changes

- Unit tests added for each new detection signal (positive and negative cases, cross-vendor isolation)
- Manually verified that AMD and Intel library names do not appear in NVIDIA finders and vice versa
- Existing NVIDIA tests continue to pass unchanged

### Additional Notes
More about the devices and libraries election could be read [here.](https://datadoghq.atlassian.net/wiki/spaces/~712020cd09e734c2ad4306ab09c6b04ef5c99d/pages/6486688189/GPU+compute+detection)

[DSCVR-364]: https://datadoghq.atlassian.net/browse/DSCVR-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSCVR-405]: https://datadoghq.atlassian.net/browse/DSCVR-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ