### PR TITLE
[observer] Add detector time metrics and benchmarking

### DIFF
--- a/cmd/observer-testbench/ui/src/App.tsx
+++ b/cmd/observer-testbench/ui/src/App.tsx
@@ -4,10 +4,11 @@ import { MetricsView } from './components/MetricsView';
 import { CorrelatorView } from './components/CorrelatorView';
 import { LogView } from './components/LogView';
 import { ReportsView } from './components/ReportsView';
+import { BenchmarkView } from './components/BenchmarkView';
 import type { EpisodeInfo, ScoreResult } from './api/client';
 import type { PhaseMarker } from './components/ChartWithAnomalyDetails';
 
-type TabID = 'timeseries' | 'correlators' | 'logs' | 'reports';
+type TabID = 'timeseries' | 'correlators' | 'logs' | 'reports' | 'benchmark';
 
 function ConnectionStatus({ state }: { state: string }) {
   const colors: Record<string, string> = {
@@ -417,6 +418,16 @@ function App() {
               >
                 Reports
               </button>
+              <button
+                onClick={() => setActiveTab('benchmark')}
+                className={`px-3 py-1.5 rounded text-sm transition-colors ${
+                  activeTab === 'benchmark'
+                    ? 'bg-purple-600 text-white'
+                    : 'text-slate-400 hover:bg-slate-700'
+                }`}
+              >
+                Benchmark
+              </button>
             </div>
           </div>
           <div className="flex items-center gap-4">
@@ -609,6 +620,13 @@ function App() {
             timeRange={activeTimeRange}
             onTimeRangeChange={setTimeRange}
             phaseMarkers={phaseMarkers}
+          />
+        </div>
+        <div className={`flex-1 flex ${activeTab !== 'benchmark' ? 'hidden' : ''}`}>
+          <BenchmarkView
+            state={state}
+            actions={actions}
+            sidebarWidth={sidebarWidth}
           />
         </div>
       </div>

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -278,6 +278,14 @@ export interface ScoreResponse {
   score?: ScoreResult;
 }
 
+export interface DetectorProcessingStats {
+  name: string;
+  count: number;
+  avg_ns: number;
+  median_ns: number;
+  p99_ns: number;
+}
+
 class ApiClient {
   private async fetch<T>(path: string, options?: RequestInit): Promise<T> {
     const response = await fetch(`${API_BASE}${path}`, options);
@@ -400,6 +408,10 @@ class ApiClient {
 
   async getScore(): Promise<ScoreResponse> {
     return this.fetch('/score');
+  }
+
+  async getBenchmarkStats(): Promise<Record<string, DetectorProcessingStats>> {
+    return this.fetch('/benchmark');
   }
 
 }

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -284,6 +284,7 @@ export interface DetectorProcessingStats {
   avg_ns: number;
   median_ns: number;
   p99_ns: number;
+  total_ns: number;
 }
 
 class ApiClient {

--- a/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
+++ b/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
@@ -8,24 +8,41 @@ import { parseTagFilter, toggleTagInInput, matchesTagFilter } from '../filters';
 
 // ── Chart constants ────────────────────────────────────────────────────────────
 
-const MARGIN = { top: 44, right: 95, bottom: 20, left: 235 };
+// The "total" bar uses a fully independent secondary x-scale (its values can be
+// orders of magnitude larger than avg/p50/p99). A visual separator + second axis
+// makes the two scales unambiguous.
+const SEP_H = 10; // extra vertical gap between per-call rows and the total row
+const MARGIN = { top: 44, right: 95, bottom: 28, left: 235 };
 const BAR_H = 15;
 const BAR_GAP = 3;
 const GROUP_PAD = 16;
-const GROUP_INNER_H = 3 * BAR_H + 2 * BAR_GAP; // 51 px
-const GROUP_H = GROUP_INNER_H + GROUP_PAD;       // 67 px
+const GROUP_INNER_H = 4 * BAR_H + 3 * BAR_GAP + SEP_H; // 91 px
+const GROUP_H = GROUP_INNER_H + GROUP_PAD;               // 107 px
 
-const STATS: { key: 'avg' | 'p50' | 'p99'; label: string; color: string }[] = [
+// Per-call stats (share the primary top x-axis, domain in ns)
+const PER_CALL_STATS: { key: 'avg' | 'p50' | 'p99'; label: string; color: string }[] = [
   { key: 'avg', label: 'avg', color: '#60a5fa' },  // blue-400
   { key: 'p50', label: 'p50', color: '#4ade80' },  // green-400
   { key: 'p99', label: 'p99', color: '#f87171' },  // red-400
 ];
 
+const TOTAL_COLOR = '#fb923c'; // orange-400
+
+// Format µs-range values (used on the primary axis and per-call labels)
 function fmtUs(ns: number): string {
   const us = ns / 1000;
   if (us < 10) return us.toFixed(2) + 'µs';
   if (us < 100) return us.toFixed(1) + 'µs';
   return us.toFixed(0) + 'µs';
+}
+
+// Format potentially large totals with auto-scaling µs → ms → s
+function fmtTotal(ns: number): string {
+  const us = ns / 1000;
+  if (us < 1_000) return us.toFixed(1) + 'µs';
+  const ms = us / 1_000;
+  if (ms < 1_000) return ms.toFixed(1) + 'ms';
+  return (ms / 1_000).toFixed(3) + 's';
 }
 
 // ── Scenario selector (same as other views) ───────────────────────────────────
@@ -82,12 +99,18 @@ interface BenchmarkBarChartProps {
   onHover: (name: string | null) => void;
 }
 
+type StatKey = 'avg' | 'p50' | 'p99' | 'total';
+
 function BenchmarkBarChart({ stats, highlighted, onHover }: BenchmarkBarChartProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
+  const [activeStat, setActiveStat] = useState<StatKey | null>(null);
   const onHoverRef = useRef(onHover);
   onHoverRef.current = onHover;
+  const onStatClickRef = useRef<(key: StatKey) => void>(() => {});
+  onStatClickRef.current = (key: StatKey) =>
+    setActiveStat((prev) => (prev === key ? null : key));
 
   // Track container width via ResizeObserver
   useEffect(() => {
@@ -116,48 +139,91 @@ function BenchmarkBarChart({ stats, highlighted, onHover }: BenchmarkBarChartPro
     d3.select(svgRef.current).selectAll('*').remove();
     const svg = d3.select(svgRef.current).attr('width', width).attr('height', totalHeight);
 
-    // Legend (above the chart area, inside the left+chart space)
+    // Legend — clickable items (click to isolate a stat, click again to reset)
     const legendG = svg.append('g').attr('transform', `translate(${MARGIN.left}, 16)`);
-    STATS.forEach(({ label, color }, i) => {
-      const lx = i * 72;
-      legendG.append('rect').attr('x', lx).attr('y', 0).attr('width', 10).attr('height', 10).attr('fill', color).attr('rx', 2);
-      legendG
-        .append('text')
-        .attr('x', lx + 14)
-        .attr('y', 9)
-        .attr('fill', color)
-        .attr('font-size', '10px')
-        .attr('font-family', 'monospace')
+
+    const legendItems: { key: StatKey; label: string; color: string; x: number; baseOpacity: number }[] = [
+      { key: 'avg',   label: 'avg',   color: '#60a5fa', x: 0,   baseOpacity: 1 },
+      { key: 'p50',   label: 'p50',   color: '#4ade80', x: 72,  baseOpacity: 1 },
+      { key: 'p99',   label: 'p99',   color: '#f87171', x: 144, baseOpacity: 1 },
+      { key: 'total', label: 'total', color: TOTAL_COLOR, x: 235, baseOpacity: 0.85 },
+    ];
+
+    // Pipe separator between per-call and total
+    legendG.append('text').attr('x', 220).attr('y', 9).attr('fill', '#475569').attr('font-size', '10px').text('|');
+
+    legendItems.forEach(({ key, label, color, x, baseOpacity }) => {
+      const isSelected = activeStat === key;
+      const isDimmed = activeStat !== null && !isSelected;
+      const itemOpacity = isDimmed ? 0.25 : baseOpacity;
+
+      const itemG = legendG.append('g')
+        .attr('transform', `translate(${x}, 0)`)
+        .style('cursor', 'pointer')
+        .attr('opacity', itemOpacity)
+        .on('click', () => onStatClickRef.current(key));
+
+      itemG.append('rect')
+        .attr('x', 0).attr('y', 0).attr('width', 10).attr('height', 10)
+        .attr('fill', color).attr('rx', 2);
+
+      itemG.append('text')
+        .attr('x', 14).attr('y', 9)
+        .attr('fill', color).attr('font-size', '10px').attr('font-family', 'monospace')
         .text(label);
+
+      // Underline when selected
+      if (isSelected) {
+        const labelWidth = label.length * 7;
+        itemG.append('line')
+          .attr('x1', 14).attr('x2', 14 + labelWidth)
+          .attr('y1', 13).attr('y2', 13)
+          .attr('stroke', color).attr('stroke-width', 1.5);
+      }
     });
+
+    // "own scale" note
+    legendG.append('text').attr('x', 283).attr('y', 9).attr('fill', '#475569').attr('font-size', '9px')
+      .attr('opacity', activeStat === null || activeStat === 'total' ? 0.7 : 0.2)
+      .text('(own scale →)');
 
     const g = svg.append('g').attr('transform', `translate(${MARGIN.left},${MARGIN.top})`);
 
-    const maxNs = d3.max(stats, (s) => s.p99_ns) ?? 1;
-    const xScale = d3.scaleLinear().domain([0, maxNs * 1.12]).range([0, innerWidth]);
+    // Primary scale: per-call stats (avg / p50 / p99)
+    const maxPerCallNs = d3.max(stats, (s) => s.p99_ns) ?? 1;
+    const xScale = d3.scaleLinear().domain([0, maxPerCallNs * 1.12]).range([0, innerWidth]);
 
-    // Top axis — suppress the zero tick label to avoid overlap with stat key labels
+    // Secondary scale: total — fully independent domain
+    const maxTotalNs = d3.max(stats, (s) => s.total_ns) ?? 1;
+    const xScaleTotal = d3.scaleLinear().domain([0, maxTotalNs * 1.12]).range([0, innerWidth]);
+
+    const perCallAxisOpacity = activeStat === 'total' ? 0.15 : 1;
+    const totalAxisOpacity   = activeStat !== null && activeStat !== 'total' ? 0.15 : 1;
+
+    // Top axis — per-call µs scale (suppress zero to avoid collision with "avg" label)
     g.append('g')
       .attr('transform', 'translate(0,-8)')
-      .call(
-        d3
-          .axisTop(xScale)
-          .ticks(5)
-          .tickFormat((d) => (+d === 0 ? '' : fmtUs(+d)))
-      )
+      .attr('opacity', perCallAxisOpacity)
+      .call(d3.axisTop(xScale).ticks(5).tickFormat((d) => (+d === 0 ? '' : fmtUs(+d))))
       .call((ax) => ax.select('.domain').attr('stroke', '#334155'))
       .call((ax) => ax.selectAll('text').attr('fill', '#64748b').attr('font-size', '10px'))
       .call((ax) => ax.selectAll('.tick line').attr('stroke', '#334155'));
 
-    // Grid lines
+    // Bottom axis — total scale (auto µs/ms/s), orange tint
+    g.append('g')
+      .attr('transform', `translate(0,${innerHeight + 8})`)
+      .attr('opacity', totalAxisOpacity)
+      .call(d3.axisBottom(xScaleTotal).ticks(5).tickFormat((d) => (+d === 0 ? '' : fmtTotal(+d))))
+      .call((ax) => ax.select('.domain').attr('stroke', '#334155'))
+      .call((ax) => ax.selectAll('text').attr('fill', TOTAL_COLOR).attr('font-size', '10px').attr('opacity', '0.7'))
+      .call((ax) => ax.selectAll('.tick line').attr('stroke', '#334155'));
+
+    // Primary grid lines (faint)
     xScale.ticks(5).forEach((t) => {
       g.append('line')
-        .attr('x1', xScale(t))
-        .attr('x2', xScale(t))
-        .attr('y1', 0)
-        .attr('y2', innerHeight)
-        .attr('stroke', '#1e293b')
-        .attr('stroke-width', 1);
+        .attr('x1', xScale(t)).attr('x2', xScale(t))
+        .attr('y1', 0).attr('y2', innerHeight)
+        .attr('stroke', '#1e293b').attr('stroke-width', 1);
     });
 
     // Draw each detector group
@@ -174,86 +240,88 @@ function BenchmarkBarChart({ stats, highlighted, onHover }: BenchmarkBarChartPro
         .on('mouseenter', () => onHoverRef.current(stat.name))
         .on('mouseleave', () => onHoverRef.current(null));
 
-      // Transparent hit zone spanning full row (including left margin)
-      groupG
-        .append('rect')
-        .attr('x', -MARGIN.left)
-        .attr('y', -2)
+      // Transparent hit zone spanning full row (including margins)
+      groupG.append('rect')
+        .attr('x', -MARGIN.left).attr('y', -2)
         .attr('width', MARGIN.left + innerWidth + MARGIN.right)
         .attr('height', GROUP_INNER_H + 4)
         .attr('fill', 'transparent');
 
-      const vals: Record<string, number> = {
-        avg: stat.avg_ns,
-        p50: stat.median_ns,
-        p99: stat.p99_ns,
-      };
+      // ── Per-call bars (avg / p50 / p99) — primary scale ──────────────────
+      const perCallVals: Record<string, number> = { avg: stat.avg_ns, p50: stat.median_ns, p99: stat.p99_ns };
 
-      STATS.forEach(({ key, color }, si) => {
+      PER_CALL_STATS.forEach(({ key, color }, si) => {
         const barY = si * (BAR_H + BAR_GAP);
-        const val = vals[key];
+        const val = perCallVals[key];
         const barW = Math.max(0, xScale(val));
+        const statOpacity = activeStat === null || activeStat === key ? 1 : 0.07;
 
-        // Bar
-        groupG
-          .append('rect')
-          .attr('x', 0)
-          .attr('y', barY)
-          .attr('width', barW)
-          .attr('height', BAR_H)
-          .attr('fill', color)
-          .attr('rx', 2);
+        groupG.append('rect')
+          .attr('x', 0).attr('y', barY).attr('width', barW).attr('height', BAR_H)
+          .attr('fill', color).attr('rx', 2).attr('opacity', statOpacity);
 
-        // Stat key label — in the margin just before x=0
-        groupG
-          .append('text')
-          .attr('x', -10)
-          .attr('y', barY + BAR_H / 2)
-          .attr('text-anchor', 'end')
-          .attr('dominant-baseline', 'middle')
-          .attr('fill', color)
-          .attr('font-size', '9px')
-          .attr('font-family', 'monospace')
+        groupG.append('text')
+          .attr('x', -10).attr('y', barY + BAR_H / 2)
+          .attr('text-anchor', 'end').attr('dominant-baseline', 'middle')
+          .attr('fill', color).attr('font-size', '9px').attr('font-family', 'monospace')
+          .attr('opacity', statOpacity)
           .text(key);
 
-        // Value label at the end of the bar
-        groupG
-          .append('text')
-          .attr('x', barW + 6)
-          .attr('y', barY + BAR_H / 2)
+        groupG.append('text')
+          .attr('x', barW + 6).attr('y', barY + BAR_H / 2)
           .attr('dominant-baseline', 'middle')
-          .attr('fill', color)
-          .attr('font-size', '10px')
-          .attr('font-family', 'monospace')
+          .attr('fill', color).attr('font-size', '10px').attr('font-family', 'monospace')
+          .attr('opacity', statOpacity)
           .text(fmtUs(val));
       });
 
-      // Detector name — right-aligned in the wide left column
-      const nameX = -60;
-      const displayName =
-        stat.name.length > 20 ? stat.name.slice(0, 19) + '…' : stat.name;
-      groupG
-        .append('text')
-        .attr('x', nameX)
-        .attr('y', GROUP_INNER_H / 2 - 7)
-        .attr('text-anchor', 'end')
+      // ── Dashed separator line before the total row ────────────────────────
+      const sepY = 3 * (BAR_H + BAR_GAP) + SEP_H / 2;
+      groupG.append('line')
+        .attr('x1', -10).attr('x2', innerWidth)
+        .attr('y1', sepY).attr('y2', sepY)
+        .attr('stroke', '#334155').attr('stroke-width', 0.5)
+        .attr('stroke-dasharray', '3,3');
+
+      // ── Total bar — secondary scale ───────────────────────────────────────
+      const totalBarY = 3 * (BAR_H + BAR_GAP) + SEP_H;
+      const totalW = Math.max(0, xScaleTotal(stat.total_ns));
+      const totalStatOpacity = activeStat === null || activeStat === 'total' ? 1 : 0.07;
+
+      groupG.append('rect')
+        .attr('x', 0).attr('y', totalBarY).attr('width', totalW).attr('height', BAR_H)
+        .attr('fill', TOTAL_COLOR).attr('opacity', totalStatOpacity * 0.75).attr('rx', 2);
+
+      groupG.append('text')
+        .attr('x', -10).attr('y', totalBarY + BAR_H / 2)
+        .attr('text-anchor', 'end').attr('dominant-baseline', 'middle')
+        .attr('fill', TOTAL_COLOR).attr('font-size', '9px').attr('font-family', 'monospace')
+        .attr('opacity', totalStatOpacity * 0.85).text('tot');
+
+      groupG.append('text')
+        .attr('x', totalW + 6).attr('y', totalBarY + BAR_H / 2)
         .attr('dominant-baseline', 'middle')
+        .attr('fill', TOTAL_COLOR).attr('font-size', '10px').attr('font-family', 'monospace')
+        .attr('opacity', totalStatOpacity * 0.85).text(fmtTotal(stat.total_ns));
+
+      // ── Detector name + call count ────────────────────────────────────────
+      const nameX = -60;
+      const displayName = stat.name.length > 20 ? stat.name.slice(0, 19) + '…' : stat.name;
+
+      groupG.append('text')
+        .attr('x', nameX).attr('y', GROUP_INNER_H / 2 - 7)
+        .attr('text-anchor', 'end').attr('dominant-baseline', 'middle')
         .attr('fill', isActive ? '#e2e8f0' : '#475569')
-        .attr('font-size', '11px')
-        .attr('font-family', 'monospace')
+        .attr('font-size', '11px').attr('font-family', 'monospace')
         .text(displayName);
 
-      groupG
-        .append('text')
-        .attr('x', nameX)
-        .attr('y', GROUP_INNER_H / 2 + 9)
-        .attr('text-anchor', 'end')
-        .attr('dominant-baseline', 'middle')
-        .attr('fill', '#475569')
-        .attr('font-size', '9px')
+      groupG.append('text')
+        .attr('x', nameX).attr('y', GROUP_INNER_H / 2 + 9)
+        .attr('text-anchor', 'end').attr('dominant-baseline', 'middle')
+        .attr('fill', '#475569').attr('font-size', '9px')
         .text(`${stat.count.toLocaleString()} calls`);
     });
-  }, [stats, highlighted, containerWidth]);
+  }, [stats, highlighted, containerWidth, activeStat]);
 
   return (
     <div ref={containerRef} className="w-full">

--- a/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
+++ b/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
@@ -1,0 +1,416 @@
+import { useState, useEffect, useMemo, useRef } from 'react';
+import * as d3 from 'd3';
+import { api } from '../api/client';
+import type { DetectorProcessingStats, ScenarioInfo } from '../api/client';
+import type { ObserverState, ObserverActions } from '../hooks/useObserver';
+import { TagFilterGroups } from './TagFilterGroups';
+import { parseTagFilter, toggleTagInInput, matchesTagFilter } from '../filters';
+
+// ── Chart constants ────────────────────────────────────────────────────────────
+
+const MARGIN = { top: 44, right: 95, bottom: 20, left: 235 };
+const BAR_H = 15;
+const BAR_GAP = 3;
+const GROUP_PAD = 16;
+const GROUP_INNER_H = 3 * BAR_H + 2 * BAR_GAP; // 51 px
+const GROUP_H = GROUP_INNER_H + GROUP_PAD;       // 67 px
+
+const STATS: { key: 'avg' | 'p50' | 'p99'; label: string; color: string }[] = [
+  { key: 'avg', label: 'avg', color: '#60a5fa' },  // blue-400
+  { key: 'p50', label: 'p50', color: '#4ade80' },  // green-400
+  { key: 'p99', label: 'p99', color: '#f87171' },  // red-400
+];
+
+function fmtUs(ns: number): string {
+  const us = ns / 1000;
+  if (us < 10) return us.toFixed(2) + 'µs';
+  if (us < 100) return us.toFixed(1) + 'µs';
+  return us.toFixed(0) + 'µs';
+}
+
+// ── Scenario selector (same as other views) ───────────────────────────────────
+
+function ScenarioSelector({
+  scenarios,
+  activeScenario,
+  onLoadScenario,
+}: {
+  scenarios: ScenarioInfo[];
+  activeScenario: string | null;
+  onLoadScenario: (name: string) => Promise<void>;
+}) {
+  return (
+    <div className="p-4 border-b border-slate-700">
+      <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">Scenarios</h2>
+      <div className="space-y-1">
+        {scenarios.length === 0 ? (
+          <div className="text-sm text-slate-500">No scenarios found</div>
+        ) : (
+          scenarios.map((scenario) => (
+            <button
+              key={scenario.name}
+              onClick={() => onLoadScenario(scenario.name)}
+              className={`w-full text-left px-3 py-2 rounded text-sm transition-colors ${
+                activeScenario === scenario.name
+                  ? 'bg-purple-600 text-white'
+                  : 'text-slate-300 hover:bg-slate-700'
+              }`}
+            >
+              <div className="font-medium">{scenario.name}</div>
+              <div className="text-xs text-slate-400 mt-0.5">
+                {[
+                  scenario.hasParquet && 'parquet',
+                  scenario.hasLogs && 'logs',
+                  scenario.hasEvents && 'events',
+                ]
+                  .filter(Boolean)
+                  .join(', ') || 'empty'}
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Bar chart ─────────────────────────────────────────────────────────────────
+
+interface BenchmarkBarChartProps {
+  stats: DetectorProcessingStats[];
+  highlighted: Set<string> | null; // null = all at full opacity
+  onHover: (name: string | null) => void;
+}
+
+function BenchmarkBarChart({ stats, highlighted, onHover }: BenchmarkBarChartProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const onHoverRef = useRef(onHover);
+  onHoverRef.current = onHover;
+
+  // Track container width via ResizeObserver
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w) setContainerWidth(Math.floor(w));
+    });
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!svgRef.current || !containerRef.current || stats.length === 0) {
+      d3.select(svgRef.current).selectAll('*').remove();
+      return;
+    }
+
+    const width = containerWidth || containerRef.current.clientWidth;
+    const innerWidth = width - MARGIN.left - MARGIN.right;
+    if (innerWidth <= 0) return;
+
+    const innerHeight = stats.length * GROUP_H - GROUP_PAD;
+    const totalHeight = innerHeight + MARGIN.top + MARGIN.bottom;
+
+    d3.select(svgRef.current).selectAll('*').remove();
+    const svg = d3.select(svgRef.current).attr('width', width).attr('height', totalHeight);
+
+    // Legend (above the chart area, inside the left+chart space)
+    const legendG = svg.append('g').attr('transform', `translate(${MARGIN.left}, 16)`);
+    STATS.forEach(({ label, color }, i) => {
+      const lx = i * 72;
+      legendG.append('rect').attr('x', lx).attr('y', 0).attr('width', 10).attr('height', 10).attr('fill', color).attr('rx', 2);
+      legendG
+        .append('text')
+        .attr('x', lx + 14)
+        .attr('y', 9)
+        .attr('fill', color)
+        .attr('font-size', '10px')
+        .attr('font-family', 'monospace')
+        .text(label);
+    });
+
+    const g = svg.append('g').attr('transform', `translate(${MARGIN.left},${MARGIN.top})`);
+
+    const maxNs = d3.max(stats, (s) => s.p99_ns) ?? 1;
+    const xScale = d3.scaleLinear().domain([0, maxNs * 1.12]).range([0, innerWidth]);
+
+    // Top axis — suppress the zero tick label to avoid overlap with stat key labels
+    g.append('g')
+      .attr('transform', 'translate(0,-8)')
+      .call(
+        d3
+          .axisTop(xScale)
+          .ticks(5)
+          .tickFormat((d) => (+d === 0 ? '' : fmtUs(+d)))
+      )
+      .call((ax) => ax.select('.domain').attr('stroke', '#334155'))
+      .call((ax) => ax.selectAll('text').attr('fill', '#64748b').attr('font-size', '10px'))
+      .call((ax) => ax.selectAll('.tick line').attr('stroke', '#334155'));
+
+    // Grid lines
+    xScale.ticks(5).forEach((t) => {
+      g.append('line')
+        .attr('x1', xScale(t))
+        .attr('x2', xScale(t))
+        .attr('y1', 0)
+        .attr('y2', innerHeight)
+        .attr('stroke', '#1e293b')
+        .attr('stroke-width', 1);
+    });
+
+    // Draw each detector group
+    stats.forEach((stat, gi) => {
+      const groupY = gi * GROUP_H;
+      const isActive = highlighted === null || highlighted.has(stat.name);
+      const opacity = isActive ? 1 : 0.15;
+
+      const groupG = g
+        .append('g')
+        .attr('transform', `translate(0,${groupY})`)
+        .attr('opacity', opacity)
+        .style('cursor', 'default')
+        .on('mouseenter', () => onHoverRef.current(stat.name))
+        .on('mouseleave', () => onHoverRef.current(null));
+
+      // Transparent hit zone spanning full row (including left margin)
+      groupG
+        .append('rect')
+        .attr('x', -MARGIN.left)
+        .attr('y', -2)
+        .attr('width', MARGIN.left + innerWidth + MARGIN.right)
+        .attr('height', GROUP_INNER_H + 4)
+        .attr('fill', 'transparent');
+
+      const vals: Record<string, number> = {
+        avg: stat.avg_ns,
+        p50: stat.median_ns,
+        p99: stat.p99_ns,
+      };
+
+      STATS.forEach(({ key, color }, si) => {
+        const barY = si * (BAR_H + BAR_GAP);
+        const val = vals[key];
+        const barW = Math.max(0, xScale(val));
+
+        // Bar
+        groupG
+          .append('rect')
+          .attr('x', 0)
+          .attr('y', barY)
+          .attr('width', barW)
+          .attr('height', BAR_H)
+          .attr('fill', color)
+          .attr('rx', 2);
+
+        // Stat key label — in the margin just before x=0
+        groupG
+          .append('text')
+          .attr('x', -10)
+          .attr('y', barY + BAR_H / 2)
+          .attr('text-anchor', 'end')
+          .attr('dominant-baseline', 'middle')
+          .attr('fill', color)
+          .attr('font-size', '9px')
+          .attr('font-family', 'monospace')
+          .text(key);
+
+        // Value label at the end of the bar
+        groupG
+          .append('text')
+          .attr('x', barW + 6)
+          .attr('y', barY + BAR_H / 2)
+          .attr('dominant-baseline', 'middle')
+          .attr('fill', color)
+          .attr('font-size', '10px')
+          .attr('font-family', 'monospace')
+          .text(fmtUs(val));
+      });
+
+      // Detector name — right-aligned in the wide left column
+      const nameX = -60;
+      const displayName =
+        stat.name.length > 20 ? stat.name.slice(0, 19) + '…' : stat.name;
+      groupG
+        .append('text')
+        .attr('x', nameX)
+        .attr('y', GROUP_INNER_H / 2 - 7)
+        .attr('text-anchor', 'end')
+        .attr('dominant-baseline', 'middle')
+        .attr('fill', isActive ? '#e2e8f0' : '#475569')
+        .attr('font-size', '11px')
+        .attr('font-family', 'monospace')
+        .text(displayName);
+
+      groupG
+        .append('text')
+        .attr('x', nameX)
+        .attr('y', GROUP_INNER_H / 2 + 9)
+        .attr('text-anchor', 'end')
+        .attr('dominant-baseline', 'middle')
+        .attr('fill', '#475569')
+        .attr('font-size', '9px')
+        .text(`${stat.count.toLocaleString()} calls`);
+    });
+  }, [stats, highlighted, containerWidth]);
+
+  return (
+    <div ref={containerRef} className="w-full">
+      <svg ref={svgRef} style={{ display: 'block' }} />
+    </div>
+  );
+}
+
+// ── Main view ─────────────────────────────────────────────────────────────────
+
+interface BenchmarkViewProps {
+  state: ObserverState;
+  actions: ObserverActions;
+  sidebarWidth: number;
+}
+
+export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewProps) {
+  const [rawStats, setRawStats] = useState<Record<string, DetectorProcessingStats> | null>(null);
+  const [tagFilterInput, setTagFilterInput] = useState('');
+  const [hoveredDetector, setHoveredDetector] = useState<string | null>(null);
+
+  // Fetch when a scenario finishes loading
+  useEffect(() => {
+    if (state.connectionState !== 'ready') return;
+    api
+      .getBenchmarkStats()
+      .then(setRawStats)
+      .catch(() => setRawStats(null));
+  }, [state.activeScenario, state.connectionState]);
+
+  // Sort by p99 descending so the slowest detectors are at the top
+  const stats = useMemo(() => {
+    if (!rawStats) return [];
+    return Object.values(rawStats).sort((a, b) => b.p99_ns - a.p99_ns);
+  }, [rawStats]);
+
+  // Tag groups: one entry per detector using the `detector:<name>` convention
+  const tagGroups = useMemo(
+    () => new Map([['detector', stats.map((s) => `detector:${s.name}`)]]),
+    [stats]
+  );
+
+  // Highlighted set: hover takes priority over tag filter
+  const highlightedSet = useMemo((): Set<string> | null => {
+    if (hoveredDetector) return new Set([hoveredDetector]);
+
+    const filter = parseTagFilter(tagFilterInput);
+    if (filter.include.size === 0 && filter.exclude.size === 0) return null;
+
+    const included = new Set<string>();
+    for (const s of stats) {
+      if (matchesTagFilter([`detector:${s.name}`], filter)) {
+        included.add(s.name);
+      }
+    }
+    return included.size > 0 ? included : null;
+  }, [hoveredDetector, tagFilterInput, stats]);
+
+  return (
+    <div className="flex-1 flex">
+      {/* Sidebar */}
+      <aside
+        className="bg-slate-800 border-r border-slate-700 overflow-y-auto flex-shrink-0"
+        style={{ width: sidebarWidth }}
+      >
+        <ScenarioSelector
+          scenarios={state.scenarios ?? []}
+          activeScenario={state.activeScenario}
+          onLoadScenario={actions.loadScenario}
+        />
+
+        {stats.length > 0 && (
+          <div className="p-4 border-b border-slate-700">
+            <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+              Detector Filter
+            </h2>
+            <div className="relative mb-2">
+              <input
+                type="text"
+                value={tagFilterInput}
+                onChange={(e) => setTagFilterInput(e.target.value)}
+                placeholder="detector:…"
+                className="w-full bg-slate-700 text-slate-200 text-xs rounded px-2 py-1.5 placeholder-slate-500 focus:outline-none focus:ring-1 focus:ring-purple-500 font-mono pr-6"
+              />
+              {tagFilterInput && (
+                <button
+                  onClick={() => setTagFilterInput('')}
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+            <TagFilterGroups
+              tagGroups={tagGroups}
+              tagFilterInput={tagFilterInput}
+              onToggleTag={(tag) => setTagFilterInput(toggleTagInInput(tagFilterInput, tag))}
+            />
+          </div>
+        )}
+
+        {stats.length > 0 && (
+          <div className="p-4">
+            <div className="text-xs text-slate-500 space-y-1">
+              <div>{stats.length} detector{stats.length !== 1 ? 's' : ''} measured</div>
+              <div className="text-slate-600">sorted by p99 descending</div>
+            </div>
+          </div>
+        )}
+      </aside>
+
+      {/* Main area */}
+      <main className="flex-1 flex flex-col min-h-0 p-6 overflow-auto">
+        {/* Empty states */}
+        {state.connectionState === 'disconnected' && (
+          <div className="text-center py-20">
+            <div className="text-slate-400 text-lg">Waiting for observer connection…</div>
+          </div>
+        )}
+        {state.connectionState === 'connected' && !state.activeScenario && (
+          <div className="text-center py-20">
+            <div className="text-slate-400 text-lg">Select a scenario to begin</div>
+          </div>
+        )}
+        {state.connectionState === 'loading' && (
+          <div className="text-center py-20">
+            <div className="text-blue-400 text-lg">Loading scenario…</div>
+          </div>
+        )}
+        {state.connectionState === 'ready' && stats.length === 0 && (
+          <div className="text-center py-20">
+            <div className="text-slate-400 text-lg">No benchmark data available</div>
+            <div className="text-slate-500 text-sm mt-2">
+              Load a scenario to see per-detector processing times.
+            </div>
+          </div>
+        )}
+
+        {/* Chart widget */}
+        {state.connectionState === 'ready' && stats.length > 0 && (
+          <div className="bg-slate-800/60 border border-slate-700 rounded-lg p-4">
+            <div className="flex items-baseline gap-3 mb-3">
+              <h2 className="text-sm font-semibold text-slate-200">
+                Detector Processing Times
+              </h2>
+              <span className="text-xs text-slate-500">
+                per processing call · hover a row or click a tag to highlight
+              </span>
+            </div>
+            <BenchmarkBarChart
+              stats={stats}
+              highlighted={highlightedSet}
+              onHover={setHoveredDetector}
+            />
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -244,6 +244,7 @@ type LogMetricsExtractor interface {
 // receive log observations. This allows detectors to incorporate log signals
 // without going through the metrics extraction path.
 type LogObserver interface {
+	Detector
 	ProcessLog(log LogView)
 }
 

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
 )
@@ -192,7 +193,10 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 	view := &logView{obs: l}
 	var logTelemetry []observerdef.ObserverTelemetry
 	for _, extractor := range e.extractors {
+		processingStartTime := time.Now()
 		out := extractor.ProcessLog(view)
+		processingTime := time.Since(processingStartTime)
+		logTelemetry = append(logTelemetry, newTelemetryGauge(extractor.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000))
 		for _, m := range out.Metrics {
 			tags := copyTags(m.Tags)
 			if !sliceContains(tags, sourceTag) {
@@ -217,7 +221,15 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 		e.telemetryMu.Unlock()
 	}
 	for _, lo := range e.logObservers {
+		processingStartTime := time.Now()
 		lo.ProcessLog(view)
+		processingTime := time.Since(processingStartTime)
+		logTelemetry = append(logTelemetry, newTelemetryGauge(lo.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000))
+		if len(logTelemetry) > 0 {
+			e.telemetryMu.Lock()
+			e.accumulatedTelemetry = append(e.accumulatedTelemetry, logTelemetry...)
+			e.telemetryMu.Unlock()
+		}
 	}
 	dataTimeSec := l.timestampMs / 1000
 	e.storage.RecordObservationTime(dataTimeSec)

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -215,19 +215,15 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 			logTelemetry = append(logTelemetry, out.Telemetry...)
 		}
 	}
-	if len(logTelemetry) > 0 {
-		e.telemetryMu.Lock()
-		e.accumulatedTelemetry = append(e.accumulatedTelemetry, logTelemetry...)
-		e.telemetryMu.Unlock()
-	}
 	for _, lo := range e.logObservers {
 		processingStartTime := time.Now()
 		lo.ProcessLog(view)
 		processingTime := time.Since(processingStartTime)
-		gauge := newTelemetryGauge(lo.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000)
-		logTelemetry = append(logTelemetry, gauge)
+		logTelemetry = append(logTelemetry, newTelemetryGauge(lo.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000))
+	}
+	if len(logTelemetry) > 0 {
 		e.telemetryMu.Lock()
-		e.accumulatedTelemetry = append(e.accumulatedTelemetry, gauge)
+		e.accumulatedTelemetry = append(e.accumulatedTelemetry, logTelemetry...)
 		e.telemetryMu.Unlock()
 	}
 	dataTimeSec := l.timestampMs / 1000

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -224,12 +224,11 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 		processingStartTime := time.Now()
 		lo.ProcessLog(view)
 		processingTime := time.Since(processingStartTime)
-		logTelemetry = append(logTelemetry, newTelemetryGauge(lo.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000))
-		if len(logTelemetry) > 0 {
-			e.telemetryMu.Lock()
-			e.accumulatedTelemetry = append(e.accumulatedTelemetry, logTelemetry...)
-			e.telemetryMu.Unlock()
-		}
+		gauge := newTelemetryGauge(lo.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000)
+		logTelemetry = append(logTelemetry, gauge)
+		e.telemetryMu.Lock()
+		e.accumulatedTelemetry = append(e.accumulatedTelemetry, gauge)
+		e.telemetryMu.Unlock()
 	}
 	dataTimeSec := l.timestampMs / 1000
 	e.storage.RecordObservationTime(dataTimeSec)
@@ -401,11 +400,6 @@ func (e *engine) processAnomaly(anomaly observerdef.Anomaly) []observerdef.Obser
 		correlator.ProcessAnomaly(anomaly)
 		processingTime := time.Since(processingStartTime)
 		allTelemetry = append(allTelemetry, newTelemetryGauge(correlator.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), anomaly.Timestamp))
-		if len(allTelemetry) > 0 {
-			e.telemetryMu.Lock()
-			e.accumulatedTelemetry = append(e.accumulatedTelemetry, allTelemetry...)
-			e.telemetryMu.Unlock()
-		}
 	}
 
 	return allTelemetry

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -314,14 +314,19 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 	var allTelemetry []observerdef.ObserverTelemetry
 
 	for _, detector := range detectors {
+		processingStartTime := time.Now()
 		result := detector.Detect(e.storage, upTo)
+		processingTime := time.Since(processingStartTime)
+		allTelemetry = append(allTelemetry, newTelemetryGauge(detector.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), upTo))
+
 		for _, anomaly := range result.Anomalies {
 			e.enrichAnomaly(&anomaly)
 			if !e.captureRawAnomaly(anomaly) {
 				continue // duplicate — skip correlators, events, and reporters
 			}
-			e.processAnomaly(anomaly)
+			correlatorTelemetry := e.processAnomaly(anomaly)
 			allAnomalies = append(allAnomalies, anomaly)
+			allTelemetry = append(allTelemetry, correlatorTelemetry...)
 
 			e.emit(engineEvent{
 				kind:      eventAnomalyCreated,
@@ -389,10 +394,21 @@ func (e *engine) enrichAnomaly(a *observerdef.Anomaly) {
 }
 
 // processAnomaly sends an anomaly to all registered correlators.
-func (e *engine) processAnomaly(anomaly observerdef.Anomaly) {
+func (e *engine) processAnomaly(anomaly observerdef.Anomaly) []observerdef.ObserverTelemetry {
+	var allTelemetry []observerdef.ObserverTelemetry
 	for _, correlator := range e.correlators {
+		processingStartTime := time.Now()
 		correlator.ProcessAnomaly(anomaly)
+		processingTime := time.Since(processingStartTime)
+		allTelemetry = append(allTelemetry, newTelemetryGauge(correlator.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), anomaly.Timestamp))
+		if len(allTelemetry) > 0 {
+			e.telemetryMu.Lock()
+			e.accumulatedTelemetry = append(e.accumulatedTelemetry, allTelemetry...)
+			e.telemetryMu.Unlock()
+		}
 	}
+
+	return allTelemetry
 }
 
 // captureRawAnomaly stores a raw anomaly for telemetry and testbench display.

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -23,12 +23,13 @@ type ObserverOutput struct {
 
 // ObserverMetadata describes the scenario and pipeline configuration.
 type ObserverMetadata struct {
-	Scenario            string   `json:"scenario"`
-	TimelineStart       int64    `json:"timeline_start"`
-	TimelineEnd         int64    `json:"timeline_end"`
-	DetectorsEnabled    []string `json:"detectors_enabled"`
-	CorrelatorsEnabled  []string `json:"correlators_enabled"`
-	TotalAnomalyPeriods int      `json:"total_anomaly_periods"`
+	Scenario            string                             `json:"scenario"`
+	TimelineStart       int64                              `json:"timeline_start"`
+	TimelineEnd         int64                              `json:"timeline_end"`
+	DetectorsEnabled    []string                           `json:"detectors_enabled"`
+	CorrelatorsEnabled  []string                           `json:"correlators_enabled"`
+	TotalAnomalyPeriods int                                `json:"total_anomaly_periods"`
+	DetectorStats       map[string]DetectorProcessingStats `json:"detector_stats,omitempty"`
 }
 
 // ObserverCorrelation is one correlation cluster.
@@ -78,6 +79,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			correlatorNames = append(correlatorNames, name)
 		}
 	}
+	detectorStats := tb.detectorProcessingStats
 	tb.mu.RUnlock()
 
 	sort.Strings(detectorNames)
@@ -127,6 +129,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			DetectorsEnabled:    detectorNames,
 			CorrelatorsEnabled:  correlatorNames,
 			TotalAnomalyPeriods: len(outCorrelations),
+			DetectorStats:       detectorStats,
 		},
 		AnomalyPeriods: outCorrelations,
 	}

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -12,6 +12,9 @@ import (
 )
 
 const (
+	// Observer
+	telemetryDetectorProcessingTimeNs = "observer.detector.processing_time_ns"
+
 	// RRCF detector
 	telemetryRRCFScore     = "observer.rrcf.score"
 	telemetryRRCFThreshold = "observer.rrcf.threshold"
@@ -31,6 +34,12 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 	gauges := make(map[string]telemetry.Gauge)
 
 	// Gauges
+	gauges[telemetryDetectorProcessingTimeNs] = telemetryComp.NewGauge(
+		"observer",
+		telemetryDetectorProcessingTimeNs,
+		[]string{"detector"},
+		"Per detector processing time in nanoseconds (doesn't include storage time)",
+	)
 	gauges[telemetryRRCFScore] = telemetryComp.NewGauge(
 		"observer",
 		telemetryRRCFScore,

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1172,14 +1172,29 @@ func (tb *TestBench) printDetectorProcessingStats() {
 	fmt.Println("\nDetector processing times:")
 	for _, name := range names {
 		s := stats[name]
-		fmt.Printf("  %-40s  avg=%8.2fµs  median=%8.2fµs  p99=%8.2fµs  (%d calls)\n",
+		fmt.Printf("  %-40s  avg=%8.2fµs  median=%8.2fµs  p99=%8.2fµs  total=%s  (%d calls)\n",
 			name,
 			s.AvgNs/1e3,
 			s.MedianNs/1e3,
 			s.P99Ns/1e3,
+			formatTotalNs(s.TotalNs),
 			s.Count,
 		)
 	}
+}
+
+// formatTotalNs formats a total duration (nanoseconds) with auto-scaling to
+// µs, ms, or s so the column width stays compact regardless of magnitude.
+func formatTotalNs(ns float64) string {
+	us := ns / 1e3
+	if us < 1_000 {
+		return fmt.Sprintf("%8.1fµs", us)
+	}
+	ms := us / 1_000
+	if ms < 1_000 {
+		return fmt.Sprintf("%8.1fms", ms)
+	}
+	return fmt.Sprintf("%8.3fs ", ms/1_000)
 }
 
 // RunSendAnomalyEvents loads a scenario, waits for correlators to finish, then

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -131,6 +131,10 @@ type TestBench struct {
 
 	// This is not directly used, it's mostly to ensure that telemetry metrics are registered in the telemetry handler
 	telemetryHandler *telemetryHandler
+
+	// detectorProcessingStats holds per-detector avg/median/p99 processing times
+	// computed after each replay run, keyed by detector name.
+	detectorProcessingStats map[string]DetectorProcessingStats
 }
 
 // ScenarioInfo describes an available scenario.
@@ -696,6 +700,9 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// Publish the ordered event log captured during replay.
 	tb.reportedEvents = replay.events
 
+	// Compute per-detector processing stats from all telemetry accumulated during the replay.
+	tb.detectorProcessingStats = computeDetectorProcessingStats(tb.engine.StateView().Telemetry())
+
 	// Mark scenario ready now that all analysis is complete
 	tb.ready = true
 }
@@ -918,6 +925,15 @@ func (tb *TestBench) GetDetectorComponentMap() map[string]string {
 	return result
 }
 
+// GetDetectorProcessingStats returns per-detector processing-time statistics
+// (avg / median / p99, in nanoseconds) computed from the last replay run.
+// Returns nil if no scenario has been run yet.
+func (tb *TestBench) GetDetectorProcessingStats() map[string]DetectorProcessingStats {
+	tb.mu.RLock()
+	defer tb.mu.RUnlock()
+	return tb.detectorProcessingStats
+}
+
 // GetCorrelations returns all correlations detected across the full run.
 func (tb *TestBench) GetCorrelations() []observerdef.ActiveCorrelation {
 	tb.mu.RLock()
@@ -1126,6 +1142,8 @@ func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) erro
 		return fmt.Errorf("loading scenario %q: %w", scenario, err)
 	}
 
+	tb.printDetectorProcessingStats()
+
 	// Write structured JSON output.
 	if outputPath != "" {
 		if err := tb.WriteObserverOutput(outputPath, verbose); err != nil {
@@ -1135,6 +1153,33 @@ func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) erro
 	}
 
 	return nil
+}
+
+// printDetectorProcessingStats prints per-detector processing-time statistics to stdout.
+func (tb *TestBench) printDetectorProcessingStats() {
+	stats := tb.GetDetectorProcessingStats()
+	if len(stats) == 0 {
+		return
+	}
+
+	// Sort by name for deterministic output.
+	names := make([]string, 0, len(stats))
+	for name := range stats {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fmt.Println("\nDetector processing times:")
+	for _, name := range names {
+		s := stats[name]
+		fmt.Printf("  %-40s  avg=%8.2fµs  median=%8.2fµs  p99=%8.2fµs  (%d calls)\n",
+			name,
+			s.AvgNs/1e3,
+			s.MedianNs/1e3,
+			s.P99Ns/1e3,
+			s.Count,
+		)
+	}
 }
 
 // RunSendAnomalyEvents loads a scenario, waits for correlators to finish, then

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -64,6 +64,7 @@ func (api *TestBenchAPI) Start(addr string) error {
 	mux.HandleFunc("/api/surprise", api.cors(api.handleSurprise))
 	mux.HandleFunc("/api/stats", api.cors(api.handleStats))
 	mux.HandleFunc("/api/score", api.cors(api.handleScore))
+	mux.HandleFunc("/api/benchmark", api.cors(api.handleBenchmark))
 	mux.HandleFunc("/api/components/", api.cors(api.handleComponentAction))
 	mux.HandleFunc("/api/correlations/compressed", api.cors(api.handleCompressedCorrelations))
 
@@ -1208,6 +1209,17 @@ func (api *TestBenchAPI) writeJSON(w http.ResponseWriter, data interface{}) {
 		log.Printf("Failed to encode JSON: %v", err)
 		http.Error(w, `{"error":"encoding error"}`, http.StatusInternalServerError)
 	}
+}
+
+// handleBenchmark returns per-detector processing-time statistics (avg/median/p99)
+// computed from the last replay run.
+func (api *TestBenchAPI) handleBenchmark(w http.ResponseWriter, _ *http.Request) {
+	stats := api.tb.GetDetectorProcessingStats()
+	if stats == nil {
+		api.writeJSON(w, map[string]DetectorProcessingStats{})
+		return
+	}
+	api.writeJSON(w, stats)
 }
 
 // writeError writes an error response.

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"sort"
+
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+)
+
+// DetectorProcessingStats holds aggregate processing-time statistics for a single
+// detector (or extractor / correlator) across all advance calls during a replay.
+// Times are in nanoseconds.
+type DetectorProcessingStats struct {
+	Name     string  `json:"name"`
+	Count    int     `json:"count"`
+	AvgNs    float64 `json:"avg_ns"`
+	MedianNs float64 `json:"median_ns"`
+	P99Ns    float64 `json:"p99_ns"`
+}
+
+// computeDetectorProcessingStats groups telemetry samples for
+// telemetryDetectorProcessingTimeNs by detector name and computes
+// avg / median / p99 for each.
+func computeDetectorProcessingStats(telemetry []observerdef.ObserverTelemetry) map[string]DetectorProcessingStats {
+	byDetector := make(map[string][]float64)
+
+	for _, t := range telemetry {
+		if t.Metric == nil || t.Metric.GetName() != telemetryDetectorProcessingTimeNs {
+			continue
+		}
+		name := t.DetectorName
+		if name == "" {
+			continue
+		}
+		byDetector[name] = append(byDetector[name], t.Metric.GetValue())
+	}
+
+	result := make(map[string]DetectorProcessingStats, len(byDetector))
+	for name, values := range byDetector {
+		result[name] = statsFromSamples(name, values)
+	}
+	return result
+}
+
+func statsFromSamples(name string, values []float64) DetectorProcessingStats {
+	if len(values) == 0 {
+		return DetectorProcessingStats{Name: name}
+	}
+
+	sum := 0.0
+	for _, v := range values {
+		sum += v
+	}
+	avg := sum / float64(len(values))
+
+	sorted := make([]float64, len(values))
+	copy(sorted, values)
+	sort.Float64s(sorted)
+
+	return DetectorProcessingStats{
+		Name:     name,
+		Count:    len(values),
+		AvgNs:    avg,
+		MedianNs: interpolatedPercentile(sorted, 50),
+		P99Ns:    interpolatedPercentile(sorted, 99),
+	}
+}
+
+// interpolatedPercentile computes a percentile via linear interpolation on a
+// sorted slice. p must be in [0, 100].
+func interpolatedPercentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	idx := (p / 100.0) * float64(n-1)
+	lo := int(idx)
+	hi := lo + 1
+	if hi >= n {
+		return sorted[n-1]
+	}
+	frac := idx - float64(lo)
+	return sorted[lo]*(1-frac) + sorted[hi]*frac
+}

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -20,6 +20,7 @@ type DetectorProcessingStats struct {
 	AvgNs    float64 `json:"avg_ns"`
 	MedianNs float64 `json:"median_ns"`
 	P99Ns    float64 `json:"p99_ns"`
+	TotalNs  float64 `json:"total_ns"` // sum of all individual call durations
 }
 
 // computeDetectorProcessingStats groups telemetry samples for
@@ -67,6 +68,7 @@ func statsFromSamples(name string, values []float64) DetectorProcessingStats {
 		AvgNs:    avg,
 		MedianNs: interpolatedPercentile(sorted, 50),
 		P99Ns:    interpolatedPercentile(sorted, 99),
+		TotalNs:  sum,
 	}
 }
 


### PR DESCRIPTION
Adds detector performance metrics and benchmarking capabilities to the observer with UI support.

Adds:
- Processing time telemetry: Measure performance across different detector types
- Processing times report: Display aggregated processing time statistics in headless mode
```
Detector processing times:
  bocpd_detector                            avg= 2591.96µs  median= 2470.25µs  p99= 4704.97µs  total=   4.943s   (1907 calls)
  connection_error_extractor                avg=    0.61µs  median=    0.38µs  p99=    3.71µs  total=    12.1ms  (19763 calls)
  log_metrics_extractor                     avg=    4.59µs  median=    2.83µs  p99=   18.18µs  total=    90.7ms  (19763 calls)
  log_pattern_extractor                     avg=   56.41µs  median=   43.38µs  p99=  170.52µs  total=   1.115s   (19763 calls)
  rrcf                                      avg= 1514.38µs  median= 1561.21µs  p99= 2009.54µs  total=   2.888s   (1907 calls)
  time_cluster_correlator                   avg=    0.35µs  median=    0.21µs  p99=    2.67µs  total=    96.3µs  (276 calls)
```
- Benchmark UI view: Visualize detector performance metrics in the testbench UI
<img width="2081" height="755" alt="Screenshot 2026-03-24 at 11 49 29" src="https://github.com/user-attachments/assets/8e466b47-8f66-4350-adcb-cddb54e32143" />

Adding soon support for input / output numbers telemetry to have more meaningful comparisons ("bocpd processing time per series")
