### PR TITLE
Wait for security-agent container readiness

### DIFF
--- a/test/new-e2e/tests/cspm/cspm_test.go
+++ b/test/new-e2e/tests/cspm/cspm_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/datadog/kubernetesagentparams"
@@ -189,14 +190,57 @@ func (s *cspmTestSuite) TestFindings() {
 	})
 	require.NoError(s.T(), err)
 	require.Len(s.T(), res.Items, 1)
-	agentPod := res.Items[0]
-	_, _, err = s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agentPod.Name, "security-agent", []string{"security-agent", "compliance", "check", "--dump-reports", "/tmp/reports", "--report"})
+	agentPodName := s.waitForSecurityAgentPodReady("datadog", res.Items[0].Name)
+	_, _, err = s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agentPodName, "security-agent", []string{"security-agent", "compliance", "check", "--dump-reports", "/tmp/reports", "--report"})
 	require.NoError(s.T(), err)
-	dumpContent, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agentPod.Name, "security-agent", []string{"cat", "/tmp/reports"})
+	dumpContent, _, err := s.Env().KubernetesCluster.KubernetesClient.PodExec("datadog", agentPodName, "security-agent", []string{"cat", "/tmp/reports"})
 	require.NoError(s.T(), err)
 	findings, err := parseFindingOutput(dumpContent)
 	require.NoError(s.T(), err)
 	s.checkFindings(findings, mergeFindings(expectedFindingsMasterEtcdNode, expectedFindingsWorkerNode))
+}
+
+func (s *cspmTestSuite) waitForSecurityAgentPodReady(namespace, podName string) string {
+	s.T().Helper()
+
+	var selectedPodName string
+	require.Eventuallyf(s.T(), func() bool {
+		pod, err := s.Env().KubernetesCluster.Client().CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})
+		if err != nil {
+			s.T().Logf("unable to get pod %s: %v", podName, err)
+			return false
+		}
+		if !podHasContainer(pod, "security-agent") {
+			s.T().Logf("pod %s does not contain security-agent yet", pod.Name)
+			return false
+		}
+		if !isContainerReady(pod, "security-agent") {
+			s.T().Logf("security-agent container is not ready yet in pod %s", pod.Name)
+			return false
+		}
+		selectedPodName = pod.Name
+		return true
+	}, 3*time.Minute, 5*time.Second, "security-agent container was not ready in pod %s", podName)
+
+	return selectedPodName
+}
+
+func podHasContainer(pod *corev1.Pod, containerName string) bool {
+	for _, container := range pod.Spec.Containers {
+		if container.Name == containerName {
+			return true
+		}
+	}
+	return false
+}
+
+func isContainerReady(pod *corev1.Pod, containerName string) bool {
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == containerName {
+			return status.Ready
+		}
+	}
+	return false
 }
 
 func (s *cspmTestSuite) TestMetrics() {


### PR DESCRIPTION
<!-- dd-meta {"pullId":"18236ade-1627-4b92-82d8-0ff618aab605","source":"chat","resourceId":"b5c800ce-1dee-458f-9cfd-86ec75364242","workflowId":"f94fe430-0c56-4669-9306-ec64c9eb227a","codeChangeId":"f94fe430-0c56-4669-9306-ec64c9eb227a","sourceType":"chat"} -->
### What does this PR do?

Adds a wait mechanism to ensure the security-agent container is fully ready before executing commands in the CSPM test. This prevents race conditions where the container may not yet be present or initialized when the test attempts to execute commands against it.

### Motivation

The CSPM CI tests have been experiencing flaky failures since March 20th with errors like "unable to upgrade connection: container not found 'securityagent'". These failures occur because the test attempts to execute commands on the security-agent container before it's fully initialized. The fix adds a polling mechanism with timeout to wait for the container to be ready and present in the pod specification before proceeding.

### Describe how you validated your changes

The fix introduces helper functions `waitForSecurityAgentPodReady()`, `podHasContainer()`, and `isContainerReady()` that:
- Poll the pod status up to 3 minutes with 5-second intervals
- Verify the security-agent container exists in the pod specification
- Verify the security-agent container is in a ready state
- Only then proceed with executing commands against the container

This eliminates the race condition by ensuring the container is fully initialized before test commands are executed.

### Additional Notes

The change is minimal and focused, affecting only the TestFindings test method in the CSPM test suite. It directly addresses the root cause of container initialization timing issues without requiring changes to pod deployment configurations.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b5c800ce-1dee-458f-9cfd-86ec75364242)

Comment @datadog to request changes