### PR TITLE
fix(discovery): disable Spring/JEE name generation to reduce memory usage

### DIFF
--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -166,6 +166,7 @@ rust_test(
     name = "dd_discovery_test",
     crate = ":dd_discovery",
     crate_features = [
+        "java-archives",
         "spring",
         "jee",
     ],

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -43,7 +43,6 @@ rust_library(
         "@crates//:thiserror",
         "@crates//:tokio",
         "@crates//:uzers",
-        "@crates//:yaml-rust2",
     ],
 )
 
@@ -85,7 +84,6 @@ rust_static_library(
         "@crates//:thiserror",
         "@crates//:tokio",
         "@crates//:uzers",
-        "@crates//:yaml-rust2",
     ],
 )
 
@@ -184,6 +182,7 @@ rust_test(
         # Optional deps needed when spring/jee features are enabled
         "@crates//:quick-xml",
         "@crates//:walkdir",
+        "@crates//:yaml-rust2",
         "@crates//:zip",
     ],
 )

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -187,6 +187,24 @@ rust_test(
     ],
 )
 
+# Unit tests without optional features (tests the production code path)
+rust_test(
+    name = "dd_discovery_nofeatures_test",
+    crate = ":dd_discovery",
+    # No crate_features — matches production build
+    data = [":testdata"],
+    edition = "2024",
+    deps = [
+        "@crates//:dircpy",
+        "@crates//:memmap2",
+        "@crates//:scopeguard",
+        "@crates//:tempfile",
+        "@crates//:temp-env",
+        # walkdir is needed by test_utils (dev-dependency)
+        "@crates//:walkdir",
+    ],
+)
+
 # Integration tests
 rust_test(
     name = "pid_integration_test",

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -43,7 +43,6 @@ rust_library(
         "@crates//:thiserror",
         "@crates//:tokio",
         "@crates//:uzers",
-        "@crates//:walkdir",
         "@crates//:yaml-rust2",
     ],
 )
@@ -86,7 +85,6 @@ rust_static_library(
         "@crates//:thiserror",
         "@crates//:tokio",
         "@crates//:uzers",
-        "@crates//:walkdir",
         "@crates//:yaml-rust2",
     ],
 )
@@ -185,6 +183,7 @@ rust_test(
         "@crates//:temp-env",
         # Optional deps needed when spring/jee features are enabled
         "@crates//:quick-xml",
+        "@crates//:walkdir",
         "@crates//:zip",
     ],
 )

--- a/pkg/discovery/module/rust/BUILD.bazel
+++ b/pkg/discovery/module/rust/BUILD.bazel
@@ -37,7 +37,6 @@ rust_library(
         "@crates//:nom",
         "@crates//:normalize-path",
         "@crates//:phf",
-        "@crates//:quick-xml",
         "@crates//:rmp-serde",
         "@crates//:serde",
         "@crates//:serde_json",
@@ -46,7 +45,6 @@ rust_library(
         "@crates//:uzers",
         "@crates//:walkdir",
         "@crates//:yaml-rust2",
-        "@crates//:zip",
     ],
 )
 
@@ -82,7 +80,6 @@ rust_static_library(
         "@crates//:nom",
         "@crates//:normalize-path",
         "@crates//:phf",
-        "@crates//:quick-xml",
         "@crates//:rmp-serde",
         "@crates//:serde",
         "@crates//:serde_json",
@@ -91,7 +88,6 @@ rust_static_library(
         "@crates//:uzers",
         "@crates//:walkdir",
         "@crates//:yaml-rust2",
-        "@crates//:zip",
     ],
 )
 
@@ -173,6 +169,10 @@ filegroup(
 rust_test(
     name = "dd_discovery_test",
     crate = ":dd_discovery",
+    crate_features = [
+        "spring",
+        "jee",
+    ],
     # Make test data available to tests
     data = [":testdata"],
     edition = "2024",
@@ -183,6 +183,9 @@ rust_test(
         "@crates//:scopeguard",
         "@crates//:tempfile",
         "@crates//:temp-env",
+        # Optional deps needed when spring/jee features are enabled
+        "@crates//:quick-xml",
+        "@crates//:zip",
     ],
 )
 

--- a/pkg/discovery/module/rust/Cargo.toml
+++ b/pkg/discovery/module/rust/Cargo.toml
@@ -7,8 +7,9 @@ rust-version.workspace = true
 
 [features]
 default = []
-spring = ["dep:zip", "dep:walkdir", "dep:yaml-rust2"]
-jee = ["dep:zip", "dep:quick-xml", "dep:walkdir"]
+java-archives = ["dep:zip", "dep:walkdir"]
+spring = ["java-archives", "dep:yaml-rust2"]
+jee = ["java-archives", "dep:quick-xml"]
 
 [lib]
 name = "dd_discovery"

--- a/pkg/discovery/module/rust/Cargo.toml
+++ b/pkg/discovery/module/rust/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 
 [features]
 default = []
-spring = ["dep:zip", "dep:walkdir"]
+spring = ["dep:zip", "dep:walkdir", "dep:yaml-rust2"]
 jee = ["dep:zip", "dep:quick-xml", "dep:walkdir"]
 
 [lib]
@@ -46,7 +46,7 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }
 uzers.workspace = true
 walkdir = { workspace = true, optional = true }
-yaml-rust2.workspace = true
+yaml-rust2 = { workspace = true, optional = true }
 zip = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/pkg/discovery/module/rust/Cargo.toml
+++ b/pkg/discovery/module/rust/Cargo.toml
@@ -52,6 +52,7 @@ zip = { workspace = true, optional = true }
 [dev-dependencies]
 dircpy.workspace = true
 walkdir.workspace = true
+yaml-rust2.workspace = true
 memmap2.workspace = true
 nix.workspace = true
 scopeguard.workspace = true

--- a/pkg/discovery/module/rust/Cargo.toml
+++ b/pkg/discovery/module/rust/Cargo.toml
@@ -5,6 +5,11 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+default = []
+spring = ["dep:zip"]
+jee = ["dep:zip", "dep:quick-xml"]
+
 [lib]
 name = "dd_discovery"
 crate-type = ["rlib", "staticlib"]
@@ -32,7 +37,7 @@ memchr.workspace = true
 nom.workspace = true
 normalize-path.workspace = true
 phf.workspace = true
-quick-xml.workspace = true
+quick-xml = { workspace = true, optional = true }
 rmp-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -42,7 +47,7 @@ tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "sig
 uzers.workspace = true
 walkdir.workspace = true
 yaml-rust2.workspace = true
-zip.workspace = true
+zip = { workspace = true, optional = true }
 
 [dev-dependencies]
 dircpy.workspace = true

--- a/pkg/discovery/module/rust/Cargo.toml
+++ b/pkg/discovery/module/rust/Cargo.toml
@@ -7,8 +7,8 @@ rust-version.workspace = true
 
 [features]
 default = []
-spring = ["dep:zip"]
-jee = ["dep:zip", "dep:quick-xml"]
+spring = ["dep:zip", "dep:walkdir"]
+jee = ["dep:zip", "dep:quick-xml", "dep:walkdir"]
 
 [lib]
 name = "dd_discovery"
@@ -45,12 +45,13 @@ dd-agent-log.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }
 uzers.workspace = true
-walkdir.workspace = true
+walkdir = { workspace = true, optional = true }
 yaml-rust2.workspace = true
 zip = { workspace = true, optional = true }
 
 [dev-dependencies]
 dircpy.workspace = true
+walkdir.workspace = true
 memmap2.workspace = true
 nix.workspace = true
 scopeguard.workspace = true

--- a/pkg/discovery/module/rust/src/fs.rs
+++ b/pkg/discovery/module/rust/src/fs.rs
@@ -6,9 +6,9 @@
 use cap_std::fs::Dir;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
-#[cfg(any(feature = "spring", feature = "jee"))]
+#[cfg(feature = "java-archives")]
 use walkdir::WalkDir;
-#[cfg(any(feature = "spring", feature = "jee"))]
+#[cfg(feature = "java-archives")]
 use zip::ZipArchive;
 
 /// SubDirFs is like a standard filesystem, except that it allows
@@ -21,7 +21,7 @@ use zip::ZipArchive;
 /// Root.FS than Dir.FS since it prevents escapes via symbolic links too.
 pub struct SubDirFs {
     dir: Dir,
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     root_path: PathBuf,
 }
 
@@ -59,7 +59,7 @@ impl UnverifiedFile {
         size_verified_reader(&self.0, max_size)
     }
 
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     pub fn verify_zip(
         self,
     ) -> Result<UnverifiedZipArchive<cap_std::fs::File>, zip::result::ZipError> {
@@ -67,7 +67,7 @@ impl UnverifiedFile {
     }
 }
 
-#[cfg(any(feature = "spring", feature = "jee"))]
+#[cfg(feature = "java-archives")]
 /// UnverifiedZipArchive is a wrapper around ZipArchive that prevents reading
 /// ZIP entry contents until size verification has been performed via the verify() method
 /// on individual entries. This ensures compile-time enforcement of size verification
@@ -77,7 +77,7 @@ impl UnverifiedFile {
 /// then call .verify(max_size) on it.
 pub struct UnverifiedZipArchive<R>(ZipArchive<R>);
 
-#[cfg(any(feature = "spring", feature = "jee"))]
+#[cfg(feature = "java-archives")]
 impl<R: Read + io::Seek> UnverifiedZipArchive<R> {
     /// Gets a ZIP entry by index, returning an UnverifiedZipFile.
     /// To read the entry contents, call .verify(max_size) on the returned file.
@@ -107,7 +107,7 @@ impl<R: Read + io::Seek> UnverifiedZipArchive<R> {
     }
 }
 
-#[cfg(any(feature = "spring", feature = "jee"))]
+#[cfg(feature = "java-archives")]
 /// UnverifiedZipFile is a wrapper around zip::read::ZipFile that prevents reading
 /// the file contents until size verification has been performed via the verify() method.
 /// This ensures compile-time enforcement of size verification for ZIP entry reads.
@@ -115,7 +115,7 @@ impl<R: Read + io::Seek> UnverifiedZipArchive<R> {
 /// Metadata access (name, size) is allowed without verification.
 pub struct UnverifiedZipFile<'a>(zip::read::ZipFile<'a>);
 
-#[cfg(any(feature = "spring", feature = "jee"))]
+#[cfg(feature = "java-archives")]
 impl<'a> UnverifiedZipFile<'a> {
     /// Verifies the ZIP entry and returns a reader that can be used to read the contents.
     pub fn verify(self, max_size: Option<u64>) -> io::Result<impl Read + 'a> {
@@ -135,13 +135,13 @@ impl SubDirFs {
         let dir = Dir::open_ambient_dir(root.as_ref(), cap_std::ambient_authority())?;
         Ok(Self {
             dir,
-            #[cfg(any(feature = "spring", feature = "jee"))]
+            #[cfg(feature = "java-archives")]
             root_path: root.as_ref().to_path_buf(),
         })
     }
 
     /// Creates a new SubDirFs rooted at the specified path relative to the current root.
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     pub fn sub<P: AsRef<Path>>(&self, path: P) -> io::Result<Self> {
         let fixed = fix_path(&path);
         let sub_path = self.root_path.join(fixed);
@@ -200,7 +200,7 @@ impl SubDirFs {
     ///
     /// Use `make_relative()` to convert the absolute paths from walkdir entries
     /// back to paths relative to SubDirFs root.
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     pub fn walker(&self, start_path: &str) -> WalkDir {
         let full_path = self.root_path.join(fix_path(&start_path));
         WalkDir::new(full_path)
@@ -213,7 +213,7 @@ impl SubDirFs {
     /// Returns None if the path is not within the SubDirFs root.
     ///
     /// This is useful when working with walkdir entries from `walker()`.
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     pub fn make_relative(&self, path: &Path) -> Option<String> {
         let relative = path.strip_prefix(&self.root_path).ok()?;
         Some(if relative.as_os_str().is_empty() {
@@ -224,7 +224,7 @@ impl SubDirFs {
     }
 }
 
-#[cfg(any(feature = "spring", feature = "jee"))]
+#[cfg(feature = "java-archives")]
 // We don't verify the size of the zip archive, the sizes of individual entries
 // are verified when we read them via the type system enforcement.
 fn verified_zip_archive(
@@ -241,7 +241,7 @@ fn verified_zip_archive(
     Ok(UnverifiedZipArchive(ZipArchive::new(file.0)?))
 }
 
-#[cfg(any(feature = "spring", feature = "jee"))]
+#[cfg(feature = "java-archives")]
 /// Returns a reader for a ZIP entry after verifying the size doesn't exceed max_size.
 fn size_verified_zip_reader<'a>(
     zip_file: zip::read::ZipFile<'a>,
@@ -303,7 +303,7 @@ pub fn size_verified_reader(
 mod tests {
     use super::*;
     use crate::test_utils::TestDataFs;
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     use std::io::Write;
 
     #[test]
@@ -568,7 +568,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     fn test_unverified_zip_archive_enforcement() {
         // Create a test ZIP archive
         let mut buf = Vec::new();
@@ -631,7 +631,7 @@ mod tests {
     }
 
     // Helper function for test_unverified_zip_archive_enforcement
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     fn create_test_zip_data() -> Vec<u8> {
         let mut buf = Vec::new();
         {

--- a/pkg/discovery/module/rust/src/fs.rs
+++ b/pkg/discovery/module/rust/src/fs.rs
@@ -6,6 +6,7 @@
 use cap_std::fs::Dir;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+#[cfg(any(feature = "spring", feature = "jee"))]
 use walkdir::WalkDir;
 #[cfg(any(feature = "spring", feature = "jee"))]
 use zip::ZipArchive;
@@ -196,7 +197,7 @@ impl SubDirFs {
     ///
     /// Use `make_relative()` to convert the absolute paths from walkdir entries
     /// back to paths relative to SubDirFs root.
-    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
+    #[cfg(any(feature = "spring", feature = "jee"))]
     pub fn walker(&self, start_path: &str) -> WalkDir {
         let full_path = self.root_path.join(fix_path(&start_path));
         WalkDir::new(full_path)

--- a/pkg/discovery/module/rust/src/fs.rs
+++ b/pkg/discovery/module/rust/src/fs.rs
@@ -7,6 +7,7 @@ use cap_std::fs::Dir;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
+#[cfg(any(feature = "spring", feature = "jee"))]
 use zip::ZipArchive;
 
 /// SubDirFs is like a standard filesystem, except that it allows
@@ -19,6 +20,7 @@ use zip::ZipArchive;
 /// Root.FS than Dir.FS since it prevents escapes via symbolic links too.
 pub struct SubDirFs {
     dir: Dir,
+    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
     root_path: PathBuf,
 }
 
@@ -56,6 +58,7 @@ impl UnverifiedFile {
         size_verified_reader(&self.0, max_size)
     }
 
+    #[cfg(any(feature = "spring", feature = "jee"))]
     pub fn verify_zip(
         self,
     ) -> Result<UnverifiedZipArchive<cap_std::fs::File>, zip::result::ZipError> {
@@ -63,6 +66,7 @@ impl UnverifiedFile {
     }
 }
 
+#[cfg(any(feature = "spring", feature = "jee"))]
 /// UnverifiedZipArchive is a wrapper around ZipArchive that prevents reading
 /// ZIP entry contents until size verification has been performed via the verify() method
 /// on individual entries. This ensures compile-time enforcement of size verification
@@ -72,6 +76,7 @@ impl UnverifiedFile {
 /// then call .verify(max_size) on it.
 pub struct UnverifiedZipArchive<R>(ZipArchive<R>);
 
+#[cfg(any(feature = "spring", feature = "jee"))]
 impl<R: Read + io::Seek> UnverifiedZipArchive<R> {
     /// Gets a ZIP entry by index, returning an UnverifiedZipFile.
     /// To read the entry contents, call .verify(max_size) on the returned file.
@@ -101,6 +106,7 @@ impl<R: Read + io::Seek> UnverifiedZipArchive<R> {
     }
 }
 
+#[cfg(any(feature = "spring", feature = "jee"))]
 /// UnverifiedZipFile is a wrapper around zip::read::ZipFile that prevents reading
 /// the file contents until size verification has been performed via the verify() method.
 /// This ensures compile-time enforcement of size verification for ZIP entry reads.
@@ -108,6 +114,7 @@ impl<R: Read + io::Seek> UnverifiedZipArchive<R> {
 /// Metadata access (name, size) is allowed without verification.
 pub struct UnverifiedZipFile<'a>(zip::read::ZipFile<'a>);
 
+#[cfg(any(feature = "spring", feature = "jee"))]
 impl<'a> UnverifiedZipFile<'a> {
     /// Verifies the ZIP entry and returns a reader that can be used to read the contents.
     pub fn verify(self, max_size: Option<u64>) -> io::Result<impl Read + 'a> {
@@ -130,6 +137,7 @@ impl SubDirFs {
     }
 
     /// Creates a new SubDirFs rooted at the specified path relative to the current root.
+    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
     pub fn sub<P: AsRef<Path>>(&self, path: P) -> io::Result<Self> {
         let fixed = fix_path(&path);
         let sub_path = self.root_path.join(fixed);
@@ -188,6 +196,7 @@ impl SubDirFs {
     ///
     /// Use `make_relative()` to convert the absolute paths from walkdir entries
     /// back to paths relative to SubDirFs root.
+    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
     pub fn walker(&self, start_path: &str) -> WalkDir {
         let full_path = self.root_path.join(fix_path(&start_path));
         WalkDir::new(full_path)
@@ -200,6 +209,7 @@ impl SubDirFs {
     /// Returns None if the path is not within the SubDirFs root.
     ///
     /// This is useful when working with walkdir entries from `walker()`.
+    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
     pub fn make_relative(&self, path: &Path) -> Option<String> {
         let relative = path.strip_prefix(&self.root_path).ok()?;
         Some(if relative.as_os_str().is_empty() {
@@ -210,6 +220,7 @@ impl SubDirFs {
     }
 }
 
+#[cfg(any(feature = "spring", feature = "jee"))]
 // We don't verify the size of the zip archive, the sizes of individual entries
 // are verified when we read them via the type system enforcement.
 fn verified_zip_archive(
@@ -226,6 +237,7 @@ fn verified_zip_archive(
     Ok(UnverifiedZipArchive(ZipArchive::new(file.0)?))
 }
 
+#[cfg(any(feature = "spring", feature = "jee"))]
 /// Returns a reader for a ZIP entry after verifying the size doesn't exceed max_size.
 fn size_verified_zip_reader<'a>(
     zip_file: zip::read::ZipFile<'a>,
@@ -287,6 +299,7 @@ pub fn size_verified_reader(
 mod tests {
     use super::*;
     use crate::test_utils::TestDataFs;
+    #[cfg(any(feature = "spring", feature = "jee"))]
     use std::io::Write;
 
     #[test]
@@ -551,6 +564,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "spring", feature = "jee"))]
     fn test_unverified_zip_archive_enforcement() {
         // Create a test ZIP archive
         let mut buf = Vec::new();
@@ -613,6 +627,7 @@ mod tests {
     }
 
     // Helper function for test_unverified_zip_archive_enforcement
+    #[cfg(any(feature = "spring", feature = "jee"))]
     fn create_test_zip_data() -> Vec<u8> {
         let mut buf = Vec::new();
         {

--- a/pkg/discovery/module/rust/src/fs.rs
+++ b/pkg/discovery/module/rust/src/fs.rs
@@ -21,7 +21,7 @@ use zip::ZipArchive;
 /// Root.FS than Dir.FS since it prevents escapes via symbolic links too.
 pub struct SubDirFs {
     dir: Dir,
-    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
+    #[cfg(any(feature = "spring", feature = "jee"))]
     root_path: PathBuf,
 }
 
@@ -132,13 +132,16 @@ impl<'a> UnverifiedZipFile<'a> {
 impl SubDirFs {
     /// Creates a new SubDirFs rooted at the specified path
     pub fn new<P: AsRef<Path>>(root: P) -> io::Result<Self> {
-        let root_path = root.as_ref().to_path_buf();
         let dir = Dir::open_ambient_dir(root.as_ref(), cap_std::ambient_authority())?;
-        Ok(Self { dir, root_path })
+        Ok(Self {
+            dir,
+            #[cfg(any(feature = "spring", feature = "jee"))]
+            root_path: root.as_ref().to_path_buf(),
+        })
     }
 
     /// Creates a new SubDirFs rooted at the specified path relative to the current root.
-    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
+    #[cfg(any(feature = "spring", feature = "jee"))]
     pub fn sub<P: AsRef<Path>>(&self, path: P) -> io::Result<Self> {
         let fixed = fix_path(&path);
         let sub_path = self.root_path.join(fixed);
@@ -210,7 +213,7 @@ impl SubDirFs {
     /// Returns None if the path is not within the SubDirFs root.
     ///
     /// This is useful when working with walkdir entries from `walker()`.
-    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
+    #[cfg(any(feature = "spring", feature = "jee"))]
     pub fn make_relative(&self, path: &Path) -> Option<String> {
         let relative = path.strip_prefix(&self.root_path).ok()?;
         Some(if relative.as_os_str().is_empty() {

--- a/pkg/discovery/module/rust/src/service_name.rs
+++ b/pkg/discovery/module/rust/src/service_name.rs
@@ -7,12 +7,14 @@ mod context;
 mod dotnet;
 mod gunicorn;
 mod java;
+#[cfg(feature = "jee")]
 mod jee;
 mod nodejs;
 mod php;
 mod python;
 mod rails;
 mod ruby;
+#[cfg(feature = "spring")]
 mod spring;
 mod uvicorn;
 
@@ -59,10 +61,15 @@ pub enum ServiceNameSource {
     Nodejs,
     Gunicorn,
     Rails,
+    #[cfg(feature = "spring")]
     Spring,
+    #[cfg(feature = "jee")]
     Jboss,
+    #[cfg(feature = "jee")]
     Tomcat,
+    #[cfg(feature = "jee")]
     Weblogic,
+    #[cfg(feature = "jee")]
     Websphere,
 }
 
@@ -76,10 +83,15 @@ impl ServiceNameSource {
             Self::Nodejs => "nodejs",
             Self::Gunicorn => "gunicorn",
             Self::Rails => "rails",
+            #[cfg(feature = "spring")]
             Self::Spring => "spring",
+            #[cfg(feature = "jee")]
             Self::Jboss => "jboss",
+            #[cfg(feature = "jee")]
             Self::Tomcat => "tomcat",
+            #[cfg(feature = "jee")]
             Self::Weblogic => "weblogic",
+            #[cfg(feature = "jee")]
             Self::Websphere => "websphere",
         }
     }

--- a/pkg/discovery/module/rust/src/service_name/java.rs
+++ b/pkg/discovery/module/rust/src/service_name/java.rs
@@ -10,7 +10,9 @@ use std::path::Path;
 const JAR_EXTENSION: &str = ".jar";
 const WAR_EXTENSION: &str = ".war";
 const APACHE_PREFIX: &str = "org.apache.";
+#[cfg(feature = "spring")]
 const SPRING_BOOT_LAUNCHER: &str = "org.springframework.boot.loader.launch.JarLauncher";
+#[cfg(feature = "spring")]
 const SPRING_BOOT_OLD_LAUNCHER: &str = "org.springframework.boot.loader.JarLauncher";
 
 /// Checks if an argument is a Java name flag (-jar, -m, or --module)
@@ -41,6 +43,7 @@ fn trim_colon_right(s: &str) -> &str {
 }
 
 /// Extracts the Java service name from the command line
+#[allow(unused_variables)]
 pub fn extract_name(
     cmdline: &crate::procfs::Cmdline,
     ctx: &mut DetectionContext,
@@ -83,7 +86,13 @@ pub fn extract_name(
 
             if arg.starts_with(|c: char| c.is_alphabetic()) {
                 // Do JEE detection to see if we can extract additional service names from context roots
+                #[cfg(feature = "jee")]
                 let (vendor_source, additional_names) = super::jee::extract_names(cmdline, ctx);
+                #[cfg(not(feature = "jee"))]
+                let (vendor_source, additional_names): (
+                    Option<ServiceNameSource>,
+                    Vec<String>,
+                ) = (None, vec![]);
 
                 // The name gets joined to the AdditionalNames, so a part of
                 // the name still comes from the command line, but report
@@ -98,6 +107,7 @@ pub fn extract_name(
                 // Check for JAR or WAR files
                 if arg.ends_with(JAR_EXTENSION) || arg.ends_with(WAR_EXTENSION) {
                     // Try to see if the application is a Spring Boot archive and extract its application name
+                    #[cfg(feature = "spring")]
                     if additional_names.is_empty()
                         && let Some(spring_app_name) =
                             super::spring::get_spring_boot_app_name(a, ctx, cmdline)
@@ -129,6 +139,7 @@ pub fn extract_name(
                 }
 
                 // Check for Spring Boot launcher classes
+                #[cfg(feature = "spring")]
                 if (arg == SPRING_BOOT_LAUNCHER || arg == SPRING_BOOT_OLD_LAUNCHER)
                     && let Some(spring_app_name) =
                         super::spring::get_spring_boot_launcher_app_name(ctx, cmdline)
@@ -160,6 +171,7 @@ mod tests {
     use crate::cmdline;
     use crate::fs::SubDirFs;
     use crate::procfs::Cmdline;
+    #[cfg(any(feature = "spring", feature = "jee"))]
     use crate::test_utils::TestDataFs;
     use std::collections::HashMap;
 
@@ -433,6 +445,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "spring")]
     fn test_spring_boot_unpacked_jar_with_new_launcher() {
         let fs = TestDataFs::new("spring");
         let mut envs = HashMap::new();
@@ -449,6 +462,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "spring")]
     fn test_spring_boot_unpacked_jar_with_classpath() {
         let fs = TestDataFs::new("spring");
         let envs = HashMap::new();
@@ -464,6 +478,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "spring")]
     fn test_spring_boot_unpacked_jar_with_old_launcher() {
         let fs = TestDataFs::new("spring");
         let mut envs = HashMap::new();
@@ -480,6 +495,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "spring")]
     fn test_spring_boot_default_options() {
         use std::io::Write;
         use tempfile::TempDir;
@@ -528,9 +544,11 @@ mod tests {
     }
 
     // JEE Integration Tests
+    #[cfg(feature = "jee")]
     const JBOSS_TEST_APP_ROOT: &str = "../sub";
 
     #[test]
+    #[cfg(feature = "jee")]
     fn test_wildfly_18_standalone() {
         let fs = TestDataFs::new("jee/jboss");
         let mut envs = HashMap::new();
@@ -588,6 +606,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "jee")]
     fn test_wildfly_18_domain() {
         let fs = TestDataFs::new("jee/jboss");
         let mut envs = HashMap::new();
@@ -656,6 +675,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "jee")]
     fn test_weblogic_12() {
         let fs = TestDataFs::new("jee/weblogic");
         let mut envs = HashMap::new();
@@ -691,6 +711,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "jee")]
     fn test_tomcat_10() {
         let fs = TestDataFs::new("jee");
         let envs = HashMap::new();

--- a/pkg/discovery/module/rust/src/service_name/java.rs
+++ b/pkg/discovery/module/rust/src/service_name/java.rs
@@ -43,11 +43,11 @@ fn trim_colon_right(s: &str) -> &str {
 }
 
 /// Extracts the Java service name from the command line
-#[allow(unused_variables)]
 pub fn extract_name(
     cmdline: &crate::procfs::Cmdline,
     ctx: &mut DetectionContext,
 ) -> Option<ServiceNameMetadata> {
+    _ = &ctx; // ctx is only used when spring/jee features are enabled
     // First pass: Look for -Ddd.service= system property (highest priority)
     let mut args_iter = cmdline.args();
     args_iter.next()?; // Skip the java executable

--- a/pkg/discovery/module/rust/src/service_name/java.rs
+++ b/pkg/discovery/module/rust/src/service_name/java.rs
@@ -171,7 +171,7 @@ mod tests {
     use crate::cmdline;
     use crate::fs::SubDirFs;
     use crate::procfs::Cmdline;
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     use crate::test_utils::TestDataFs;
     use std::collections::HashMap;
 

--- a/pkg/discovery/module/rust/src/test_utils.rs
+++ b/pkg/discovery/module/rust/src/test_utils.rs
@@ -51,7 +51,7 @@ impl AsRef<Path> for TestDataFs {
 }
 
 impl TestDataFs {
-    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
+    #[cfg(any(feature = "spring", feature = "jee"))]
     pub fn new_empty() -> Self {
         let temp_dir = TempDir::new().unwrap();
         let subdirfs = SubDirFs::new(temp_dir.path()).unwrap();

--- a/pkg/discovery/module/rust/src/test_utils.rs
+++ b/pkg/discovery/module/rust/src/test_utils.rs
@@ -51,6 +51,7 @@ impl AsRef<Path> for TestDataFs {
 }
 
 impl TestDataFs {
+    #[cfg_attr(not(any(feature = "spring", feature = "jee")), allow(dead_code))]
     pub fn new_empty() -> Self {
         let temp_dir = TempDir::new().unwrap();
         let subdirfs = SubDirFs::new(temp_dir.path()).unwrap();

--- a/pkg/discovery/module/rust/src/test_utils.rs
+++ b/pkg/discovery/module/rust/src/test_utils.rs
@@ -51,7 +51,7 @@ impl AsRef<Path> for TestDataFs {
 }
 
 impl TestDataFs {
-    #[cfg(any(feature = "spring", feature = "jee"))]
+    #[cfg(feature = "java-archives")]
     pub fn new_empty() -> Self {
         let temp_dir = TempDir::new().unwrap();
         let subdirfs = SubDirFs::new(temp_dir.path()).unwrap();


### PR DESCRIPTION
### What does this PR do?

Makes the Spring and JEE (JBoss, Tomcat, WebLogic, WebSphere) service name generation in the Rust discovery module optional and disabled by default via Cargo feature flags. This removes `zip`, `walkdir`, `yaml-rust2`, and `quick-xml` from the default dependency set, gating them behind three new features:

- `java-archives` — enables ZIP/WAR archive scanning (`zip`, `walkdir`)
- `spring` — enables Spring Boot application name detection (`yaml-rust2`, implies `java-archives`)
- `jee` — enables JEE vendor detection (`quick-xml`, implies `java-archives`)

The production Bazel build compiles without these features for now, while tests enable them to maintain full coverage. A new `dd_discovery_nofeatures_test` Bazel target ensures the no-features code path compiles and passes.

### Motivation

Fixes https://datadoghq.atlassian.net/browse/DSCVR-401

The system-probe-lite process was consuming >20 MiB RSS on some nodes due to opening and parsing Java archives (JARs/WARs) for Spring/JEE service name detection. In one test, profiling with `valgrind --tool=massif` showed peak usage of 17 MiB with these features used vs 458 KiB with them disabled, since the `zip` crate allocates significant memory when opening archives like large Bazel JARs.

Disable the Spring/JEE service name generation for now as a minimal, backportable workaround until a proper solution can be developed.

### Describe how you validated your changes

- `bazel build --config=lint //pkg/discovery/module/rust/...` passes
- Both `dd_discovery_test` (all features) and `dd_discovery_nofeatures_test` (no features) Bazel test targets pass
- Massif profiling confirmed the memory reduction (17 MiB → 458 KiB peak)