### PR TITLE
Do not use pty on windows on bazel helper

### DIFF
--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -26,6 +26,6 @@ def bazel(ctx: Context, *args: str, capture_output: bool = False, sudo: bool = F
         (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(("bazel", *args)),
         echo=True,
         in_stream=False,
-        **({"hide": "out"} if capture_output else {"pty": sys.stdout.isatty()}),  # type: ignore[dict-item]
+        **({"hide": "out"} if capture_output else {"pty": sys.stdout.isatty() and sys.platform != "win32"}),  # type: ignore[dict-item]
     )
     return result.stdout if capture_output else None


### PR DESCRIPTION
### What does this PR do?

It avoids setting `pty=True` on `ctx.run` call from the bazel wrapper helper on Windows.

### Motivation

This option relies on the [pty](https://docs.python.org/3/library/pty.html) module from stdlib, which is unix only. On windows, this results in failure with the message:

```
You indicated pty=True, but your platform doesn't support the 'pty' module!
```

Which comes from [here](https://github.com/pyinvoke/invoke/blob/07b836f2663bb073a7bcef3d6c454e1dc6b867ae/invoke/runners.py#L1310-L1312).

### Describe how you validated your changes

Running `dda inv tidy` with and without the change.

### Additional Notes

Obviously this has the unfortunate effect of making the output from bazel uglier / less user-friendly on windows, but that's better than not working and it's expected to be a temporary state anyway.
