### PR TITLE
refactor(healthplatform): abstract persistence, disable on Kubernetes

### DIFF
--- a/comp/healthplatform/impl/health-platform.go
+++ b/comp/healthplatform/impl/health-platform.go
@@ -12,7 +12,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -29,6 +28,7 @@ import (
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	healthplatformdef "github.com/DataDog/datadog-agent/comp/healthplatform/def"
 	issuesmod "github.com/DataDog/datadog-agent/comp/healthplatform/impl/issues"
+	configenv "github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/version"
 
 	// Import issue modules to trigger their init() registration
@@ -69,7 +69,7 @@ type healthPlatformImpl struct {
 
 	// Persistence
 	persistedIssues map[string]*PersistedIssue // Persisted issues with status tracking
-	persistencePath string                     // Path to the persistence file
+	persistence     issuesPersistence          // Persistence backend (disk or noop)
 
 	// Issue module registry (combines checks + remediations)
 	issueRegistry *issuesmod.Registry
@@ -215,9 +215,18 @@ func NewComponent(reqs Requires) (Provides, error) {
 
 	reqs.Log.Info("Creating health platform component")
 
-	// Build persistence path: <run_path>/health-platform/issues.json
-	runPath := reqs.Config.GetString("run_path")
-	persistencePath := filepath.Join(runPath, "health-platform", "issues.json")
+	// Select persistence backend: noop on Kubernetes (emptyDir makes disk persistence meaningless),
+	// disk-based elsewhere so issues survive agent restarts.
+	var persistence issuesPersistence
+	if configenv.IsKubernetes() {
+		reqs.Log.Info("Running on Kubernetes: health platform persistence disabled (ephemeral storage)")
+		persistence = &noopPersistence{}
+	} else {
+		runPath := reqs.Config.GetString("run_path")
+		persistencePath := filepath.Join(runPath, "health-platform", "issues.json")
+		persistence = newDiskPersistence(persistencePath)
+	}
+
 	// Create unified issue registry and register all self-registered modules
 	issueRegistry := issuesmod.NewRegistry()
 	for _, module := range issuesmod.GetAllModules() {
@@ -241,7 +250,7 @@ func NewComponent(reqs Requires) (Provides, error) {
 
 		// Persistence
 		persistedIssues: make(map[string]*PersistedIssue),
-		persistencePath: persistencePath,
+		persistence:     persistence,
 	}
 
 	// Initialize check runner (must be after comp is created as it needs the reporter interface)
@@ -593,20 +602,15 @@ func (h *healthPlatformImpl) initForwarder(reqs Requires) error {
 // Persistence Methods
 // ============================================================================
 
-// loadFromDisk loads persisted issues from disk
+// loadFromDisk loads persisted issues via the persistence backend
 func (h *healthPlatformImpl) loadFromDisk() error {
-	data, err := os.ReadFile(h.persistencePath)
+	state, err := h.persistence.load()
 	if err != nil {
-		if os.IsNotExist(err) {
-			h.log.Info("No persisted issues file found, starting fresh")
-			return nil
-		}
-		return fmt.Errorf("failed to read persisted issues: %w", err)
+		return err
 	}
-
-	var state PersistedState
-	if err := json.Unmarshal(data, &state); err != nil {
-		return fmt.Errorf("failed to unmarshal persisted issues: %w", err)
+	if state == nil {
+		h.log.Info("No persisted issues found, starting fresh")
+		return nil
 	}
 
 	h.issuesMux.Lock()
@@ -631,11 +635,11 @@ func (h *healthPlatformImpl) loadFromDisk() error {
 		}
 	}
 
-	h.log.Info(fmt.Sprintf("Loaded %d persisted issues from disk (%d active)", len(state.Issues), activeCount))
+	h.log.Info(fmt.Sprintf("Loaded %d persisted issues (%d active)", len(state.Issues), activeCount))
 	return nil
 }
 
-// saveToDisk persists issues to disk using atomic write (temp file + rename)
+// saveToDisk persists the current issue state via the persistence backend
 func (h *healthPlatformImpl) saveToDisk() error {
 	h.issuesMux.RLock()
 	// Make a deep copy to avoid race conditions during marshaling
@@ -648,7 +652,7 @@ func (h *healthPlatformImpl) saveToDisk() error {
 	}
 	h.issuesMux.RUnlock()
 
-	// Prune resolved issues older than the TTL before writing to disk
+	// Prune resolved issues older than the TTL before saving
 	pruneOldResolvedIssues(issuesCopy)
 
 	state := PersistedState{
@@ -656,29 +660,7 @@ func (h *healthPlatformImpl) saveToDisk() error {
 		Issues:    issuesCopy,
 	}
 
-	data, err := json.MarshalIndent(state, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal issues: %w", err)
-	}
-
-	// Ensure directory exists
-	dir := filepath.Dir(h.persistencePath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create persistence directory: %w", err)
-	}
-
-	// Write to temp file first
-	tmpPath := h.persistencePath + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
-		return fmt.Errorf("failed to write temp file: %w", err)
-	}
-
-	if err := os.Rename(tmpPath, h.persistencePath); err != nil {
-		os.Remove(tmpPath) // Clean up temp file on failure
-		return fmt.Errorf("failed to rename temp file: %w", err)
-	}
-
-	return nil
+	return h.persistence.save(&state)
 }
 
 // ============================================================================

--- a/comp/healthplatform/impl/persistence.go
+++ b/comp/healthplatform/impl/persistence.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package healthplatformimpl
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// issuesPersistence abstracts loading and saving persisted issue state.
+// Two implementations exist: diskPersistence for bare-metal/VM environments, and
+// noopPersistence for environments with ephemeral storage (e.g. Kubernetes with emptyDir).
+type issuesPersistence interface {
+	// load reads persisted state from storage.
+	// Returns (nil, nil) when no prior state exists.
+	load() (*PersistedState, error)
+	// save writes the given state to storage.
+	save(state *PersistedState) error
+}
+
+// diskPersistence persists issue state to a JSON file using an atomic write
+// (temp file + rename) to avoid corruption on crash.
+type diskPersistence struct {
+	path string
+}
+
+func newDiskPersistence(path string) *diskPersistence {
+	return &diskPersistence{path: path}
+}
+
+func (d *diskPersistence) load() (*PersistedState, error) {
+	data, err := os.ReadFile(d.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read persisted issues: %w", err)
+	}
+
+	var state PersistedState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal persisted issues: %w", err)
+	}
+	return &state, nil
+}
+
+func (d *diskPersistence) save(state *PersistedState) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal issues: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(d.path), 0755); err != nil {
+		return fmt.Errorf("failed to create persistence directory: %w", err)
+	}
+
+	tmpPath := d.path + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, d.path); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	return nil
+}

--- a/comp/healthplatform/impl/persistence_noop.go
+++ b/comp/healthplatform/impl/persistence_noop.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package healthplatformimpl
+
+// noopPersistence is used in environments where disk persistence is not meaningful,
+// such as Kubernetes pods backed by emptyDir volumes where state is lost on restart anyway.
+// It silently discards all writes and returns no state on load.
+type noopPersistence struct{}
+
+func (n *noopPersistence) load() (*PersistedState, error) { return nil, nil }
+func (n *noopPersistence) save(_ *PersistedState) error   { return nil }


### PR DESCRIPTION
### What does this PR do?

Introduces an `issuesPersistence` interface in the health platform component with two implementations:

- **`diskPersistence`**: atomic write to disk via temp-file + rename (existing behaviour, unchanged for bare-metal/VM)
- **`noopPersistence`**: silent no-ops for environments where disk persistence is not meaningful

At startup, `NewComponent` calls `configenv.IsKubernetes()` to select the appropriate backend. On Kubernetes (where `datadogrun` is typically an `emptyDir` volume), the noop backend is chosen and an explicit info log is emitted.

### Motivation

On Kubernetes DaemonSet deployments the `run_path` volume is `emptyDir`, so the `issues.json` file is lost on every pod restart. This caused two silent problems:

1. Pointless disk I/O on every `ReportIssue` / `ClearIssuesForCheck` call.
2. Every issue was always `IssueStateNew` (never `IssueStateOngoing`) because persisted state was never available at startup — misleading operators and triggering spurious re-alerts.

The fix makes the K8s degradation explicit and intentional rather than a silent failure mode.

### Describe how you validated your changes

- `go build ./comp/healthplatform/...` passes cleanly.
- Existing unit tests are unaffected: they use a temp-dir path and don't set `KUBERNETES_SERVICE_PORT`, so they continue to exercise `diskPersistence`.

### Additional Notes

- No behaviour change on non-Kubernetes environments.
- A follow-up could switch the `datadogrun` volume to `hostPath` in the Helm chart for operators who want true persistence on K8s, but that is out of scope for this agent-side change.