### PR TITLE
[observer] Add counters telemetry type

### DIFF
--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -72,6 +72,8 @@ export interface SeriesInfo {
   pointCount: number;
   /** True when the series lives in an extractor storage namespace (log-derived metrics). */
   virtual?: boolean;
+  /** Telemetry metrics: counter deltas use :sum and cumulative display; gauges use the selected aggregation. */
+  metricKind?: 'gauge' | 'counter';
 }
 
 export interface Point {

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -33,6 +33,17 @@ function formatSeriesLabel(tags: string[]): string {
   return tags.join(', ');
 }
 
+/** Prefix sum of per-bucket deltas (time-ordered) — total from scenario start. */
+function cumulativeFromStart(points: Point[]): Point[] {
+  if (points.length === 0) return points;
+  const sorted = [...points].sort((a, b) => a.timestamp - b.timestamp);
+  let acc = 0;
+  return sorted.map((p) => {
+    acc += p.value;
+    return { timestamp: p.timestamp, value: acc };
+  });
+}
+
 
 interface MetricGroup {
   key: string;
@@ -218,7 +229,14 @@ export function MetricsView({
   }, [allSeries]);
 
   const filteredSeries = useMemo(
-    () => allSeries.filter((s) => getAggregationType(s.name) === aggregationType),
+    () =>
+      allSeries.filter((s) => {
+        const agg = getAggregationType(s.name);
+        if (s.metricKind === 'counter') {
+          return agg === 'sum';
+        }
+        return agg === aggregationType;
+      }),
     [allSeries, aggregationType]
   );
 
@@ -806,9 +824,17 @@ export function MetricsView({
                   <>
                     <div className="flex items-center gap-3">
                       <div className="flex-1 border-t border-purple-800/50" />
-                      <div className="flex items-center gap-1.5 text-xs text-purple-400 font-medium">
-                        <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-purple-600 text-white text-[9px] font-bold">T</span>
-                        Telemetry Metrics
+                      <div className="flex flex-col items-center gap-0.5 shrink-0">
+                        <div className="flex items-center gap-1.5 text-xs text-purple-400 font-medium">
+                          <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-purple-600 text-white text-[9px] font-bold">T</span>
+                          Telemetry Metrics
+                        </div>
+                        <span
+                          className="text-[10px] text-slate-500 max-w-md text-center px-2"
+                          title="Counter metrics: sum of deltas per time bucket, displayed as a running total from scenario start. Gauges follow the aggregation control."
+                        >
+                          Counters: cumulative from start · Gauges: aggregation above
+                        </span>
                       </div>
                       <div className="flex-1 border-t border-purple-800/50" />
                     </div>
@@ -819,6 +845,8 @@ export function MetricsView({
                           return g && g.namespace === 'telemetry';
                         })
                         .map((groupKey) => {
+                          const group = groupByKey.get(groupKey);
+                          const isCounterTelemetry = group?.members.some((m) => m.metricKind === 'counter');
                           const dataList = groupSeriesData.get(groupKey) ?? [];
                           if (dataList.length === 0) return null;
                           const chartSeries = showAnomalyOnlySeriesLines
@@ -828,17 +856,21 @@ export function MetricsView({
                           const seriesIDs = new Set(chartSeries.map((d) => d.id));
                           const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
                           const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
+                          const mapPoints = (pts: Point[]) =>
+                            isCounterTelemetry ? cumulativeFromStart(pts) : pts;
                           const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
                             label: formatSeriesLabel(d.tags),
-                            points: d.points,
+                            points: mapPoints(d.points),
                             seriesId: d.id,
                           }));
                           const primary = chartSeries[0];
+                          const chartTitleBase = getBaseMetricName(primary.name);
+                          const chartTitle = isCounterTelemetry ? `${chartTitleBase} (cumulative)` : primary.name;
                           return (
                             <ChartWithAnomalyDetails
                               key={groupKey}
-                              name={primary.name}
-                              points={primary.points}
+                              name={chartTitle}
+                              points={mapPoints(primary.points)}
                               anomalyMarkers={anomalyMarkers}
                               anomalies={seriesAnomalies}
                               correlationRanges={[]}

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -233,7 +233,7 @@ export function MetricsView({
       allSeries.filter((s) => {
         const agg = getAggregationType(s.name);
         if (s.metricKind === 'counter') {
-          return agg === 'sum';
+          return agg === 'sum' || agg === 'avg';
         }
         return agg === aggregationType;
       }),

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -233,7 +233,7 @@ export function MetricsView({
       allSeries.filter((s) => {
         const agg = getAggregationType(s.name);
         if (s.metricKind === 'counter') {
-          return agg === 'sum' || agg === 'avg';
+          return agg === 'sum' || agg === 'avg' || agg === 'count';
         }
         return agg === aggregationType;
       }),

--- a/comp/observer/def/component.go
+++ b/comp/observer/def/component.go
@@ -376,12 +376,25 @@ type Point struct {
 	Value     float64
 }
 
+// MetricKind distinguishes gauge (absolute level) from counter (increment) telemetry.
+// Gauge samples are exported with Set; counter samples with Add(value) on the backend counter.
+type MetricKind int
+
+const (
+	// MetricKindGauge is the default: the metric value is an absolute level.
+	MetricKindGauge MetricKind = iota
+	// MetricKindCounter indicates the value is a delta added to the named counter.
+	MetricKindCounter
+)
+
 // Describes a telemetry event that is emitted by the observer.
 // This could be a metric or a log for instance.
 type ObserverTelemetry struct {
 	DetectorName string
 	Metric       MetricView
 	Log          LogView
+	// Kind is telemetry metric kind; zero means gauge (backward compatible).
+	Kind MetricKind
 }
 
 // DetectionResult contains outputs from anomaly detection.

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -98,10 +98,14 @@ func (e *LogPatternExtractor) GetContextByKey(key string) (observerdef.MetricCon
 
 // ProcessLog clusters the log message and emits a count metric for its pattern.
 func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.LogMetricsExtractorOutput {
+	telemetry := []observerdef.ObserverTelemetry{}
 	message := string(log.GetContent())
 	clusterResult := e.PatternClusterer.Process(message)
 	if clusterResult == nil {
 		return observerdef.LogMetricsExtractorOutput{}
+	}
+	if clusterResult.IsNew {
+		telemetry = append(telemetry, newTelemetryCounter(e.Name(), telemetryLogPatternExtractorPatternCount, 1, log.GetTimestampUnixMilli()/1000))
 	}
 
 	patternKey := NewPatternKeyInfo(clusterResult.Cluster.ID)
@@ -123,8 +127,6 @@ func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.Lo
 			Tags:       log.GetTags(),
 			ContextKey: contextKey,
 		}},
-		Telemetry: []observerdef.ObserverTelemetry{
-			newTelemetryGauge(e.Name(), telemetryLogPatternExtractorPatternCount, float64(e.PatternClusterer.NumClusters()), log.GetTimestampUnixMilli()/1000),
-		},
+		Telemetry: telemetry,
 	}
 }

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -20,6 +20,18 @@ const (
 	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
 )
 
+// telemetryCounterMetricNames lists storage metric names (no :agg suffix) emitted as counter deltas.
+// Keep in sync with counters registered in newTelemetryHandler.
+var telemetryCounterMetricNames = map[string]struct{}{
+	telemetryLogPatternExtractorPatternCount: {},
+}
+
+// IsTelemetryCounterMetricName reports whether the metric name is observer counter telemetry.
+func IsTelemetryCounterMetricName(name string) bool {
+	_, ok := telemetryCounterMetricNames[name]
+	return ok
+}
+
 // This is used to:
 // 1. Enumerate all the telemetry metrics that are emitted by the observer
 // 2. Send them to the backend if we are running in observer mode (not testbench)
@@ -46,6 +58,7 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 		"RRCF dynamic anomaly detection threshold (post-warmup)",
 	)
 
+	// Also add each name to telemetryCounterMetricNames (testbench /api/series sum + metricKind).
 	counters[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewCounter(
 		"observer",
 		telemetryLogPatternExtractorPatternCount,

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -20,18 +20,6 @@ const (
 	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
 )
 
-// telemetryCounterMetricNames lists storage metric names (no :agg suffix) emitted as counter deltas.
-// Keep in sync with counters registered in newTelemetryHandler.
-var telemetryCounterMetricNames = map[string]struct{}{
-	telemetryLogPatternExtractorPatternCount: {},
-}
-
-// IsTelemetryCounterMetricName reports whether the metric name is observer counter telemetry.
-func IsTelemetryCounterMetricName(name string) bool {
-	_, ok := telemetryCounterMetricNames[name]
-	return ok
-}
-
 // This is used to:
 // 1. Enumerate all the telemetry metrics that are emitted by the observer
 // 2. Send them to the backend if we are running in observer mode (not testbench)
@@ -58,7 +46,6 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 		"RRCF dynamic anomaly detection threshold (post-warmup)",
 	)
 
-	// Also add each name to telemetryCounterMetricNames (testbench /api/series sum + metricKind).
 	counters[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewCounter(
 		"observer",
 		telemetryLogPatternExtractorPatternCount,
@@ -110,6 +97,15 @@ func (h *telemetryHandler) isMetricRegistered(metricName string) bool {
 		return true
 	}
 	_, ok := h.telemetryCounters[metricName]
+	return ok
+}
+
+// isCounterMetric reports whether the storage metric name (no :agg suffix) is a registered counter.
+func (h *telemetryHandler) isCounterMetric(name string) bool {
+	if h == nil {
+		return false
+	}
+	_, ok := h.telemetryCounters[name]
 	return ok
 }
 

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -24,11 +24,13 @@ const (
 // 1. Enumerate all the telemetry metrics that are emitted by the observer
 // 2. Send them to the backend if we are running in observer mode (not testbench)
 type telemetryHandler struct {
-	telemetryGauges map[string]telemetry.Gauge
+	telemetryGauges   map[string]telemetry.Gauge
+	telemetryCounters map[string]telemetry.Counter
 }
 
 func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 	gauges := make(map[string]telemetry.Gauge)
+	counters := make(map[string]telemetry.Counter)
 
 	// Gauges
 	gauges[telemetryRRCFScore] = telemetryComp.NewGauge(
@@ -51,7 +53,8 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 	)
 
 	return &telemetryHandler{
-		telemetryGauges: gauges,
+		telemetryGauges:   gauges,
+		telemetryCounters: counters,
 	}
 }
 
@@ -61,23 +64,39 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 // Note 2: we don't send logs to the backend
 func (h *telemetryHandler) handleTelemetry(events []observerdef.ObserverTelemetry) {
 	for _, event := range events {
-		if event.Metric != nil {
-			gauge, isGauge := h.telemetryGauges[event.Metric.GetName()]
-			if isGauge {
-				gauge.Set(event.Metric.GetValue(), event.Metric.GetRawTags()...)
+		if event.Metric == nil {
+			continue
+		}
+		name := event.Metric.GetName()
+		tags := event.Metric.GetRawTags()
+		value := event.Metric.GetValue()
+
+		switch event.Kind {
+		case observerdef.MetricKindCounter:
+			counter, ok := h.telemetryCounters[name]
+			if ok {
+				counter.Add(value, tags...)
 				continue
 			}
-
-			pkglog.Warnf("[observer] telemetry gauge not found: %s", event.Metric.GetName())
+			pkglog.Warnf("[observer] telemetry counter not found: %s", name)
+		default:
+			gauge, ok := h.telemetryGauges[name]
+			if ok {
+				gauge.Set(value, tags...)
+				continue
+			}
+			pkglog.Warnf("[observer] telemetry gauge not found: %s", name)
 		}
 	}
 }
 
 // isMetricRegistered checks if a metric is registered in the telemetry handler
 func (h *telemetryHandler) isMetricRegistered(metricName string) bool {
-	_, isRegistered := h.telemetryGauges[metricName]
-
-	return isRegistered
+	if _, ok := h.telemetryGauges[metricName]; ok {
+		return true
+	}
+	_, ok := h.telemetryCounters[metricName]
+	return ok
 }
 
 // newTelemetryGauge creates a new telemetry gauge for the given telemetry name, detector name, and data time.
@@ -85,6 +104,21 @@ func (h *telemetryHandler) isMetricRegistered(metricName string) bool {
 func newTelemetryGauge(detectorName string, telemetryName string, value float64, dataTimeSec int64) observerdef.ObserverTelemetry {
 	return observerdef.ObserverTelemetry{
 		DetectorName: detectorName,
+		Kind:         observerdef.MetricKindGauge,
+		Metric: &metricObs{
+			name:      telemetryName,
+			value:     value,
+			tags:      []string{"detector:" + detectorName},
+			timestamp: dataTimeSec,
+		},
+	}
+}
+
+// newTelemetryCounter creates counter telemetry: the value is added to the named counter (must be registered in newTelemetryHandler).
+func newTelemetryCounter(detectorName string, telemetryName string, value float64, dataTimeSec int64) observerdef.ObserverTelemetry {
+	return observerdef.ObserverTelemetry{
+		DetectorName: detectorName,
+		Kind:         observerdef.MetricKindCounter,
 		Metric: &metricObs{
 			name:      telemetryName,
 			value:     value,

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -16,7 +16,7 @@ const (
 	telemetryRRCFScore     = "observer.rrcf.score"
 	telemetryRRCFThreshold = "observer.rrcf.threshold"
 
-	// Log pattern extractor
+	// Log pattern extractor — counter: delta (new clusters) per processed log
 	telemetryLogPatternExtractorPatternCount = "observer.log_pattern_extractor.pattern_count"
 )
 
@@ -45,11 +45,12 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 		[]string{"detector"},
 		"RRCF dynamic anomaly detection threshold (post-warmup)",
 	)
-	gauges[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewGauge(
+
+	counters[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewCounter(
 		"observer",
 		telemetryLogPatternExtractorPatternCount,
 		[]string{"detector"},
-		"Log pattern extractor pattern count",
+		"Log pattern extractor new clusters added per processed log",
 	)
 
 	return &telemetryHandler{

--- a/comp/observer/impl/telemetry_test.go
+++ b/comp/observer/impl/telemetry_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package observerimpl
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/comp/core/telemetry/noopsimpl"
+	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTelemetryHandler_CounterAdd(t *testing.T) {
+	tel := noopsimpl.GetCompatComponent()
+	h := newTelemetryHandler(tel)
+
+	const counterName = "observer.telemetry.test_counter"
+	h.telemetryCounters[counterName] = tel.NewCounter(
+		"observer",
+		counterName,
+		[]string{"detector"},
+		"test counter",
+	)
+
+	h.handleTelemetry([]observerdef.ObserverTelemetry{
+		newTelemetryCounter("det-a", counterName, 2, 100),
+		newTelemetryCounter("det-a", counterName, 3, 101),
+	})
+	// No-op telemetry: asserts routing does not warn or panic.
+}
+
+func TestTelemetryHandler_GaugeSet(t *testing.T) {
+	tel := noopsimpl.GetCompatComponent()
+	h := newTelemetryHandler(tel)
+
+	h.handleTelemetry([]observerdef.ObserverTelemetry{
+		newTelemetryGauge("det", telemetryRRCFScore, 0.5, 100),
+	})
+}
+
+func TestTelemetryHandler_IsMetricRegistered(t *testing.T) {
+	tel := noopsimpl.GetCompatComponent()
+	h := newTelemetryHandler(tel)
+
+	const counterName = "observer.telemetry.test_counter2"
+	h.telemetryCounters[counterName] = tel.NewCounter(
+		"observer",
+		counterName,
+		[]string{"detector"},
+		"test",
+	)
+
+	require.True(t, h.isMetricRegistered(telemetryRRCFScore))
+	require.True(t, h.isMetricRegistered(counterName))
+	require.False(t, h.isMetricRegistered("observer.unknown.metric"))
+}

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -445,6 +445,8 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 		Tags       []string `json:"tags"`
 		PointCount int      `json:"pointCount"`
 		Virtual    bool     `json:"virtual"`
+		// MetricKind is "counter" or "gauge" for telemetry namespace; omitted otherwise.
+		MetricKind string `json:"metricKind,omitempty"`
 	}
 
 	var allSeries []seriesInfo
@@ -456,7 +458,19 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 	for _, ns := range storage.Namespaces() {
 		metas := storage.ListSeriesMetadata(ns)
 		for _, m := range metas {
-			for _, agg := range []Aggregate{AggregateAverage, AggregateCount} {
+			aggs := []Aggregate{AggregateAverage, AggregateCount}
+			if m.Namespace == "telemetry" && IsTelemetryCounterMetricName(m.Name) {
+				aggs = append(aggs, AggregateSum)
+			}
+			var metricKind string
+			if m.Namespace == "telemetry" {
+				if IsTelemetryCounterMetricName(m.Name) {
+					metricKind = "counter"
+				} else {
+					metricKind = "gauge"
+				}
+			}
+			for _, agg := range aggs {
 				nameWithAgg := m.Name + ":" + aggSuffix(agg)
 				compactID := strconv.Itoa(int(m.Handle)) + ":" + aggSuffix(agg)
 				_, virtual := extractorNs[m.Namespace]
@@ -467,6 +481,7 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 					Tags:       m.Tags,
 					PointCount: m.PointCount,
 					Virtual:    virtual,
+					MetricKind: metricKind,
 				})
 			}
 		}

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -452,6 +452,7 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 	var allSeries []seriesInfo
 
 	extractorNs := api.tb.extractorNamespaces()
+	telHandler := api.tb.telemetryHandler
 
 	// Get series metadata from all namespaces — no point data materialized.
 	// Use compact numeric IDs: "{numericID}:{aggSuffix}" (e.g. "42:avg").
@@ -459,12 +460,12 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 		metas := storage.ListSeriesMetadata(ns)
 		for _, m := range metas {
 			aggs := []Aggregate{AggregateAverage, AggregateCount}
-			if m.Namespace == "telemetry" && IsTelemetryCounterMetricName(m.Name) {
+			if m.Namespace == "telemetry" && telHandler != nil && telHandler.isCounterMetric(m.Name) {
 				aggs = append(aggs, AggregateSum)
 			}
 			var metricKind string
 			if m.Namespace == "telemetry" {
-				if IsTelemetryCounterMetricName(m.Name) {
+				if telHandler != nil && telHandler.isCounterMetric(m.Name) {
 					metricKind = "counter"
 				} else {
 					metricKind = "gauge"


### PR DESCRIPTION
Adds counters as telemetry type and also changes type of log pattern telemetry to counter.

Adds:
- Counter support in the observer component
- UI updates to display telemetry data
- Log pattern telemetry is now a counter