### PR TITLE
tasks: build_tags: remove dead serverless fips tag.

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -66,7 +66,6 @@ ALL_TAGS = {
     "requirefips",  # used for Linux FIPS mode to avoid having to set GOFIPS
     "seclmax",  # used for security agent/system-probe to compile the full feature set of secl
     "serverless",
-    "serverlessfips",  # used for FIPS mode in the serverless build in datadog-lambda-extension
     "sharedlibrarycheck",
     "systemd",
     "systemprobechecks",  # used to include system-probe based checks in the agent build


### PR DESCRIPTION
### What does this PR do?

Remove an unused build tag

### Motivation

It's never referenced in the code, and isn't passed to any build since it isn't part of any actual tag set. Only the ALL_TAGS one
Since we're starting to look at how to handle go build tags in bazel, the easiest migration is a plain removal :grin: 

### Describe how you validated your changes

Static analysis should be enough, but I trust that this will break one way or another if incorrect

### Additional Notes
