### PR TITLE
[CWS] Fix race in SBOM resolver causing panics

### DIFF
--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -854,7 +854,7 @@ func (r *Resolver) GetWorkload(id containerutils.ContainerID) *SBOM {
 		return r.hostSBOM
 	}
 
-	sbom, _ := r.sboms.Get(id)
+	sbom, _ := r.sboms.Peek(id)
 	return sbom
 }
 

--- a/pkg/security/resolvers/sbom/resolver.go
+++ b/pkg/security/resolvers/sbom/resolver.go
@@ -511,6 +511,10 @@ func (r *Resolver) enrichSBOMsWithUsage() (bool, error) {
 			continue
 		}
 
+		if uncompressedSBOM == nil {
+			continue
+		}
+
 		for _, sbom := range r.sboms.Values() {
 			sbom.Lock()
 			if sbom.data != nil && sbom.workloadKey == workloadKey(image.Name) {


### PR DESCRIPTION
### What does this PR do?

This PR fixes two panics in the SBOM resolver.

### Motivation

Replace Get with Peek in GetWorkload to fix a race condition
GetWorkload acquires sbomsLock.RLock(), which allows multiple goroutines to hold the read lock simultaneously. However, simplelru.LRU.Get() is not a read-only operation — it calls MoveToFront() internally, which writes to the LRU's internal doubly-linked list. When called concurrently with enrichSBOMsWithUsage (which also holds RLock and iterates the list via Values()), this corrupts the linked list's pointer state and can cause Values() to traverse more nodes than expected, resulting in an index out of range panic.

Replacing Get with Peek in GetWorkload avoids the write to the internal list, making the operation truly read-only and safe under a shared read lock.

Handle nil uncompressed SBOMs in enrichSBOMsWithUsage
UncompressSBOM can return a nil SBOM without an error (e.g. when the image's SBOM is not yet available). The nil check was missing, causing a nil pointer dereference further down when accessing uncompressedSBOM.CycloneDXBOM.Components. An explicit continue is added to skip nil SBOMs.

### Describe how you validated your changes

### Additional Notes
