### PR TITLE
[WP] Do not serialize <nil> IPs

### DIFF
--- a/pkg/security/module/server_linux.go
+++ b/pkg/security/module/server_linux.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
 	"github.com/DataDog/datadog-agent/pkg/security/serializers"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/containerd/containerd/protobuf/proto"
@@ -295,7 +296,7 @@ func createSSHSessionPatcher(ev *model.Event, p *probe.Probe) sshSessionPatcher 
 			userSessionCtx := &serializers.SSHSessionContextSerializer{
 				SSHSessionID:  strconv.FormatUint(uint64(ev.ProcessContext.UserSession.SSHSessionID), 16),
 				SSHClientPort: ev.ProcessContext.UserSession.SSHClientPort,
-				SSHClientIP:   ev.ProcessContext.UserSession.SSHClientIP.IP.String(),
+				SSHClientIP:   utils.GetIPStringFromIPNet(ev.ProcessContext.UserSession.SSHClientIP),
 			}
 			return probe.NewSSHUserSessionPatcher(
 				userSessionCtx,

--- a/pkg/security/probe/field_handlers_ebpf.go
+++ b/pkg/security/probe/field_handlers_ebpf.go
@@ -1029,7 +1029,7 @@ func (fh *EBPFFieldHandlers) ResolveSessionIdentity(e *model.Event, evtCtx *mode
 	if evtCtx.K8SUsername != "" {
 		sessionIdentity = evtCtx.K8SUsername
 	} else if evtCtx.SSHClientPort != 0 {
-		sessionIdentity = evtCtx.SSHClientIP.String() + ":" + strconv.Itoa(evtCtx.SSHClientPort)
+		sessionIdentity = utils.GetIPStringFromIPNet(evtCtx.SSHClientIP) + ":" + strconv.Itoa(evtCtx.SSHClientPort)
 	} else {
 		sessionIdentity = e.ProcessContext.User
 	}

--- a/pkg/security/resolvers/usersessions/resolver_linux.go
+++ b/pkg/security/resolvers/usersessions/resolver_linux.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model/usersession"
 	"github.com/DataDog/datadog-agent/pkg/security/seclog"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // UserSessionKey describes the key to a user session
@@ -76,7 +77,7 @@ type incrementalFileReader struct {
 // SSHSessionKey describes the key to a ssh session in the LRU
 type SSHSessionKey struct {
 	SSHDPid string
-	IP      string // net.IP.String()
+	IP      string // GetIpStringFromIPNet is used
 	Port    string
 }
 
@@ -335,7 +336,7 @@ func parseSSHLogLine(line string, sshSessionParsed *lru.Cache[SSHSessionKey, SSH
 		}
 		key := SSHSessionKey{
 			SSHDPid: sshLogLine.SSHDPid,
-			IP:      parsedIP.String(),
+			IP:      utils.GetIPStringFromIPNet(net.IPNet{IP: parsedIP}),
 			Port:    sshParsedLine.Port,
 		}
 		value := SSHSessionValue{

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/security/secl
 
-go 1.25.0
+go 1.25.7
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/pkg/security/seclwin/go.mod
+++ b/pkg/security/seclwin/go.mod
@@ -1,8 +1,8 @@
 module github.com/DataDog/datadog-agent/pkg/security/seclwin
 
-go 1.25.0
+go 1.25.7
 
-require github.com/DataDog/datadog-agent/pkg/security/secl v0.56.0-rc.3
+require github.com/DataDog/datadog-agent/pkg/security/secl v0.56.0
 
 require (
 	github.com/alecthomas/participle v0.7.1 // indirect

--- a/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
+++ b/pkg/security/security_profile/activity_tree/activity_tree_proto_enc_v1.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/text/runes"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
@@ -129,7 +130,7 @@ func ipPortContextToProto(ipPort *model.IPPortContext) *adproto.IPPortContext {
 		return nil
 	}
 	return &adproto.IPPortContext{
-		Ip:   ipPort.IPNet.IP.String(),
+		Ip:   utils.GetIPStringFromIPNet(ipPort.IPNet),
 		Port: uint32(ipPort.Port),
 	}
 }

--- a/pkg/security/security_profile/activity_tree/socket_node.go
+++ b/pkg/security/security_profile/activity_tree/socket_node.go
@@ -10,6 +10,7 @@ package activitytree
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // BindNode is used to store a bind node
@@ -58,7 +59,7 @@ func (sn *SocketNode) evictImageTag(imageTag string) bool {
 
 // InsertBindEvent inserts a bind even inside a socket node
 func (sn *SocketNode) InsertBindEvent(evt *model.BindEvent, event *model.Event, imageTag string, generationType NodeGenerationType, rules []*model.MatchedRule, dryRun bool) bool {
-	evtIP := evt.Addr.IPNet.IP.String()
+	evtIP := utils.GetIPStringFromIPNet(evt.Addr.IPNet)
 	for _, n := range sn.Bind {
 		if evt.Addr.Port == n.Port && evtIP == n.IP && evt.Protocol == n.Protocol {
 			if !dryRun {

--- a/pkg/security/serializers/serializers_base.go
+++ b/pkg/security/serializers/serializers_base.go
@@ -442,7 +442,7 @@ func newIMDSEventSerializer(e *model.IMDSEvent) *IMDSEventSerializer {
 // nolint: deadcode, unused
 func newIPPortSerializer(c *model.IPPortContext) IPPortSerializer {
 	return IPPortSerializer{
-		IP:   c.IPNet.IP.String(),
+		IP:   utils.GetIPStringFromIPNet(c.IPNet),
 		Port: c.Port,
 	}
 }
@@ -450,7 +450,7 @@ func newIPPortSerializer(c *model.IPPortContext) IPPortSerializer {
 // nolint: deadcode, unused
 func newIPPortFamilySerializer(c *model.IPPortContext, family string) IPPortFamilySerializer {
 	return IPPortFamilySerializer{
-		IP:     c.IPNet.IP.String(),
+		IP:     utils.GetIPStringFromIPNet(c.IPNet),
 		Port:   c.Port,
 		Family: family,
 	}

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1057,17 +1057,10 @@ func serializeK8sContext(e *model.Event, ctx *model.UserSessionContext, userSess
 }
 
 func serializeSSHContext(ctx *model.UserSessionContext, userSessionContextSerializer *UserSessionContextSerializer) {
-	sshClientIP := utils.GetIPStringFromIPNet(ctx.SSHClientIP)
-
-	sshAuthMethod := model.SSHAuthMethodToString(usersession.AuthType(ctx.SSHAuthMethod))
-	if sshAuthMethod == "<nil>" {
-		sshAuthMethod = ""
-	}
-
 	userSessionContextSerializer.SSHSessionID = strconv.FormatUint(uint64(ctx.SSHSessionID), 16)
 	userSessionContextSerializer.SSHClientPort = ctx.SSHClientPort
-	userSessionContextSerializer.SSHClientIP = sshClientIP
-	userSessionContextSerializer.SSHAuthMethod = sshAuthMethod
+	userSessionContextSerializer.SSHClientIP = utils.GetIPStringFromIPNet(ctx.SSHClientIP)
+	userSessionContextSerializer.SSHAuthMethod = model.SSHAuthMethodToString(usersession.AuthType(ctx.SSHAuthMethod))
 	userSessionContextSerializer.SSHPublicKey = ctx.SSHPublicKey
 }
 

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -1057,10 +1057,7 @@ func serializeK8sContext(e *model.Event, ctx *model.UserSessionContext, userSess
 }
 
 func serializeSSHContext(ctx *model.UserSessionContext, userSessionContextSerializer *UserSessionContextSerializer) {
-	sshClientIP := ctx.SSHClientIP.IP.String()
-	if sshClientIP == "<nil>" {
-		sshClientIP = ""
-	}
+	sshClientIP := utils.GetIPStringFromIPNet(ctx.SSHClientIP)
 
 	sshAuthMethod := model.SSHAuthMethodToString(usersession.AuthType(ctx.SSHAuthMethod))
 	if sshAuthMethod == "<nil>" {

--- a/pkg/security/utils/ipnet.go
+++ b/pkg/security/utils/ipnet.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package utils holds utils related files
+package utils
+
+import "net"
+
+// GetIPStringFromIPNet returns the string representation of the IP from an IPNet,
+// returning an empty string when the IP is nil.
+func GetIPStringFromIPNet(ipNet net.IPNet) string {
+	if len(ipNet.IP) == 0 {
+		return ""
+	}
+	return ipNet.IP.String()
+}


### PR DESCRIPTION
### What does this PR do?
Add a custom function to return a nil string if the IPNet To String returns `"<nil>"`

### Motivation
The lib used to convert IPNet to string returns `"<nil>"` instead of an empty string so the omitempty was not working and the field was serialised.
