### PR TITLE
[SNMP] Correct in_speed/out_speed unit in config template

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4301,8 +4301,8 @@ api_key:
 #         #   "10.0.0.1":              # target device IP address
 #         #     - match_field: "name"  # (required) the field to match, can be `name` (interface name) or `index` (ifIndex)
 #         #       match_value: "eth0"  # (required) the value to match
-#         #       in_speed: 50         # (optional) inbound speed value in bytes per sec, no value or 0 means no override
-#         #       out_speed: 25        # (optional) outbound speed value in bytes per sec, no value or 0 means no override
+#         #       in_speed: 50         # (optional) inbound speed value in bits per sec, no value or 0 means no override
+#         #       out_speed: 25        # (optional) outbound speed value in bits per sec, no value or 0 means no override
 #         #       tags:                # (optional) interface level tags
 #         #         - "testTagKey:testTagValue"
 #         #         - "tagKey2:tagValue2"


### PR DESCRIPTION
The `in_speed` and `out_speed` fields in the SNMP check config template were documented as "bytes per sec", but the code has always treated them as bits per second.

The bandwidth utilization calculation in `report_bandwidth_usage.go` multiplies octets by 8 before dividing by the speed value, which only produces correct results if the speed is in bps. This is also consistent with how ifHighSpeed (Mbps) is converted to bps when no override is set.

Users who followed the template docs would configure a value 8x too small, resulting in bandwidth utilization metrics inflated by 8x.