### PR TITLE
fix(discovery): Limit concurrency and use single-threaded tokio runtime

### DIFF
--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -92,9 +92,11 @@ fn setup_socket(socket_path: &str) -> Result<UnixListener> {
     Ok(sock)
 }
 
-async fn handle_services(
-    req: Request<hyper::body::Incoming>,
-) -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
+async fn handle_services<B>(req: Request<B>) -> Result<Response<BoxBody<Bytes, std::io::Error>>>
+where
+    B: hyper::body::Body<Data = Bytes>,
+    B::Error: std::fmt::Display,
+{
     if req
         .headers()
         .get(CONTENT_TYPE)
@@ -240,9 +242,11 @@ fn too_many_requests() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
         .map_err(|e| anyhow!("Failed to build too many requests response: {}", e))
 }
 
-async fn handle_request(
-    req: Request<hyper::body::Incoming>,
-) -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
+async fn handle_request<B>(req: Request<B>) -> Result<Response<BoxBody<Bytes, std::io::Error>>>
+where
+    B: hyper::body::Body<Data = Bytes>,
+    B::Error: std::fmt::Display,
+{
     match (req.method(), req.uri().path()) {
         (&Method::POST, "/discovery/services") => {
             debug!("Handling /discovery/services request");
@@ -366,6 +370,71 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    fn services_request() -> Request<Full<Bytes>> {
+        Request::builder()
+            .method(Method::POST)
+            .uri("/discovery/services")
+            .header(CONTENT_TYPE, "application/json")
+            .body(Full::new(Bytes::from("{}")))
+            .unwrap_or_else(|e| panic!("Failed to build request: {e}"))
+    }
+
+    #[tokio::test]
+    async fn test_concurrency_limit() {
+        // Acquire both permits to saturate the semaphore (limit=2).
+        let permit1 = SERVICES_SEMAPHORE
+            .try_acquire()
+            .unwrap_or_else(|e| panic!("Failed to acquire first permit: {e}"));
+        let permit2 = SERVICES_SEMAPHORE
+            .try_acquire()
+            .unwrap_or_else(|e| panic!("Failed to acquire second permit: {e}"));
+
+        // With both permits held, handle_request should return 429.
+        let resp = handle_request(services_request())
+            .await
+            .unwrap_or_else(|e| panic!("handle_request failed: {e}"));
+        assert_eq!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "Expected 429 when semaphore is exhausted"
+        );
+
+        // Other endpoints should still work even with both permits held.
+        for path in [
+            "/discovery/state",
+            "/config",
+            "/config/by-source",
+            "/debug/stats",
+        ] {
+            let req = Request::builder()
+                .method(Method::GET)
+                .uri(path)
+                .body(Full::new(Bytes::new()))
+                .unwrap_or_else(|e| panic!("Failed to build request: {e}"));
+            let resp = handle_request(req)
+                .await
+                .unwrap_or_else(|e| panic!("handle_request failed for {path}: {e}"));
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "Expected 200 for {path} even when semaphore is exhausted"
+            );
+        }
+
+        // Release one permit — request should now get through (not 429).
+        drop(permit1);
+        let resp = handle_request(services_request())
+            .await
+            .unwrap_or_else(|e| panic!("handle_request failed: {e}"));
+        assert_ne!(
+            resp.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "Should not get 429 when a permit is available"
+        );
+
+        drop(permit2);
+    }
 
     #[test]
     fn test_remove_pid_file_deletes_file() {

--- a/pkg/discovery/module/rust/src/main.rs
+++ b/pkg/discovery/module/rust/src/main.rs
@@ -40,10 +40,15 @@ use log::{debug, error, info, warn};
 use serde_json::json;
 use tokio::net::UnixListener;
 use tokio::signal::unix::{SignalKind, signal};
+use tokio::sync::Semaphore;
 
 mod cli;
 
 use cli::Args;
+
+/// We choose 2 because one is for regular agent checks and another one is for manual troubleshooting.
+/// This matches the Go system-probe's DefaultMaxConcurrentRequests.
+static SERVICES_SEMAPHORE: Semaphore = Semaphore::const_new(2);
 
 static BADREQUEST: &[u8] = b"Bad request";
 static NOTFOUND: &[u8] = b"Not found";
@@ -114,7 +119,7 @@ async fn handle_services(
         }
     };
 
-    let services = get_services(params);
+    let services = tokio::task::spawn_blocking(|| get_services(params)).await?;
     debug!("Found {} services", services.services.len());
 
     Response::builder()
@@ -224,12 +229,30 @@ fn not_found() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
         .map_err(|e| anyhow!("Failed to build not found response: {}", e))
 }
 
+fn too_many_requests() -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
+    Response::builder()
+        .status(StatusCode::TOO_MANY_REQUESTS)
+        .body(
+            Full::new(Bytes::from("Too many requests"))
+                .map_err(|e| match e {})
+                .boxed(),
+        )
+        .map_err(|e| anyhow!("Failed to build too many requests response: {}", e))
+}
+
 async fn handle_request(
     req: Request<hyper::body::Incoming>,
 ) -> Result<Response<BoxBody<Bytes, std::io::Error>>> {
     match (req.method(), req.uri().path()) {
         (&Method::POST, "/discovery/services") => {
             debug!("Handling /discovery/services request");
+            let _permit = match SERVICES_SEMAPHORE.try_acquire() {
+                Ok(permit) => permit,
+                Err(_) => {
+                    warn!("rejecting request for path=/discovery/services concurrency_limit=2");
+                    return too_many_requests();
+                }
+            };
             handle_services(req).await
         }
         (&Method::GET, "/discovery/state") => handle_state().await,
@@ -313,7 +336,7 @@ async fn run_system_probe_lite(socket_path: &str) -> Result<()> {
     }
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     let args = Args::parse(env::args())?;
     dd_agent_log::init(dd_agent_log::LogConfig {


### PR DESCRIPTION
## What does this PR do?

Limits concurrent requests to the `/discovery/services` endpoint to 2 (matching Go system-probe's `DefaultMaxConcurrentRequests`) and switches the tokio runtime to single-threaded (`current_thread` flavor).

Key changes:
- Add a static `Semaphore` with 2 permits to gate `/discovery/services` requests, returning 429 when exhausted
- Move `get_services` into `spawn_blocking` so the CPU-bound work doesn't block the async runtime
- Switch to `#[tokio::main(flavor = "current_thread")]` since the workload doesn't benefit from a multi-threaded runtime
- Add unit tests for the concurrency limit behavior

## Motivation

### Problem: SPL misuses the async runtime

SPL runs synchronous `/proc`-scanning code directly on tokio async worker threads, uses the default multi-threaded runtime (which creates one thread per CPU — 8 on an 8-CPU machine), and has no concurrency limits. This combination causes several problems:

1. **Unnecessary arena proliferation from serialized requests.** Even when requests arrive one at a time, tokio's work-stealing scheduler can schedule successive requests onto different worker threads. Each thread that touches glibc `malloc` creates its own glibc malloc arena. This means serialized `/discovery/services` traffic — which does substantial allocation for `/proc` scanning — ends up spreading allocations across multiple arenas, inflating RSS well beyond what a single-threaded server would use.

2. **Unbounded parallelism from concurrent requests.** In test environments (and potentially production in case of unforeseen problems), multiple callers can hit `/discovery/services` simultaneously. With 8 tokio worker threads and no concurrency limit, up to 8 instances of the expensive `/proc`-scanning handler run in parallel, each allocating heavily into its own arena.

3. **Head-of-line blocking.** Since the synchronous `/proc`-scanning code runs directly on the async worker threads, if all worker threads are occupied by `/discovery/services` requests, other endpoints (health checks, etc.) are blocked until those requests complete.

### Fix

- **Single-threaded runtime** (`current_thread` flavor): Since SPL's workload (except the `/services` endpoint) is light, a single-threaded runtime eliminates unnecessary threads and keeps all allocations in a minimal number of glibc arenas.
- **`spawn_blocking` for the handler**: The CPU-bound `/proc` scanning is offloaded to the blocking thread pool so the async runtime thread remains responsive for other endpoints.
- **Concurrency semaphore (2 permits)**: Limits concurrent `/discovery/services` processing to 2, matching Go system-probe's `DefaultMaxConcurrentRequests`. Excess requests get 429 Too Many Requests immediately, preventing resource exhaustion.

## Benchmark results

Tested on an 8-CPU machine by sending 100 serialized requests followed by 200 parallel requests, measuring glibc malloc arenas and `Pss_Anon` (private anonymous memory from `/proc/PID/smaps_rollup`) at three points: after startup, after serial requests, and after parallel requests.

### glibc malloc arenas

| Phase | main | this PR |
|---|---|---|
| After startup | **9 arenas**, 1.3 MB system | **1 arena**, 135 KB system |
| After 100 serial requests | **9 arenas**, 2.5 MB system | **2 arenas**, 905 KB system |
| After 200 parallel requests | **9 arenas**, 7.7 MB system | **3 arenas**, 2.4 MB system |

On main, glibc immediately creates 9 arenas (1 per thread = 8 tokio workers + 1 main) at startup. Even serialized requests spread allocations across multiple arenas. After parallel load, total system bytes grow to 7.7 MB.

With this PR, only 1 arena exists at startup (single-threaded runtime). After serial load, `spawn_blocking` adds 1 more arena. After parallel load, only 3 arenas total — a **3x reduction** in arena count and **3.2x reduction** in malloc system bytes.

### Private anonymous memory (Pss_Anon from smaps_rollup)

| Phase | main | this PR |
|---|---|---|
| After startup | 584 KB | 396 KB |
| After 100 serial requests | 2,400 KB | 1,136 KB |
| After 200 parallel requests | **8,536 KB** | **2,780 KB** |

After parallel load, main uses **8.5 MB** of private anonymous memory vs **2.8 MB** with this PR — a **3.1x reduction**. Even after purely serialized requests, main uses 2.1x more memory because tokio scatters allocations across all worker thread arenas.

## Describe how you validated your changes

- Added unit test `test_concurrency_limit` that verifies 429 is returned when permits are exhausted and requests succeed when permits are available
- Ran the arena benchmark test described above comparing main vs this branch
- Verified other endpoints remain unaffected by the semaphore

## Additional Notes

The `too_many_requests()` helper follows the same pattern as the existing `not_found()` response builder.