### PR TITLE
[WP] Add is_session_leader field to process events

### DIFF
--- a/docs/cloud-workload-security/backend_linux.md
+++ b/docs/cloud-workload-security/backend_linux.md
@@ -1453,6 +1453,10 @@ Workload Protection events for Linux systems have the following JSON schema:
                     "type": "boolean",
                     "description": "Indicates whether the process is a kworker"
                 },
+                "is_session_leader": {
+                    "type": "boolean",
+                    "description": "Indicates whether the process is a session leader"
+                },
                 "is_exec": {
                     "type": "boolean",
                     "description": "Indicates whether the process entry is from a new binary execution"
@@ -1630,6 +1634,10 @@ Workload Protection events for Linux systems have the following JSON schema:
                 "is_kworker": {
                     "type": "boolean",
                     "description": "Indicates whether the process is a kworker"
+                },
+                "is_session_leader": {
+                    "type": "boolean",
+                    "description": "Indicates whether the process is a session leader"
                 },
                 "is_exec": {
                     "type": "boolean",
@@ -4648,6 +4656,10 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "boolean",
             "description": "Indicates whether the process is a kworker"
         },
+        "is_session_leader": {
+            "type": "boolean",
+            "description": "Indicates whether the process is a session leader"
+        },
         "is_exec": {
             "type": "boolean",
             "description": "Indicates whether the process entry is from a new binary execution"
@@ -4727,6 +4739,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `envs_truncated` | Indicator of environments variable truncation |
 | `is_thread` | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | `is_kworker` | Indicates whether the process is a kworker |
+| `is_session_leader` | Indicates whether the process is a session leader |
 | `is_exec` | Indicates whether the process entry is from a new binary execution |
 | `is_exec_child` | Indicates whether the process is an exec following another exec |
 | `is_parent_missing` | Indicates whether the direct parent is missing |
@@ -4884,6 +4897,10 @@ Workload Protection events for Linux systems have the following JSON schema:
             "type": "boolean",
             "description": "Indicates whether the process is a kworker"
         },
+        "is_session_leader": {
+            "type": "boolean",
+            "description": "Indicates whether the process is a session leader"
+        },
         "is_exec": {
             "type": "boolean",
             "description": "Indicates whether the process entry is from a new binary execution"
@@ -4978,6 +4995,7 @@ Workload Protection events for Linux systems have the following JSON schema:
 | `envs_truncated` | Indicator of environments variable truncation |
 | `is_thread` | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | `is_kworker` | Indicates whether the process is a kworker |
+| `is_session_leader` | Indicates whether the process is a session leader |
 | `is_exec` | Indicates whether the process entry is from a new binary execution |
 | `is_exec_child` | Indicates whether the process is an exec following another exec |
 | `is_parent_missing` | Indicates whether the direct parent is missing |

--- a/docs/cloud-workload-security/backend_linux.schema.json
+++ b/docs/cloud-workload-security/backend_linux.schema.json
@@ -1442,6 +1442,10 @@
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
         },
+        "is_session_leader": {
+          "type": "boolean",
+          "description": "Indicates whether the process is a session leader"
+        },
         "is_exec": {
           "type": "boolean",
           "description": "Indicates whether the process entry is from a new binary execution"
@@ -1619,6 +1623,10 @@
         "is_kworker": {
           "type": "boolean",
           "description": "Indicates whether the process is a kworker"
+        },
+        "is_session_leader": {
+          "type": "boolean",
+          "description": "Indicates whether the process is a session leader"
         },
         "is_exec": {
           "type": "boolean",

--- a/docs/cloud-workload-security/linux_expressions.md
+++ b/docs/cloud-workload-security/linux_expressions.md
@@ -278,6 +278,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.ancestors.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`process.ancestors.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`process.ancestors.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`process.ancestors.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`process.ancestors.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`process.ancestors.length`](#common-string-length-doc) | Length of the corresponding element |
 | [`process.ancestors.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
@@ -389,6 +390,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`process.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`process.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`process.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`process.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`process.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`process.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -481,6 +483,7 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | [`process.parent.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`process.parent.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`process.parent.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`process.parent.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`process.parent.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`process.parent.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`process.parent.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -887,6 +890,7 @@ A process was executed (does not trigger on fork syscalls).
 | [`exec.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`exec.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`exec.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`exec.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`exec.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`exec.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`exec.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -1007,6 +1011,7 @@ A process was terminated
 | [`exit.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`exit.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`exit.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`exit.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`exit.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`exit.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`exit.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -1471,6 +1476,7 @@ A ptrace command was executed
 | [`ptrace.tracee.ancestors.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`ptrace.tracee.ancestors.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`ptrace.tracee.ancestors.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`ptrace.tracee.ancestors.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`ptrace.tracee.ancestors.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`ptrace.tracee.ancestors.length`](#common-string-length-doc) | Length of the corresponding element |
 | [`ptrace.tracee.ancestors.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
@@ -1582,6 +1588,7 @@ A ptrace command was executed
 | [`ptrace.tracee.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`ptrace.tracee.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`ptrace.tracee.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`ptrace.tracee.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`ptrace.tracee.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`ptrace.tracee.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`ptrace.tracee.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -1674,6 +1681,7 @@ A ptrace command was executed
 | [`ptrace.tracee.parent.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`ptrace.tracee.parent.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`ptrace.tracee.parent.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`ptrace.tracee.parent.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`ptrace.tracee.parent.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`ptrace.tracee.parent.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`ptrace.tracee.parent.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -1974,6 +1982,7 @@ A setrlimit command was executed
 | [`setrlimit.target.ancestors.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`setrlimit.target.ancestors.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`setrlimit.target.ancestors.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`setrlimit.target.ancestors.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`setrlimit.target.ancestors.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`setrlimit.target.ancestors.length`](#common-string-length-doc) | Length of the corresponding element |
 | [`setrlimit.target.ancestors.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
@@ -2085,6 +2094,7 @@ A setrlimit command was executed
 | [`setrlimit.target.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`setrlimit.target.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`setrlimit.target.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`setrlimit.target.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`setrlimit.target.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`setrlimit.target.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`setrlimit.target.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -2177,6 +2187,7 @@ A setrlimit command was executed
 | [`setrlimit.target.parent.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`setrlimit.target.parent.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`setrlimit.target.parent.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`setrlimit.target.parent.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`setrlimit.target.parent.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`setrlimit.target.parent.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`setrlimit.target.parent.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -2382,6 +2393,7 @@ A signal was sent
 | [`signal.target.ancestors.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`signal.target.ancestors.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`signal.target.ancestors.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`signal.target.ancestors.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`signal.target.ancestors.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`signal.target.ancestors.length`](#common-string-length-doc) | Length of the corresponding element |
 | [`signal.target.ancestors.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
@@ -2493,6 +2505,7 @@ A signal was sent
 | [`signal.target.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`signal.target.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`signal.target.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`signal.target.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`signal.target.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`signal.target.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`signal.target.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -2585,6 +2598,7 @@ A signal was sent
 | [`signal.target.parent.interpreter.file.user`](#common-filefields-user-doc) | User of the file's owner |
 | [`signal.target.parent.is_exec`](#common-process-is_exec-doc) | Indicates whether the process entry is from a new binary execution |
 | [`signal.target.parent.is_kworker`](#common-pidcontext-is_kworker-doc) | Indicates whether the process is a kworker |
+| [`signal.target.parent.is_session_leader`](#common-pidcontext-is_session_leader-doc) | Indicates whether the process is a session leader |
 | [`signal.target.parent.is_thread`](#common-process-is_thread-doc) | Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program) |
 | [`signal.target.parent.mntns`](#common-pidcontext-mntns-doc) | MNTNS ID of the process |
 | [`signal.target.parent.netns`](#common-pidcontext-netns-doc) | NetNS ID of the process |
@@ -3243,6 +3257,15 @@ Definition: Whether the IP address belongs to a public network
 
 `*.is_public` has 9 possible prefixes:
 `accept.addr` `bind.addr` `connect.addr` `network.destination` `network.source` `network_flow_monitor.flows.destination` `network_flow_monitor.flows.source` `packet.destination` `packet.source`
+
+
+### `*.is_session_leader` {#common-pidcontext-is_session_leader-doc}
+Type: bool
+
+Definition: Indicates whether the process is a session leader
+
+`*.is_session_leader` has 14 possible prefixes:
+`exec` `exit` `process` `process.ancestors` `process.parent` `ptrace.tracee` `ptrace.tracee.ancestors` `ptrace.tracee.parent` `setrlimit.target` `setrlimit.target.ancestors` `setrlimit.target.parent` `signal.target` `signal.target.ancestors` `signal.target.parent`
 
 
 ### `*.is_thread` {#common-process-is_thread-doc}

--- a/docs/cloud-workload-security/secl_linux.json
+++ b/docs/cloud-workload-security/secl_linux.json
@@ -498,6 +498,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "process.ancestors.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "process.ancestors.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -1053,6 +1058,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "process.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "process.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -1511,6 +1521,11 @@
           "name": "process.parent.is_kworker",
           "definition": "Indicates whether the process is a kworker",
           "property_doc_link": "common-pidcontext-is_kworker-doc"
+        },
+        {
+          "name": "process.parent.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
         },
         {
           "name": "process.parent.is_thread",
@@ -3211,6 +3226,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "exec.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "exec.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -3783,6 +3803,11 @@
           "name": "exit.is_kworker",
           "definition": "Indicates whether the process is a kworker",
           "property_doc_link": "common-pidcontext-is_kworker-doc"
+        },
+        {
+          "name": "exit.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
         },
         {
           "name": "exit.is_thread",
@@ -5783,6 +5808,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "ptrace.tracee.ancestors.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "ptrace.tracee.ancestors.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -6338,6 +6368,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "ptrace.tracee.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "ptrace.tracee.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -6796,6 +6831,11 @@
           "name": "ptrace.tracee.parent.is_kworker",
           "definition": "Indicates whether the process is a kworker",
           "property_doc_link": "common-pidcontext-is_kworker-doc"
+        },
+        {
+          "name": "ptrace.tracee.parent.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
         },
         {
           "name": "ptrace.tracee.parent.is_thread",
@@ -8142,6 +8182,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "setrlimit.target.ancestors.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "setrlimit.target.ancestors.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -8697,6 +8742,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "setrlimit.target.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "setrlimit.target.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -9155,6 +9205,11 @@
           "name": "setrlimit.target.parent.is_kworker",
           "definition": "Indicates whether the process is a kworker",
           "property_doc_link": "common-pidcontext-is_kworker-doc"
+        },
+        {
+          "name": "setrlimit.target.parent.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
         },
         {
           "name": "setrlimit.target.parent.is_thread",
@@ -10078,6 +10133,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "signal.target.ancestors.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "signal.target.ancestors.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -10633,6 +10693,11 @@
           "property_doc_link": "common-pidcontext-is_kworker-doc"
         },
         {
+          "name": "signal.target.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
+        },
+        {
           "name": "signal.target.is_thread",
           "definition": "Indicates whether the process is considered a thread (that is, a child process that hasn't executed another program)",
           "property_doc_link": "common-process-is_thread-doc"
@@ -11091,6 +11156,11 @@
           "name": "signal.target.parent.is_kworker",
           "definition": "Indicates whether the process is a kworker",
           "property_doc_link": "common-pidcontext-is_kworker-doc"
+        },
+        {
+          "name": "signal.target.parent.is_session_leader",
+          "definition": "Indicates whether the process is a session leader",
+          "property_doc_link": "common-pidcontext-is_session_leader-doc"
         },
         {
           "name": "signal.target.parent.is_thread",
@@ -13253,6 +13323,31 @@
         "network_flow_monitor.flows.source",
         "packet.destination",
         "packet.source"
+      ],
+      "constants": "",
+      "constants_link": "",
+      "examples": []
+    },
+    {
+      "name": "*.is_session_leader",
+      "link": "common-pidcontext-is_session_leader-doc",
+      "type": "bool",
+      "definition": "Indicates whether the process is a session leader",
+      "prefixes": [
+        "exec",
+        "exit",
+        "process",
+        "process.ancestors",
+        "process.parent",
+        "ptrace.tracee",
+        "ptrace.tracee.ancestors",
+        "ptrace.tracee.parent",
+        "setrlimit.target",
+        "setrlimit.target.ancestors",
+        "setrlimit.target.parent",
+        "signal.target",
+        "signal.target.ancestors",
+        "signal.target.parent"
       ],
       "constants": "",
       "constants_link": "",

--- a/pkg/security/ebpf/c/include/constants/offsets/process.h
+++ b/pkg/security/ebpf/c/include/constants/offsets/process.h
@@ -51,4 +51,15 @@ u64 __attribute__((always_inline)) get_task_struct_pid_offset() {
     return task_struct_pid_offset;
 }
 
+u64 __attribute__((always_inline)) get_task_struct_signal_offset() {
+    u64 offset;
+    LOAD_CONSTANT("task_struct_signal_offset", offset);
+    return offset;
+}
+
+u64 __attribute__((always_inline)) get_signal_struct_pids_offset() {
+    u64 offset;
+    LOAD_CONSTANT("signal_struct_pids_offset", offset);
+    return offset;
+}
 #endif

--- a/pkg/security/ebpf/c/include/helpers/process.h
+++ b/pkg/security/ebpf/c/include/helpers/process.h
@@ -41,6 +41,7 @@ void __attribute__((always_inline)) copy_pid_cache_except_exit_ts(struct pid_cac
     dst->user_session_id = src->user_session_id;
     dst->fork_timestamp = src->fork_timestamp;
     dst->fork_flags = src->fork_flags;
+    dst->is_session_leader = src->is_session_leader;
     dst->credentials = src->credentials;
 }
 
@@ -114,6 +115,9 @@ static struct proc_cache_t *__attribute__((always_inline)) fill_process_context_
 
     // copy user session id
     data->user_session_id = pid_entry->user_session_id;
+
+    // copy session leader status from cache
+    data->is_session_leader = pid_entry->is_session_leader;
 
     struct proc_cache_t *pc = get_proc_from_cookie(pid_entry->cookie);
     if (pc) {

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -814,7 +814,9 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
     // update pid <-> cookie mapping
     if (fork_entry) {
         fork_entry->cookie = cookie;
-    } else {
+    }
+
+    if (!fork_entry) {
         struct pid_cache_t new_pid_entry = {
             .cookie = cookie,
         };
@@ -823,6 +825,26 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
         if (fork_entry == NULL) {
             // should never happen, ignore
             return 0;
+        }
+    }
+
+    // compute session leader status: pid == sid (task->signal->pids[PIDTYPE_SID]->numbers[0].nr)
+    {
+        u64 signal_offset = get_task_struct_signal_offset();
+        u64 pids_offset = get_signal_struct_pids_offset();
+        if (signal_offset != 0 && pids_offset != 0) {
+            struct task_struct *cur_task = (struct task_struct *)bpf_get_current_task();
+            void *signal_ptr = NULL;
+            bpf_probe_read_kernel(&signal_ptr, sizeof(signal_ptr), (void *)cur_task + signal_offset);
+            if (signal_ptr) {
+                struct pid *sid_pid = NULL;
+                bpf_probe_read_kernel(&sid_pid, sizeof(sid_pid), signal_ptr + pids_offset + 3 * sizeof(void *));
+                if (sid_pid) {
+                    u32 sid = 0;
+                    bpf_probe_read_kernel(&sid, sizeof(sid), (void *)sid_pid + get_pid_numbers_offset());
+                    fork_entry->is_session_leader = (sid != 0 && sid == tgid) ? 1 : 0;
+                }
+            }
         }
     }
 

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -814,9 +814,7 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
     // update pid <-> cookie mapping
     if (fork_entry) {
         fork_entry->cookie = cookie;
-    }
-
-    if (!fork_entry) {
+    } else {
         struct pid_cache_t new_pid_entry = {
             .cookie = cookie,
         };

--- a/pkg/security/ebpf/c/include/structs/events_context.h
+++ b/pkg/security/ebpf/c/include/structs/events_context.h
@@ -29,12 +29,11 @@ struct process_context_t {
     u32 tid;
     u32 netns;
     u32 mntns;
-    u32 is_kworker;
+    u32 is_kworker:16;
+    u32 is_session_leader:16;
     u32 ppid;
     u64 inode;
     u64 user_session_id;
-    u32 is_session_leader;
-    u32 padding_session;
 };
 
 struct ktimeval {

--- a/pkg/security/ebpf/c/include/structs/events_context.h
+++ b/pkg/security/ebpf/c/include/structs/events_context.h
@@ -33,6 +33,8 @@ struct process_context_t {
     u32 ppid;
     u64 inode;
     u64 user_session_id;
+    u32 is_session_leader;
+    u32 padding_session;
 };
 
 struct ktimeval {

--- a/pkg/security/ebpf/c/include/structs/process.h
+++ b/pkg/security/ebpf/c/include/structs/process.h
@@ -37,6 +37,8 @@ struct pid_cache_t {
     u64 exit_timestamp;
     u64 user_session_id;
     u64 fork_flags;
+    u32 is_session_leader;
+    u32 padding_session;
     struct credentials_t credentials;
 };
 

--- a/pkg/security/probe/constantfetch/constant_names.go
+++ b/pkg/security/probe/constantfetch/constant_names.go
@@ -92,6 +92,10 @@ const (
 	OffsetNameTaskStructRealParent = "task_struct_real_parent_offset"
 	OffsetNameTaskStructTGID       = "task_struct_tgid_offset"
 
+	// session leader detection
+	OffsetNameTaskStructSignal    = "task_struct_signal_offset"
+	OffsetNameSignalStructPIDs    = "signal_struct_pids_offset"
+
 	// splice event
 	OffsetNamePipeInodeInfoStructBufs     = "pipe_inode_info_bufs_offset"
 	OffsetNamePipeInodeInfoStructNrbufs   = "pipe_inode_info_nrbufs_offset"    // kernels < 5.5

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -88,6 +88,8 @@ func computeCallbacksTable() map[string]func(*kernel.Version) uint64 {
 		SizeOfInode:                           getSizeOfStructInode,
 		OffsetNameSuperBlockStructSMagic:      getSuperBlockMagicOffset,
 		OffsetNameSignalStructStructTTY:       getSignalTTYOffset,
+		OffsetNameTaskStructSignal:            getTaskStructSignalOffset,
+		OffsetNameSignalStructPIDs:            getSignalStructPIDsOffset,
 		OffsetNameTTYStructStructName:         getTTYNameOffset,
 		OffsetNameCredStructUID:               getCredsUIDOffset,
 		OffsetNameCredStructCapInheritable:    getCredCapInheritableOffset,
@@ -1114,4 +1116,18 @@ func getTaskStructTGIDOffset(kv *kernel.Version) uint64 {
 	default:
 		return ErrorSentinel
 	}
+}
+
+// getTaskStructSignalOffset returns the offset of the signal field in task_struct
+// This is the primary path through BTF; the fallback returns ErrorSentinel
+// to signal that the offset could not be determined.
+func getTaskStructSignalOffset(_ *kernel.Version) uint64 {
+	return ErrorSentinel
+}
+
+// getSignalStructPIDsOffset returns the offset of the pids array in signal_struct
+// This is the primary path through BTF; the fallback returns ErrorSentinel
+// to signal that the offset could not be determined.
+func getSignalStructPIDsOffset(_ *kernel.Version) uint64 {
+	return ErrorSentinel
 }

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -3272,6 +3272,8 @@ func AppendProbeRequestsToFetcher(constantFetcher constantfetch.ConstantFetcher,
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSuperBlockStructSMagic, "struct super_block", "s_magic")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameDentryStructDSB, "struct dentry", "d_sb")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSignalStructStructTTY, "struct signal_struct", "tty")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameTaskStructSignal, "struct task_struct", "signal")
+	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameSignalStructPIDs, "struct signal_struct", "pids")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameTTYStructStructName, "struct tty_struct", "name")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameCredStructUID, "struct cred", "uid")
 	appendOffsetofRequest(constantFetcher, constantfetch.OffsetNameCredStructCapInheritable, "struct cred", "cap_inheritable")

--- a/pkg/security/secl/model/accessors_unix.go
+++ b/pkg/security/secl/model/accessors_unix.go
@@ -3334,6 +3334,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "exec.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exec.Process.PIDContext.IsSessionLeader
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "exec.is_thread":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
@@ -4732,6 +4743,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 				ctx.AppendResolvedField(field)
 				ev := ctx.Event.(*Event)
 				return ev.Exit.Process.PIDContext.IsKworker
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "exit.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Exit.Process.PIDContext.IsSessionLeader
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -10843,6 +10865,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "process.ancestors.is_session_leader":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.BaseEvent.ProcessContext.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.PIDContext.IsSessionLeader
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "BaseEvent.ProcessContext.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.PIDContext.IsSessionLeader
+				})
+				ctx.BoolCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "process.ancestors.is_thread":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
@@ -12560,6 +12609,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "process.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.BaseEvent.ProcessContext.Process.PIDContext.IsSessionLeader
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "process.is_thread":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
@@ -13982,6 +14042,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return false
 				}
 				return ev.BaseEvent.ProcessContext.Parent.PIDContext.IsKworker
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "process.parent.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.BaseEvent.ProcessContext.HasParent() {
+					return false
+				}
+				return ev.BaseEvent.ProcessContext.Parent.PIDContext.IsSessionLeader
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -17214,6 +17288,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.ancestors.is_session_leader":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.PTrace.Tracee.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.PIDContext.IsSessionLeader
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "PTrace.Tracee.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.PIDContext.IsSessionLeader
+				})
+				ctx.BoolCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.ancestors.is_thread":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
@@ -18931,6 +19032,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "ptrace.tracee.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.PTrace.Tracee.Process.PIDContext.IsSessionLeader
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "ptrace.tracee.is_thread":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
@@ -20353,6 +20465,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return false
 				}
 				return ev.PTrace.Tracee.Parent.PIDContext.IsKworker
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "ptrace.tracee.parent.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.PTrace.Tracee.HasParent() {
+					return false
+				}
+				return ev.PTrace.Tracee.Parent.PIDContext.IsSessionLeader
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -25013,6 +25139,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.ancestors.is_session_leader":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Setrlimit.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.PIDContext.IsSessionLeader
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Setrlimit.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.PIDContext.IsSessionLeader
+				})
+				ctx.BoolCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.ancestors.is_thread":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
@@ -26730,6 +26883,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "setrlimit.target.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Setrlimit.Target.Process.PIDContext.IsSessionLeader
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "setrlimit.target.is_thread":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
@@ -28152,6 +28316,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return false
 				}
 				return ev.Setrlimit.Target.Parent.PIDContext.IsKworker
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "setrlimit.target.parent.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Setrlimit.Target.HasParent() {
+					return false
+				}
+				return ev.Setrlimit.Target.Parent.PIDContext.IsSessionLeader
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -31906,6 +32084,33 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.IteratorWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.ancestors.is_session_leader":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				iterator := &ProcessAncestorsIterator{Root: ev.Signal.Target.Ancestor}
+				if regID != "" {
+					element := iterator.At(ctx, regID, ctx.Registers[regID])
+					if element == nil {
+						return nil
+					}
+					result := element.ProcessContext.Process.PIDContext.IsSessionLeader
+					return []bool{result}
+				}
+				if result, ok := ctx.BoolCache[field]; ok {
+					return result
+				}
+				results := newIterator(iterator, "Signal.Target.Ancestor", ctx, nil, func(ev *Event, current *ProcessCacheEntry) bool {
+					return current.ProcessContext.Process.PIDContext.IsSessionLeader
+				})
+				ctx.BoolCache[field] = results
+				return results
+			},
+			Field:  field,
+			Weight: eval.IteratorWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.ancestors.is_thread":
 		return &eval.BoolArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []bool {
@@ -33623,6 +33828,17 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 			Weight: eval.FunctionWeight,
 			Offset: offset,
 		}, nil
+	case "signal.target.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				return ev.Signal.Target.Process.PIDContext.IsSessionLeader
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
 	case "signal.target.is_thread":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
@@ -35045,6 +35261,20 @@ func (_ *Model) GetEvaluator(field eval.Field, regID eval.RegisterID, offset int
 					return false
 				}
 				return ev.Signal.Target.Parent.PIDContext.IsKworker
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+			Offset: offset,
+		}, nil
+	case "signal.target.parent.is_session_leader":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+				ctx.AppendResolvedField(field)
+				ev := ctx.Event.(*Event)
+				if !ev.Signal.Target.HasParent() {
+					return false
+				}
+				return ev.Signal.Target.Parent.PIDContext.IsSessionLeader
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -36959,6 +37189,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"exec.interpreter.file.user",
 		"exec.is_exec",
 		"exec.is_kworker",
+		"exec.is_session_leader",
 		"exec.is_thread",
 		"exec.mntns",
 		"exec.netns",
@@ -37072,6 +37303,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"exit.interpreter.file.user",
 		"exit.is_exec",
 		"exit.is_kworker",
+		"exit.is_session_leader",
 		"exit.is_thread",
 		"exit.mntns",
 		"exit.netns",
@@ -37448,6 +37680,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.ancestors.interpreter.file.user",
 		"process.ancestors.is_exec",
 		"process.ancestors.is_kworker",
+		"process.ancestors.is_session_leader",
 		"process.ancestors.is_thread",
 		"process.ancestors.length",
 		"process.ancestors.mntns",
@@ -37559,6 +37792,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.interpreter.file.user",
 		"process.is_exec",
 		"process.is_kworker",
+		"process.is_session_leader",
 		"process.is_thread",
 		"process.mntns",
 		"process.netns",
@@ -37651,6 +37885,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"process.parent.interpreter.file.user",
 		"process.parent.is_exec",
 		"process.parent.is_kworker",
+		"process.parent.is_session_leader",
 		"process.parent.is_thread",
 		"process.parent.mntns",
 		"process.parent.netns",
@@ -37781,6 +38016,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.ancestors.interpreter.file.user",
 		"ptrace.tracee.ancestors.is_exec",
 		"ptrace.tracee.ancestors.is_kworker",
+		"ptrace.tracee.ancestors.is_session_leader",
 		"ptrace.tracee.ancestors.is_thread",
 		"ptrace.tracee.ancestors.length",
 		"ptrace.tracee.ancestors.mntns",
@@ -37892,6 +38128,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.interpreter.file.user",
 		"ptrace.tracee.is_exec",
 		"ptrace.tracee.is_kworker",
+		"ptrace.tracee.is_session_leader",
 		"ptrace.tracee.is_thread",
 		"ptrace.tracee.mntns",
 		"ptrace.tracee.netns",
@@ -37984,6 +38221,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"ptrace.tracee.parent.interpreter.file.user",
 		"ptrace.tracee.parent.is_exec",
 		"ptrace.tracee.parent.is_kworker",
+		"ptrace.tracee.parent.is_session_leader",
 		"ptrace.tracee.parent.is_thread",
 		"ptrace.tracee.parent.mntns",
 		"ptrace.tracee.parent.netns",
@@ -38242,6 +38480,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.ancestors.interpreter.file.user",
 		"setrlimit.target.ancestors.is_exec",
 		"setrlimit.target.ancestors.is_kworker",
+		"setrlimit.target.ancestors.is_session_leader",
 		"setrlimit.target.ancestors.is_thread",
 		"setrlimit.target.ancestors.length",
 		"setrlimit.target.ancestors.mntns",
@@ -38353,6 +38592,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.interpreter.file.user",
 		"setrlimit.target.is_exec",
 		"setrlimit.target.is_kworker",
+		"setrlimit.target.is_session_leader",
 		"setrlimit.target.is_thread",
 		"setrlimit.target.mntns",
 		"setrlimit.target.netns",
@@ -38445,6 +38685,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"setrlimit.target.parent.interpreter.file.user",
 		"setrlimit.target.parent.is_exec",
 		"setrlimit.target.parent.is_kworker",
+		"setrlimit.target.parent.is_session_leader",
 		"setrlimit.target.parent.is_thread",
 		"setrlimit.target.parent.mntns",
 		"setrlimit.target.parent.netns",
@@ -38622,6 +38863,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.ancestors.interpreter.file.user",
 		"signal.target.ancestors.is_exec",
 		"signal.target.ancestors.is_kworker",
+		"signal.target.ancestors.is_session_leader",
 		"signal.target.ancestors.is_thread",
 		"signal.target.ancestors.length",
 		"signal.target.ancestors.mntns",
@@ -38733,6 +38975,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.interpreter.file.user",
 		"signal.target.is_exec",
 		"signal.target.is_kworker",
+		"signal.target.is_session_leader",
 		"signal.target.is_thread",
 		"signal.target.mntns",
 		"signal.target.netns",
@@ -38825,6 +39068,7 @@ func (ev *Event) GetFields() []eval.Field {
 		"signal.target.parent.interpreter.file.user",
 		"signal.target.parent.is_exec",
 		"signal.target.parent.is_kworker",
+		"signal.target.parent.is_session_leader",
 		"signal.target.parent.is_thread",
 		"signal.target.parent.mntns",
 		"signal.target.parent.netns",
@@ -39533,6 +39777,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "exec", reflect.Bool, "bool", false, nil
 	case "exec.is_kworker":
 		return "exec", reflect.Bool, "bool", false, nil
+	case "exec.is_session_leader":
+		return "exec", reflect.Bool, "bool", false, nil
 	case "exec.is_thread":
 		return "exec", reflect.Bool, "bool", false, nil
 	case "exec.mntns":
@@ -39758,6 +40004,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	case "exit.is_exec":
 		return "exit", reflect.Bool, "bool", false, nil
 	case "exit.is_kworker":
+		return "exit", reflect.Bool, "bool", false, nil
+	case "exit.is_session_leader":
 		return "exit", reflect.Bool, "bool", false, nil
 	case "exit.is_thread":
 		return "exit", reflect.Bool, "bool", false, nil
@@ -40511,6 +40759,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Bool, "bool", false, nil
 	case "process.ancestors.is_kworker":
 		return "", reflect.Bool, "bool", false, nil
+	case "process.ancestors.is_session_leader":
+		return "", reflect.Bool, "bool", false, nil
 	case "process.ancestors.is_thread":
 		return "", reflect.Bool, "bool", false, nil
 	case "process.ancestors.length":
@@ -40733,6 +40983,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "", reflect.Bool, "bool", false, nil
 	case "process.is_kworker":
 		return "", reflect.Bool, "bool", false, nil
+	case "process.is_session_leader":
+		return "", reflect.Bool, "bool", false, nil
 	case "process.is_thread":
 		return "", reflect.Bool, "bool", false, nil
 	case "process.mntns":
@@ -40916,6 +41168,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	case "process.parent.is_exec":
 		return "", reflect.Bool, "bool", false, nil
 	case "process.parent.is_kworker":
+		return "", reflect.Bool, "bool", false, nil
+	case "process.parent.is_session_leader":
 		return "", reflect.Bool, "bool", false, nil
 	case "process.parent.is_thread":
 		return "", reflect.Bool, "bool", false, nil
@@ -41177,6 +41431,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.ancestors.is_kworker":
 		return "ptrace", reflect.Bool, "bool", false, nil
+	case "ptrace.tracee.ancestors.is_session_leader":
+		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.ancestors.is_thread":
 		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.ancestors.length":
@@ -41399,6 +41655,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.is_kworker":
 		return "ptrace", reflect.Bool, "bool", false, nil
+	case "ptrace.tracee.is_session_leader":
+		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.is_thread":
 		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.mntns":
@@ -41582,6 +41840,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	case "ptrace.tracee.parent.is_exec":
 		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.parent.is_kworker":
+		return "ptrace", reflect.Bool, "bool", false, nil
+	case "ptrace.tracee.parent.is_session_leader":
 		return "ptrace", reflect.Bool, "bool", false, nil
 	case "ptrace.tracee.parent.is_thread":
 		return "ptrace", reflect.Bool, "bool", false, nil
@@ -42099,6 +42359,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.ancestors.is_kworker":
 		return "setrlimit", reflect.Bool, "bool", false, nil
+	case "setrlimit.target.ancestors.is_session_leader":
+		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.ancestors.is_thread":
 		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.ancestors.length":
@@ -42321,6 +42583,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.is_kworker":
 		return "setrlimit", reflect.Bool, "bool", false, nil
+	case "setrlimit.target.is_session_leader":
+		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.is_thread":
 		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.mntns":
@@ -42504,6 +42768,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	case "setrlimit.target.parent.is_exec":
 		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.parent.is_kworker":
+		return "setrlimit", reflect.Bool, "bool", false, nil
+	case "setrlimit.target.parent.is_session_leader":
 		return "setrlimit", reflect.Bool, "bool", false, nil
 	case "setrlimit.target.parent.is_thread":
 		return "setrlimit", reflect.Bool, "bool", false, nil
@@ -42859,6 +43125,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.ancestors.is_kworker":
 		return "signal", reflect.Bool, "bool", false, nil
+	case "signal.target.ancestors.is_session_leader":
+		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.ancestors.is_thread":
 		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.ancestors.length":
@@ -43081,6 +43349,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.is_kworker":
 		return "signal", reflect.Bool, "bool", false, nil
+	case "signal.target.is_session_leader":
+		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.is_thread":
 		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.mntns":
@@ -43264,6 +43534,8 @@ func (ev *Event) GetFieldMetadata(field eval.Field) (eval.EventType, reflect.Kin
 	case "signal.target.parent.is_exec":
 		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.parent.is_kworker":
+		return "signal", reflect.Bool, "bool", false, nil
+	case "signal.target.parent.is_session_leader":
 		return "signal", reflect.Bool, "bool", false, nil
 	case "signal.target.parent.is_thread":
 		return "signal", reflect.Bool, "bool", false, nil
@@ -44248,6 +44520,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("exec.is_exec", &ev.Exec.Process.IsExec, value)
 	case "exec.is_kworker":
 		return ev.setBoolFieldValue("exec.is_kworker", &ev.Exec.Process.PIDContext.IsKworker, value)
+	case "exec.is_session_leader":
+		return ev.setBoolFieldValue("exec.is_session_leader", &ev.Exec.Process.PIDContext.IsSessionLeader, value)
 	case "exec.is_thread":
 		return ev.setBoolFieldValue("exec.is_thread", &ev.Exec.Process.IsThread, value)
 	case "exec.mntns":
@@ -44589,6 +44863,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("exit.is_exec", &ev.Exit.Process.IsExec, value)
 	case "exit.is_kworker":
 		return ev.setBoolFieldValue("exit.is_kworker", &ev.Exit.Process.PIDContext.IsKworker, value)
+	case "exit.is_session_leader":
+		return ev.setBoolFieldValue("exit.is_session_leader", &ev.Exit.Process.PIDContext.IsSessionLeader, value)
 	case "exit.is_thread":
 		return ev.setBoolFieldValue("exit.is_thread", &ev.Exit.Process.IsThread, value)
 	case "exit.mntns":
@@ -45522,6 +45798,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("process.ancestors.is_exec", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.IsExec, value)
 	case "process.ancestors.is_kworker":
 		return ev.setBoolFieldValue("process.ancestors.is_kworker", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.PIDContext.IsKworker, value)
+	case "process.ancestors.is_session_leader":
+		return ev.setBoolFieldValue("process.ancestors.is_session_leader", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.PIDContext.IsSessionLeader, value)
 	case "process.ancestors.is_thread":
 		return ev.setBoolFieldValue("process.ancestors.is_thread", &ev.BaseEvent.ProcessContext.Ancestor.ProcessContext.Process.IsThread, value)
 	case "process.ancestors.length":
@@ -45859,6 +46137,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("process.is_exec", &ev.BaseEvent.ProcessContext.Process.IsExec, value)
 	case "process.is_kworker":
 		return ev.setBoolFieldValue("process.is_kworker", &ev.BaseEvent.ProcessContext.Process.PIDContext.IsKworker, value)
+	case "process.is_session_leader":
+		return ev.setBoolFieldValue("process.is_session_leader", &ev.BaseEvent.ProcessContext.Process.PIDContext.IsSessionLeader, value)
 	case "process.is_thread":
 		return ev.setBoolFieldValue("process.is_thread", &ev.BaseEvent.ProcessContext.Process.IsThread, value)
 	case "process.mntns":
@@ -46153,6 +46433,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("process.parent.is_exec", &ev.BaseEvent.ProcessContext.Parent.IsExec, value)
 	case "process.parent.is_kworker":
 		return ev.setBoolFieldValue("process.parent.is_kworker", &ev.BaseEvent.ProcessContext.Parent.PIDContext.IsKworker, value)
+	case "process.parent.is_session_leader":
+		return ev.setBoolFieldValue("process.parent.is_session_leader", &ev.BaseEvent.ProcessContext.Parent.PIDContext.IsSessionLeader, value)
 	case "process.parent.is_thread":
 		return ev.setBoolFieldValue("process.parent.is_thread", &ev.BaseEvent.ProcessContext.Parent.IsThread, value)
 	case "process.parent.mntns":
@@ -46533,6 +46815,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("ptrace.tracee.ancestors.is_exec", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.IsExec, value)
 	case "ptrace.tracee.ancestors.is_kworker":
 		return ev.setBoolFieldValue("ptrace.tracee.ancestors.is_kworker", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.PIDContext.IsKworker, value)
+	case "ptrace.tracee.ancestors.is_session_leader":
+		return ev.setBoolFieldValue("ptrace.tracee.ancestors.is_session_leader", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.PIDContext.IsSessionLeader, value)
 	case "ptrace.tracee.ancestors.is_thread":
 		return ev.setBoolFieldValue("ptrace.tracee.ancestors.is_thread", &ev.PTrace.Tracee.Ancestor.ProcessContext.Process.IsThread, value)
 	case "ptrace.tracee.ancestors.length":
@@ -46870,6 +47154,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("ptrace.tracee.is_exec", &ev.PTrace.Tracee.Process.IsExec, value)
 	case "ptrace.tracee.is_kworker":
 		return ev.setBoolFieldValue("ptrace.tracee.is_kworker", &ev.PTrace.Tracee.Process.PIDContext.IsKworker, value)
+	case "ptrace.tracee.is_session_leader":
+		return ev.setBoolFieldValue("ptrace.tracee.is_session_leader", &ev.PTrace.Tracee.Process.PIDContext.IsSessionLeader, value)
 	case "ptrace.tracee.is_thread":
 		return ev.setBoolFieldValue("ptrace.tracee.is_thread", &ev.PTrace.Tracee.Process.IsThread, value)
 	case "ptrace.tracee.mntns":
@@ -47164,6 +47450,8 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return ev.setBoolFieldValue("ptrace.tracee.parent.is_exec", &ev.PTrace.Tracee.Parent.IsExec, value)
 	case "ptrace.tracee.parent.is_kworker":
 		return ev.setBoolFieldValue("ptrace.tracee.parent.is_kworker", &ev.PTrace.Tracee.Parent.PIDContext.IsKworker, value)
+	case "ptrace.tracee.parent.is_session_leader":
+		return ev.setBoolFieldValue("ptrace.tracee.parent.is_session_leader", &ev.PTrace.Tracee.Parent.PIDContext.IsSessionLeader, value)
 	case "ptrace.tracee.parent.is_thread":
 		return ev.setBoolFieldValue("ptrace.tracee.parent.is_thread", &ev.PTrace.Tracee.Parent.IsThread, value)
 	case "ptrace.tracee.parent.mntns":
@@ -48334,6 +48622,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setBoolFieldValue("setrlimit.target.ancestors.is_kworker", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.PIDContext.IsKworker, value)
+	case "setrlimit.target.ancestors.is_session_leader":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Ancestor == nil {
+			ev.Setrlimit.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setBoolFieldValue("setrlimit.target.ancestors.is_session_leader", &ev.Setrlimit.Target.Ancestor.ProcessContext.Process.PIDContext.IsSessionLeader, value)
 	case "setrlimit.target.ancestors.is_thread":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -49070,6 +49366,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target = &ProcessContext{}
 		}
 		return ev.setBoolFieldValue("setrlimit.target.is_kworker", &ev.Setrlimit.Target.Process.PIDContext.IsKworker, value)
+	case "setrlimit.target.is_session_leader":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		return ev.setBoolFieldValue("setrlimit.target.is_session_leader", &ev.Setrlimit.Target.Process.PIDContext.IsSessionLeader, value)
 	case "setrlimit.target.is_thread":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -49907,6 +50208,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Setrlimit.Target.Parent = &Process{}
 		}
 		return ev.setBoolFieldValue("setrlimit.target.parent.is_kworker", &ev.Setrlimit.Target.Parent.PIDContext.IsKworker, value)
+	case "setrlimit.target.parent.is_session_leader":
+		if ev.Setrlimit.Target == nil {
+			ev.Setrlimit.Target = &ProcessContext{}
+		}
+		if ev.Setrlimit.Target.Parent == nil {
+			ev.Setrlimit.Target.Parent = &Process{}
+		}
+		return ev.setBoolFieldValue("setrlimit.target.parent.is_session_leader", &ev.Setrlimit.Target.Parent.PIDContext.IsSessionLeader, value)
 	case "setrlimit.target.parent.is_thread":
 		if ev.Setrlimit.Target == nil {
 			ev.Setrlimit.Target = &ProcessContext{}
@@ -51105,6 +51414,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
 		}
 		return ev.setBoolFieldValue("signal.target.ancestors.is_kworker", &ev.Signal.Target.Ancestor.ProcessContext.Process.PIDContext.IsKworker, value)
+	case "signal.target.ancestors.is_session_leader":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Ancestor == nil {
+			ev.Signal.Target.Ancestor = &ProcessCacheEntry{}
+		}
+		return ev.setBoolFieldValue("signal.target.ancestors.is_session_leader", &ev.Signal.Target.Ancestor.ProcessContext.Process.PIDContext.IsSessionLeader, value)
 	case "signal.target.ancestors.is_thread":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -51841,6 +52158,11 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target = &ProcessContext{}
 		}
 		return ev.setBoolFieldValue("signal.target.is_kworker", &ev.Signal.Target.Process.PIDContext.IsKworker, value)
+	case "signal.target.is_session_leader":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		return ev.setBoolFieldValue("signal.target.is_session_leader", &ev.Signal.Target.Process.PIDContext.IsSessionLeader, value)
 	case "signal.target.is_thread":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}
@@ -52678,6 +53000,14 @@ func (ev *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			ev.Signal.Target.Parent = &Process{}
 		}
 		return ev.setBoolFieldValue("signal.target.parent.is_kworker", &ev.Signal.Target.Parent.PIDContext.IsKworker, value)
+	case "signal.target.parent.is_session_leader":
+		if ev.Signal.Target == nil {
+			ev.Signal.Target = &ProcessContext{}
+		}
+		if ev.Signal.Target.Parent == nil {
+			ev.Signal.Target.Parent = &Process{}
+		}
+		return ev.setBoolFieldValue("signal.target.parent.is_session_leader", &ev.Signal.Target.Parent.PIDContext.IsSessionLeader, value)
 	case "signal.target.parent.is_thread":
 		if ev.Signal.Target == nil {
 			ev.Signal.Target = &ProcessContext{}

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -187,6 +187,7 @@ func deepCopyPIDContext(fieldToCopy PIDContext) PIDContext {
 	copied := PIDContext{}
 	copied.ExecInode = fieldToCopy.ExecInode
 	copied.IsKworker = fieldToCopy.IsKworker
+	copied.IsSessionLeader = fieldToCopy.IsSessionLeader
 	copied.MntNS = fieldToCopy.MntNS
 	copied.NSID = fieldToCopy.NSID
 	copied.NetNS = fieldToCopy.NetNS

--- a/pkg/security/secl/model/marshallers_linux.go
+++ b/pkg/security/secl/model/marshallers_linux.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// PidCacheEntrySize is the size of the pid_cache_t
-	PidCacheEntrySize = 88
+	PidCacheEntrySize = 96
 )
 
 // BinaryMarshaler interface implemented by every event type
@@ -147,7 +147,13 @@ func (e *Process) MarshalPidCache(data []byte, bootTime time.Time) (int, error) 
 	marshalTime(data[16:24], e.ExitTime.Sub(bootTime))
 	binary.NativeEndian.PutUint64(data[24:32], e.UserSession.K8SSessionID)
 	binary.NativeEndian.PutUint64(data[32:40], e.ForkFlags)
-	written := 40
+	if e.IsSessionLeader {
+		binary.NativeEndian.PutUint32(data[40:44], 1)
+	} else {
+		binary.NativeEndian.PutUint32(data[40:44], 0)
+	}
+	binary.NativeEndian.PutUint32(data[44:48], 0) // padding
+	written := 48
 
 	n, err := MarshalBinary(data[written:], &e.Credentials)
 	if err != nil {

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -640,7 +640,8 @@ type PIDContext struct {
 	Tid           uint32 `field:"tid"`        // SECLDoc[tid] Definition:`Thread ID of the thread`
 	NetNS         uint32 `field:"netns"`      // SECLDoc[netns] Definition:`NetNS ID of the process`
 	MntNS         uint32 `field:"mntns"`      // SECLDoc[mntns] Definition:`MNTNS ID of the process`
-	IsKworker     bool   `field:"is_kworker"` // SECLDoc[is_kworker] Definition:`Indicates whether the process is a kworker`
+	IsKworker       bool   `field:"is_kworker"` // SECLDoc[is_kworker] Definition:`Indicates whether the process is a kworker`
+	IsSessionLeader bool   `field:"is_session_leader"` // SECLDoc[is_session_leader] Definition:`Indicates whether the process is a session leader`
 	PPid          uint32 `field:"ppid"`       // SECLDoc[ppid] Definition:`Parent process ID`
 	ExecInode     uint64 `field:"-"`          // used to track exec and event loss
 	UserSessionID uint64 `field:"-"`          // used to track user sessions from kernel space

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -131,7 +131,7 @@ func (e *CapsetEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *Credentials) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 48 {
+	if len(data) < 40 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -588,7 +588,7 @@ func (e *SELinuxEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself, process_context_t kernel side
 func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 48 {
+	if len(data) < 40 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -596,14 +596,13 @@ func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
 	p.Tid = binary.NativeEndian.Uint32(data[4:8])
 	p.NetNS = binary.NativeEndian.Uint32(data[8:12])
 	p.MntNS = binary.NativeEndian.Uint32(data[12:16])
-	p.IsKworker = binary.NativeEndian.Uint32(data[16:20]) > 0
+	p.IsKworker = binary.NativeEndian.Uint16(data[16:18]) > 0
+	p.IsSessionLeader = binary.NativeEndian.Uint16(data[18:20]) > 0
 	p.PPid = binary.NativeEndian.Uint32(data[20:24])
 	p.ExecInode = binary.NativeEndian.Uint64(data[24:32])
 	p.UserSessionID = binary.NativeEndian.Uint64(data[32:40])
-	p.IsSessionLeader = binary.NativeEndian.Uint32(data[40:44]) > 0
-	// data[44:48] is padding
 
-	return 48, nil
+	return 40, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself
@@ -1034,7 +1033,7 @@ func (e *CgroupWriteEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // EventUnmarshalBinary unmarshals a binary representation of itself
 func (adlc *ActivityDumpLoadConfig) EventUnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 48 {
+	if len(data) < 40 {
 		return 0, ErrNotEnoughData
 	}
 

--- a/pkg/security/secl/model/unmarshallers_linux.go
+++ b/pkg/security/secl/model/unmarshallers_linux.go
@@ -228,20 +228,22 @@ func (e *Process) UnmarshalPidCacheBinary(data []byte) (int, error) {
 	e.ExitTime = unmarshalTime(data[16:24])
 	e.UserSession.K8SSessionID = binary.NativeEndian.Uint64(data[24:32])
 	e.ForkFlags = binary.NativeEndian.Uint64(data[32:40])
+	e.IsSessionLeader = binary.NativeEndian.Uint32(data[40:44]) > 0
+	// data[44:48] is padding
 
 	// Unmarshal the credentials contained in pid_cache_t
-	read, err := e.Credentials.UnmarshalBinary(data[40:])
+	read, err := e.Credentials.UnmarshalBinary(data[48:])
 	if err != nil {
 		return 0, err
 	}
-	read += 40
+	read += 48
 
 	return validateReadSize(size, read)
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (e *Process) UnmarshalBinary(data []byte) (int, error) {
-	const size = 292 // size of struct exec_event_t starting from process_entry_t, inclusive
+	const size = 300 // size of struct exec_event_t starting from process_entry_t, inclusive
 	if len(data) < size {
 		return 0, ErrNotEnoughData
 	}
@@ -586,7 +588,7 @@ func (e *SELinuxEvent) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself, process_context_t kernel side
 func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 40 {
+	if len(data) < 48 {
 		return 0, ErrNotEnoughData
 	}
 
@@ -598,8 +600,10 @@ func (p *PIDContext) UnmarshalBinary(data []byte) (int, error) {
 	p.PPid = binary.NativeEndian.Uint32(data[20:24])
 	p.ExecInode = binary.NativeEndian.Uint64(data[24:32])
 	p.UserSessionID = binary.NativeEndian.Uint64(data[32:40])
+	p.IsSessionLeader = binary.NativeEndian.Uint32(data[40:44]) > 0
+	// data[44:48] is padding
 
-	return 40, nil
+	return 48, nil
 }
 
 // UnmarshalBinary unmarshalls a binary representation of itself

--- a/pkg/security/serializers/deserializers.go
+++ b/pkg/security/serializers/deserializers.go
@@ -67,7 +67,8 @@ func newProcess(ps *ProcessSerializer) model.Process {
 		PIDContext: model.PIDContext{
 			Pid:       ps.Pid,
 			Tid:       ps.Tid,
-			IsKworker: ps.IsKworker,
+			IsKworker:       ps.IsKworker,
+			IsSessionLeader: ps.IsSessionLeader,
 			PPid:      getPointerValue(ps.PPid),
 		},
 	}

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -7,6 +7,7 @@ package serializers
 
 import (
 	json "encoding/json"
+	model "github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model"
 	utils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
@@ -1153,12 +1154,6 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 			} else {
 				out.IsKworker = bool(in.Bool())
 			}
-		case "is_session_leader":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.IsSessionLeader = bool(in.Bool())
-			}
 		case "is_exec":
 			if in.IsNull() {
 				in.Skip()
@@ -1252,26 +1247,12 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 		case "tracer":
 			if in.IsNull() {
 				in.Skip()
+				out.Tracer = nil
 			} else {
-				in.Delim('{')
-				if !in.IsDelim('}') {
-					out.Tracer = make(map[string]string)
-				} else {
-					out.Tracer = nil
+				if out.Tracer == nil {
+					out.Tracer = new(model.TracerMetadata)
 				}
-				for !in.IsDelim('}') {
-					key := string(in.String())
-					in.WantColon()
-					var v18 string
-					if in.IsNull() {
-						in.Skip()
-					} else {
-						v18 = string(in.String())
-					}
-					(out.Tracer)[key] = v18
-					in.WantComma()
-				}
-				in.Delim('}')
+				easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(in, out.Tracer)
 			}
 		case "variables":
 			if in.IsNull() {
@@ -1309,14 +1290,14 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		}
 		{
 			out.RawByte('[')
-			for v19, v20 := range in.Ancestors {
-				if v19 > 0 {
+			for v18, v19 := range in.Ancestors {
+				if v18 > 0 {
 					out.RawByte(',')
 				}
-				if v20 == nil {
+				if v19 == nil {
 					out.RawString("null")
 				} else {
-					(*v20).MarshalEasyJSON(out)
+					(*v19).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -1432,11 +1413,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v21, v22 := range in.CapsAttempted {
-				if v21 > 0 {
+			for v20, v21 := range in.CapsAttempted {
+				if v20 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v22))
+				out.String(string(v21))
 			}
 			out.RawByte(']')
 		}
@@ -1446,11 +1427,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v23, v24 := range in.CapsUsed {
-				if v23 > 0 {
+			for v22, v23 := range in.CapsUsed {
+				if v22 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v24))
+				out.String(string(v23))
 			}
 			out.RawByte(']')
 		}
@@ -1490,11 +1471,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v25, v26 := range in.Args {
-				if v25 > 0 {
+			for v24, v25 := range in.Args {
+				if v24 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v26))
+				out.String(string(v25))
 			}
 			out.RawByte(']')
 		}
@@ -1509,11 +1490,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v27, v28 := range in.Envs {
-				if v27 > 0 {
+			for v26, v27 := range in.Envs {
+				if v26 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v28))
+				out.String(string(v27))
 			}
 			out.RawByte(']')
 		}
@@ -1532,11 +1513,6 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		const prefix string = ",\"is_kworker\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
-	}
-	if in.IsSessionLeader {
-		const prefix string = ",\"is_session_leader\":"
-		out.RawString(prefix)
-		out.Bool(bool(in.IsSessionLeader))
 	}
 	if in.IsExec {
 		const prefix string = ",\"is_exec\":"
@@ -1565,11 +1541,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v29, v30 := range *in.Syscalls {
-				if v29 > 0 {
+			for v28, v29 := range *in.Syscalls {
+				if v28 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers7(out, v30)
+				easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers7(out, v29)
 			}
 			out.RawByte(']')
 		}
@@ -1579,37 +1555,23 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v31, v32 := range in.AWSSecurityCredentials {
-				if v31 > 0 {
+			for v30, v31 := range in.AWSSecurityCredentials {
+				if v30 > 0 {
 					out.RawByte(',')
 				}
-				if v32 == nil {
+				if v31 == nil {
 					out.RawString("null")
 				} else {
-					(*v32).MarshalEasyJSON(out)
+					(*v31).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
 		}
 	}
-	if len(in.Tracer) != 0 {
+	if in.Tracer != nil {
 		const prefix string = ",\"tracer\":"
 		out.RawString(prefix)
-		{
-			out.RawByte('{')
-			v33First := true
-			for v33Name, v33Value := range in.Tracer {
-				if v33First {
-					v33First = false
-				} else {
-					out.RawByte(',')
-				}
-				out.String(string(v33Name))
-				out.RawByte(':')
-				out.String(string(v33Value))
-			}
-			out.RawByte('}')
-		}
+		easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(out, *in.Tracer)
 	}
 	if len(in.Variables) != 0 {
 		const prefix string = ",\"variables\":"
@@ -1627,6 +1589,157 @@ func (v ProcessContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(l, v)
+}
+func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(in *jlexer.Lexer, out *model.TracerMetadata) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		switch key {
+		case "schema_version":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.SchemaVersion = uint8(in.Uint8())
+			}
+		case "runtime_id":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.RuntimeID = string(in.String())
+			}
+		case "tracer_language":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.TracerLanguage = string(in.String())
+			}
+		case "tracer_version":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.TracerVersion = string(in.String())
+			}
+		case "hostname":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.Hostname = string(in.String())
+			}
+		case "service_name":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ServiceName = string(in.String())
+			}
+		case "service_env":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ServiceEnv = string(in.String())
+			}
+		case "service_version":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ServiceVersion = string(in.String())
+			}
+		case "process_tags":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ProcessTags = string(in.String())
+			}
+		case "container_id":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ContainerID = string(in.String())
+			}
+		case "logs_collected":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.LogsCollected = bool(in.Bool())
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(out *jwriter.Writer, in model.TracerMetadata) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"schema_version\":"
+		out.RawString(prefix[1:])
+		out.Uint8(uint8(in.SchemaVersion))
+	}
+	if in.RuntimeID != "" {
+		const prefix string = ",\"runtime_id\":"
+		out.RawString(prefix)
+		out.String(string(in.RuntimeID))
+	}
+	{
+		const prefix string = ",\"tracer_language\":"
+		out.RawString(prefix)
+		out.String(string(in.TracerLanguage))
+	}
+	{
+		const prefix string = ",\"tracer_version\":"
+		out.RawString(prefix)
+		out.String(string(in.TracerVersion))
+	}
+	{
+		const prefix string = ",\"hostname\":"
+		out.RawString(prefix)
+		out.String(string(in.Hostname))
+	}
+	if in.ServiceName != "" {
+		const prefix string = ",\"service_name\":"
+		out.RawString(prefix)
+		out.String(string(in.ServiceName))
+	}
+	if in.ServiceEnv != "" {
+		const prefix string = ",\"service_env\":"
+		out.RawString(prefix)
+		out.String(string(in.ServiceEnv))
+	}
+	if in.ServiceVersion != "" {
+		const prefix string = ",\"service_version\":"
+		out.RawString(prefix)
+		out.String(string(in.ServiceVersion))
+	}
+	if in.ProcessTags != "" {
+		const prefix string = ",\"process_tags\":"
+		out.RawString(prefix)
+		out.String(string(in.ProcessTags))
+	}
+	if in.ContainerID != "" {
+		const prefix string = ",\"container_id\":"
+		out.RawString(prefix)
+		out.String(string(in.ContainerID))
+	}
+	if in.LogsCollected {
+		const prefix string = ",\"logs_collected\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.LogsCollected))
+	}
+	out.RawByte('}')
 }
 func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers7(in *jlexer.Lexer, out *SyscallSerializer) {
 	isTopLevel := in.IsStart()
@@ -1792,21 +1905,21 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(i
 					out.Flows = (out.Flows)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v34 *FlowSerializer
+					var v32 *FlowSerializer
 					if in.IsNull() {
 						in.Skip()
-						v34 = nil
+						v32 = nil
 					} else {
-						if v34 == nil {
-							v34 = new(FlowSerializer)
+						if v32 == nil {
+							v32 = new(FlowSerializer)
 						}
 						if in.IsNull() {
 							in.Skip()
 						} else {
-							(*v34).UnmarshalEasyJSON(in)
+							(*v32).UnmarshalEasyJSON(in)
 						}
 					}
-					out.Flows = append(out.Flows, v34)
+					out.Flows = append(out.Flows, v32)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1841,14 +1954,14 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(o
 		}
 		{
 			out.RawByte('[')
-			for v35, v36 := range in.Flows {
-				if v35 > 0 {
+			for v33, v34 := range in.Flows {
+				if v33 > 0 {
 					out.RawByte(',')
 				}
-				if v36 == nil {
+				if v34 == nil {
 					out.RawString("null")
 				} else {
-					(*v36).MarshalEasyJSON(out)
+					(*v34).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -2134,13 +2247,13 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(
 					out.Tags = (out.Tags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v37 string
+					var v35 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v37 = string(in.String())
+						v35 = string(in.String())
 					}
-					out.Tags = append(out.Tags, v37)
+					out.Tags = append(out.Tags, v35)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2197,11 +2310,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(
 		}
 		{
 			out.RawByte('[')
-			for v38, v39 := range in.Tags {
-				if v38 > 0 {
+			for v36, v37 := range in.Tags {
+				if v36 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v39))
+				out.String(string(v37))
 			}
 			out.RawByte(']')
 		}
@@ -2736,13 +2849,13 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.MatchedRules = (out.MatchedRules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v40 MatchedRuleSerializer
+					var v38 MatchedRuleSerializer
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						(v40).UnmarshalEasyJSON(in)
+						(v38).UnmarshalEasyJSON(in)
 					}
-					out.MatchedRules = append(out.MatchedRules, v40)
+					out.MatchedRules = append(out.MatchedRules, v38)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2825,11 +2938,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 		}
 		{
 			out.RawByte('[')
-			for v41, v42 := range in.MatchedRules {
-				if v41 > 0 {
+			for v39, v40 := range in.MatchedRules {
+				if v39 > 0 {
 					out.RawByte(',')
 				}
-				(v42).MarshalEasyJSON(out)
+				(v40).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}

--- a/pkg/security/serializers/serializers_base_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_base_linux_easyjson.go
@@ -7,7 +7,6 @@ package serializers
 
 import (
 	json "encoding/json"
-	model "github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model"
 	utils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
@@ -1154,6 +1153,12 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 			} else {
 				out.IsKworker = bool(in.Bool())
 			}
+		case "is_session_leader":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.IsSessionLeader = bool(in.Bool())
+			}
 		case "is_exec":
 			if in.IsNull() {
 				in.Skip()
@@ -1247,12 +1252,26 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(i
 		case "tracer":
 			if in.IsNull() {
 				in.Skip()
-				out.Tracer = nil
 			} else {
-				if out.Tracer == nil {
-					out.Tracer = new(model.TracerMetadata)
+				in.Delim('{')
+				if !in.IsDelim('}') {
+					out.Tracer = make(map[string]string)
+				} else {
+					out.Tracer = nil
 				}
-				easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(in, out.Tracer)
+				for !in.IsDelim('}') {
+					key := string(in.String())
+					in.WantColon()
+					var v18 string
+					if in.IsNull() {
+						in.Skip()
+					} else {
+						v18 = string(in.String())
+					}
+					(out.Tracer)[key] = v18
+					in.WantComma()
+				}
+				in.Delim('}')
 			}
 		case "variables":
 			if in.IsNull() {
@@ -1290,14 +1309,14 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		}
 		{
 			out.RawByte('[')
-			for v18, v19 := range in.Ancestors {
-				if v18 > 0 {
+			for v19, v20 := range in.Ancestors {
+				if v19 > 0 {
 					out.RawByte(',')
 				}
-				if v19 == nil {
+				if v20 == nil {
 					out.RawString("null")
 				} else {
-					(*v19).MarshalEasyJSON(out)
+					(*v20).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -1413,11 +1432,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v20, v21 := range in.CapsAttempted {
-				if v20 > 0 {
+			for v21, v22 := range in.CapsAttempted {
+				if v21 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v21))
+				out.String(string(v22))
 			}
 			out.RawByte(']')
 		}
@@ -1427,11 +1446,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v22, v23 := range in.CapsUsed {
-				if v22 > 0 {
+			for v23, v24 := range in.CapsUsed {
+				if v23 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v23))
+				out.String(string(v24))
 			}
 			out.RawByte(']')
 		}
@@ -1471,11 +1490,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v24, v25 := range in.Args {
-				if v24 > 0 {
+			for v25, v26 := range in.Args {
+				if v25 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v25))
+				out.String(string(v26))
 			}
 			out.RawByte(']')
 		}
@@ -1490,11 +1509,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v26, v27 := range in.Envs {
-				if v26 > 0 {
+			for v27, v28 := range in.Envs {
+				if v27 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v27))
+				out.String(string(v28))
 			}
 			out.RawByte(']')
 		}
@@ -1513,6 +1532,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		const prefix string = ",\"is_kworker\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
+	}
+	if in.IsSessionLeader {
+		const prefix string = ",\"is_session_leader\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsSessionLeader))
 	}
 	if in.IsExec {
 		const prefix string = ",\"is_exec\":"
@@ -1541,11 +1565,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v28, v29 := range *in.Syscalls {
-				if v28 > 0 {
+			for v29, v30 := range *in.Syscalls {
+				if v29 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers7(out, v29)
+				easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers7(out, v30)
 			}
 			out.RawByte(']')
 		}
@@ -1555,23 +1579,37 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(o
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v30, v31 := range in.AWSSecurityCredentials {
-				if v30 > 0 {
+			for v31, v32 := range in.AWSSecurityCredentials {
+				if v31 > 0 {
 					out.RawByte(',')
 				}
-				if v31 == nil {
+				if v32 == nil {
 					out.RawString("null")
 				} else {
-					(*v31).MarshalEasyJSON(out)
+					(*v32).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
 		}
 	}
-	if in.Tracer != nil {
+	if len(in.Tracer) != 0 {
 		const prefix string = ",\"tracer\":"
 		out.RawString(prefix)
-		easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(out, *in.Tracer)
+		{
+			out.RawByte('{')
+			v33First := true
+			for v33Name, v33Value := range in.Tracer {
+				if v33First {
+					v33First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.String(string(v33Name))
+				out.RawByte(':')
+				out.String(string(v33Value))
+			}
+			out.RawByte('}')
+		}
 	}
 	if len(in.Variables) != 0 {
 		const prefix string = ",\"variables\":"
@@ -1589,157 +1627,6 @@ func (v ProcessContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessContextSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers6(l, v)
-}
-func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(in *jlexer.Lexer, out *model.TracerMetadata) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		switch key {
-		case "schema_version":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.SchemaVersion = uint8(in.Uint8())
-			}
-		case "runtime_id":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.RuntimeID = string(in.String())
-			}
-		case "tracer_language":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.TracerLanguage = string(in.String())
-			}
-		case "tracer_version":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.TracerVersion = string(in.String())
-			}
-		case "hostname":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.Hostname = string(in.String())
-			}
-		case "service_name":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ServiceName = string(in.String())
-			}
-		case "service_env":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ServiceEnv = string(in.String())
-			}
-		case "service_version":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ServiceVersion = string(in.String())
-			}
-		case "process_tags":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ProcessTags = string(in.String())
-			}
-		case "container_id":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ContainerID = string(in.String())
-			}
-		case "logs_collected":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.LogsCollected = bool(in.Bool())
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(out *jwriter.Writer, in model.TracerMetadata) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"schema_version\":"
-		out.RawString(prefix[1:])
-		out.Uint8(uint8(in.SchemaVersion))
-	}
-	if in.RuntimeID != "" {
-		const prefix string = ",\"runtime_id\":"
-		out.RawString(prefix)
-		out.String(string(in.RuntimeID))
-	}
-	{
-		const prefix string = ",\"tracer_language\":"
-		out.RawString(prefix)
-		out.String(string(in.TracerLanguage))
-	}
-	{
-		const prefix string = ",\"tracer_version\":"
-		out.RawString(prefix)
-		out.String(string(in.TracerVersion))
-	}
-	{
-		const prefix string = ",\"hostname\":"
-		out.RawString(prefix)
-		out.String(string(in.Hostname))
-	}
-	if in.ServiceName != "" {
-		const prefix string = ",\"service_name\":"
-		out.RawString(prefix)
-		out.String(string(in.ServiceName))
-	}
-	if in.ServiceEnv != "" {
-		const prefix string = ",\"service_env\":"
-		out.RawString(prefix)
-		out.String(string(in.ServiceEnv))
-	}
-	if in.ServiceVersion != "" {
-		const prefix string = ",\"service_version\":"
-		out.RawString(prefix)
-		out.String(string(in.ServiceVersion))
-	}
-	if in.ProcessTags != "" {
-		const prefix string = ",\"process_tags\":"
-		out.RawString(prefix)
-		out.String(string(in.ProcessTags))
-	}
-	if in.ContainerID != "" {
-		const prefix string = ",\"container_id\":"
-		out.RawString(prefix)
-		out.String(string(in.ContainerID))
-	}
-	if in.LogsCollected {
-		const prefix string = ",\"logs_collected\":"
-		out.RawString(prefix)
-		out.Bool(bool(in.LogsCollected))
-	}
-	out.RawByte('}')
 }
 func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers7(in *jlexer.Lexer, out *SyscallSerializer) {
 	isTopLevel := in.IsStart()
@@ -1905,21 +1792,21 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(i
 					out.Flows = (out.Flows)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v32 *FlowSerializer
+					var v34 *FlowSerializer
 					if in.IsNull() {
 						in.Skip()
-						v32 = nil
+						v34 = nil
 					} else {
-						if v32 == nil {
-							v32 = new(FlowSerializer)
+						if v34 == nil {
+							v34 = new(FlowSerializer)
 						}
 						if in.IsNull() {
 							in.Skip()
 						} else {
-							(*v32).UnmarshalEasyJSON(in)
+							(*v34).UnmarshalEasyJSON(in)
 						}
 					}
-					out.Flows = append(out.Flows, v32)
+					out.Flows = append(out.Flows, v34)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1954,14 +1841,14 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers9(o
 		}
 		{
 			out.RawByte('[')
-			for v33, v34 := range in.Flows {
-				if v33 > 0 {
+			for v35, v36 := range in.Flows {
+				if v35 > 0 {
 					out.RawByte(',')
 				}
-				if v34 == nil {
+				if v36 == nil {
 					out.RawString("null")
 				} else {
-					(*v34).MarshalEasyJSON(out)
+					(*v36).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -2247,13 +2134,13 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(
 					out.Tags = (out.Tags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v35 string
+					var v37 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v35 = string(in.String())
+						v37 = string(in.String())
 					}
-					out.Tags = append(out.Tags, v35)
+					out.Tags = append(out.Tags, v37)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2310,11 +2197,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers12(
 		}
 		{
 			out.RawByte('[')
-			for v36, v37 := range in.Tags {
-				if v36 > 0 {
+			for v38, v39 := range in.Tags {
+				if v38 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v37))
+				out.String(string(v39))
 			}
 			out.RawByte(']')
 		}
@@ -2849,13 +2736,13 @@ func easyjsonA1e47abeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.MatchedRules = (out.MatchedRules)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v38 MatchedRuleSerializer
+					var v40 MatchedRuleSerializer
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						(v38).UnmarshalEasyJSON(in)
+						(v40).UnmarshalEasyJSON(in)
 					}
-					out.MatchedRules = append(out.MatchedRules, v38)
+					out.MatchedRules = append(out.MatchedRules, v40)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2938,11 +2825,11 @@ func easyjsonA1e47abeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 		}
 		{
 			out.RawByte('[')
-			for v39, v40 := range in.MatchedRules {
-				if v39 > 0 {
+			for v41, v42 := range in.MatchedRules {
+				if v41 > 0 {
 					out.RawByte(',')
 				}
-				(v40).MarshalEasyJSON(out)
+				(v42).MarshalEasyJSON(out)
 			}
 			out.RawByte(']')
 		}

--- a/pkg/security/serializers/serializers_linux.go
+++ b/pkg/security/serializers/serializers_linux.go
@@ -320,6 +320,8 @@ type ProcessSerializer struct {
 	IsThread bool `json:"is_thread,omitempty"`
 	// Indicates whether the process is a kworker
 	IsKworker bool `json:"is_kworker,omitempty"`
+	// Indicates whether the process is a session leader
+	IsSessionLeader bool `json:"is_session_leader,omitempty"`
 	// Indicates whether the process entry is from a new binary execution
 	IsExec bool `json:"is_exec,omitempty"`
 	// Indicates whether the process is an exec following another exec
@@ -972,7 +974,8 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 			Envs:            envs,
 			EnvsTruncated:   envsTruncated,
 			IsThread:        ps.IsThread,
-			IsKworker:       ps.IsKworker,
+			IsKworker:        ps.IsKworker,
+		IsSessionLeader: ps.IsSessionLeader,
 			IsExec:          ps.IsExec,
 			IsExecExec:      ps.IsExecExec,
 			IsParentMissing: ps.IsParentMissing,
@@ -1029,7 +1032,8 @@ func newProcessSerializer(ps *model.Process, e *model.Event) *ProcessSerializer 
 	return &ProcessSerializer{
 		Pid:             ps.Pid,
 		Tid:             ps.Tid,
-		IsKworker:       ps.IsKworker,
+		IsKworker:        ps.IsKworker,
+		IsSessionLeader: ps.IsSessionLeader,
 		IsExec:          ps.IsExec,
 		IsExecExec:      ps.IsExecExec,
 		IsParentMissing: ps.IsParentMissing,

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -7,6 +7,7 @@ package serializers
 
 import (
 	json "encoding/json"
+	model "github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model"
 	utils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
@@ -2494,12 +2495,6 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 			} else {
 				out.IsKworker = bool(in.Bool())
 			}
-		case "is_session_leader":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.IsSessionLeader = bool(in.Bool())
-			}
 		case "is_exec":
 			if in.IsNull() {
 				in.Skip()
@@ -2593,26 +2588,12 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		case "tracer":
 			if in.IsNull() {
 				in.Skip()
+				out.Tracer = nil
 			} else {
-				in.Delim('{')
-				if !in.IsDelim('}') {
-					out.Tracer = make(map[string]string)
-				} else {
-					out.Tracer = nil
+				if out.Tracer == nil {
+					out.Tracer = new(model.TracerMetadata)
 				}
-				for !in.IsDelim('}') {
-					key := string(in.String())
-					in.WantColon()
-					var v18 string
-					if in.IsNull() {
-						in.Skip()
-					} else {
-						v18 = string(in.String())
-					}
-					(out.Tracer)[key] = v18
-					in.WantComma()
-				}
-				in.Delim('}')
+				easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(in, out.Tracer)
 			}
 		case "variables":
 			if in.IsNull() {
@@ -2730,11 +2711,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v19, v20 := range in.CapsAttempted {
-				if v19 > 0 {
+			for v18, v19 := range in.CapsAttempted {
+				if v18 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v20))
+				out.String(string(v19))
 			}
 			out.RawByte(']')
 		}
@@ -2744,11 +2725,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v21, v22 := range in.CapsUsed {
-				if v21 > 0 {
+			for v20, v21 := range in.CapsUsed {
+				if v20 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v22))
+				out.String(string(v21))
 			}
 			out.RawByte(']')
 		}
@@ -2788,11 +2769,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v23, v24 := range in.Args {
-				if v23 > 0 {
+			for v22, v23 := range in.Args {
+				if v22 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v24))
+				out.String(string(v23))
 			}
 			out.RawByte(']')
 		}
@@ -2807,11 +2788,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v25, v26 := range in.Envs {
-				if v25 > 0 {
+			for v24, v25 := range in.Envs {
+				if v24 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v26))
+				out.String(string(v25))
 			}
 			out.RawByte(']')
 		}
@@ -2830,11 +2811,6 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		const prefix string = ",\"is_kworker\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
-	}
-	if in.IsSessionLeader {
-		const prefix string = ",\"is_session_leader\":"
-		out.RawString(prefix)
-		out.Bool(bool(in.IsSessionLeader))
 	}
 	if in.IsExec {
 		const prefix string = ",\"is_exec\":"
@@ -2863,11 +2839,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v27, v28 := range *in.Syscalls {
-				if v27 > 0 {
+			for v26, v27 := range *in.Syscalls {
+				if v26 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v28)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v27)
 			}
 			out.RawByte(']')
 		}
@@ -2877,37 +2853,23 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v29, v30 := range in.AWSSecurityCredentials {
-				if v29 > 0 {
+			for v28, v29 := range in.AWSSecurityCredentials {
+				if v28 > 0 {
 					out.RawByte(',')
 				}
-				if v30 == nil {
+				if v29 == nil {
 					out.RawString("null")
 				} else {
-					(*v30).MarshalEasyJSON(out)
+					(*v29).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
 		}
 	}
-	if len(in.Tracer) != 0 {
+	if in.Tracer != nil {
 		const prefix string = ",\"tracer\":"
 		out.RawString(prefix)
-		{
-			out.RawByte('{')
-			v31First := true
-			for v31Name, v31Value := range in.Tracer {
-				if v31First {
-					v31First = false
-				} else {
-					out.RawByte(',')
-				}
-				out.String(string(v31Name))
-				out.RawByte(':')
-				out.String(string(v31Value))
-			}
-			out.RawByte('}')
-		}
+		easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(out, *in.Tracer)
 	}
 	if len(in.Variables) != 0 {
 		const prefix string = ",\"variables\":"
@@ -2925,6 +2887,157 @@ func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(l, v)
+}
+func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(in *jlexer.Lexer, out *model.TracerMetadata) {
+	isTopLevel := in.IsStart()
+	if in.IsNull() {
+		if isTopLevel {
+			in.Consumed()
+		}
+		in.Skip()
+		return
+	}
+	in.Delim('{')
+	for !in.IsDelim('}') {
+		key := in.UnsafeFieldName(false)
+		in.WantColon()
+		switch key {
+		case "schema_version":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.SchemaVersion = uint8(in.Uint8())
+			}
+		case "runtime_id":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.RuntimeID = string(in.String())
+			}
+		case "tracer_language":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.TracerLanguage = string(in.String())
+			}
+		case "tracer_version":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.TracerVersion = string(in.String())
+			}
+		case "hostname":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.Hostname = string(in.String())
+			}
+		case "service_name":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ServiceName = string(in.String())
+			}
+		case "service_env":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ServiceEnv = string(in.String())
+			}
+		case "service_version":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ServiceVersion = string(in.String())
+			}
+		case "process_tags":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ProcessTags = string(in.String())
+			}
+		case "container_id":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.ContainerID = string(in.String())
+			}
+		case "logs_collected":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.LogsCollected = bool(in.Bool())
+			}
+		default:
+			in.SkipRecursive()
+		}
+		in.WantComma()
+	}
+	in.Delim('}')
+	if isTopLevel {
+		in.Consumed()
+	}
+}
+func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(out *jwriter.Writer, in model.TracerMetadata) {
+	out.RawByte('{')
+	first := true
+	_ = first
+	{
+		const prefix string = ",\"schema_version\":"
+		out.RawString(prefix[1:])
+		out.Uint8(uint8(in.SchemaVersion))
+	}
+	if in.RuntimeID != "" {
+		const prefix string = ",\"runtime_id\":"
+		out.RawString(prefix)
+		out.String(string(in.RuntimeID))
+	}
+	{
+		const prefix string = ",\"tracer_language\":"
+		out.RawString(prefix)
+		out.String(string(in.TracerLanguage))
+	}
+	{
+		const prefix string = ",\"tracer_version\":"
+		out.RawString(prefix)
+		out.String(string(in.TracerVersion))
+	}
+	{
+		const prefix string = ",\"hostname\":"
+		out.RawString(prefix)
+		out.String(string(in.Hostname))
+	}
+	if in.ServiceName != "" {
+		const prefix string = ",\"service_name\":"
+		out.RawString(prefix)
+		out.String(string(in.ServiceName))
+	}
+	if in.ServiceEnv != "" {
+		const prefix string = ",\"service_env\":"
+		out.RawString(prefix)
+		out.String(string(in.ServiceEnv))
+	}
+	if in.ServiceVersion != "" {
+		const prefix string = ",\"service_version\":"
+		out.RawString(prefix)
+		out.String(string(in.ServiceVersion))
+	}
+	if in.ProcessTags != "" {
+		const prefix string = ",\"process_tags\":"
+		out.RawString(prefix)
+		out.String(string(in.ProcessTags))
+	}
+	if in.ContainerID != "" {
+		const prefix string = ",\"container_id\":"
+		out.RawString(prefix)
+		out.String(string(in.ContainerID))
+	}
+	if in.LogsCollected {
+		const prefix string = ",\"logs_collected\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.LogsCollected))
+	}
+	out.RawByte('}')
 }
 func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in *jlexer.Lexer, out *SyscallSerializer) {
 	isTopLevel := in.IsStart()
@@ -3095,13 +3208,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v32 string
+					var v30 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v32 = string(in.String())
+						v30 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v32)
+					out.CapEffective = append(out.CapEffective, v30)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3122,13 +3235,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v33 string
+					var v31 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v33 = string(in.String())
+						v31 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v33)
+					out.CapPermitted = append(out.CapPermitted, v31)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3236,11 +3349,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v34, v35 := range in.CapEffective {
-				if v34 > 0 {
+			for v32, v33 := range in.CapEffective {
+				if v32 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v35))
+				out.String(string(v33))
 			}
 			out.RawByte(']')
 		}
@@ -3252,11 +3365,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v36, v37 := range in.CapPermitted {
-				if v36 > 0 {
+			for v34, v35 := range in.CapPermitted {
+				if v34 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v37))
+				out.String(string(v35))
 			}
 			out.RawByte(']')
 		}
@@ -3760,13 +3873,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 					out.Argv = (out.Argv)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v38 string
+					var v36 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v38 = string(in.String())
+						v36 = string(in.String())
 					}
-					out.Argv = append(out.Argv, v38)
+					out.Argv = append(out.Argv, v36)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3814,11 +3927,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v39, v40 := range in.Argv {
-				if v39 > 0 {
+			for v37, v38 := range in.Argv {
+				if v37 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v40))
+				out.String(string(v38))
 			}
 			out.RawByte(']')
 		}
@@ -4067,13 +4180,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 					out.K8SGroups = (out.K8SGroups)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v41 string
+					var v39 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v41 = string(in.String())
+						v39 = string(in.String())
 					}
-					out.K8SGroups = append(out.K8SGroups, v41)
+					out.K8SGroups = append(out.K8SGroups, v39)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4091,34 +4204,34 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v42 []string
+					var v40 []string
 					if in.IsNull() {
 						in.Skip()
-						v42 = nil
+						v40 = nil
 					} else {
 						in.Delim('[')
-						if v42 == nil {
+						if v40 == nil {
 							if !in.IsDelim(']') {
-								v42 = make([]string, 0, 4)
+								v40 = make([]string, 0, 4)
 							} else {
-								v42 = []string{}
+								v40 = []string{}
 							}
 						} else {
-							v42 = (v42)[:0]
+							v40 = (v40)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v43 string
+							var v41 string
 							if in.IsNull() {
 								in.Skip()
 							} else {
-								v43 = string(in.String())
+								v41 = string(in.String())
 							}
-							v42 = append(v42, v43)
+							v40 = append(v40, v41)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.K8SExtra)[key] = v42
+					(out.K8SExtra)[key] = v40
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -4173,11 +4286,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		}
 		{
 			out.RawByte('[')
-			for v44, v45 := range in.K8SGroups {
-				if v44 > 0 {
+			for v42, v43 := range in.K8SGroups {
+				if v42 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v45))
+				out.String(string(v43))
 			}
 			out.RawByte(']')
 		}
@@ -4192,24 +4305,24 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		}
 		{
 			out.RawByte('{')
-			v46First := true
-			for v46Name, v46Value := range in.K8SExtra {
-				if v46First {
-					v46First = false
+			v44First := true
+			for v44Name, v44Value := range in.K8SExtra {
+				if v44First {
+					v44First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v46Name))
+				out.String(string(v44Name))
 				out.RawByte(':')
-				if v46Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v44Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v47, v48 := range v46Value {
-						if v47 > 0 {
+					for v45, v46 := range v44Value {
+						if v45 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v48))
+						out.String(string(v46))
 					}
 					out.RawByte(']')
 				}
@@ -4381,13 +4494,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v49 string
+					var v47 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v49 = string(in.String())
+						v47 = string(in.String())
 					}
-					out.Flags = append(out.Flags, v49)
+					out.Flags = append(out.Flags, v47)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4498,13 +4611,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 					out.Hashes = (out.Hashes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v50 string
+					var v48 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v50 = string(in.String())
+						v48 = string(in.String())
 					}
-					out.Hashes = append(out.Hashes, v50)
+					out.Hashes = append(out.Hashes, v48)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4715,11 +4828,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v51, v52 := range in.Flags {
-				if v51 > 0 {
+			for v49, v50 := range in.Flags {
+				if v49 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v52))
+				out.String(string(v50))
 			}
 			out.RawByte(']')
 		}
@@ -4779,11 +4892,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v53, v54 := range in.Hashes {
-				if v53 > 0 {
+			for v51, v52 := range in.Hashes {
+				if v51 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v54))
+				out.String(string(v52))
 			}
 			out.RawByte(']')
 		}
@@ -5183,13 +5296,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v55 string
+					var v53 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v55 = string(in.String())
+						v53 = string(in.String())
 					}
-					out.Flags = append(out.Flags, v55)
+					out.Flags = append(out.Flags, v53)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5300,13 +5413,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.Hashes = (out.Hashes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v56 string
+					var v54 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v56 = string(in.String())
+						v54 = string(in.String())
 					}
-					out.Hashes = append(out.Hashes, v56)
+					out.Hashes = append(out.Hashes, v54)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5557,11 +5670,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v57, v58 := range in.Flags {
-				if v57 > 0 {
+			for v55, v56 := range in.Flags {
+				if v55 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v58))
+				out.String(string(v56))
 			}
 			out.RawByte(']')
 		}
@@ -5621,11 +5734,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v59, v60 := range in.Hashes {
-				if v59 > 0 {
+			for v57, v58 := range in.Hashes {
+				if v57 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v60))
+				out.String(string(v58))
 			}
 			out.RawByte(']')
 		}
@@ -6002,9 +6115,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 						*out.SyscallsEventSerializer = (*out.SyscallsEventSerializer)[:0]
 					}
 					for !in.IsDelim(']') {
-						var v61 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in, &v61)
-						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v61)
+						var v59 SyscallSerializer
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in, &v59)
+						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v59)
 						in.WantComma()
 					}
 					in.Delim(']')
@@ -6432,11 +6545,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v62, v63 := range *in.SyscallsEventSerializer {
-				if v62 > 0 {
+			for v60, v61 := range *in.SyscallsEventSerializer {
+				if v60 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v63)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v61)
 			}
 			out.RawByte(']')
 		}
@@ -6789,13 +6902,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v64 string
+					var v62 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v64 = string(in.String())
+						v62 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v64)
+					out.CapEffective = append(out.CapEffective, v62)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -6816,13 +6929,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v65 string
+					var v63 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v65 = string(in.String())
+						v63 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v65)
+					out.CapPermitted = append(out.CapPermitted, v63)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -6913,11 +7026,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v66, v67 := range in.CapEffective {
-				if v66 > 0 {
+			for v64, v65 := range in.CapEffective {
+				if v64 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v67))
+				out.String(string(v65))
 			}
 			out.RawByte(']')
 		}
@@ -6929,11 +7042,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v68, v69 := range in.CapPermitted {
-				if v68 > 0 {
+			for v66, v67 := range in.CapPermitted {
+				if v66 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v69))
+				out.String(string(v67))
 			}
 			out.RawByte(']')
 		}
@@ -6986,13 +7099,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 					out.Hostnames = (out.Hostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v70 string
+					var v68 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v70 = string(in.String())
+						v68 = string(in.String())
 					}
-					out.Hostnames = append(out.Hostnames, v70)
+					out.Hostnames = append(out.Hostnames, v68)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7029,11 +7142,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v71, v72 := range in.Hostnames {
-				if v71 > 0 {
+			for v69, v70 := range in.Hostnames {
+				if v69 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v72))
+				out.String(string(v70))
 			}
 			out.RawByte(']')
 		}
@@ -7085,13 +7198,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v73 string
+					var v71 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v73 = string(in.String())
+						v71 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v73)
+					out.CapEffective = append(out.CapEffective, v71)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7112,13 +7225,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v74 string
+					var v72 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v74 = string(in.String())
+						v72 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v74)
+					out.CapPermitted = append(out.CapPermitted, v72)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7144,11 +7257,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v75, v76 := range in.CapEffective {
-				if v75 > 0 {
+			for v73, v74 := range in.CapEffective {
+				if v73 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v76))
+				out.String(string(v74))
 			}
 			out.RawByte(']')
 		}
@@ -7160,11 +7273,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v77, v78 := range in.CapPermitted {
-				if v77 > 0 {
+			for v75, v76 := range in.CapPermitted {
+				if v75 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v78))
+				out.String(string(v76))
 			}
 			out.RawByte(']')
 		}
@@ -7211,13 +7324,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 					out.CapsAttempted = (out.CapsAttempted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v79 string
+					var v77 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v79 = string(in.String())
+						v77 = string(in.String())
 					}
-					out.CapsAttempted = append(out.CapsAttempted, v79)
+					out.CapsAttempted = append(out.CapsAttempted, v77)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7238,13 +7351,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 					out.CapsUsed = (out.CapsUsed)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v80 string
+					var v78 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v80 = string(in.String())
+						v78 = string(in.String())
 					}
-					out.CapsUsed = append(out.CapsUsed, v80)
+					out.CapsUsed = append(out.CapsUsed, v78)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7269,11 +7382,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v81, v82 := range in.CapsAttempted {
-				if v81 > 0 {
+			for v79, v80 := range in.CapsAttempted {
+				if v79 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v82))
+				out.String(string(v80))
 			}
 			out.RawByte(']')
 		}
@@ -7288,11 +7401,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		}
 		{
 			out.RawByte('[')
-			for v83, v84 := range in.CapsUsed {
-				if v83 > 0 {
+			for v81, v82 := range in.CapsUsed {
+				if v81 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v84))
+				out.String(string(v82))
 			}
 			out.RawByte(']')
 		}
@@ -7501,13 +7614,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 					out.Helpers = (out.Helpers)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v85 string
+					var v83 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v85 = string(in.String())
+						v83 = string(in.String())
 					}
-					out.Helpers = append(out.Helpers, v85)
+					out.Helpers = append(out.Helpers, v83)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7572,11 +7685,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 		}
 		{
 			out.RawByte('[')
-			for v86, v87 := range in.Helpers {
-				if v86 > 0 {
+			for v84, v85 := range in.Helpers {
+				if v84 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v87))
+				out.String(string(v85))
 			}
 			out.RawByte(']')
 		}
@@ -7837,13 +7950,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(
 					out.Hostnames = (out.Hostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v88 string
+					var v86 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v88 = string(in.String())
+						v86 = string(in.String())
 					}
-					out.Hostnames = append(out.Hostnames, v88)
+					out.Hostnames = append(out.Hostnames, v86)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7874,11 +7987,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v89, v90 := range in.Hostnames {
-				if v89 > 0 {
+			for v87, v88 := range in.Hostnames {
+				if v87 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v90))
+				out.String(string(v88))
 			}
 			out.RawByte(']')
 		}

--- a/pkg/security/serializers/serializers_linux_easyjson.go
+++ b/pkg/security/serializers/serializers_linux_easyjson.go
@@ -7,7 +7,6 @@ package serializers
 
 import (
 	json "encoding/json"
-	model "github.com/DataDog/datadog-agent/pkg/discovery/tracermetadata/model"
 	utils "github.com/DataDog/datadog-agent/pkg/security/utils"
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
@@ -2495,6 +2494,12 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 			} else {
 				out.IsKworker = bool(in.Bool())
 			}
+		case "is_session_leader":
+			if in.IsNull() {
+				in.Skip()
+			} else {
+				out.IsSessionLeader = bool(in.Bool())
+			}
 		case "is_exec":
 			if in.IsNull() {
 				in.Skip()
@@ -2588,12 +2593,26 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		case "tracer":
 			if in.IsNull() {
 				in.Skip()
-				out.Tracer = nil
 			} else {
-				if out.Tracer == nil {
-					out.Tracer = new(model.TracerMetadata)
+				in.Delim('{')
+				if !in.IsDelim('}') {
+					out.Tracer = make(map[string]string)
+				} else {
+					out.Tracer = nil
 				}
-				easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(in, out.Tracer)
+				for !in.IsDelim('}') {
+					key := string(in.String())
+					in.WantColon()
+					var v18 string
+					if in.IsNull() {
+						in.Skip()
+					} else {
+						v18 = string(in.String())
+					}
+					(out.Tracer)[key] = v18
+					in.WantComma()
+				}
+				in.Delim('}')
 			}
 		case "variables":
 			if in.IsNull() {
@@ -2711,11 +2730,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v18, v19 := range in.CapsAttempted {
-				if v18 > 0 {
+			for v19, v20 := range in.CapsAttempted {
+				if v19 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v19))
+				out.String(string(v20))
 			}
 			out.RawByte(']')
 		}
@@ -2725,11 +2744,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v20, v21 := range in.CapsUsed {
-				if v20 > 0 {
+			for v21, v22 := range in.CapsUsed {
+				if v21 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v21))
+				out.String(string(v22))
 			}
 			out.RawByte(']')
 		}
@@ -2769,11 +2788,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v22, v23 := range in.Args {
-				if v22 > 0 {
+			for v23, v24 := range in.Args {
+				if v23 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v23))
+				out.String(string(v24))
 			}
 			out.RawByte(']')
 		}
@@ -2788,11 +2807,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v24, v25 := range in.Envs {
-				if v24 > 0 {
+			for v25, v26 := range in.Envs {
+				if v25 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v25))
+				out.String(string(v26))
 			}
 			out.RawByte(']')
 		}
@@ -2811,6 +2830,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		const prefix string = ",\"is_kworker\":"
 		out.RawString(prefix)
 		out.Bool(bool(in.IsKworker))
+	}
+	if in.IsSessionLeader {
+		const prefix string = ",\"is_session_leader\":"
+		out.RawString(prefix)
+		out.Bool(bool(in.IsSessionLeader))
 	}
 	if in.IsExec {
 		const prefix string = ",\"is_exec\":"
@@ -2839,11 +2863,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v26, v27 := range *in.Syscalls {
-				if v26 > 0 {
+			for v27, v28 := range *in.Syscalls {
+				if v27 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v27)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v28)
 			}
 			out.RawByte(']')
 		}
@@ -2853,23 +2877,37 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v28, v29 := range in.AWSSecurityCredentials {
-				if v28 > 0 {
+			for v29, v30 := range in.AWSSecurityCredentials {
+				if v29 > 0 {
 					out.RawByte(',')
 				}
-				if v29 == nil {
+				if v30 == nil {
 					out.RawString("null")
 				} else {
-					(*v29).MarshalEasyJSON(out)
+					(*v30).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
 		}
 	}
-	if in.Tracer != nil {
+	if len(in.Tracer) != 0 {
 		const prefix string = ",\"tracer\":"
 		out.RawString(prefix)
-		easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(out, *in.Tracer)
+		{
+			out.RawByte('{')
+			v31First := true
+			for v31Name, v31Value := range in.Tracer {
+				if v31First {
+					v31First = false
+				} else {
+					out.RawByte(',')
+				}
+				out.String(string(v31Name))
+				out.RawByte(':')
+				out.String(string(v31Value))
+			}
+			out.RawByte('}')
+		}
 	}
 	if len(in.Variables) != 0 {
 		const prefix string = ",\"variables\":"
@@ -2887,157 +2925,6 @@ func (v ProcessSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *ProcessSerializer) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers16(l, v)
-}
-func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(in *jlexer.Lexer, out *model.TracerMetadata) {
-	isTopLevel := in.IsStart()
-	if in.IsNull() {
-		if isTopLevel {
-			in.Consumed()
-		}
-		in.Skip()
-		return
-	}
-	in.Delim('{')
-	for !in.IsDelim('}') {
-		key := in.UnsafeFieldName(false)
-		in.WantColon()
-		switch key {
-		case "schema_version":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.SchemaVersion = uint8(in.Uint8())
-			}
-		case "runtime_id":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.RuntimeID = string(in.String())
-			}
-		case "tracer_language":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.TracerLanguage = string(in.String())
-			}
-		case "tracer_version":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.TracerVersion = string(in.String())
-			}
-		case "hostname":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.Hostname = string(in.String())
-			}
-		case "service_name":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ServiceName = string(in.String())
-			}
-		case "service_env":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ServiceEnv = string(in.String())
-			}
-		case "service_version":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ServiceVersion = string(in.String())
-			}
-		case "process_tags":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ProcessTags = string(in.String())
-			}
-		case "container_id":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.ContainerID = string(in.String())
-			}
-		case "logs_collected":
-			if in.IsNull() {
-				in.Skip()
-			} else {
-				out.LogsCollected = bool(in.Bool())
-			}
-		default:
-			in.SkipRecursive()
-		}
-		in.WantComma()
-	}
-	in.Delim('}')
-	if isTopLevel {
-		in.Consumed()
-	}
-}
-func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgDiscoveryTracermetadataModel(out *jwriter.Writer, in model.TracerMetadata) {
-	out.RawByte('{')
-	first := true
-	_ = first
-	{
-		const prefix string = ",\"schema_version\":"
-		out.RawString(prefix[1:])
-		out.Uint8(uint8(in.SchemaVersion))
-	}
-	if in.RuntimeID != "" {
-		const prefix string = ",\"runtime_id\":"
-		out.RawString(prefix)
-		out.String(string(in.RuntimeID))
-	}
-	{
-		const prefix string = ",\"tracer_language\":"
-		out.RawString(prefix)
-		out.String(string(in.TracerLanguage))
-	}
-	{
-		const prefix string = ",\"tracer_version\":"
-		out.RawString(prefix)
-		out.String(string(in.TracerVersion))
-	}
-	{
-		const prefix string = ",\"hostname\":"
-		out.RawString(prefix)
-		out.String(string(in.Hostname))
-	}
-	if in.ServiceName != "" {
-		const prefix string = ",\"service_name\":"
-		out.RawString(prefix)
-		out.String(string(in.ServiceName))
-	}
-	if in.ServiceEnv != "" {
-		const prefix string = ",\"service_env\":"
-		out.RawString(prefix)
-		out.String(string(in.ServiceEnv))
-	}
-	if in.ServiceVersion != "" {
-		const prefix string = ",\"service_version\":"
-		out.RawString(prefix)
-		out.String(string(in.ServiceVersion))
-	}
-	if in.ProcessTags != "" {
-		const prefix string = ",\"process_tags\":"
-		out.RawString(prefix)
-		out.String(string(in.ProcessTags))
-	}
-	if in.ContainerID != "" {
-		const prefix string = ",\"container_id\":"
-		out.RawString(prefix)
-		out.String(string(in.ContainerID))
-	}
-	if in.LogsCollected {
-		const prefix string = ",\"logs_collected\":"
-		out.RawString(prefix)
-		out.Bool(bool(in.LogsCollected))
-	}
-	out.RawByte('}')
 }
 func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in *jlexer.Lexer, out *SyscallSerializer) {
 	isTopLevel := in.IsStart()
@@ -3208,13 +3095,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v30 string
+					var v32 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v30 = string(in.String())
+						v32 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v30)
+					out.CapEffective = append(out.CapEffective, v32)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3235,13 +3122,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v31 string
+					var v33 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v31 = string(in.String())
+						v33 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v31)
+					out.CapPermitted = append(out.CapPermitted, v33)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3349,11 +3236,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v32, v33 := range in.CapEffective {
-				if v32 > 0 {
+			for v34, v35 := range in.CapEffective {
+				if v34 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v33))
+				out.String(string(v35))
 			}
 			out.RawByte(']')
 		}
@@ -3365,11 +3252,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers18(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v34, v35 := range in.CapPermitted {
-				if v34 > 0 {
+			for v36, v37 := range in.CapPermitted {
+				if v36 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v35))
+				out.String(string(v37))
 			}
 			out.RawByte(']')
 		}
@@ -3873,13 +3760,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 					out.Argv = (out.Argv)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v36 string
+					var v38 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v36 = string(in.String())
+						v38 = string(in.String())
 					}
-					out.Argv = append(out.Argv, v36)
+					out.Argv = append(out.Argv, v38)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3927,11 +3814,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers23(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v37, v38 := range in.Argv {
-				if v37 > 0 {
+			for v39, v40 := range in.Argv {
+				if v39 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v38))
+				out.String(string(v40))
 			}
 			out.RawByte(']')
 		}
@@ -4180,13 +4067,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 					out.K8SGroups = (out.K8SGroups)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v39 string
+					var v41 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v39 = string(in.String())
+						v41 = string(in.String())
 					}
-					out.K8SGroups = append(out.K8SGroups, v39)
+					out.K8SGroups = append(out.K8SGroups, v41)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4204,34 +4091,34 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 				for !in.IsDelim('}') {
 					key := string(in.String())
 					in.WantColon()
-					var v40 []string
+					var v42 []string
 					if in.IsNull() {
 						in.Skip()
-						v40 = nil
+						v42 = nil
 					} else {
 						in.Delim('[')
-						if v40 == nil {
+						if v42 == nil {
 							if !in.IsDelim(']') {
-								v40 = make([]string, 0, 4)
+								v42 = make([]string, 0, 4)
 							} else {
-								v40 = []string{}
+								v42 = []string{}
 							}
 						} else {
-							v40 = (v40)[:0]
+							v42 = (v42)[:0]
 						}
 						for !in.IsDelim(']') {
-							var v41 string
+							var v43 string
 							if in.IsNull() {
 								in.Skip()
 							} else {
-								v41 = string(in.String())
+								v43 = string(in.String())
 							}
-							v40 = append(v40, v41)
+							v42 = append(v42, v43)
 							in.WantComma()
 						}
 						in.Delim(']')
 					}
-					(out.K8SExtra)[key] = v40
+					(out.K8SExtra)[key] = v42
 					in.WantComma()
 				}
 				in.Delim('}')
@@ -4286,11 +4173,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		}
 		{
 			out.RawByte('[')
-			for v42, v43 := range in.K8SGroups {
-				if v42 > 0 {
+			for v44, v45 := range in.K8SGroups {
+				if v44 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v43))
+				out.String(string(v45))
 			}
 			out.RawByte(']')
 		}
@@ -4305,24 +4192,24 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers26(
 		}
 		{
 			out.RawByte('{')
-			v44First := true
-			for v44Name, v44Value := range in.K8SExtra {
-				if v44First {
-					v44First = false
+			v46First := true
+			for v46Name, v46Value := range in.K8SExtra {
+				if v46First {
+					v46First = false
 				} else {
 					out.RawByte(',')
 				}
-				out.String(string(v44Name))
+				out.String(string(v46Name))
 				out.RawByte(':')
-				if v44Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+				if v46Value == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
 					out.RawString("null")
 				} else {
 					out.RawByte('[')
-					for v45, v46 := range v44Value {
-						if v45 > 0 {
+					for v47, v48 := range v46Value {
+						if v47 > 0 {
 							out.RawByte(',')
 						}
-						out.String(string(v46))
+						out.String(string(v48))
 					}
 					out.RawByte(']')
 				}
@@ -4494,13 +4381,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v47 string
+					var v49 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v47 = string(in.String())
+						v49 = string(in.String())
 					}
-					out.Flags = append(out.Flags, v47)
+					out.Flags = append(out.Flags, v49)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4611,13 +4498,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 					out.Hashes = (out.Hashes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v48 string
+					var v50 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v48 = string(in.String())
+						v50 = string(in.String())
 					}
-					out.Hashes = append(out.Hashes, v48)
+					out.Hashes = append(out.Hashes, v50)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -4828,11 +4715,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v49, v50 := range in.Flags {
-				if v49 > 0 {
+			for v51, v52 := range in.Flags {
+				if v51 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v50))
+				out.String(string(v52))
 			}
 			out.RawByte(']')
 		}
@@ -4892,11 +4779,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers27(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v51, v52 := range in.Hashes {
-				if v51 > 0 {
+			for v53, v54 := range in.Hashes {
+				if v53 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v52))
+				out.String(string(v54))
 			}
 			out.RawByte(']')
 		}
@@ -5296,13 +5183,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v53 string
+					var v55 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v53 = string(in.String())
+						v55 = string(in.String())
 					}
-					out.Flags = append(out.Flags, v53)
+					out.Flags = append(out.Flags, v55)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5413,13 +5300,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 					out.Hashes = (out.Hashes)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v54 string
+					var v56 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v54 = string(in.String())
+						v56 = string(in.String())
 					}
-					out.Hashes = append(out.Hashes, v54)
+					out.Hashes = append(out.Hashes, v56)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -5670,11 +5557,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v55, v56 := range in.Flags {
-				if v55 > 0 {
+			for v57, v58 := range in.Flags {
+				if v57 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v56))
+				out.String(string(v58))
 			}
 			out.RawByte(']')
 		}
@@ -5734,11 +5621,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers29(
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v57, v58 := range in.Hashes {
-				if v57 > 0 {
+			for v59, v60 := range in.Hashes {
+				if v59 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v58))
+				out.String(string(v60))
 			}
 			out.RawByte(']')
 		}
@@ -6115,9 +6002,9 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 						*out.SyscallsEventSerializer = (*out.SyscallsEventSerializer)[:0]
 					}
 					for !in.IsDelim(']') {
-						var v59 SyscallSerializer
-						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in, &v59)
-						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v59)
+						var v61 SyscallSerializer
+						easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(in, &v61)
+						*out.SyscallsEventSerializer = append(*out.SyscallsEventSerializer, v61)
 						in.WantComma()
 					}
 					in.Delim(']')
@@ -6545,11 +6432,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers30(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v60, v61 := range *in.SyscallsEventSerializer {
-				if v60 > 0 {
+			for v62, v63 := range *in.SyscallsEventSerializer {
+				if v62 > 0 {
 					out.RawByte(',')
 				}
-				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v61)
+				easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers17(out, v63)
 			}
 			out.RawByte(']')
 		}
@@ -6902,13 +6789,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v62 string
+					var v64 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v62 = string(in.String())
+						v64 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v62)
+					out.CapEffective = append(out.CapEffective, v64)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -6929,13 +6816,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v63 string
+					var v65 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v63 = string(in.String())
+						v65 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v63)
+					out.CapPermitted = append(out.CapPermitted, v65)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7026,11 +6913,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v64, v65 := range in.CapEffective {
-				if v64 > 0 {
+			for v66, v67 := range in.CapEffective {
+				if v66 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v65))
+				out.String(string(v67))
 			}
 			out.RawByte(']')
 		}
@@ -7042,11 +6929,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers32(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v66, v67 := range in.CapPermitted {
-				if v66 > 0 {
+			for v68, v69 := range in.CapPermitted {
+				if v68 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v67))
+				out.String(string(v69))
 			}
 			out.RawByte(']')
 		}
@@ -7099,13 +6986,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 					out.Hostnames = (out.Hostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v68 string
+					var v70 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v68 = string(in.String())
+						v70 = string(in.String())
 					}
-					out.Hostnames = append(out.Hostnames, v68)
+					out.Hostnames = append(out.Hostnames, v70)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7142,11 +7029,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers33(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v69, v70 := range in.Hostnames {
-				if v69 > 0 {
+			for v71, v72 := range in.Hostnames {
+				if v71 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v70))
+				out.String(string(v72))
 			}
 			out.RawByte(']')
 		}
@@ -7198,13 +7085,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v71 string
+					var v73 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v71 = string(in.String())
+						v73 = string(in.String())
 					}
-					out.CapEffective = append(out.CapEffective, v71)
+					out.CapEffective = append(out.CapEffective, v73)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7225,13 +7112,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v72 string
+					var v74 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v72 = string(in.String())
+						v74 = string(in.String())
 					}
-					out.CapPermitted = append(out.CapPermitted, v72)
+					out.CapPermitted = append(out.CapPermitted, v74)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7257,11 +7144,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v73, v74 := range in.CapEffective {
-				if v73 > 0 {
+			for v75, v76 := range in.CapEffective {
+				if v75 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v74))
+				out.String(string(v76))
 			}
 			out.RawByte(']')
 		}
@@ -7273,11 +7160,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers34(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v75, v76 := range in.CapPermitted {
-				if v75 > 0 {
+			for v77, v78 := range in.CapPermitted {
+				if v77 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v76))
+				out.String(string(v78))
 			}
 			out.RawByte(']')
 		}
@@ -7324,13 +7211,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 					out.CapsAttempted = (out.CapsAttempted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v77 string
+					var v79 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v77 = string(in.String())
+						v79 = string(in.String())
 					}
-					out.CapsAttempted = append(out.CapsAttempted, v77)
+					out.CapsAttempted = append(out.CapsAttempted, v79)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7351,13 +7238,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 					out.CapsUsed = (out.CapsUsed)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v78 string
+					var v80 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v78 = string(in.String())
+						v80 = string(in.String())
 					}
-					out.CapsUsed = append(out.CapsUsed, v78)
+					out.CapsUsed = append(out.CapsUsed, v80)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7382,11 +7269,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		out.RawString(prefix[1:])
 		{
 			out.RawByte('[')
-			for v79, v80 := range in.CapsAttempted {
-				if v79 > 0 {
+			for v81, v82 := range in.CapsAttempted {
+				if v81 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v80))
+				out.String(string(v82))
 			}
 			out.RawByte(']')
 		}
@@ -7401,11 +7288,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers35(
 		}
 		{
 			out.RawByte('[')
-			for v81, v82 := range in.CapsUsed {
-				if v81 > 0 {
+			for v83, v84 := range in.CapsUsed {
+				if v83 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v82))
+				out.String(string(v84))
 			}
 			out.RawByte(']')
 		}
@@ -7614,13 +7501,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 					out.Helpers = (out.Helpers)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v83 string
+					var v85 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v83 = string(in.String())
+						v85 = string(in.String())
 					}
-					out.Helpers = append(out.Helpers, v83)
+					out.Helpers = append(out.Helpers, v85)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7685,11 +7572,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers38(
 		}
 		{
 			out.RawByte('[')
-			for v84, v85 := range in.Helpers {
-				if v84 > 0 {
+			for v86, v87 := range in.Helpers {
+				if v86 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v85))
+				out.String(string(v87))
 			}
 			out.RawByte(']')
 		}
@@ -7950,13 +7837,13 @@ func easyjsonDdc0fdbeDecodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(
 					out.Hostnames = (out.Hostnames)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v86 string
+					var v88 string
 					if in.IsNull() {
 						in.Skip()
 					} else {
-						v86 = string(in.String())
+						v88 = string(in.String())
 					}
-					out.Hostnames = append(out.Hostnames, v86)
+					out.Hostnames = append(out.Hostnames, v88)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -7987,11 +7874,11 @@ func easyjsonDdc0fdbeEncodeGithubComDataDogDatadogAgentPkgSecuritySerializers42(
 			out.RawString("null")
 		} else {
 			out.RawByte('[')
-			for v87, v88 := range in.Hostnames {
-				if v87 > 0 {
+			for v89, v90 := range in.Hostnames {
+				if v89 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v88))
+				out.String(string(v90))
 			}
 			out.RawByte(']')
 		}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1778,6 +1778,57 @@ func TestProcessIsThread(t *testing.T) {
 	})
 }
 
+func TestProcessIsSessionLeader(t *testing.T) {
+	SkipIfNotAvailable(t)
+
+	if ebpfLessEnabled {
+		t.Skip("is_session_leader not supported in ebpfless mode")
+	}
+
+	setsidPath := which(t, "setsid")
+	sleepPath := which(t, "sleep")
+	shPath := which(t, "sh")
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_session_leader",
+			Expression: fmt.Sprintf(`exec.file.path == "%s" && process.is_session_leader`, shPath),
+		},
+		{
+			ID:         "test_not_session_leader",
+			Expression: fmt.Sprintf(`exec.file.path == "%s" && !process.is_session_leader`, sleepPath),
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("session-leader", func(t *testing.T) {
+		test.WaitSignalFromRule(t, func() error {
+			// setsid creates a new session, making the child process a session leader
+			cmd := exec.Command(setsidPath, shPath, "-c", "true")
+			return cmd.Run()
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_session_leader")
+			assert.True(t, event.ProcessContext.IsSessionLeader, "process should be a session leader")
+		}, "test_session_leader")
+	})
+
+	t.Run("not-session-leader", func(t *testing.T) {
+		test.WaitSignalFromRule(t, func() error {
+			// A regular child process is NOT a session leader
+			cmd := exec.Command(sleepPath, "0")
+			return cmd.Run()
+		}, func(event *model.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_not_session_leader")
+			assert.False(t, event.ProcessContext.IsSessionLeader, "process should not be a session leader")
+		}, "test_not_session_leader")
+	})
+}
+
 func TestProcessExit(t *testing.T) {
 	SkipIfNotAvailable(t)
 


### PR DESCRIPTION
Add a new boolean field `is_session_leader` to CWS process events that indicates whether a process is a session leader (PID == SID).

The session ID is read from the kernel via:
 ```
task->signal->pids[PIDTYPE_SID]->numbers[0].nr
```

and compared against the process tgid. Two new kernel offset constants are introduced (task_struct_signal_offset, signal_struct_pids_offset) resolved via BTF at runtime.

The field is exposed in SECL as process.is_session_leader and propagates to all process-related event types (exec, exit, signal, ptrace, etc.).

Example of condition where this could be useful: spawning of a session leader shell from a not known binary (e.g. a shell given by the `shell` command of a sliver C2 implant
```
exec.file.name in ["sh", "bash", "zsh", "dash"] &&
  process.is_session_leader &&
  process.parent.file.name not in ["sshd", "login", "systemd", "init", "su", "sudo", "cron", "tmux: server", "screen", "agetty"]
  ```

