### PR TITLE
[CWS] Track cgroup v2 creation and deletion via eBPF events

### DIFF
--- a/pkg/security/ebpf/c/include/constants/enums.h
+++ b/pkg/security/ebpf/c/include/constants/enums.h
@@ -130,6 +130,7 @@ enum SYSCALL_STATE
     APPROVED,        // approved but can be discarded later
     DISCARDED,       // discarded
     SAMPLED,         // sampled
+    INTERNAL,        // internal event
 };
 
 enum MONITOR_KEYS

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -797,7 +797,11 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
             if ((fork_entry->fork_flags & CLONE_INTO_CGROUP) == 0) {
                 fill_cgroup_context(parent_pc, &pc.cgroup);
             } else {
-                pc.cgroup.cgroup_file.ino = bpf_get_current_cgroup_id();
+                u64 has_current_cgroup_id_helper = 0;
+                LOAD_CONSTANT("has_current_cgroup_id_helper", has_current_cgroup_id_helper);
+                if (has_current_cgroup_id_helper) {
+                    pc.cgroup.cgroup_file.ino = bpf_get_current_cgroup_id();
+                }
             }
         }
     }

--- a/pkg/security/ebpf/c/include/hooks/exec.h
+++ b/pkg/security/ebpf/c/include/hooks/exec.h
@@ -794,8 +794,10 @@ int __attribute__((always_inline)) send_exec_event(ctx_t *ctx) {
             parent_inode = parent_pc->entry.executable.path_key.ino;
 
             // inherit the parent cgroup context
-            if ((fork_entry->fork_flags & (CLONE_INTO_CGROUP | CLONE_NEWCGROUP)) == 0) {
+            if ((fork_entry->fork_flags & CLONE_INTO_CGROUP) == 0) {
                 fill_cgroup_context(parent_pc, &pc.cgroup);
+            } else {
+                pc.cgroup.cgroup_file.ino = bpf_get_current_cgroup_id();
             }
         }
     }

--- a/pkg/security/ebpf/c/include/hooks/open.h
+++ b/pkg/security/ebpf/c/include/hooks/open.h
@@ -101,9 +101,14 @@ int __attribute__((always_inline)) handle_open(ctx_t *ctx, struct path *path) {
     // do not pop, we want to keep track of the mount ref counter later in the stack
     approve_syscall(syscall, open_approvers);
 
+    if (is_cgroup2fs(syscall->open.dentry) && syscall->state != ACCEPTED) {
+        // do not discard INTERNAL events as we need to resolve the mode later in the call path
+        syscall->state = INTERNAL;
+    }
+
     syscall->resolver.key = syscall->open.file.path_key;
     syscall->resolver.dentry = syscall->open.dentry;
-    syscall->resolver.discarder_event_type = dentry_resolver_discarder_event_type(syscall);
+    syscall->resolver.discarder_event_type = syscall->state != INTERNAL ? dentry_resolver_discarder_event_type(syscall) : 0;
     syscall->resolver.iteration = 0;
     syscall->resolver.ret = 0;
 
@@ -245,6 +250,11 @@ int __attribute__((always_inline)) _sys_open_ret(void *ctx, struct syscall_cache
     };
 
     fill_file(syscall->open.dentry, &event.file);
+
+    // cgroup internal event, allow only dir event
+    if (syscall->state == INTERNAL && !S_ISDIR(event.file.metadata.mode)) {
+        return 0;
+    }
 
     struct proc_cache_t *entry;
     if (syscall->open.pid_tgid != 0) {

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -63,6 +63,12 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
         syscall->rmdir.dentry = dentry;
         syscall->policy = fetch_policy(EVENT_RMDIR);
 
+        // let the cgroup event being forwarded as it is used userspace side to track the cgroups
+        if (is_cgroup2fs(syscall->rmdir.dentry) && S_ISDIR(syscall->rmdir.file.metadata.mode)) {
+            syscall->state = ACCEPTED;
+            break;
+        }
+
         if (approve_syscall(syscall, rmdir_approvers) == DISCARDED) {
             // do not pop, we want to invalidate the inode even if the syscall is discarded
             return 0;
@@ -86,6 +92,12 @@ int hook_security_inode_rmdir(ctx_t *ctx) {
 
         // fake rmdir event as we will generate and rmdir event at the end
         syscall->policy = fetch_policy(EVENT_RMDIR);
+
+        // let the cgroup event being forwarded as it is used userspace side to track the cgroups
+        if (is_cgroup2fs(syscall->unlink.dentry) && S_ISDIR(syscall->unlink.file.metadata.mode)) {
+            syscall->state = ACCEPTED;
+            break;
+        }
 
         if (approve_syscall(syscall, rmdir_approvers) == DISCARDED) {
             // do not pop, we want to invalidate the inode even if the syscall is discarded

--- a/pkg/security/ebpf/c/include/hooks/rmdir.h
+++ b/pkg/security/ebpf/c/include/hooks/rmdir.h
@@ -149,7 +149,7 @@ int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
         return 0;
     }
 
-    if (syscall->state != DISCARDED && is_event_enabled(EVENT_RMDIR)) {
+    if (syscall->state != DISCARDED) {
         struct rmdir_event_t event = {
             .syscall.retval = retval,
             .syscall_ctx.id = syscall->ctx_id,

--- a/pkg/security/ebpf/kernel/kernel_bpf.go
+++ b/pkg/security/ebpf/kernel/kernel_bpf.go
@@ -187,6 +187,12 @@ func (k *Version) HasBpfGetCurrentCgroupIDForSchedCLS() bool {
 	return features.HaveProgramHelper(ebpf.SchedCLS, asm.FnGetCurrentCgroupId) == nil
 }
 
+// HasBpfGetCurrentCgroupID returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
+// Kernel version >= 4.18
+func (k *Version) HasBpfGetCurrentCgroupID() bool {
+	return features.HaveProgramHelper(ebpf.Kprobe, asm.FnGetCurrentCgroupId) == nil
+}
+
 // HasBpfGetSocketCookieForCgroupSocket returns if the kernel supports bpf_get_socket_cookie for Cgroup Socket program type
 // https://github.com/torvalds/linux/commit/c5dbb89fc2ac013afe67b9e4fcb3743c02b567cd
 func (k *Version) HasBpfGetSocketCookieForCgroupSocket() bool {

--- a/pkg/security/ebpf/kernel/kernel_nobpf.go
+++ b/pkg/security/ebpf/kernel/kernel_nobpf.go
@@ -86,6 +86,12 @@ func (k *Version) HasBpfGetCurrentCgroupIDForSchedCLS() bool {
 	return false
 }
 
+// HasBpfGetCurrentCgroupID returns if the kernel supports bpf_get_current_cgroup_id for Sched CLS program type
+// Kernel version >= 4.18
+func (k *Version) HasBpfGetCurrentCgroupID() bool {
+	return false
+}
+
 // HasBpfGetSocketCookieForCgroupSocket returns if the kernel supports bpf_get_socket_cookie for Cgroup Socket program type
 // https://github.com/torvalds/linux/commit/c5dbb89fc2ac013afe67b9e4fcb3743c02b567cd
 func (k *Version) HasBpfGetSocketCookieForCgroupSocket() bool {

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -331,6 +331,9 @@ var (
 	// MetricCGroupResolverFallbackFailed is the name of the metric used to report the number of failed fallbacks
 	// Tags: -
 	MetricCGroupResolverFallbackFailed = newRuntimeMetric(".cgroup_resolver.fallback_failed")
+	// MetricCGroupResolverRemainingPids is the name of the metric used to report when a cgroup being delete still has pids
+	// Tags: -
+	MetricCGroupResolverRemainingPids = newRuntimeMetric(".cgroup_resolver.remaining_pids")
 
 	// Security Profile metrics
 

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1346,7 +1346,7 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 
 		// handle cgroup v2 deletion
 		fs := p.fieldHandlers.ResolveFileFilesystem(event, &event.Rmdir.File)
-		if fs == "cgroup2" && event.Rmdir.File.PathKey.Inode != 0 && event.Rmdir.File.IsDir() {
+		if fs == "cgroup2" && event.Rmdir.File.PathKey.Inode != 0 && event.Rmdir.File.IsDir() && event.Rmdir.Retval == 0 {
 			p.Resolvers.CGroupResolver.Delete(event.Rmdir.File.PathKey.Inode)
 		}
 	case model.FileUnlinkEventType:

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -2745,6 +2745,10 @@ func (p *EBPFProbe) initManagerOptionsConstants() {
 			Value: utils.BoolTouint64(p.kernelVersion.HasBpfGetCurrentCgroupIDForSchedCLS()),
 		},
 		manager.ConstantEditor{
+			Name:  "has_current_cgroup_id_helper",
+			Value: utils.BoolTouint64(p.kernelVersion.HasBpfGetCurrentCgroupID()),
+		},
+		manager.ConstantEditor{
 			Name:  "event_sampling_open_enabled",
 			Value: utils.BoolTouint64(p.config.RuntimeSecurity.EventSamplingOpenEnabled),
 		},

--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -1325,6 +1325,16 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		if !p.regularUnmarshalEvent(&event.Open, eventType, offset, dataLen, data) {
 			return false
 		}
+
+		// handle cgroup v2 creation
+		fs := p.fieldHandlers.ResolveFileFilesystem(event, &event.Open.File)
+
+		if fs == "cgroup2" && event.Open.File.PathKey.Inode != 0 && event.Open.File.FileFields.IsDir() {
+			cgroupContext := model.CGroupContext{
+				CGroupPathKey: event.Open.File.PathKey,
+			}
+			p.Resolvers.CGroupResolver.Add(cgroupContext, time.Now())
+		}
 	case model.FileMkdirEventType:
 		if !p.regularUnmarshalEvent(&event.Mkdir, eventType, offset, dataLen, data) {
 			return false
@@ -1333,9 +1343,21 @@ func (p *EBPFProbe) handleRegularEvent(event *model.Event, offset int, dataLen u
 		if !p.regularUnmarshalEvent(&event.Rmdir, eventType, offset, dataLen, data) {
 			return false
 		}
+
+		// handle cgroup v2 deletion
+		fs := p.fieldHandlers.ResolveFileFilesystem(event, &event.Rmdir.File)
+		if fs == "cgroup2" && event.Rmdir.File.PathKey.Inode != 0 && event.Rmdir.File.IsDir() {
+			p.Resolvers.CGroupResolver.Delete(event.Rmdir.File.PathKey.Inode)
+		}
 	case model.FileUnlinkEventType:
 		if !p.regularUnmarshalEvent(&event.Unlink, eventType, offset, dataLen, data) {
 			return false
+		}
+
+		// handle cgroup v2 deletion
+		fs := p.fieldHandlers.ResolveFileFilesystem(event, &event.Unlink.File)
+		if fs == "cgroup2" && event.Unlink.File.PathKey.Inode != 0 && event.Unlink.File.IsDir() {
+			p.Resolvers.CGroupResolver.Delete(event.Unlink.File.PathKey.Inode)
 		}
 	case model.FileRenameEventType:
 		if !p.regularUnmarshalEvent(&event.Rename, eventType, offset, dataLen, data) {

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -36,7 +36,10 @@ func NewCacheEntry(containerContext model.ContainerContext, cgroupContext model.
 		cgroupContext:    cgroupContext,
 		pids:             make(map[uint32]bool, 10),
 	}
-	cacheEntry.pids[pid] = true
+
+	if pid != 0 {
+		cacheEntry.pids[pid] = true
+	}
 
 	// should not happen but added as a safe-guard to avoid overriding
 	// a Releasable pointer which would cause Releasable callbacks to not be called

--- a/pkg/security/resolvers/cgroup/model/model.go
+++ b/pkg/security/resolvers/cgroup/model/model.go
@@ -133,11 +133,13 @@ func (cgce *CacheEntry) RemovePID(pid uint32) int {
 }
 
 // AddPID adds a pid to the list of pids
-func (cgce *CacheEntry) AddPID(pid uint32) {
+func (cgce *CacheEntry) AddPID(pid uint32) int {
 	cgce.lock.Lock()
 	defer cgce.lock.Unlock()
 
 	cgce.pids[pid] = true
+
+	return len(cgce.pids)
 }
 
 // SetPIDs set the pids list

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -68,6 +68,7 @@ type Resolver struct {
 	deletedCgroups  atomic.Int64
 	fallbackSucceed atomic.Int64
 	fallbackFailed  atomic.Int64
+	remainingPids   atomic.Int64
 }
 
 // NewResolver returns a new cgroups monitor
@@ -213,7 +214,7 @@ func (cr *Resolver) resolveAndPushNewCacheEntry(pid uint32, cgroupContext model.
 	return cr.pushNewCacheEntry(pid, containerContext, cgroupContext)
 }
 
-func (cr *Resolver) resolveFromFallback(pid uint32, ppid uint32, createdAt time.Time) *cgroupModel.CacheEntry {
+func (cr *Resolver) resolveFromFallback(pid uint32, ppid uint32) *cgroupModel.CacheEntry {
 	cid, cgroup, _, err := cr.cgroupFS.FindCGroupContext(pid, pid)
 	if err == nil && cgroup.CGroupID != "" {
 		// check if the cgroup is already in the cache
@@ -238,7 +239,7 @@ func (cr *Resolver) resolveFromFallback(pid uint32, ppid uint32, createdAt time.
 		}
 		containerContext := model.ContainerContext{
 			ContainerID: cid,
-			CreatedAt:   uint64(createdAt.UnixNano()),
+			CreatedAt:   uint64(cgroup.CreatedAt.UnixNano()),
 		}
 		seclog.Tracef("fallback to resolve cgroup for pid %d: %s", pid, cgroup.CGroupID)
 		cr.fallbackSucceed.Inc()
@@ -273,7 +274,7 @@ func (cr *Resolver) resolveFromFallback(pid uint32, ppid uint32, createdAt time.
 		}
 		containerContext := model.ContainerContext{
 			ContainerID: cid,
-			CreatedAt:   uint64(createdAt.UnixNano()),
+			CreatedAt:   uint64(cgroup.CreatedAt.UnixNano()),
 		}
 		seclog.Tracef("fallback to resolve parent cgroup for ppid %d: %s", ppid, cgroup.CGroupID)
 		cr.fallbackSucceed.Inc()
@@ -313,7 +314,16 @@ func (cr *Resolver) Delete(inode uint64) {
 
 	seclog.Tracef("received a cgroup delete : %d", inode)
 
-	cr.syncOrDeleteCaheEntry(cacheEntry, 0)
+	// try to resync remaining pids
+	if pids := cacheEntry.GetPIDs(); len(pids) > 0 {
+		cr.remainingPids.Inc()
+
+		for _, pid := range pids {
+			cr.resolveFromFallback(pid, pid)
+		}
+	}
+
+	cr.removeCacheEntry(cacheEntry)
 }
 
 // AddPID update the cgroup cache to associates a cgroup and a pid
@@ -360,7 +370,7 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupC
 		}
 	}
 
-	return cr.resolveFromFallback(pid, ppid, createdAt)
+	return cr.resolveFromFallback(pid, ppid)
 }
 
 func (cr *Resolver) iterateCacheEntries(cb func(*cgroupModel.CacheEntry) bool) {
@@ -506,6 +516,11 @@ func (cr *Resolver) SendStats() error {
 	}
 	if count := cr.fallbackFailed.Swap(0); count > 0 {
 		if err := cr.statsdClient.Count(metrics.MetricCGroupResolverFallbackFailed, count, []string{}, 1.0); err != nil {
+			return fmt.Errorf("failed to send cgroup_resolver metric: %w", err)
+		}
+	}
+	if count := cr.remainingPids.Swap(0); count > 0 {
+		if err := cr.statsdClient.Count(metrics.MetricCGroupResolverRemainingPids, count, []string{}, 1.0); err != nil {
 			return fmt.Errorf("failed to send cgroup_resolver metric: %w", err)
 		}
 	}

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -45,17 +45,6 @@ const (
 	maxHistoryEntries           = 1024
 )
 
-// ResolverInterface defines the interface implemented by a cgroup resolver
-type ResolverInterface interface {
-	Start(context.Context)
-	AddPID(*model.ProcessCacheEntry)
-	DelPID(uint32)
-	GetWorkload(containerutils.ContainerID) (*cgroupModel.CacheEntry, bool)
-	GetWorkloadByCGroupID(containerutils.CGroupID) (*cgroupModel.CacheEntry, bool)
-	Len() int
-	RegisterListener(Event, utils.Listener[*cgroupModel.CacheEntry]) error
-}
-
 // FSInterface defines the interface for CGroupFS operations
 type FSInterface interface {
 	FindCGroupContext(tgid, pid uint32) (containerutils.ContainerID, utils.CGroupContext, string, error)
@@ -205,7 +194,7 @@ func (cr *Resolver) resolveAndPushNewCacheEntry(pid uint32, cgroupContext model.
 	if !cgroupContext.IsResolved() {
 		path, err := cr.dentryResolver.Resolve(cgroupContext.CGroupPathKey, false)
 		if err != nil {
-			seclog.Debugf("failed to fallback to resolve dentry for pid %d and path key %v", pid, cgroupContext.CGroupPathKey)
+			seclog.Debugf("failed to fallback to resolve dentry for pid %d and path key %+v: %v", pid, cgroupContext.CGroupPathKey, err)
 			return nil
 		}
 
@@ -293,6 +282,35 @@ func (cr *Resolver) resolveFromFallback(pid uint32, ppid uint32, createdAt time.
 	cr.fallbackFailed.Inc()
 
 	return nil
+}
+
+// Add registers a new cgroup entry
+func (cr *Resolver) Add(cgroupContext model.CGroupContext, createdAt time.Time) *cgroupModel.CacheEntry {
+	cr.Lock()
+	defer cr.Unlock()
+
+	if cacheEntry, found := cr.cacheEntriesByPathKey.Get(cgroupContext.CGroupPathKey.Inode); found {
+		return cacheEntry
+	}
+
+	seclog.Tracef("add a new empty cgroup : %d", cgroupContext.CGroupPathKey.Inode)
+
+	return cr.resolveAndPushNewCacheEntry(0, cgroupContext, createdAt)
+}
+
+// Delete removes the cgroup associated with the given inode
+func (cr *Resolver) Delete(inode uint64) {
+	cr.Lock()
+	defer cr.Unlock()
+
+	cacheEntry, ok := cr.cacheEntriesByPathKey.Get(inode)
+	if !ok {
+		return
+	}
+
+	seclog.Tracef("delete cgroup : %d", inode)
+
+	cr.removeCacheEntry(cacheEntry)
 }
 
 // AddPID update the cgroup cache to associates a cgroup and a pid

--- a/pkg/security/resolvers/cgroup/resolver.go
+++ b/pkg/security/resolvers/cgroup/resolver.go
@@ -153,9 +153,11 @@ func (cr *Resolver) syncOrDeleteCaheEntry(cacheEntry *cgroupModel.CacheEntry, de
 	}
 
 	// otherwise sync it with new values
-	pids = slices.DeleteFunc(pids, func(todel uint32) bool {
-		return todel == deletedPid
-	})
+	if deletedPid != 0 {
+		pids = slices.DeleteFunc(pids, func(todel uint32) bool {
+			return todel == deletedPid
+		})
+	}
 	cacheEntry.SetPIDs(pids)
 }
 
@@ -180,7 +182,6 @@ func (cr *Resolver) pushNewCacheEntry(pid uint32, containerContext model.Contain
 	// push pid:PathKey pair to an history cache for fallbacks for short lived processes
 	cr.history.Add(pid, cgroupContext.CGroupPathKey.Inode)
 
-	cr.NotifyListeners(CGroupCreated, cacheEntry)
 	cr.addedCgroups.Inc()
 
 	return cacheEntry
@@ -220,7 +221,9 @@ func (cr *Resolver) resolveFromFallback(pid uint32, ppid uint32, createdAt time.
 			seclog.Tracef("fallback to resolve cgroup for pid %d with existing path key %+v", pid, cacheEntry.GetCGroupID())
 			cr.fallbackSucceed.Inc()
 
-			cacheEntry.AddPID(pid)
+			if l := cacheEntry.AddPID(pid); l == 1 {
+				cr.NotifyListeners(CGroupCreated, cacheEntry)
+			}
 
 			return cacheEntry
 		}
@@ -308,9 +311,9 @@ func (cr *Resolver) Delete(inode uint64) {
 		return
 	}
 
-	seclog.Tracef("delete cgroup : %d", inode)
+	seclog.Tracef("received a cgroup delete : %d", inode)
 
-	cr.removeCacheEntry(cacheEntry)
+	cr.syncOrDeleteCaheEntry(cacheEntry, 0)
 }
 
 // AddPID update the cgroup cache to associates a cgroup and a pid
@@ -327,7 +330,10 @@ func (cr *Resolver) AddPID(pid uint32, ppid uint32, createdAt time.Time, cgroupC
 		cr.iterateCacheEntries(func(cacheEntry *cgroupModel.CacheEntry) bool {
 			if cc := cacheEntry.GetCGroupContext(); cc.Equals(&cgroupContext) {
 				// if the cgroup context is the same, add the pid to the cache entry
-				cacheEntry.AddPID(pid)
+				if l := cacheEntry.AddPID(pid); l == 1 {
+					cr.NotifyListeners(CGroupCreated, cacheEntry)
+				}
+
 				cacheEntryFound = cacheEntry
 			} else if cacheEntry.ContainsPID(pid) {
 				cgroupsToClean = append(cgroupsToClean, cacheEntry)

--- a/pkg/security/resolvers/cgroup/resolver_test.go
+++ b/pkg/security/resolvers/cgroup/resolver_test.go
@@ -63,7 +63,7 @@ func TestResolvePidCgroupFallback_SuccessDirectResolution(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 5678, time.Now())
+	cacheEntry := resolver.resolveFromFallback(1234, 5678)
 	assert.NotNil(t, cacheEntry)
 	assert.Equal(t, containerutils.CGroupID("test-cgroup-id"), cacheEntry.GetCGroupID())
 	assert.Equal(t, uint64(9876), cacheEntry.GetCGroupInode())
@@ -83,7 +83,7 @@ func TestResolvePidCgroupFallback_FailInvalidPPid(t *testing.T) {
 		errors.New("not found"),
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 1234, time.Now())
+	cacheEntry := resolver.resolveFromFallback(1234, 1234)
 	assert.Nil(t, cacheEntry)
 
 	// Test case 2: PPid is 0
@@ -94,7 +94,7 @@ func TestResolvePidCgroupFallback_FailInvalidPPid(t *testing.T) {
 		errors.New("not found"),
 	)
 
-	cacheEntry = resolver.resolveFromFallback(1234, 0, time.Now())
+	cacheEntry = resolver.resolveFromFallback(1234, 0)
 	assert.Nil(t, cacheEntry)
 
 	mockFS.AssertExpectations(t)
@@ -126,7 +126,7 @@ func TestResolvePidCgroupFallback_SuccessFromHistory(t *testing.T) {
 		errors.New("not found"),
 	)
 
-	cacheEntry = resolver.resolveFromFallback(1234, 5678, time.Now())
+	cacheEntry = resolver.resolveFromFallback(1234, 5678)
 	assert.NotNil(t, cacheEntry)
 	assert.Equal(t, containerutils.CGroupID("parent-cgroup-id"), cacheEntry.GetCGroupID())
 	assert.Equal(t, parentPathKey, cacheEntry.GetCGroupContext().CGroupPathKey)
@@ -161,7 +161,7 @@ func TestResolvePidCgroupFallback_SuccessFromParentProc(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 5678, time.Now())
+	cacheEntry := resolver.resolveFromFallback(1234, 5678)
 	assert.NotNil(t, cacheEntry)
 	assert.Equal(t, containerutils.CGroupID("parent-cgroup-id"), cacheEntry.GetCGroupID())
 	assert.Equal(t, expectedContext.CGroupFileInode, cacheEntry.GetCGroupInode())
@@ -189,7 +189,7 @@ func TestResolvePidCgroupFallback_CompleteFailure(t *testing.T) {
 		errors.New("parent not found"),
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 5678, time.Now())
+	cacheEntry := resolver.resolveFromFallback(1234, 5678)
 	assert.Nil(t, cacheEntry)
 
 	mockFS.AssertExpectations(t)
@@ -223,7 +223,7 @@ func TestResolvePidCgroupFallback_HistoryFoundButCGroupMissing(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 5678, time.Now())
+	cacheEntry := resolver.resolveFromFallback(1234, 5678)
 	assert.NotNil(t, cacheEntry)
 	assert.Equal(t, containerutils.CGroupID("fallback-cgroup-id"), cacheEntry.GetCGroupID())
 	assert.Equal(t, expectedContext.CGroupFileInode, cacheEntry.GetCGroupInode())
@@ -255,7 +255,7 @@ func TestResolvePidCgroupFallback_EmptyCGroupIDIgnored(t *testing.T) {
 		errors.New("parent not found"),
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 5678, time.Now())
+	cacheEntry := resolver.resolveFromFallback(1234, 5678)
 	assert.Nil(t, cacheEntry)
 
 	mockFS.AssertExpectations(t)
@@ -276,7 +276,7 @@ func TestResolvePidCgroupFallback_UpdateExistingCacheEntry(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry := resolver.resolveFromFallback(1234, 9999, time.Now())
+	cacheEntry := resolver.resolveFromFallback(1234, 9999)
 	assert.NotNil(t, cacheEntry)
 
 	// Mock resolution that returns empty CGroupID (should be ignored)
@@ -291,7 +291,7 @@ func TestResolvePidCgroupFallback_UpdateExistingCacheEntry(t *testing.T) {
 		nil,
 	)
 
-	cacheEntry = resolver.resolveFromFallback(5678, 9999, time.Now())
+	cacheEntry = resolver.resolveFromFallback(5678, 9999)
 	assert.NotNil(t, cacheEntry)
 	assert.Equal(t, containerutils.CGroupID("fallback-cgroup-id-success"), cacheEntry.GetCGroupID())
 

--- a/pkg/security/secl/model/model_unix.go
+++ b/pkg/security/secl/model/model_unix.go
@@ -14,6 +14,7 @@ package model
 import (
 	"net/netip"
 	"runtime"
+	"syscall"
 	"time"
 	"unsafe"
 
@@ -472,6 +473,11 @@ type FileFields struct {
 
 	NLink uint32 `field:"-"`
 	Flags int32  `field:"-"`
+}
+
+// IsDir reports whether the file mode represents a directory.
+func (f *FileFields) IsDir() bool {
+	return f.Mode&syscall.S_IFMT == syscall.S_IFDIR
 }
 
 // FileEvent is the common file event type

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/moby/sys/mountinfo"
 	"golang.org/x/sys/unix"
@@ -156,6 +157,7 @@ type CGroupContext struct {
 	CGroupID          containerutils.CGroupID
 	CGroupFileMountID uint32
 	CGroupFileInode   uint64
+	CreatedAt         time.Time
 }
 
 var defaultCGroupMountpoints = []string{
@@ -267,8 +269,10 @@ func (cfs *CGroupFS) FindCGroupContext(tgid, pid uint32) (containerutils.Contain
 				if err = unix.Statx(unix.AT_FDCWD, cgroupPath, 0, unix.STATX_INO|unix.STATX_MNT_ID, &fileStatx); err == nil {
 					cgroupContext.CGroupFileMountID = uint32(fileStatx.Mnt_id)
 					cgroupContext.CGroupFileInode = fileStatx.Ino
+					cgroupContext.CreatedAt = time.Unix(fileStatx.Mtime.Sec, int64(fileStatx.Mtime.Nsec))
 				} else if err = unix.Stat(cgroupPath, &fileStats); err == nil {
 					cgroupContext.CGroupFileInode = fileStats.Ino
+					cgroupContext.CreatedAt = time.Unix(fileStats.Mtim.Sec, int64(fileStats.Mtim.Nsec))
 				}
 				if err == nil {
 					return true, nil


### PR DESCRIPTION
- Add INTERNAL syscall state to pass cgroup2fs open events through the kernel pipeline without discarding them, filtering to directory-only opens in sys_open_ret
- Hook open/rmdir/unlink events on cgroup2fs: force ACCEPTED on rmdir/unlink directory events so cgroup deletions are always forwarded
- Add CGroupResolver.Add() and Delete() methods to register/unregister cgroup entries by inode from userspace event handlers
- Handle cgroup v2 creation/deletion in probe_ebpf.go by detecting filesystem == "cgroup2" and calling the resolver accordingly
- Fix exec cgroup inheritance: drop CLONE_NEWCGROUP from the fork flag guard — only CLONE_INTO_CGROUP should skip parent cgroup context inheritance; use bpf_get_current_cgroup_id() when entering a new cgroup
- Guard NewCacheEntry against pid=0 being inserted into the pids map
- Remove unused ResolverInterface
- Add FileFields.IsDir() helper
- Improve dentry resolve debug log to include the error

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
