### PR TITLE
[auto-jira][AGENTCFG-63] flare: extract buildFlareBaseURL to eliminate duplicated AddAgentVersionToDomain call

### DIFF
--- a/comp/core/flare/helpers/send_flare.go
+++ b/comp/core/flare/helpers/send_flare.go
@@ -252,7 +252,7 @@ func SendTo(cfg pkgconfigmodel.Reader, archivePath, caseID, email, apiKey, url s
 	}
 
 	apiKey = configUtils.SanitizeAPIKey(apiKey)
-	baseURL, _ := configUtils.AddAgentVersionToDomain(url, "flare")
+	baseURL, _ := buildFlareBaseURL(url)
 
 	transport := httputils.CreateHTTPTransport(cfg)
 	client := &http.Client{
@@ -315,10 +315,17 @@ func isRetryableFlareError(err error, statusCode int) bool {
 		strings.Contains(errStr, "temporary failure")
 }
 
+// buildFlareBaseURL returns the versioned flare domain for a given raw endpoint URL.
+// It is used by both GetFlareEndpoint and SendTo to avoid duplicating the
+// AddAgentVersionToDomain call.
+func buildFlareBaseURL(rawURL string) (string, error) {
+	return configUtils.AddAgentVersionToDomain(rawURL, "flare")
+}
+
 // GetFlareEndpoint creates the flare endpoint URL
 func GetFlareEndpoint(cfg config.Reader) string {
 	// Create flare endpoint to the shape of "https://<version>-flare.agent.datadoghq.com/support/flare"
-	flareRoute, _ := configUtils.AddAgentVersionToDomain(configUtils.GetInfraEndpoint(cfg), "flare")
+	flareRoute, _ := buildFlareBaseURL(configUtils.GetInfraEndpoint(cfg))
 	return flareRoute + datadogSupportURL
 }
 


### PR DESCRIPTION
## Summary

Both `GetFlareEndpoint` and `SendTo` in `comp/core/flare/helpers/send_flare.go` independently called `configUtils.AddAgentVersionToDomain(url, "flare")`. This PR extracts that into a private `buildFlareBaseURL` helper so both functions share the same implementation.

Before:
- `GetFlareEndpoint` (line 321): `flareRoute, _ := configUtils.AddAgentVersionToDomain(configUtils.GetInfraEndpoint(cfg), "flare")`
- `SendTo` (line 255): `baseURL, _ := configUtils.AddAgentVersionToDomain(url, "flare")`

After:
- Both call `buildFlareBaseURL(url)` which wraps `configUtils.AddAgentVersionToDomain(url, "flare")`

## Test plan
- [x] `go test -tags test ./comp/core/flare/helpers/...` — all pass
- [x] `dda inv linter.go --targets=./comp/core/flare/helpers` — 0 issues

Fixes AGENTCFG-63

_Created by [Auto-JIRA](https://github.com/DataDog/datadog-agent/blob/main/.claude/skills/auto-jira/SKILL.md)._