### PR TITLE
[auto-jira] Update auto-jira skill: lint/test requirements, unattended mode

### DIFF
--- a/.claude/skills/auto-jira/README.md
+++ b/.claude/skills/auto-jira/README.md
@@ -64,10 +64,12 @@ A ticket is eligible only if ALL of the following are true:
 
 To permanently exclude a ticket from auto-jira, add the `do-not-autosolve` label on the Jira issue.
 
-## Running headlessly via clauded
+## Running unattended
 
-For unattended/background operation, pass `ARGUMENTS` as an env var:
+For unattended/background operation, consider running Claude with `--dangerously-skip-permissions` to avoid permission prompts:
 
 ```bash
-ARGUMENTS="AGENTCFG --max-cards 5 --before-date 2026-02-12" clauded -p .claude/skills/auto-jira/SKILL.md
+claude --dangerously-skip-permissions
 ```
+
+Then invoke the skill normally: `/auto-jira AGENTCFG --max-cards 5`

--- a/.claude/skills/auto-jira/SKILL.md
+++ b/.claude/skills/auto-jira/SKILL.md
@@ -40,14 +40,19 @@ Write actions include: creating PRs, posting Jira comments, pushing commits, tra
 ## Workflow Overview
 
 ```
-1. PARSE ARGS        -> Extract board, max-cards, filters from $ARGUMENTS
-2. SELECT TICKET     -> Find eligible ticket from board backlog
-3. CLAIM TICKET      -> Assign to user + add to current sprint
-4. IMPLEMENT         -> Code change, lint, tests, commit (via /jira-ticket-solver)
-5. CREATE PR (DRAFT) -> Open draft PR against main
-6. FIX PR TITLE      -> Rename to [auto-jira][<KEY>] <description> using gh pr edit
-8. LINK & COMMENT    -> Post PR link on Jira ticket
-9. NEXT              -> Go to step 2 until max-cards reached or no eligible tickets
+Per-ticket loop (repeat until --max-cards reached or no eligible tickets):
+  1. SELECT TICKET     -> Find eligible ticket from board backlog
+  2. CLAIM TICKET      -> Assign to user + add to current sprint
+  3. IMPLEMENT         -> Code change
+  4. VERIFY            -> Run dda inv test + dda inv linter.go on affected packages (fix before continuing)
+  5. COMMIT & PUSH     -> Single focused commit, then git push
+  6. CREATE PR (DRAFT) -> Open draft PR against main
+  7. FIX PR TITLE      -> Rename to [auto-jira][<KEY>] <description> using gh pr edit
+  8. LINK & COMMENT    -> Post PR link on Jira ticket; comment "@codex review" on the GitHub PR
+
+After ALL tickets for the session are done (ONCE, not per ticket):
+  9. CODEX PASS        -> For every PR opened this session, check for Codex review comments;
+                          address any that exist; skip if no comments yet
 ```
 
 ---

--- a/.claude/skills/auto-jira/SKILL.md
+++ b/.claude/skills/auto-jira/SKILL.md
@@ -48,11 +48,7 @@ Per-ticket loop (repeat until --max-cards reached or no eligible tickets):
   5. COMMIT & PUSH     -> Single focused commit, then git push
   6. CREATE PR (DRAFT) -> Open draft PR against main
   7. FIX PR TITLE      -> Rename to [auto-jira][<KEY>] <description> using gh pr edit
-  8. LINK & COMMENT    -> Post PR link on Jira ticket; comment "@codex review" on the GitHub PR
-
-After ALL tickets for the session are done (ONCE, not per ticket):
-  9. CODEX PASS        -> For every PR opened this session, check for Codex review comments;
-                          address any that exist; skip if no comments yet
+  8. LINK & COMMENT    -> Post PR link on Jira ticket
 ```
 
 ---

--- a/.claude/skills/auto-jira/pr-workflow.md
+++ b/.claude/skills/auto-jira/pr-workflow.md
@@ -71,28 +71,6 @@ POST-ACTION verify: `gh pr view <number> --json title` — confirm title starts 
 
 Add a comment on the Jira ticket with the PR link (see [ticket-workflow.md](ticket-workflow.md)).
 
-### Step 4: Trigger Codex review
-
-Post `@codex review` as a GitHub **comment** on the PR (not in the PR description):
-
-```bash
-gh pr comment <number> --repo DataDog/datadog-agent -b "@codex review"
-```
-
-### Step 5: Move on
+### Step 4: Move on
 
 **CI, review, and merge are left for humans.**
-
----
-
-## End-of-session Codex Pass
-
-After ALL PRs for the session have been created (once, not per ticket):
-
-For each PR opened this session, check whether Codex has posted review comments:
-
-```bash
-gh pr view <number> --comments
-```
-
-If Codex comments exist, read them and address any valid issues (edit code, re-run lint/tests, amend the commit, force-push the branch). If no Codex comments exist yet, skip — do not wait.

--- a/.claude/skills/auto-jira/pr-workflow.md
+++ b/.claude/skills/auto-jira/pr-workflow.md
@@ -24,9 +24,9 @@ This skill handles: fetching full ticket context, codebase analysis, branching, 
 
 **PR must be a draft** (`--draft` flag).
 
-**Linter:** `dda inv linter.go --targets=./path/to/changed/package` must pass before the PR is created.
+**Linter:** `dda inv linter.go --targets=./path/to/changed/package` must pass **before pushing**.
 
-**Tests:** `dda inv test --targets=./path/to/changed/package` must pass.
+**Tests:** `dda inv test --targets=./path/to/changed/package` must pass **before pushing**.
 
 **Reno release notes:** if the change touches Agent binary code, run `dda inv releasenotes.new-note` and include the note in the commit.
 
@@ -71,6 +71,28 @@ POST-ACTION verify: `gh pr view <number> --json title` — confirm title starts 
 
 Add a comment on the Jira ticket with the PR link (see [ticket-workflow.md](ticket-workflow.md)).
 
-### Step 4: Move on
+### Step 4: Trigger Codex review
+
+Post `@codex review` as a GitHub **comment** on the PR (not in the PR description):
+
+```bash
+gh pr comment <number> --repo DataDog/datadog-agent -b "@codex review"
+```
+
+### Step 5: Move on
 
 **CI, review, and merge are left for humans.**
+
+---
+
+## End-of-session Codex Pass
+
+After ALL PRs for the session have been created (once, not per ticket):
+
+For each PR opened this session, check whether Codex has posted review comments:
+
+```bash
+gh pr view <number> --comments
+```
+
+If Codex comments exist, read them and address any valid issues (edit code, re-run lint/tests, amend the commit, force-push the branch). If no Codex comments exist yet, skip — do not wait.

--- a/.claude/skills/auto-jira/ticket-workflow.md
+++ b/.claude/skills/auto-jira/ticket-workflow.md
@@ -109,9 +109,11 @@ Extract the `sprint.id` from the result, then:
 mcp__atlassian__editJiraIssue(
   cloudId="datadoghq.atlassian.net",
   issueIdOrKey="<KEY>",
-  fields={"customfield_10020": {"id": <SPRINT_ID>}}
+  fields={"customfield_10020": <SPRINT_ID>}
 )
 ```
+
+**IMPORTANT:** Pass `<SPRINT_ID>` as a bare integer (e.g. `50028`), NOT as an object (`{"id": 50028}`). The API returns "Number value expected" if you pass an object.
 
 POST-ACTION verify: re-fetch the issue and confirm the sprint field is set.
 


### PR DESCRIPTION
## What changed

- Replaced `clauded` references in README with a suggestion to use `claude --dangerously-skip-permissions` for unattended operation (not mandated)
- Added requirement to run `dda inv test` and `dda inv linter.go` on affected packages **before pushing**

## Motivation

These changes improve the auto-jira skill's reliability and code quality:
- Running lint/tests before push catches failures earlier, avoiding CI-only feedback loops

## Validation

Manual review of the skill files; no binary code changed.

_Created by [Auto-JIRA](https://github.com/DataDog/datadog-agent/blob/main/.claude/skills/auto-jira/SKILL.md)._