### PR TITLE
Fix main ci breakage because of owners lint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,7 +65,8 @@
 /.github/CODEOWNERS                                  # do not notify anyone
 /.github/*_TEMPLATE.md                               @DataDog/agent-devx
 /.github/chainguard/**                               @DataDog/agent-devx
-/.github/dependabot.yaml                             @DataDog/agent-devx
+# Removed temporarily
+# /.github/dependabot.yaml                             @DataDog/agent-devx
 /.github/workflows/cws-btfhub-sync.yml               @DataDog/agent-security @DataDog/agent-devx
 /.github/workflows/gohai.yml                         @DataDog/agent-configuration @DataDog/agent-devx
 /.github/workflows/go-update-commenter.yml           @DataDog/agent-runtimes @DataDog/agent-devx


### PR DESCRIPTION
### What does this PR do?

Comments out the ownership of the dependabot config until we restore it.