### PR TITLE
[backport/7.77.x] Hide gui app by default

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -65,6 +65,13 @@ if [ -n "$DD_AGENT_DIST_CHANNEL" ]; then
     agent_dist_channel="$DD_AGENT_DIST_CHANNEL"
 fi
 
+# Per-user install only: show the menu bar icon. Defaults to false (headless GUI).
+# Set DD_GUI_APP_MENU_ENABLED=true to remove --headless from the plist and show the menu bar icon.
+gui_app_menu_enabled=false
+if [ "$DD_GUI_APP_MENU_ENABLED" = "true" ]; then
+    gui_app_menu_enabled=true
+fi
+
 if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
   # Examples:
   #  - 20   = defaults to highest patch version x.20.2
@@ -659,10 +666,24 @@ else
     printf "${BLUE}\n* A datadog.yaml configuration file already exists. It will not be overwritten.\n${NC}\n"
 fi
 
-# Starting the app
-if [ "$systemdaemon_install" = false ]; then
-    $cmd_real_user open -a 'Datadog Agent.app'
-else
+# Per-user GUI: plist has --headless by default; optionally strip it and reload launchd here
+user_gui_plist="${install_user_home}/Library/LaunchAgents/com.datadoghq.gui.plist"
+if [ "$systemdaemon_install" = false ] && [ "$gui_app_menu_enabled" = true ] && [ -f "$user_gui_plist" ]; then
+    printf "${BLUE}\n    - Enabling menu bar GUI (DD_GUI_APP_MENU_ENABLED=true)...\n${NC}"
+    $sudo_cmd sed -i '' '/<string>--headless<\/string>/d' "$user_gui_plist"
+    # Restart the GUI so it picks up the updated plist without --headless
+    $cmd_launchctl bootout "gui/$user_uid/com.datadoghq.gui" 2>/dev/null || true
+    # Wait for the old process to fully exit before loading the new configuration
+    count=0
+    while pgrep -U "$user_uid" -f "Datadog Agent.app/Contents/MacOS/gui" > /dev/null 2>&1 && [ $count -lt 20 ]; do
+        sleep 0.5
+        count=$((count + 1))
+    done
+    $cmd_launchctl load -w "$user_gui_plist"
+fi
+
+# Per-user: GUI is started by postinst (headless) or by launchctl load above (menu bar); no open needed
+if [ "$systemdaemon_install" != false ]; then
     printf "${BLUE}\n* Installing $service_name as a system-wide LaunchDaemon ...\n\n${NC}"
     # Remove the Agent login item and unload the agent for current user
     # if it is running - it's not running if the script was launched when

--- a/omnibus/config/templates/datadog-agent/gui.launchd.plist.erb
+++ b/omnibus/config/templates/datadog-agent/gui.launchd.plist.erb
@@ -16,6 +16,7 @@
         <key>ProgramArguments</key>
         <array>
             <string>/Applications/Datadog Agent.app/Contents/MacOS/gui</string>
+            <string>--headless</string>
             <!-- Uncomment to enable file-based logging instead of unified logging (os_log) -->
             <!-- <string>--use-file-logging</string> -->
         </array>

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -158,13 +158,8 @@ if [ -f "/tmp/install-ddagent/system-wide" ]; then
   # System-wide installation: Install GUI app for all users (headless mode)
   echo "# Configuring GUI app for system-wide installation"
 
-  # Install GUI appfor ALL users (headless mode)
+  # Install GUI app for ALL users (headless mode by default from plist template)
   cp -vf "$CONF_DIR/com.datadoghq.gui.plist.example" /Library/LaunchAgents/com.datadoghq.gui.plist
-
-  # Add --headless flag to ProgramArguments (inserts before the closing </array> tag)
-  sed -i '' '/<\/array>/i\
-            <string>--headless<\/string>
-' /Library/LaunchAgents/com.datadoghq.gui.plist
 
   # Set proper ownership and permissions for system-wide LaunchAgent
   chown root:wheel /Library/LaunchAgents/com.datadoghq.gui.plist
@@ -207,8 +202,10 @@ else
   sudo -Hu "$INSTALL_USER" ln -vs $CONF_DIR/datadog.yaml "$USER_HOME/.datadog-agent/datadog.yaml"
   sudo -Hu "$INSTALL_USER" ln -vs $CONF_DIR/checks.d "$USER_HOME/.datadog-agent/checks.d"
 
-  # Create the tray icon app launchctl service
+  # Tray app: headless by default from plist template. install_mac_os.sh may remove --headless
+  # if DD_GUI_APP_MENU_ENABLED=true (postinst does not see that env var from the installer).
   sudo -Hu "$INSTALL_USER" cp -vf "$CONF_DIR/com.datadoghq.gui.plist.example" "$USER_HOME/Library/LaunchAgents/com.datadoghq.gui.plist"
+
   sudo -Hu "$INSTALL_USER" launchctl load -w "$USER_HOME/Library/LaunchAgents/com.datadoghq.agent.plist"
 
   # Load the GUI LaunchAgent
@@ -219,6 +216,9 @@ else
   echo "=========================================="
   echo "Datadog Agent GUI"
   echo "=========================================="
+  echo "The menu bar icon is hidden by default (headless GUI for WiFi metrics)."
+  echo "When installing via install_mac_os.sh, set DD_GUI_APP_MENU_ENABLED=true to show it."
+  echo ""
   echo "To enable WiFi data collection (SSID/BSSID), grant Location permission:"
   echo "  System Settings -> Privacy & Security -> Location Services -> Enable 'Datadog Agent'"
   echo ""

--- a/releasenotes/notes/bump-cloudflare-circl-cve-73a90a28a17786c1.yaml
+++ b/releasenotes/notes/bump-cloudflare-circl-cve-73a90a28a17786c1.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    Bump github.com/cloudflare/circl to fix v1.6.3 to fix CVE-2026-1229.

--- a/releasenotes/notes/macos-hide-gui-app-icon-9a7b354d7cc219df.yaml
+++ b/releasenotes/notes/macos-hide-gui-app-icon-9a7b354d7cc219df.yaml
@@ -6,10 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-security:
+enhancements:
   - |
-<<<<<<<< HEAD:releasenotes/notes/bump-cloudflare-circl-cve-73a90a28a17786c1.yaml
-    Bump github.com/cloudflare/circl to fix v1.6.3 to fix CVE-2026-1229.
-========
     Hide GUI app by default for MacOS agent per-user install.
->>>>>>>> 61713a70d82 (Hide gui app by default (#48240)):releasenotes/notes/macos-hide-gui-app-icon-9a7b354d7cc219df.yaml

--- a/releasenotes/notes/macos-hide-gui-app-icon-9a7b354d7cc219df.yaml
+++ b/releasenotes/notes/macos-hide-gui-app-icon-9a7b354d7cc219df.yaml
@@ -8,4 +8,8 @@
 ---
 security:
   - |
+<<<<<<<< HEAD:releasenotes/notes/bump-cloudflare-circl-cve-73a90a28a17786c1.yaml
     Bump github.com/cloudflare/circl to fix v1.6.3 to fix CVE-2026-1229.
+========
+    Hide GUI app by default for MacOS agent per-user install.
+>>>>>>>> 61713a70d82 (Hide gui app by default (#48240)):releasenotes/notes/macos-hide-gui-app-icon-9a7b354d7cc219df.yaml


### PR DESCRIPTION
## Summary
Backport of #48240 to 7.77.x

- Hide the macOS GUI app menu bar icon by default (headless mode)
- Add `DD_GUI_APP_MENU_ENABLED=true` option to show the menu bar icon

## Test plan
- [x] Verify macOS install works with GUI hidden by default
- [x] Verify `DD_GUI_APP_MENU_ENABLED=true` shows the menu bar icon