### PR TITLE
[backport/7.77.x] Hide dmg mount

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -557,7 +557,7 @@ fi
 printf "${BLUE}\n* Installing datadog-agent, you might be asked for your sudo password...\n${NC}"
 $sudo_cmd hdiutil detach "/Volumes/datadog_agent" >/dev/null 2>&1 || true
 printf "${BLUE}\n    - Mounting the DMG installer...\n${NC}"
-$sudo_cmd hdiutil attach "$dmg_file" -mountpoint "/Volumes/datadog_agent" >/dev/null
+$sudo_cmd hdiutil attach "$dmg_file" -mountpoint "/Volumes/datadog_agent" -nobrowse >/dev/null
 if [ "$systemdaemon_install" != false ] && [ -f "$systemwide_servicefile_name" ]; then
     printf "${BLUE}\n    - Stopping system-wide Datadog Agent daemon ...\n${NC}"
     # we use "|| true" because if the service is not started/loaded, the commands fail

--- a/releasenotes/notes/bump-cloudflare-circl-cve-73a90a28a17786c1.yaml
+++ b/releasenotes/notes/bump-cloudflare-circl-cve-73a90a28a17786c1.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    Bump github.com/cloudflare/circl to fix v1.6.3 to fix CVE-2026-1229.

--- a/releasenotes/notes/macos-hide-dmg-mount-9cbf94075289de68.yaml
+++ b/releasenotes/notes/macos-hide-dmg-mount-9cbf94075289de68.yaml
@@ -8,4 +8,8 @@
 ---
 security:
   - |
+<<<<<<<< HEAD:releasenotes/notes/bump-cloudflare-circl-cve-73a90a28a17786c1.yaml
     Bump github.com/cloudflare/circl to fix v1.6.3 to fix CVE-2026-1229.
+========
+    Hide DMG mount in MacOS agent installation process.
+>>>>>>>> 39228a6e8c7 (Hide dmg mount (#48246)):releasenotes/notes/macos-hide-dmg-mount-9cbf94075289de68.yaml

--- a/releasenotes/notes/macos-hide-dmg-mount-9cbf94075289de68.yaml
+++ b/releasenotes/notes/macos-hide-dmg-mount-9cbf94075289de68.yaml
@@ -6,10 +6,6 @@
 #
 # Each section note must be formatted as reStructuredText.
 ---
-security:
+enhancements:
   - |
-<<<<<<<< HEAD:releasenotes/notes/bump-cloudflare-circl-cve-73a90a28a17786c1.yaml
-    Bump github.com/cloudflare/circl to fix v1.6.3 to fix CVE-2026-1229.
-========
     Hide DMG mount in MacOS agent installation process.
->>>>>>>> 39228a6e8c7 (Hide dmg mount (#48246)):releasenotes/notes/macos-hide-dmg-mount-9cbf94075289de68.yaml


### PR DESCRIPTION
## Summary
Backport of #48246 to 7.77.x

- Add `-nobrowse` flag to `hdiutil attach` to prevent the DMG mount from appearing in Finder during installation

## Test plan
- [ ] Verify macOS DMG install does not show the mount point in Finder