### PR TITLE
Stop canceling manual jobs when canceling prev pipeline

### DIFF
--- a/tasks/libs/pipeline/tools.py
+++ b/tasks/libs/pipeline/tools.py
@@ -136,7 +136,7 @@ def gracefully_cancel_pipeline(repo: Project, pipeline: ProjectPipeline, force_c
         jobs_by_name[job.name] = cast(ProjectJob, job)
 
         if job.stage in force_cancel_stages or (
-            job.status not in ["running", "canceled", "success"] and "cleanup" not in job.name
+            job.status not in ["running", "canceled", "success", "manual"] and "cleanup" not in job.name
         ):
             repo.jobs.get(job.id, lazy=True).cancel()
 


### PR DESCRIPTION
### What does this PR do?

Stop canceling manual jobs when canceling prev pipeline

### Motivation

Canceling a non-triggered manual job has the secondary effect of triggering triggers that were depending on that manual job. This was deploying the Full Host Profiler on Datadog Reliability Environment anytime the `cancel-prev-pipelines` was ran.