### PR TITLE
trigger deployment only when the main schedule is ran

### DIFF
--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -278,7 +278,9 @@ dev_deploy-host-profiler-devtest:
 deploy_host_profiler_to_reliability_env_nightly:
   extends: .trigger_relenv_base
   rules:
-    - !reference [.on_scheduled_main]
+    # Only trigger if the pipeline was triggered by conductor on main in a nightly bucket branch
+    - if: $DDR_WORKFLOW_ID != null && $CI_COMMIT_BRANCH == "main" && ($BUCKET_BRANCH == "nightly" || $BUCKET_BRANCH == "oldnightly")
+      when: always
   needs:
     - dev_nightly-host-profiler-standalone
 

--- a/.gitlab/deploy/dev_container_deploy/docker_linux.yml
+++ b/.gitlab/deploy/dev_container_deploy/docker_linux.yml
@@ -278,7 +278,7 @@ dev_deploy-host-profiler-devtest:
 deploy_host_profiler_to_reliability_env_nightly:
   extends: .trigger_relenv_base
   rules:
-    - !reference [.on_deploy_nightly_repo_branch]
+    - !reference [.on_scheduled_main]
   needs:
     - dev_nightly-host-profiler-standalone
 


### PR DESCRIPTION
### What does this PR do?

Changes the trigger rule for `deploy_host_profiler_to_reliability_env_nightly` from `.on_deploy_nightly_repo_branch` to 
```
$DDR_WORKFLOW_ID != null && $CI_COMMIT_BRANCH == "main" && ($BUCKET_BRANCH == "nightly" || $BUCKET_BRANCH == "oldnightly")
```

### Motivation

The rel-env deployment would fire on every commit to main that went through the nightly deploy pipeline. We now restricts the trigger to the once a day nightly conductor-orchestrated pipeline.
